### PR TITLE
Update TSSLServerSocket.cpp

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLServerSocket.cpp
@@ -40,7 +40,7 @@ TSSLServerSocket::TSSLServerSocket(int port, int sendTimeout, int recvTimeout,
   factory_->server(true);
 }
 
-shared_ptr<TSocket> TSSLServerSocket::createSocket(int client) {
+shared_ptr<TSocket> TSSLServerSocket::createSocket(THRIFT_SOCKET client) {
   return factory_->createSocket(client);
 }
 


### PR DESCRIPTION
I think it's a bug to declare createSocket with parameters "int socket"  while the base class
TServerSocket declares the virtual function createSocket with parameters "THRIFT_SOCKET socket"
On windows THRIFT_SOCKET resolves to UINT_PTR hence TSSLServerSocket::createSocket function 
did not get called from the guts.

Hence a nasty hanging problem was happening for me while testing ssl feature using official test_server/test_client.

I also posted my question at
http://stackoverflow.com/questions/21213094/c-thrift-client-not-working-with-ssl-ssl-connect-hangs
