### PR TITLE
Adds composer.json for Thrift dev-master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "apache/thrift",
+    "description": "Apache Thrift RPC system",
+    "homepage": "http://thrift.apache.org/",
+    "type": "library",
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "Apache Thrift Developers",
+            "email": "dev@thrift.apache.org",
+            "homepage": "http://thrift.apache.org"
+        }
+    ],
+    "support": {
+        "email": "dev@thrift.apache.org",
+        "issues": "https://issues.apache.org/jira/browse/THRIFT"
+    },
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-0": {"Thrift": "lib/php/lib/"}
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}


### PR DESCRIPTION
Adds composer.json for Thrift dev-master branch

Given that the next release will likely be 1.0.0, i've aliased the dev-master branch to 1.0.x-dev, so anyone requiring 1.0.x-dev will get the most recent commit in dev-master.

When 1.0.0 will be tagged/released, supposedly creating a branch for it (e.g. 1.0.x), we'll switch (on master) the alias to 1.1.x-dev, so:
- anyone requiring 1.0.\* will get the most recent tagged version (stable release) along branch 1.0.x (until lowering minimum-stability to dev, in which case it will yield the most recent commit along that branch)
- anyone requiring 1.0.x-dev will get the most recent commit in branch 1.0
- anyone requiring 1.1.x-dev will get the most recent commit in dev-master.

And so on
