### PR TITLE
Add composer.json for Thrift 0.9.1 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,5 @@
     "autoload": {
         "psr-0": {"Thrift": "lib/php/lib/"}
     },
-    "minimum-stability": "dev",
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.9.x-dev"
-        }
-    }
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
The 0.9.1 release is missing composer.json.
This patch applies the same composer.json from branch 0.9.x into branch 0.9.1

I do not know if it is safe to force the 0.9.1 tag to include this commit, or if a "0.9.1a" approach is feasible.
