### PR TITLE
fix issue with cpp server on Windows (WSAStartup wasn't called)

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -160,6 +160,9 @@ void TServerSocket::setTcpRecvBuffer(int tcpRecvBuffer) {
 }
 
 void TServerSocket::listen() {
+#ifdef _WIN32
+    TWinsockSingleton::create();
+#endif // _WIN32
   THRIFT_SOCKET sv[2];
   if (-1 == THRIFT_SOCKETPAIR(AF_LOCAL, SOCK_STREAM, 0, sv)) {
     GlobalOutput.perror("TServerSocket::listen() socketpair() ", THRIFT_GET_SOCKET_ERROR);


### PR DESCRIPTION
Hello!
I tried to launch C++ server on Windows OS and found a bug - TServerSocket can't start to listen because WSAStartup wasn't called.
