### PR TITLE
Update TBufferTransports.cpp

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -360,6 +360,8 @@ void TMemoryBuffer::ensureCanWrite(uint32_t len) {
   rBound_ += offset;
   wBase_ += offset;
   wBound_ = buffer_ + bufferSize_;
+  delete new_buffer;
+  new_buffer=NULL;
 }
 
 void TMemoryBuffer::writeSlow(const uint8_t* buf, uint32_t len) {


### PR DESCRIPTION
In void TMemoryBuffer::ensureCanWrite(uint32_t len)
Storage is returned from allocation function "realloc(void *, size_t)". 
Assigning: "new_buffer" = storage returned from "realloc(this->buffer_, new_size)". 
Variable "new_buffer" going out of scope leaks the storage it points to.
so deleting the new_buffer and releasing memory.
