### PR TITLE
Fix charp JSONProtocol.ReadJSONDouble (specify InvariantCulture)

### DIFF
--- a/lib/csharp/src/Protocol/TJSONProtocol.cs
+++ b/lib/csharp/src/Protocol/TJSONProtocol.cs
@@ -863,7 +863,8 @@ namespace Thrift.Protocol
 				}
 				try
 				{
-					return Double.Parse(ReadJSONNumericChars());
+                    // need call Double.Parse with explicit specify InvariantCulture in second parameter
+                    return Double.Parse(ReadJSONNumericChars(), CultureInfo.InvariantCulture);
 				}
 				catch (FormatException)
 				{


### PR DESCRIPTION
Hello, guys.

I caught error on serialization from application working under localized (Russian) Windows. Cause Double.Parse wait a system decimal separator. I fixed JSONProtocol.ReadJSONDouble method, made Double.Parse call with explicit specify InvariantCulture in second parameter.

I think my little fix is pretty clear for you. But if it's not, I would be glad to explain more details.

Sincerely, Alexander Makarov.
