### PR TITLE
THRIFT-2543 Generated enum type in haskell should be qualified

### DIFF
--- a/compiler/cpp/src/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/generate/t_hs_generator.cc
@@ -1482,7 +1482,7 @@ string t_hs_generator::render_hs_type(t_type* type, bool needs_parens) {
     }
 
   } else if (type->is_enum()) {
-    return capitalize(((t_enum*)type)->get_name());
+    return type_name((t_enum*)type);
 
   } else if (type->is_struct() || type->is_xception()) {
     return type_name((t_struct*)type);


### PR DESCRIPTION
Compile following thrift files
**a.thrift**

``` thrift
enum X {
  A = 1,
  B = 2,
  C = 4,
  D = 8
}
```

**b.thrift**

``` thrift
include "a.thrift"

struct B {
  1: a.X x;
  2: i32 y;
}
```

In generated haskell file, we find
**B_Types.hs**

``` haskell
import qualified A_Types

data B = B{f_B_x :: Maybe X,f_B_y :: Maybe Int32} deriving (Show,Eq,Typeable)
```

It should be
**B_Types.hs**

``` haskell
import qualified A_Types

data B = B{f_B_x :: Maybe A_Types.X,f_B_y :: Maybe Int32} deriving (Show,Eq,Typeable)
```
