### PR TITLE
[thrift] Compiler: allow annotations without "= value"

### DIFF
--- a/compiler/cpp/src/thrifty.yy
+++ b/compiler/cpp/src/thrifty.yy
@@ -186,6 +186,7 @@ const int struct_is_union = 1;
 %type<ttype>     TypeAnnotations
 %type<ttype>     TypeAnnotationList
 %type<tannot>    TypeAnnotation
+%type<id>        TypeAnnotationValue
 
 %type<tfield>    Field
 %type<tfieldid>  FieldIdentifier
@@ -1256,12 +1257,24 @@ TypeAnnotationList:
     }
 
 TypeAnnotation:
-  tok_identifier '=' tok_literal CommaOrSemicolonOptional
+  tok_identifier TypeAnnotationValue CommaOrSemicolonOptional
     {
-      pdebug("TypeAnnotation -> tok_identifier = tok_literal");
+      pdebug("TypeAnnotation -> TypeAnnotationValue");
       $$ = new t_annotation;
       $$->key = $1;
-      $$->val = $3;
+      $$->val = $2;
+    }
+
+TypeAnnotationValue:
+  '=' tok_literal
+    {
+      pdebug("TypeAnnotationValue -> = tok_literal");
+      $$ = $2;
+    }
+|
+    {
+      pdebug("TypeAnnotationValue ->");
+      $$ = strdup("1");
     }
 
 %%

--- a/test/AnnotationTest.thrift
+++ b/test/AnnotationTest.thrift
@@ -28,6 +28,7 @@ struct foo {
   cpp.type = "DenseFoo",
   python.type = "DenseFoo",
   java.final = "",
+  annotation.without.value,
 )
 
 exception foo_error {


### PR DESCRIPTION
Summary: (foo) is the same as (foo = 1), for brevity

Test: AnnotationTest.thrift still compiles
