### PR TITLE
Please add more OSGI package exports to the Java manifest file

### DIFF
--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -123,7 +123,7 @@
         <attribute name="Bundle-Description" value="Apache Thrift library"/>
         <attribute name="Bundle-License" value="${license}"/>
         <attribute name="Bundle-ActivationPolicy" value="lazy"/>
-        <attribute name="Export-Package" value="${thrift.groupid};version=${version}"/>
+        <attribute name="Export-Package" value="${thrift.groupid},${thrift.groupid}.async,${thrift.groupid}.meta_data,${thrift.groupid}.protocol,${thrift.groupid}.scheme,${thrift.groupid}.server,${thrift.groupid}.transport;version=${version}"/>
       </manifest>
       <fileset dir="${build.dir}">
         <include name="org/apache/thrift/**/*.class"/>


### PR DESCRIPTION
When trying to use the Thrift jar in an OSGI application, I get the following error:

> org.osgi.framework.BundleException: Unresolved constraint in bundle ... : Unable to resolve 9.0: missing requirement [9.0] osgi.wiring.package; (osgi.wiring.package=org.apache.thrift.server)

Upon further inspection, I noticed that the jar's manifest file only exports the package org.apache.thrift, which is useful but arguably not sufficient in scope for most applications (I need access to TSimpleServer, etc.)

Please consider adding additional package exports so I don't have to re-wrap the compiled class files in a custom  manifest. Thanks :)
