### PR TITLE
Ruby: remove thin as a runtime requirement (THRIFT-2145)

### DIFF
--- a/lib/rb/lib/thrift.rb
+++ b/lib/rb/lib/thrift.rb
@@ -62,6 +62,5 @@ require 'thrift/server/nonblocking_server'
 require 'thrift/server/simple_server'
 require 'thrift/server/threaded_server'
 require 'thrift/server/thread_pool_server'
-require 'thrift/server/thin_http_server'
 
 require 'thrift/thrift_native'

--- a/lib/rb/spec/thin_http_server_spec.rb
+++ b/lib/rb/spec/thin_http_server_spec.rb
@@ -19,6 +19,7 @@
 
 require 'spec_helper'
 require 'rack/test'
+require 'thrift/server/thin_http_server'
 
 describe Thrift::ThinHTTPServer do
 


### PR DESCRIPTION
See [THRIFT-2145](https://issues.apache.org/jira/browse/THRIFT-2145).
