### PR TITLE
Memory Leak fix in t_program.h

### DIFF
--- a/compiler/cpp/src/parse/t_program.h
+++ b/compiler/cpp/src/parse/t_program.h
@@ -72,6 +72,15 @@ class t_program : public t_doc {
     name_ = program_name(path);
     scope_ = new t_scope();
   }
+  
+  ~t_program()
+  {
+   if(scope_)
+   {
+     delete scope_; 
+     scope_ = NULL; 
+   }
+  }
 
   // Path accessor
   const std::string& get_path() const { return path_; }


### PR DESCRIPTION
In constructor Allocating memory by calling "new t_scope". 
Assigning: "this->scope_" = "new t_scope". 
The constructor allocates field "scope_" of "t_program" but there is no destructor in the code.
destructor should deallocate memroy for scope_. 
which sometimes causes Resource Leak.
To resolve the issue added destructor and released the scope_
