### PR TITLE
Update TSSLServerSocket.h

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLServerSocket.h
@@ -50,7 +50,7 @@ class TSSLServerSocket: public TServerSocket {
   TSSLServerSocket(int port, int sendTimeout, int recvTimeout,
                    boost::shared_ptr<TSSLSocketFactory> factory);
  protected:
-  boost::shared_ptr<TSocket> createSocket(int socket);
+  boost::shared_ptr<TSocket> createSocket(THRIFT_SOCKET socket);
   boost::shared_ptr<TSSLSocketFactory> factory_;
 };
 


### PR DESCRIPTION
I think it's a bug to declare createSocket with parameters "int socket"  while the base class
TServerSocket declares the virtual function createSocket with parameters "THRIFT_SOCKET socket"
On windows THRIFT_SOCKET resolves to UINT_PTR hence TSSLServerSocket::createSocket function 
did not get called from the guts.

Hence a nasty hanging problem was happening for me while testing ssl feature using official test_server/test_client.

I also posted my question at
http://stackoverflow.com/questions/21213094/c-thrift-client-not-working-with-ssl-ssl-connect-hangs
