### PR TITLE
THRIFT-1981 ensure all php libs are installed

### DIFF
--- a/lib/php/Makefile.am
+++ b/lib/php/Makefile.am
@@ -40,6 +40,10 @@ phpbasedir = $(phpdir)/Base
 phpbase_DATA = \
   lib/Thrift/Base/TBase.php
 
+phpclassloaderdir = $(phpdir)/ClassLoader
+phpclassloader_DATA = \
+  lib/Thrift/ClassLoader/ThriftClassLoader.php
+
 phpexceptiondir = $(phpdir)/Exception
 phpexception_DATA = \
   lib/Thrift/Exception/TApplicationException.php \
@@ -74,6 +78,20 @@ phpprotocoljson_DATA = \
 phpserializerdir = $(phpdir)/Serializer
 phpserializer_DATA = \
   lib/Thrift/Serializer/TBinarySerializer.php
+
+phpserverdir = $(phpdir)/Server
+phpserver_DATA = \
+  lib/Thrift/Server/TServerSocket.php \
+  lib/Thrift/Server/TForkingServer.php \
+  lib/Thrift/Server/TServer.php \
+  lib/Thrift/Server/TServerTransport.php \
+  lib/Thrift/Server/TSimpleServer.php
+
+phpstringfuncdir = $(phpdir)/StringFunc
+phpstringfunc_DATA = \
+  lib/Thrift/StringFunc/Mbstring.php \
+  lib/Thrift/StringFunc/Core.php \
+  lib/Thrift/StringFunc/TStringFunc.php
 
 phptransportdir = $(phpdir)/Transport
 phptransport_DATA = \


### PR DESCRIPTION
When building a Debian package not all php files are included. When
installing the php5 libs package and trying to create a client there are
missing dependencies. This change adds to the Makefile.am those
dependencies, which one assumes should be installed as part of the
package.
