### PR TITLE
fix bug in compatc_protocol.go, prevent memory leak

### DIFF
--- a/lib/go/thrift/compact_protocol.go
+++ b/lib/go/thrift/compact_protocol.go
@@ -352,6 +352,7 @@ func (p *TCompactProtocol) ReadStructBegin() (name string, err error) {
 func (p *TCompactProtocol) ReadStructEnd() error {
 	// consume the last field we read off the wire.
 	p.lastFieldId = p.lastField[len(p.lastField)-1]
+	p.lastField = p.lastField[:len(p.lastField)-1]
 	return nil
 }
 


### PR DESCRIPTION
After a long time running on compatct protocol, I found that the memory still increase and never drop.
By using go tool pprof, I found that p.lastField grows and never decrease. So I realized that in function `ReadStructEnd` there should pop the last element to prevent memory leak.
