### PR TITLE
New option: reuse-objects for Java generator

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -78,6 +78,9 @@ public:
       android_legacy_ = true;
     }
 
+    iter = parsed_options.find("reuse-objects");
+    reuse_objects_ = (iter != parsed_options.end());
+
     out_dir_base_ = (bean_style_ ? "gen-javabean" : "gen-java");
   }
 
@@ -197,16 +200,19 @@ public:
   void generate_deserialize_set_element  (std::ofstream& out,
                                           t_set*      tset,
                                           std::string prefix="",
+                                          std::string obj="",
                                           bool has_metadata = true);
 
   void generate_deserialize_map_element  (std::ofstream& out,
                                           t_map*      tmap,
                                           std::string prefix="",
+                                          std::string obj="",
                                           bool has_metadata = true);
 
   void generate_deserialize_list_element (std::ofstream& out,
                                           t_list*     tlist,
                                           std::string prefix="",
+                                          std::string obj="",
                                           bool has_metadata = true);
 
   void generate_serialize_field          (std::ofstream& out,
@@ -310,6 +316,7 @@ public:
   bool android_legacy_;
   bool java5_;
   bool sorted_containers_;
+  bool reuse_objects_;
 };
 
 
@@ -3079,9 +3086,17 @@ void t_java_generator::generate_deserialize_field(ofstream& out,
 void t_java_generator::generate_deserialize_struct(ofstream& out,
                                                    t_struct* tstruct,
                                                    string prefix) {
-  out <<
-    indent() << prefix << " = new " << type_name(tstruct) << "();" << endl <<
-    indent() << prefix << ".read(iprot);" << endl;
+
+    if (reuse_objects_) {
+      indent(out) << "if (" << prefix << " == null) {" << endl;
+      indent_up();
+    }
+    indent(out) << prefix << " = new " << type_name(tstruct) << "();" << endl;
+    if (reuse_objects_) {
+      indent_down();
+      indent(out) << "}" << endl;
+    }
+    indent(out) << prefix << ".read(iprot);" << endl;
 }
 
 /**
@@ -3126,7 +3141,14 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
     }
   }
 
-  indent(out) << prefix << " = new " << type_name(ttype, false, true);
+  if (reuse_objects_) {
+    indent(out) << "if (" << prefix << " == null) {" << endl;
+    indent_up();
+  }
+
+  out << 
+      indent() << prefix << " = new " << type_name(ttype, false, true); 
+
   // size the collection correctly
   if (sorted_containers_ && (ttype->is_map() || ttype->is_set())) {
     // TreeSet and TreeMap don't have any constructor which takes a capactity as an argument
@@ -3138,21 +3160,17 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
       << ");" << endl;
   }
 
-  // For loop iterates over elements
-  string i = tmp("_i");
-  indent(out) <<
-    "for (int " << i << " = 0; " <<
-    i << " < " << obj << ".size" << "; " <<
-    "++" << i << ")" << endl;
-
-  scope_up(out);
+  if (reuse_objects_) {
+    indent_down();
+    indent(out) << "}" << endl;
+  }
 
   if (ttype->is_map()) {
-    generate_deserialize_map_element(out, (t_map*)ttype, prefix, has_metadata);
+    generate_deserialize_map_element(out, (t_map*)ttype, prefix, obj, has_metadata);
   } else if (ttype->is_set()) {
-    generate_deserialize_set_element(out, (t_set*)ttype, prefix, has_metadata);
+    generate_deserialize_set_element(out, (t_set*)ttype, prefix, obj, has_metadata);
   } else if (ttype->is_list()) {
-    generate_deserialize_list_element(out, (t_list*)ttype, prefix, has_metadata);
+    generate_deserialize_list_element(out, (t_list*)ttype, prefix, obj, has_metadata);
   }
 
   scope_down(out);
@@ -3176,14 +3194,24 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
  */
 void t_java_generator::generate_deserialize_map_element(ofstream& out,
                                                         t_map* tmap,
-                                                        string prefix, bool has_metadata) {
+                                                        string prefix, 
+                                                        string obj, bool has_metadata) {
   string key = tmp("_key");
   string val = tmp("_val");
   t_field fkey(tmap->get_key_type(), key);
   t_field fval(tmap->get_val_type(), val);
 
-  indent(out) << declare_field(&fkey) << endl;
-  indent(out) << declare_field(&fval) << endl;
+  indent(out) << declare_field(&fkey, reuse_objects_, false) << endl;
+  indent(out) << declare_field(&fval, reuse_objects_, false) << endl;
+
+  // For loop iterates over elements
+     string i = tmp("_i");
+     indent(out) <<
+       "for (int " << i << " = 0; " <<
+          i << " < " << obj << ".size" << "; " <<
+          "++" << i << ")" << endl;
+  
+  scope_up(out);
 
   generate_deserialize_field(out, &fkey, "", has_metadata);
   generate_deserialize_field(out, &fval, "", has_metadata);
@@ -3196,15 +3224,25 @@ void t_java_generator::generate_deserialize_map_element(ofstream& out,
  */
 void t_java_generator::generate_deserialize_set_element(ofstream& out,
                                                         t_set* tset,
-                                                        string prefix, bool has_metadata) {
+                                                        string prefix, 
+                                                        string obj, bool has_metadata) {
   string elem = tmp("_elem");
   t_field felem(tset->get_elem_type(), elem);
 
-  indent(out) << declare_field(&felem) << endl;
+  indent(out) << declare_field(&felem, reuse_objects_, false) << endl;
 
+  // For loop iterates over elements
+     string i = tmp("_i");
+     indent(out) <<
+       "for (int " << i << " = 0; " <<
+          i << " < " << obj << ".size" << "; " <<
+          "++" << i << ")" << endl;
+  scope_up(out);
+  
   generate_deserialize_field(out, &felem, "", has_metadata);
 
   indent(out) << prefix << ".add(" << elem << ");" << endl;
+
 }
 
 /**
@@ -3212,12 +3250,21 @@ void t_java_generator::generate_deserialize_set_element(ofstream& out,
  */
 void t_java_generator::generate_deserialize_list_element(ofstream& out,
                                                          t_list* tlist,
-                                                         string prefix, bool has_metadata) {
+                                                         string prefix, 
+                                                         string obj, bool has_metadata) {
   string elem = tmp("_elem");
   t_field felem(tlist->get_elem_type(), elem);
 
-  indent(out) << declare_field(&felem) << endl;
+  indent(out) << declare_field(&felem, reuse_objects_, false) << endl;
 
+  // For loop iterates over elements
+     string i = tmp("_i");
+     indent(out) <<
+       "for (int " << i << " = 0; " <<
+          i << " < " << obj << ".size" << "; " <<
+          "++" << i << ")" << endl;
+  scope_up(out);
+ 
   generate_deserialize_field(out, &felem, "", has_metadata);
 
   indent(out) << prefix << ".add(" << elem << ");" << endl;
@@ -4529,6 +4576,7 @@ THRIFT_REGISTER_GENERATOR(java, "Java",
 "    nocamel:         Do not use CamelCase field accessors with beans.\n"
 "    android_legacy:  Do not use java.io.IOException(throwable) (available for Android 2.3 and above).\n"
 "    java5:           Generate Java 1.5 compliant code (includes android_legacy flag).\n"
+"    reuse-objects:   Data objects will not be allocated, but existing instances will be used (read and write).\n"
 "    sorted_containers:\n"
 "                     Use TreeSet/TreeMap instead of HashSet/HashMap as a implementation of set/map.\n"
 )

--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -75,6 +75,7 @@
     <pathelement location="${build.test.dir}"/>
     <pathelement location="${jar.file}"/>
     <pathelement location="${test.jar.file}"/>
+
   </path>
 
   <!-- Tasks --> 
@@ -123,7 +124,21 @@
         <attribute name="Bundle-Description" value="Apache Thrift library"/>
         <attribute name="Bundle-License" value="${license}"/>
         <attribute name="Bundle-ActivationPolicy" value="lazy"/>
-        <attribute name="Export-Package" value="${thrift.groupid};version=${version}"/>
+        <attribute name="Export-Package" value="${thrift.groupid}.async;uses:=&quot;
+${thrift.groupid}.protocol,${thrift.groupid}.transport,org.slf4j,${thrift.groupid}&quot;;version=&quot;${version}&quot;,
+${thrift.groupid}.protocol;uses:=&quot;${thrift.groupid}.transport,${thrift.groupid},${thrift.groupid}.scheme&quot;
+;version=&quot;${version}&quot;,${thrift.groupid}.server;uses:=&quot;${thrift.groupid}.transport,${thrift.groupid}.protocol,
+${thrift.groupid},org.slf4j,javax.servlet,javax.servlet.http&quot;;version=&quot;${version}&quot;,${thrift.groupid}.transport;
+uses:=&quot;${thrift.groupid}.protocol,${thrift.groupid},org.apache.http.client,org.apache.http.params,org.apache.http.entity,
+org.apache.http.client.methods,org.apache.http,org.slf4j,javax.net.ssl,javax.net,javax.security.sasl,
+javax.security.auth.callback&quot;;version=&quot;${version}&quot;,${thrift.groupid};uses:=&quot;${thrift.groupid}.protocol,
+${thrift.groupid}.async,${thrift.groupid}.server,${thrift.groupid}.transport,org.slf4j,org.apache.log4j,
+${thrift.groupid}.scheme&quot;;version=&quot;${version}&quot;,${thrift.groupid}.meta_data;uses:=&quot;${thrift.groupid}&quot;
+;version=&quot;${version}&quot;,${thrift.groupid}.scheme;uses:=&quot;${thrift.groupid}.protocol,
+${thrift.groupid}&quot;;version=&quot;${version}&quot;"/>
+       <attribute name="Import-Package" value="javax.net,javax.net.ssl,javax.security.auth.callback,
+javax.security.sasl,javax.servlet;resolution:=optional,javax.servlet.http;resolution:=optional,
+resolution:=optional,org.slf4j;resolution:=optional;version=&quot;[1.4,2)&quot;"/>
       </manifest>
       <fileset dir="${build.dir}">
         <include name="org/apache/thrift/**/*.class"/>
@@ -253,6 +268,9 @@
     </exec>
     <exec executable="../../compiler/cpp/thrift" failonerror="true">
       <arg line="--gen java:hashcode ${test.thrift.home}/ManyOptionals.thrift"/>
+    </exec>
+    <exec executable="../../compiler/cpp/thrift" failonerror="true">
+      <arg line="--gen java:reuse-objects ${test.thrift.home}/ReuseObjects.thrift"/>
     </exec>
   </target>
 

--- a/lib/java/test/org/apache/thrift/TestReuse.java
+++ b/lib/java/test/org/apache/thrift/TestReuse.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift;
+
+import java.util.HashSet;
+
+import junit.framework.TestCase;
+
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TType;
+
+import thrift.test.Reuse;
+
+// Tests reusing objects for deserialization.
+//
+public class TestReuse extends TestCase {
+
+  public void testReuseObject() throws Exception {
+    TSerializer   binarySerializer   = new   TSerializer(new TBinaryProtocol.Factory());
+    TDeserializer binaryDeserializer = new TDeserializer(new TBinaryProtocol.Factory());
+
+    Reuse ru1 = new Reuse();
+    HashSet<String> hs1 = new HashSet<String>();
+    byte[] serBytes;    
+    String st1 = new String("string1");
+    String st2 = new String("string2");
+
+    ru1.setVal1(11);
+    ru1.setVal2(hs1);
+    ru1.addToVal2(st1);
+    
+    serBytes = binarySerializer.serialize(ru1);
+
+    // update hash set after serialization
+    hs1.add(st2);
+
+    binaryDeserializer.deserialize(ru1, serBytes);
+   
+    assertTrue( ru1.getVal2() == hs1 );
+    assertTrue( hs1.size() == 2 );
+  }
+
+}

--- a/test/ReuseObjects.thrift
+++ b/test/ReuseObjects.thrift
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has option to reuse objects for deserialization
+
+namespace java thrift.test
+
+struct Reuse {
+  1: i32 val1;
+  2: set<string> val2;
+}
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-2368
For applications serializing and deserializing millions of transactions it is important to avoid unnecessary memory allocations - the allocated and abandoned objects needs to be collected and deleted by GC, which creates "stop-the-world" pauses. The new compiler option forces thrift compiler to generate code which is reusing existing objects for deserialization (this is up to caller to make sure that read data will fit). Without that option compiler generates the same code as originally.

code generated by original compiler (0.9.1):

```
         case 1: // HEADER
            if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
              struct.header = new com.gtech.ngin.ncp.libs.thrift.binary.BinaryHeaderStruct();
              struct.header.read(iprot);
              struct.setHeaderIsSet(true);
            } else { 
              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
            }
            break;
          case 2: // KEYS
            if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
              {
                org.apache.thrift.protocol.TSet _set0 = iprot.readSetBegin();
                struct.keys = new HashSet<com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct>(2*_set0.size);
                for (int _i1 = 0; _i1 < _set0.size; ++_i1)
                {
                  com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct _elem2;
                  _elem2 = new com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct();
                  _elem2.read(iprot);
                  struct.keys.add(_elem2);
                }
                iprot.readSetEnd();
              }
              struct.setKeysIsSet(true);
            } else { 
              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
            }
            break;
```

code generated with enabled "java:reuse-objects" option:

```
          case 1: // HEADER
            if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
              if (struct.header == null) {
                struct.header = new com.gtech.ngin.ncp.libs.thrift.binary.BinaryHeaderStruct();
              }
              struct.header.read(iprot);
              struct.setHeaderIsSet(true);
            } else {
              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
            }
            break;
          case 2: // KEYS
            if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
              {
                org.apache.thrift.protocol.TSet _set0 = iprot.readSetBegin();
                if (struct.keys == null) {
                  struct.keys = new HashSet<com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct>(2*_set0.size);
                }
                com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct _elem1 = new com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct();
                for (int _i2 = 0; _i2 < _set0.size; ++_i2)
                {
                  if (_elem1 == null) {
                    _elem1 = new com.gtech.ngin.ncp.libs.thrift.binary.BinaryKeyStruct();
                  }
                  _elem1.read(iprot);
                  struct.keys.add(_elem1);
                }
                iprot.readSetEnd();
              }
              struct.setKeysIsSet(true);
            } else {
              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
            }
            break;
```
