### PR TITLE
thrift: clean up enum value assignment

### DIFF
--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -307,10 +307,8 @@ void t_c_glib_generator::generate_enum(t_enum *tenum) {
 
     f_types_ <<
       indent() << this->nspace_uc << name_uc << "_" << (*c_iter)->get_name();
-    if ((*c_iter)->has_value()) {
-      f_types_ <<
-        " = " << (*c_iter)->get_value();
-    }
+    f_types_ <<
+      " = " << (*c_iter)->get_value();
   }
 
   indent_down();

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -507,7 +507,7 @@ void t_cpp_generator::generate_enum_constant_list(std::ofstream& f,
     }
     indent(f)
       << prefix << (*c_iter)->get_name() << suffix;
-    if (include_values && (*c_iter)->has_value()) {
+    if (include_values) {
       f << " = " << (*c_iter)->get_value();
     }
   }

--- a/compiler/cpp/src/generate/t_d_generator.cc
+++ b/compiler/cpp/src/generate/t_d_generator.cc
@@ -188,9 +188,7 @@ class t_d_generator : public t_oop_generator {
         f_types_ << "," << endl;
       }
       indent(f_types_) << (*c_iter)->get_name();
-      if ((*c_iter)->has_value()) {
-        f_types_ << " = " << (*c_iter)->get_value();
-      }
+      f_types_ << " = " << (*c_iter)->get_value();
     }
 
     f_types_ << endl;

--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -686,11 +686,7 @@ void t_go_generator::generate_enum(t_enum* tenum)
     int value = -1;
 
     for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-        if ((*c_iter)->has_value()) {
-            value = (*c_iter)->get_value();
-        } else {
-            ++value;
-        }
+      value = (*c_iter)->get_value();
 
         string iter_std_name(escape_string((*c_iter)->get_name()));
         string iter_name((*c_iter)->get_name());

--- a/compiler/cpp/src/parse/t_enum.h
+++ b/compiler/cpp/src/parse/t_enum.h
@@ -74,18 +74,6 @@ class t_enum : public t_type {
     return "enum";
   }
 
-  void resolve_values() {
-    const std::vector<t_enum_value*>& enum_values = get_constants();
-    std::vector<t_enum_value*>::const_iterator c_iter;
-    int lastValue = -1;
-    for (c_iter = enum_values.begin(); c_iter != enum_values.end(); ++c_iter) {
-      if (! (*c_iter)->has_value()) {
-        (*c_iter)->set_value(++lastValue);
-      } else {
-        lastValue = (*c_iter)->get_value();
-      }
-    }
-  }
 
  private:
   std::vector<t_enum_value*> constants_;

