### PR TITLE
thrift.el: fix formatting for package.el compatibility [THRIFT-2142]

### DIFF
--- a/contrib/thrift.el
+++ b/contrib/thrift.el
@@ -1,4 +1,7 @@
-;;
+;;; thrift.el --- Major mode for Apache Thrift files
+
+;; Keywords: files
+
 ;; Licensed to the Apache Software Foundation (ASF) under one
 ;; or more contributor license agreements. See the NOTICE file
 ;; distributed with this work for additional information
@@ -15,11 +18,18 @@
 ;; KIND, either express or implied. See the License for the
 ;; specific language governing permissions and limitations
 ;; under the License.
+
+;;; Commentary:
+
 ;;
+
+;;; Code:
 
 (require 'font-lock)
 
 (defvar thrift-mode-hook nil)
+
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.thrift\\'" . thrift-mode))
 
 (defvar thrift-indent-level 2
@@ -34,7 +44,7 @@
    '("\\<\\([0-9]+\\)\\>" . font-lock-variable-name-face)   ;; ordinals
    '("\\<\\(\\w+\\)\\s-*(" (1 font-lock-function-name-face))  ;; functions
    )
-  "Thrift Keywords")
+  "Thrift Keywords.")
 
 ;; indentation
 (defun thrift-indent-line ()
@@ -110,10 +120,11 @@
     (modify-syntax-entry ?* ". 23" thrift-mode-syntax-table)
     (modify-syntax-entry ?\n "> b" thrift-mode-syntax-table)
     thrift-mode-syntax-table)
-  "Syntax table for thrift-mode")
+  "Syntax table for thrift-mode.")
 
+;;;###autoload
 (defun thrift-mode ()
-  "Mode for editing Thrift files"
+  "Mode for editing Thrift files."
   (interactive)
   (kill-all-local-variables)
   (set-syntax-table thrift-mode-syntax-table)
@@ -123,4 +134,6 @@
   (run-hooks 'thrift-mode-hook)
   (set (make-local-variable 'indent-line-function) 'thrift-indent-line)
   )
-(provide 'thrift-mode)
+
+(provide 'thrift)
+;;; thrift.el ends here


### PR DESCRIPTION
The standard `package.el` library used in recent Emacsen requires package source files to conform to certain formatting conventions, since it parses metadata out of them.

These changes will allow `thrift.el` to be added to popular elisp package
repositories such as Marmalade and [MELPA](http://melpa.milkbox.net/).
