### PR TITLE
THRIFT-2429

### DIFF
--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -55,6 +55,7 @@ check_PROGRAMS = \
 	DebugProtoTest \
 	JSONProtoTest \
 	OptionalRequiredTest \
+	TerseWritesTest \
 	SpecializationTest \
 	AllProtocolsTest \
 	TransportTest \
@@ -168,6 +169,14 @@ OptionalRequiredTest_SOURCES = \
 OptionalRequiredTest_LDADD = libtestgencpp.la
 
 #
+# TerseWritesTest
+#
+TerseWritesTest_SOURCES = \
+	TerseWritesTest.cpp
+
+TerseWritesTest_LDADD = libtestgencpp.la
+
+#
 # SpecializationTest
 #
 SpecializationTest_SOURCES = \
@@ -213,7 +222,7 @@ gen-cpp/Service.cpp gen-cpp/StressTest_types.cpp: $(top_srcdir)/test/StressTest.
 	$(THRIFT) --gen cpp:dense $<
 
 gen-cpp/SecondService.cpp gen-cpp/ThriftTest_constants.cpp gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_types.h: $(top_srcdir)/test/ThriftTest.thrift
-	$(THRIFT) --gen cpp:dense $<
+	$(THRIFT) --gen cpp:dense,terse_writes $<
 
 gen-cpp/ChildService.cpp: processor/proc.thrift
 	$(THRIFT) --gen cpp:templates,cob_style $<

--- a/lib/cpp/test/TerseWritesTest.cpp
+++ b/lib/cpp/test/TerseWritesTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+#include "gen-cpp/ThriftTest_types.h"
+
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include "gen-cpp/ThriftTest_types.h"
+
+using apache::thrift::transport::TMemoryBuffer;
+using apache::thrift::protocol::TBinaryProtocol;
+using boost::shared_ptr;
+using namespace thrift::test;
+
+int main() {
+  shared_ptr<TMemoryBuffer> buf(new TMemoryBuffer());
+  shared_ptr<TBinaryProtocol> prot(new TBinaryProtocol(buf));
+
+  BoolTest btest;
+  btest.__isset.b = false;
+  btest.__isset.s = false;
+
+  BoolTest btestread;
+
+  btest.write(prot.get());
+  btestread.read(prot.get());
+  assert(btest.__isset.b == false);
+  assert(btest.__isset.s == false);
+  assert(btest.s == "true");
+
+  // Try without optional keyword
+  Bonk bonk;
+  bonk.type = 1;
+  Bonk bonkread;
+  bonk.write(prot.get());
+  bonkread.read(prot.get());
+  assert(bonkread.__isset.message == false);
+  assert(bonkread.__isset.type == true);
+  assert(bonkread.__isset.type == 1);
+
+  return 0;
+}


### PR DESCRIPTION
Original diff summary:

```
Add "terse_writes" c++ gen option to thrift compiler.

Summary:
Add "terse_writes" c++ generator option to thrift compiler, to
suppress writing non-optional/non-required fields if they haven't
changed from the default value.

 - This is default-off, whitelist-only.
   It may be whitelisted per-.thrift, or per struct.

 - On a Unicorn loadgen benchmark appeared to save roughly 2/3rds of
   the SearchRequest deserialization cost (fields are only sparsely set).

 - This will not affect embedded structs, or strings with non-""
   default values, since we only want this change to do inexpensive
   integer-like comparisons.

 - Also, the user is advised that:
   - default values for whitelisted structs shouldn't be changed.
     (or, if they are, upgraded to optional/required)
   - if one re-read()s into an old struct, one should __clear() it first.
     however, this is not a new problem for anybody with optional fields.

This diff introduces "safe" mode for `terse_writes` in order to
prevent us from producing stupid bugs in PHP (and Python) land.

If we don't require explicit default value to be set, we have to
make PHP / Python logic to correctly understand `null` / `None` and
treat them as default field values.
```

davejwatson:

It sounds like the proposal in THRIFT-2429 is to make this the default for optional fields as well, with no compiler flag, which is just minor changes to this diff.
