### PR TITLE
Remove dependency on commons-lang3 (THRIFT-2260)

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -363,9 +363,6 @@ string t_java_generator::java_package() {
 string t_java_generator::java_type_imports() {
   string hash_builder;
   string tree_set_and_map;
-  if (gen_hash_code_) {
-    hash_builder = "import org.apache.commons.lang3.builder.HashCodeBuilder;\n";
-  }
   if (sorted_containers_) {
     tree_set_and_map = string() + 
       "import java.util.TreeSet;\n" +
@@ -1240,19 +1237,19 @@ void t_java_generator::generate_union_hashcode(ofstream& out, t_struct* tstruct)
   if (gen_hash_code_) {
     indent(out) << "@Override" << endl;
     indent(out) << "public int hashCode() {" << endl;
-    indent(out) << "  HashCodeBuilder hcb = new HashCodeBuilder();" << endl;
-    indent(out) << "  hcb.append(this.getClass().getName());" << endl;
+    indent(out) << "  List<Object> list = new ArrayList<Object>();" << endl;
+    indent(out) << "  list.add(this.getClass().getName());" << endl;
     indent(out) << "  org.apache.thrift.TFieldIdEnum setField = getSetField();" << endl;
     indent(out) << "  if (setField != null) {" << endl;
-    indent(out) << "    hcb.append(setField.getThriftFieldId());" << endl;
+    indent(out) << "    list.add(setField.getThriftFieldId());" << endl;
     indent(out) << "    Object value = getFieldValue();" << endl;
     indent(out) << "    if (value instanceof org.apache.thrift.TEnum) {" << endl;
-    indent(out) << "      hcb.append(((org.apache.thrift.TEnum)getFieldValue()).getValue());" << endl;
+    indent(out) << "      list.add(((org.apache.thrift.TEnum)getFieldValue()).getValue());" << endl;
     indent(out) << "    } else {" << endl;
-    indent(out) << "      hcb.append(value);" << endl;
+    indent(out) << "      list.add(value);" << endl;
     indent(out) << "    }" << endl;
     indent(out) << "  }" << endl;
-    indent(out) << "  return hcb.toHashCode();" << endl;
+    indent(out) << "  return list.hashCode();" << endl;
     indent(out) << "}";
   } else {
     indent(out) << "/**" << endl;
@@ -1591,7 +1588,7 @@ void t_java_generator::generate_java_struct_equality(ofstream& out,
     indent() << "public int hashCode() {" << endl;
   indent_up();
   if (gen_hash_code_) {
-    indent(out) << "HashCodeBuilder builder = new HashCodeBuilder();" << endl;
+    indent(out) << "List<Object> list = new ArrayList<Object>();" << endl;
 
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
       out << endl;
@@ -1608,17 +1605,17 @@ void t_java_generator::generate_java_struct_equality(ofstream& out,
       }
 
       indent(out) << "boolean present_" << name << " = " << present << ";" << endl;
-      indent(out) << "builder.append(present_" << name << ");" << endl;
+      indent(out) << "list.add(present_" << name << ");" << endl;
       indent(out) << "if (present_" << name << ")" << endl;
       if (t->is_enum()) {
-        indent(out) << "  builder.append(" << name << ".getValue());" << endl;
+        indent(out) << "  list.add(" << name << ".getValue());" << endl;
       } else {
-        indent(out) << "  builder.append(" << name << ");" << endl;
+        indent(out) << "  list.add(" << name << ");" << endl;
       }
     }
 
     out << endl;
-    indent(out) << "return builder.toHashCode();" << endl;
+    indent(out) << "return list.hashCode();" << endl;
   } else {
     indent(out) << "return 0;" << endl;
   }

--- a/contrib/Vagrantfile
+++ b/contrib/Vagrantfile
@@ -31,7 +31,7 @@ sudo apt-get upgrade -qq -y
 sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make libqt4-dev git debhelper
 
 # Java dependencies
-sudo apt-get install -qq ant openjdk-7-jdk libcommons-lang3-java
+sudo apt-get install -qq ant openjdk-7-jdk
 
 # Python dependencies
 sudo apt-get install -qq python-all python-all-dev python-all-dbg python-setuptools

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Build-Depends: debhelper (>= 5), build-essential, mono-gmcs, python-dev, ant,
     mono-devel,  libmono-system-web2.0-cil, erlang-base, ruby1.8-dev, autoconf, python-support,
     automake, pkg-config, libtool, bison, flex, libboost-dev | libboost1.40-dev, python-all,
-    python-all-dev, python-all-dbg, openjdk-6-jdk | java-sdk, libcommons-lang3-java,
+    python-all-dev, python-all-dbg, openjdk-6-jdk | java-sdk,
     libboost-test-dev | libboost-test1.40-dev, libevent-dev, perl (>= 5.8.0-7),
     php5, php5-dev, libglib2.0-dev, libqt4-dev
 Maintainer: Thrift Developer's <dev@thrift.apache.org>
@@ -78,7 +78,6 @@ Package: libthrift-java
 Architecture: all
 Section: libs
 Depends: java-gcj-compat | java1-runtime | java2-runtime, ${misc:Depends}
-Recommends: libcommons-lang3-java
 Description: Java bindings for Thrift
  Thrift is a software framework for scalable cross-language services
  development. It combines a software stack with a code generation engine to

--- a/lib/java/build.properties
+++ b/lib/java/build.properties
@@ -27,6 +27,5 @@ mvn.ant.task.version=2.1.3
 httpclient.version=4.2.5
 httpcore.version=4.2.4
 slf4j.version=1.5.8
-commons-lang3.version=3.1
 servlet.version=2.5
 

--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -318,7 +318,6 @@
 
       <!-- Thrift dependencies list -->
       <dependency groupId="org.slf4j" artifactId="slf4j-api" version="${slf4j.version}"/>
-      <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="${commons-lang3.version}"/>
       <dependency groupId="javax.servlet" artifactId="servlet-api" version="${servlet.version}" scope="provided"/>
       <dependency groupId="org.apache.httpcomponents" artifactId="httpclient" version="${httpclient.version}"/>
       <dependency groupId="org.apache.httpcomponents" artifactId="httpcore" version="${httpcore.version}"/>


### PR DESCRIPTION
Call List.hashCode instead of using HashCodeBuilder.  This commit
removes the dependency on commons-lang3 and prepares the generator for
always emitting a high-quality hash code.
