### PR TITLE
0.9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ gen-*
 /compiler/cpp/thriftl.cc
 /compiler/cpp/thrifty.cc
 /compiler/cpp/thrifty.h
+/compiler/cpp/thrifty.hh
 /compiler/cpp/version.h
 /config.*
 /configure

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,6 +38,9 @@ else
   exit 1
 fi
 
+# automake <= 1.11 names yacc output .h rather than .hh -- see THRIFT-1614
+echo '#include "thrifty.h"' > compiler/cpp/thrifty.hh
+
 autoscan
 $LIBTOOLIZE --copy --automake
 aclocal -I ./aclocal

--- a/compiler/cpp/Makefile.am
+++ b/compiler/cpp/Makefile.am
@@ -106,6 +106,7 @@ EXTRA_DIST = \
              $(WINDOWS_DIST)
 
 clean-local:
-	$(RM) thriftl.cc thrifty.cc thrifty.h version.h windows/version.h
+	$(RM) thriftl.cc thrifty.cc thrifty.h thrifty.hh version.h windows/version.h
+	echo '#include "thrifty.h"' > compiler/cpp/thrifty.hh
 
 src/main.cc: version.h

--- a/compiler/cpp/README_Windows.txt
+++ b/compiler/cpp/README_Windows.txt
@@ -1,8 +1,8 @@
 Building the Thrift IDL compiler in Windows
 -------------------------------------------
 
-The Visual Studio project contains pre-build commands to generate the 
-thriftl.cc, thrifty.cc and thrifty.h files which are necessary to build 
+The Visual Studio project contains pre-build commands to generate the
+thriftl.cc, thrifty.cc and thrifty.hh files which are necessary to build
 the compiler. These depend on bison, flex and their dependencies to
 work properly. If this doesn't work on a system, try these manual
 pre-build steps.
@@ -22,9 +22,9 @@ In the generated thriftl.cc, comment out #include <unistd.h>
 
 Place a copy of bison.simple in thrift/compiler/cpp
 > bison -y -o "src/thrifty.cc" --defines src/thrifty.yy
-> move src\thrifty.cc.h  src\thrifty.h
+> move src\thrifty.cc.hh  src\thrifty.hh
 
-Download inttypes.h from the interwebs and place it in an include path 
+Download inttypes.h from the interwebs and place it in an include path
 location (e.g. thrift/compiler/cpp/src).
 
 Build the compiler in Visual Studio.

--- a/compiler/cpp/compiler.vcxproj
+++ b/compiler/cpp/compiler.vcxproj
@@ -45,7 +45,7 @@
     <ClInclude Include="src\parse\t_type.h" />
     <ClInclude Include="src\parse\t_typedef.h" />
     <ClInclude Include="src\platform.h" />
-    <ClInclude Include="src\thrifty.h" />
+    <ClInclude Include="src\thrifty.hh" />
     <ClInclude Include="src\windows\config.h" />
     <ClInclude Include="src\windows\version.h" />
   </ItemGroup>
@@ -166,7 +166,7 @@
     </Link>
     <PreBuildEvent>
       <Command>flex -o "src\\thriftl.cc" src/thriftl.ll
-bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
+bison -y -o "src\thrifty.cc" --defines="src/thrifty.hh" src/thrifty.yy</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -185,7 +185,7 @@ bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
     </Link>
     <PreBuildEvent>
       <Command>flex -o "src\thriftl.cc" src/thriftl.ll
-bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
+bison -y -o "src\thrifty.cc" --defines="src/thrifty.hh" src/thrifty.yy</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -208,7 +208,7 @@ bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
     </Link>
     <PreBuildEvent>
       <Command>flex -o "src\thriftl.cc" src/thriftl.ll
-bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
+bison -y -o "src\thrifty.cc" --defines="src/thrifty.hh" src/thrifty.yy</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -231,7 +231,7 @@ bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
     </Link>
     <PreBuildEvent>
       <Command>flex -o "src\thriftl.cc" src/thriftl.ll
-bison -y -o "src\thrifty.cc" --defines="src/thrifty.h" src/thrifty.yy</Command>
+bison -y -o "src\thrifty.cc" --defines="src/thrifty.hh" src/thrifty.yy</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/compiler/cpp/compiler.vcxproj.filters
+++ b/compiler/cpp/compiler.vcxproj.filters
@@ -71,7 +71,7 @@
       <Filter>parse</Filter>
     </ClInclude>
     <ClInclude Include="src\platform.h" />
