### PR TITLE
Fixing http client

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -43,7 +43,8 @@ module Thrift
     def flush
       http = Net::HTTP.new @url.host, @url.port
       http.use_ssl = @url.scheme == "https"
-      resp, data = http.post(@url.request_uri, @outbuf, @headers)
+      resp = http.post(@url.request_uri, @outbuf, @headers)
+      data = resp.body
       @inbuf = StringIO.new data
       @outbuf = ""
     end

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -39,7 +39,11 @@ class ThriftHTTPClientTransportSpec < Spec::ExampleGroup
       Net::HTTP.should_receive(:new).with("my.domain.com", 80).and_return do
         mock("Net::HTTP").tee do |http|
           http.should_receive(:use_ssl=).with(false)
-          http.should_receive(:post).with("/path/to/service?param=value", "a test frame", {"Content-Type"=>"application/x-thrift"}).and_return([nil, "data"])
+          http.should_receive(:post).with("/path/to/service?param=value", "a test frame", {"Content-Type"=>"application/x-thrift"}).and_return do
+            mock("Net::HTTPOK").tee do |response|
+              response.should_receive(:body).and_return "data"
+            end
+          end
         end
       end
       @client.flush
@@ -55,7 +59,11 @@ class ThriftHTTPClientTransportSpec < Spec::ExampleGroup
       Net::HTTP.should_receive(:new).with("my.domain.com", 80).and_return do
         mock("Net::HTTP").tee do |http|
           http.should_receive(:use_ssl=).with(false)
-          http.should_receive(:post).with("/path/to/service?param=value", "test", headers).and_return([nil, "data"])
+          http.should_receive(:post).with("/path/to/service?param=value", "test", headers).and_return do
+            mock("Net::HTTPOK").tee do |response|
+              response.should_receive(:body).and_return "data"
+            end
+          end
         end
       end
       @client.flush


### PR DESCRIPTION
Correct way of using Net::HTTP (ruby 1.8.x, 1.9.x)
