### PR TITLE
Output booleans as json boolean instead of 0/1 in TSimpleJSONProtocol.

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -231,7 +231,8 @@ public class TSimpleJSONProtocol extends TProtocol {
   }
 
   public void writeBool(boolean b) throws TException {
-    writeByte(b ? (byte)1 : (byte)0);
+    writeContext._write();
+    _writeStringData(b ? "true" : "false");
   }
 
   public void writeByte(byte b) throws TException {


### PR DESCRIPTION
The JSON specification contains a boolean type. Outputting integers
instead can potentially cause issues with applications expecting
booleans.

See: http://www.json.org/
