### PR TITLE
Make _Fields static final (THRIFT-2172)

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -1331,7 +1331,7 @@ void t_java_generator::generate_java_struct_definition(ofstream &out,
     }
 
     if (optionals > 0) {
-      std::string output_string = "private _Fields optionals[] = {";
+      std::string output_string = "private static final _Fields optionals[] = {";
       for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
         if ((*m_iter)->get_req() == t_field::T_OPTIONAL) {
           output_string = output_string + "_Fields." + constant_name((*m_iter)->get_name()) + ",";


### PR DESCRIPTION
optionals has the same values for every instance and wastes a lot of
memory when one instantiates many Thrift objects.  Note that optionals
is not read from or written to and could be removed.
