### PR TITLE
String Generation With Nested Single Quotes

### DIFF
--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -396,7 +396,7 @@ string t_js_generator::render_const_value(t_type* type, t_const_value* value) {
     t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
     switch (tbase) {
     case t_base_type::TYPE_STRING:
-      out << "'" << value->get_string() << "'";
+      out << '"' << value->get_string() << '"';
       break;
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");


### PR DESCRIPTION
If I have a string in a struct with an apostrophe, string generation in the thrift js compiler will generate a malformed and un-escaped string, this wraps the outputted string in double quotes rather than single quotes.
