### PR TITLE
Update TNonblockingServer.cpp

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -1405,8 +1405,9 @@ bool TNonblockingIOThread::notify(TNonblockingServer::TConnection* conn) {
   }
 
   const int kSize = sizeof(conn);
-  if (send(fd, const_cast_sockopt(&conn), kSize, 0) != kSize) {
-    return false;
+  while (send(fd, const_cast_sockopt(&conn), kSize, 0) != kSize) {
+    usleep(10);
+    //return false;
   }
 
   return true;


### PR DESCRIPTION
if failed to notify pipe, the TConnection will be leak, which cause memory getting larger, and the most important, cause fd getting larger, so eventually it will cause "cannot get new fd" error.
if not fixed, it will cause fd leak, you can observ by using "lsof |grep can" to see whether there are fds with "cannot identify protocol"
