### PR TITLE
 THRIFT-1914 Python: Support for Multiplexing Services on any Transport

### DIFF
--- a/lib/py/src/TMultiplexedProcessor.py
+++ b/lib/py/src/TMultiplexedProcessor.py
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from thrift.Thrift import TProcessor, TMessageType, TException
+from thrift.protocol import TProtocolDecorator, TMultiplexedProtocol
+
+class TMultiplexedProcessor(TProcessor):
+  def __init__(self):
+    self.services = {}
+
+  def registerProcessor(self, serviceName, processor):
+    self.services[serviceName] = processor
+
+  def process(self, iprot, oprot):
+    (name, type, seqid) = iprot.readMessageBegin();
+    if type != TMessageType.CALL & type != TMessageType.ONEWAY:
+      raise TException("This should not have happened!?")
+
+    index = name.find(TMultiplexedProtocol.SEPARATOR)
+    if index < 0:
+      raise TException("Service name not found in message name: " + name + ". Did you forget to use TMultiplexProtocol in your client?")
+
+    serviceName = name[0:index]
+    call = name[index+len(TMultiplexedProtocol.SEPARATOR):]
+    if not self.services.has_key(serviceName):
+      raise TException("Service name not found: " + serviceName + ". Did you forget to call registerProcessor()?")
+
+    standardMessage = (
+      call,
+      type,
+      seqid
+    )
+    return self.services[serviceName].process(StoredMessageProtocol(iprot, standardMessage), oprot)
+
+
+class StoredMessageProtocol(TProtocolDecorator.TProtocolDecorator):
+  def __init__(self, protocol, messageBegin):
+    TProtocolDecorator.TProtocolDecorator.__init__(self, protocol)
+    self.messageBegin = messageBegin
+
+  def readMessageBegin(self):
+    return self.messageBegin

--- a/lib/py/src/protocol/TMultiplexedProtocol.py
+++ b/lib/py/src/protocol/TMultiplexedProtocol.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from thrift.Thrift import TMessageType
+from thrift.protocol import TProtocolDecorator
+
+SEPARATOR = ":"
+
+class TMultiplexedProtocol(TProtocolDecorator.TProtocolDecorator):
+  def __init__(self, protocol, serviceName):
+    TProtocolDecorator.TProtocolDecorator.__init__(self, protocol)
+    self.serviceName = serviceName
+
+  def writeMessageBegin(self, name, type, seqid):
+    if (type == TMessageType.CALL or
+        type == TMessageType.ONEWAY):
+      self.protocol.writeMessageBegin(
+        self.serviceName + SEPARATOR + name,
+        type,
+        seqid
+      )
+    else:
+      self.protocol.writeMessageBegin(name, type, seqid)

--- a/lib/py/src/protocol/TProtocolDecorator.py
+++ b/lib/py/src/protocol/TProtocolDecorator.py
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from thrift.protocol.TProtocol import TProtocolBase
+from types import *
+
+class TProtocolDecorator():
+  def __init__(self, protocol):
+    TProtocolBase(protocol)
+    self.protocol = protocol
+
+  def __getattr__(self, name):
+    if hasattr(self.protocol, name):
+      member = getattr(self.protocol, name)
+      if type(member) in [MethodType, UnboundMethodType, FunctionType, LambdaType, BuiltinFunctionType, BuiltinMethodType]:
+        return lambda *args, **kwargs: self._wrap(member, args, kwargs)
+      else:
+        return member
+    raise AttributeError(name)
+
+  def _wrap(self, func, args, kwargs):
+    if type(func) == MethodType:
+      result = func(*args, **kwargs)
+    else:
+      result = func(self.protocol, *args, **kwargs)
+    return result


### PR DESCRIPTION
copy patch from: https://issues.apache.org/jira/browse/THRIFT-1914 add some testcases.

add new options multiple, if set True, will test ThriftTest and SecondService.

run server:

```
$ python TestServer.py --port=9999 --multiple -v TSimpleServer
```

run client:

```
$ python TestClient.py --host=127.0.0.1 --port=9999 --multiple
...................
----------------------------------------------------------------------
Ran 19 tests in 0.693s

OK
```

**END**
