### PR TITLE
Nodejs: fix(transport): If we have residual data from the previous call, be sure...

### DIFF
--- a/lib/nodejs/lib/thrift/transport.js
+++ b/lib/nodejs/lib/thrift/transport.js
@@ -42,6 +42,7 @@ TFramedTransport.receiver = function(callback) {
       var dat = new Buffer(data.length + residual.length);
       residual.copy(dat, 0, 0);
       data.copy(dat, residual.length, 0);
+      data = dat;
       residual = null;
     }
 


### PR DESCRIPTION
... to copy it into the actual buffer we will be reading later

I am seeing an issue where we are creating a `Buffer` of larger than 1GB so v8 crashes with a fatal exception:
`FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData() length exceeds max acceptable value`.

I believe this is due to the fact that we don't actually copy the residual data into the `data` buffer before reading it, so when we go to create the new `frame` buffer, we are using the result of `binary.readInt(data, 0)`. Because the residual data isn't there, we create an overly large int. 

I'm seeing this bug in node-thrift 0.9.0, but the bug seems like it would still exist in the latest version.
