### PR TITLE
THRIFT-2456 Support async operations outside Silverlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,8 @@ node_modules
 /lib/c_glib/test/testtransportsocket
 /lib/c_glib/thriftc.pc
 /lib/c_glib/thrift_c_glib.pc
-/lib/csharp/src/bin/
-/lib/csharp/src/obj/
+/lib/csharp/**/bin/
+/lib/csharp/**/obj/
 /lib/d/libthriftd.a
 /lib/d/test/serialization_benchmark
 /lib/d/test/transport_test

--- a/lib/csharp/src/Transport/THttpClient.cs
+++ b/lib/csharp/src/Transport/THttpClient.cs
@@ -216,7 +216,6 @@ namespace Thrift.Transport
             return connection;
 		}
 
-#if SILVERLIGHT
         public override IAsyncResult BeginFlush(AsyncCallback callback, object state)
         {
             // Extract request and reset buffer
@@ -266,7 +265,6 @@ namespace Thrift.Transport
             }
 
         }
-
 
         private void GetRequestStreamCallback(IAsyncResult asynchronousResult)
         {
@@ -375,7 +373,6 @@ namespace Thrift.Transport
             }
         }
 
-#endif
 #region " IDisposable Support "
 		private bool _IsDisposed;
 

--- a/lib/csharp/src/Transport/TTransport.cs
+++ b/lib/csharp/src/Transport/TTransport.cs
@@ -76,11 +76,12 @@ namespace Thrift.Transport
         
         public virtual IAsyncResult BeginFlush(AsyncCallback callback, object state)
         {
-            return null;
+            throw new NotSupportedException("Asynchronous operations are not supported by this transport.");
         }
 
         public virtual void EndFlush(IAsyncResult asyncResult)
         {
+            throw new NotSupportedException("Asynchronous operations are not supported by this transport.");
         }
 
 		#region " IDisposable Support "


### PR DESCRIPTION
I altered TTransport to throw the NotSupportedExceptions to make it more obvious what's going on if someone generates their client using the async option, and then uses a transport that doesn't support it.
