### PR TITLE
THRIFT-1267: Node.js can't throw exceptions. 

### DIFF
--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -860,7 +860,7 @@ void t_js_generator::generate_process_function(t_service* tservice,
     indent_up();
 
     f_service_ <<
-      indent() << "var result = new " << resultname << "((typeof success === 'object' ? success : {\"success\": success}));" << endl <<
+      indent() << "var result = new " << resultname << "((typeof success === 'object' && typeof success.read !== 'function' ? success : {\"success\": success}));" << endl <<
       indent() << "output.writeMessageBegin(\"" << tfunction->get_name() <<
         "\", Thrift.MessageType.REPLY, seqid);" << endl <<
       indent() << "result.write(output);" << endl <<


### PR DESCRIPTION
Fixes from https://issues.apache.org/jira/browse/THRIFT-1267