--- a/compiler/cpp/src/parse/t_enum_value.h
+++ b/compiler/cpp/src/parse/t_enum_value.h
@@ -31,40 +31,24 @@
  */
 class t_enum_value : public t_doc {
  public:
-  t_enum_value(std::string name) :
-    name_(name),
-    has_value_(false),
-    value_(0) {}
-
   t_enum_value(std::string name, int value) :
     name_(name),
-    has_value_(true),
     value_(value) {}
 
   ~t_enum_value() {}
 
-  const std::string& get_name() {
+  const std::string& get_name() const {
     return name_;
   }
 
-  bool has_value() {
-    return has_value_;
-  }
-
-  int get_value() {
+  int get_value() const {
     return value_;
-  }
-
-  void set_value(int val) {
-    has_value_ = true;
-    value_ = val;
   }
 
   std::map<std::string, std::string> annotations_;
 
  private:
   std::string name_;
-  bool has_value_;
   int value_;
 };
 

--- a/lib/cpp/test/EnumTest.cpp
+++ b/lib/cpp/test/EnumTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#define BOOST_TEST_MODULE EnumTest
+#include <boost/test/unit_test.hpp>
+#include "thrift/test/gen-cpp/EnumTest_types.h"
+
+BOOST_AUTO_TEST_SUITE( EnumTest )
+
+BOOST_AUTO_TEST_CASE( test_enum ) {
+  // Check that all the enum values match what we expect
+  BOOST_CHECK_EQUAL(ME1_0, 0);
+  BOOST_CHECK_EQUAL(ME1_1, 1);
+  BOOST_CHECK_EQUAL(ME1_2, 2);
+  BOOST_CHECK_EQUAL(ME1_3, 3);
+  BOOST_CHECK_EQUAL(ME1_5, 5);
+  BOOST_CHECK_EQUAL(ME1_6, 6);
+
+  BOOST_CHECK_EQUAL(ME2_0, 0);
+  BOOST_CHECK_EQUAL(ME2_1, 1);
+  BOOST_CHECK_EQUAL(ME2_2, 2);
+
+  BOOST_CHECK_EQUAL(ME3_0, 0);
+  BOOST_CHECK_EQUAL(ME3_1, 1);
+  BOOST_CHECK_EQUAL(ME3_N2, -2);
+  BOOST_CHECK_EQUAL(ME3_N1, -1);
+  BOOST_CHECK_EQUAL(ME3_D0, 0);
+  BOOST_CHECK_EQUAL(ME3_D1, 1);
+  BOOST_CHECK_EQUAL(ME3_9, 9);
+  BOOST_CHECK_EQUAL(ME3_10, 10);
+
+  BOOST_CHECK_EQUAL(ME4_A, 0x7ffffffd);
+  BOOST_CHECK_EQUAL(ME4_B, 0x7ffffffe);
+  BOOST_CHECK_EQUAL(ME4_C, 0x7fffffff);
+}
+
+BOOST_AUTO_TEST_CASE( test_enum_constant ) {
+  MyStruct ms;
+  BOOST_CHECK_EQUAL(ms.me2_2, 2);
+  BOOST_CHECK_EQUAL(ms.me3_n2, -2);
+  BOOST_CHECK_EQUAL(ms.me3_d1, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -20,6 +20,8 @@
 noinst_LTLIBRARIES = libtestgencpp.la libprocessortest.la
 nodist_libtestgencpp_la_SOURCES = \
 	gen-cpp/DebugProtoTest_types.cpp \
+	gen-cpp/EnumTest_types.cpp \
+	gen-cpp/EnumTest_types.h \
 	gen-cpp/OptionalRequiredTest_types.cpp \
 	gen-cpp/DebugProtoTest_types.cpp \
 	gen-cpp/ThriftTest_types.cpp \
@@ -60,7 +62,8 @@ check_PROGRAMS = \
 	TransportTest \
 	ZlibTest \
 	TFileTransportTest \
-	UnitTests
+	UnitTests \
+	EnumTest
 # disable these test ... too strong
 #       processor_test
 #	concurrency_test
@@ -105,6 +108,13 @@ ZlibTest_LDADD = \
   $(top_builddir)/lib/cpp/libthriftz.la \
   $(BOOST_ROOT_PATH)/lib/libboost_unit_test_framework.a \
   -lz
+
+EnumTest_SOURCES = \
+  EnumTest.cpp
+
+EnumTest_LDADD = \
+  libtestgencpp.la \
+  $(BOOST_ROOT_PATH)/lib/libboost_unit_test_framework.a
 
 TFileTransportTest_SOURCES = \
 	TFileTransportTest.cpp
@@ -205,6 +215,9 @@ THRIFT = $(top_builddir)/compiler/cpp/thrift
 
 gen-cpp/DebugProtoTest_types.cpp gen-cpp/DebugProtoTest_types.h: $(top_srcdir)/test/DebugProtoTest.thrift
 	$(THRIFT) --gen cpp:dense $<
+
+gen-cpp/EnumTest_types.cpp gen-cpp/EnumTest_types.h: $(top_srcdir)/test/EnumTest.thrift
+	$(THRIFT) --gen cpp $<
 
 gen-cpp/OptionalRequiredTest_types.cpp gen-cpp/OptionalRequiredTest_types.h: $(top_srcdir)/test/OptionalRequiredTest.thrift
 	$(THRIFT) --gen cpp:dense $<

--- a/test/EnumTest.thrift
+++ b/test/EnumTest.thrift
@@ -1,0 +1,46 @@
+enum MyEnum1 {
+  ME1_0 = 0,
+  ME1_1 = 1,
+  ME1_2,
+  ME1_3,
+  ME1_5 = 5,
+  ME1_6,
+}
+
+enum MyEnum2 {
+  ME2_0,
+  ME2_1,
+  ME2_2,
+}
+
+enum MyEnum3 {
+  ME3_0,
+  ME3_1,
+  ME3_N2 = -2,
+  ME3_N1,
+  ME3_D0,
+  ME3_D1,
+  ME3_9 = 9,
+  ME3_10,
+}
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+}
+
+enum MyEnum5 {
+  // attempting to explicitly use values out of the i32 range will also fail
+  // ME5_A = 0x80000000,
+  // ME5_B = 0x100000000,
+}
+
+struct MyStruct {
+  1: MyEnum2 me2_2 = MyEnum1.ME2_2
+  2: MyEnum3 me3_n2 = MyEnum3.ME3_N2
+  3: MyEnum3 me3_d1 = MyEnum3.ME3_D1
+}


### PR DESCRIPTION
```
Summary:
Clean up how enum values are handled if an integer value is not
explicitly specified in the thrift file.

For example, the following used to be a compile error, but
works now:

  enum MyEnum {
    SOMEVALUE
  }
  struct MyStruct {
    1: MyEnum e = SOMEVALUE
  }

This change also cleans up some of the error handling with out-of-range
values.  Previously thrift simply issued a warning for enum values that
didn't fit in an i32, but serialized them as i32 anyway.  Now
out-of-range enum values result in a compile failure.

Test Plan:
Included a new unit test to verify the assignment of enum values.  I
also verified that g++ makes the same enum value assignments when
compiling these enums as C++ code.
```
