### PR TITLE
Remove spurious semicolon (THRIFT-2193)

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -3981,7 +3981,7 @@ void t_java_generator::generate_deep_copy_non_container(ofstream& out, std::stri
   (void) dest_name;
   if (type->is_base_type() || type->is_enum() || type->is_typedef()) {
     if (((t_base_type*)type)->is_binary()) {
-      out << "org.apache.thrift.TBaseHelper.copyBinary(" << source_name << ");" << endl;
+      out << "org.apache.thrift.TBaseHelper.copyBinary(" << source_name << ")" << endl;
     } else {
       // everything else can be copied directly
       out << source_name;


### PR DESCRIPTION
This commit suppresses empty statement warnings from Google
error-prone.
