### PR TITLE
Pack TCompact doubles using little endian

### DIFF
--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -250,7 +250,7 @@ class TCompactProtocol(TProtocolBase):
 
   @writer
   def writeDouble(self, dub):
-    self.trans.write(pack('!d', dub))
+    self.trans.write(pack('<d', dub))
 
   def __writeString(self, s):
     self.__writeSize(len(s))
@@ -383,7 +383,7 @@ class TCompactProtocol(TProtocolBase):
   @reader
   def readDouble(self):
     buff = self.trans.readAll(8)
-    val, = unpack('!d', buff)
+    val, = unpack('<d', buff)
     return val
 
   def __readString(self):


### PR DESCRIPTION
This patch is intended to resolve https://issues.apache.org/jira/browse/THRIFT-1639

It changes the packing and unpacking of doubles in python TCompact to use little endian explicitly rather than network byte order.  This brings it in line with the Java TCompact implementation; the two are currently incompatible for any thrift structure that has a double.
