### PR TITLE
modified the way of exception exit for more friendly

### DIFF
--- a/lib/erl/src/thrift_binary_protocol.erl
+++ b/lib/erl/src/thrift_binary_protocol.erl
@@ -333,7 +333,11 @@ parse_factory_options([{strict_write, Bool} | Rest], Opts) when is_boolean(Bool)
 new_protocol_factory(TransportFactory, Options) ->
     ParsedOpts = parse_factory_options(Options, #tbp_opts{}),
     F = fun() ->
-                {ok, Transport} = TransportFactory(),
+                {ok, Transport} = 
+                    case TransportFactory() of
+                        {ok, Tran} -> {ok, Tran};
+                        _Any       -> erlang:exit(_Any)
+                    end,
                 thrift_binary_protocol:new(
                   Transport,
                   [{strict_read,  ParsedOpts#tbp_opts.strict_read},

--- a/lib/erl/src/thrift_client.erl
+++ b/lib/erl/src/thrift_client.erl
@@ -106,7 +106,10 @@ read_result(Client = #tclient{protocol = Proto0,
             handle_application_exception(NewClient);
 
         #protocol_message_begin{type = ?tMessageType_REPLY} ->
-            handle_reply(NewClient, Function, ReplyType)
+            handle_reply(NewClient, Function, ReplyType);
+
+        _Any ->
+            erlang:exit(_Any)
     end.
 
 


### PR DESCRIPTION
Hi:
For the old, when the can not connect to the `Thrift Server`, it will : 

```
** exception error: no match of right hand side value {error,econnrefused}
     in function  thrift_binary_protocol:'-new_protocol_factory/2-fun-0-'/2 (src/erlang_thrift/thrift_binary_protocol.erl, line 336)
     in call from thrift_client_util:new/4 (src/erlang_thrift/thrift_client_util.erl, line 59)
```

that is not very friendly. So, I modified the `thrift_binary_protocol` module.

In addition，if the connection tcp closed, it will exception error via not very friendly way.

Thanks.