-    <ClInclude Include="src\thrifty.h" />
+    <ClInclude Include="src\thrifty.hh" />
     <ClInclude Include="src\windows\config.h">
       <Filter>windows</Filter>
     </ClInclude>

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -3295,9 +3295,9 @@ void t_cpp_generator::generate_process_function(t_service* tservice,
       indent() << "  " << args_obj << " = new " << argstype << ";\n" <<
       indent() << "} else {\n" <<
       indent() << "  " << args_obj << "->clear();\n" << indent() << "}\n\n" <<
-      indent() << args_obj << "->read(iprot);" << endl <<
+      indent() << "uint32_t bytes = " << args_obj << "->read(iprot);" << endl <<
       indent() << "iprot->readMessageEnd();" << endl <<
-      indent() << "uint32_t bytes = iprot->getTransport()->readEnd();" << endl << endl <<
+      indent() << "iprot->getTransport()->readEnd();" << endl << endl <<
       indent() << "if (this->eventHandler_.get() != NULL) {" << endl <<
       indent() << "  this->eventHandler_->postRead(ctx, " <<
         service_func_name << ", bytes);" << endl <<

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -72,7 +72,7 @@ class t_cpp_generator : public t_oop_generator {
     gen_templates_only_ =
       (iter != parsed_options.end() && iter->second == "only");
 
-    out_dir_base_ = "gen-cpp";
+    out_dir_base_ = program->is_out_path_absolute() ? "" : "gen-cpp";
   }
 
   /**
@@ -4639,7 +4639,8 @@ string t_cpp_generator::get_include_prefix(const t_program& program) const {
     // if flag is turned off or this is absolute path, return empty prefix
     return "";
   }
-
+  if (out_dir_base_.empty())
+    return include_prefix;
   string::size_type last_slash = string::npos;
   if ((last_slash = include_prefix.rfind("/")) != string::npos) {
     return include_prefix.substr(0, last_slash) + "/" + out_dir_base_ + "/";

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -1593,6 +1593,8 @@ void t_cpp_generator::generate_struct_clear(std::ofstream& out, t_struct* tstruc
         case t_base_type::TYPE_STRING:
         break;
       }
+    } else if (tt->is_enum()) {
+      out << indent() << tfield->get_name() << " = (" + type_name(tt) + ")0;\n";
     }
   }
   if (has_optional) {

--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -48,7 +48,7 @@
  * Must be included AFTER parse/t_program.h, but I can't remember why anymore
  * because I wrote this a while ago.
  */
-#include "thrifty.h"
+#include "thrifty.hh"
 
 void thrift_reserved_keyword(char* keyword) {
   yyerror("Cannot use reserved language keyword: \"%s\"\n", keyword);

--- a/compiler/cpp/src/thrifty.yy
+++ b/compiler/cpp/src/thrifty.yy
@@ -653,7 +653,7 @@ ConstValue:
       $$ = new t_const_value();
       $$->set_integer($1);
       if (!g_allow_64bit_consts && ($1 < INT32_MIN || $1 > INT32_MAX)) {
-        pwarning(1, "64-bit constant \"%"PRIi64"\" may not work in all languages.\n", $1);
+        pwarning(1, "64-bit constant \"%" PRIi64 "\" may not work in all languages.\n", $1);
       }
     }
 | tok_dub_constant

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -478,7 +478,7 @@ void TNonblockingServer::TConnection::workSocket() {
       // Don't allow giant frame sizes.  This prevents bad clients from
       // causing us to try and allocate a giant buffer.
       GlobalOutput.printf("TNonblockingServer: frame size too large "
-                          "(%"PRIu32" > %zu) from client %s. remote side not "
+                          "(%" PRIu32 " > %zu) from client %s. remote side not "
                           "using TFramedTransport?",
                           readWant_, server_->getMaxFrameSize(),
                           tSocket_->getSocketInfo().c_str());

--- a/rat_exclude
+++ b/rat_exclude
@@ -18,6 +18,7 @@ ylwrap
 *.m4
 autom4te.cache
 thrifty.h
+thrifty.hh
 version.h
 version.h.in
 md5.c


### PR DESCRIPTION
Eliminate redundant allocations for temporary args during RPC processing. 
The change is suitable for ThreadPoolServer where each thread processes its own connection.

We create thread local request/response arguments instead of allocating them on stack in TDispatchProcessor. This way, the next  RPC reuses already allocated strings and arrays.
In order to make sure that the objects are semantically empty we added a new method "clear" that resets all its fields to their initial values (0 for basic types, empty for containers) and unsets optional fields.

On our system total CPU load during high QPS periods (18000 QPS and more ) was cut by factor of 2 .