### PR TITLE
THRIFT-2551 OutOfMemoryError kills serve thread

### DIFF
--- a/lib/java/src/org/apache/thrift/server/TThreadPoolServer.java
+++ b/lib/java/src/org/apache/thrift/server/TThreadPoolServer.java
@@ -140,7 +140,6 @@ public class TThreadPoolServer extends TServer {
               break;
             }
           } catch(OutOfMemoryError ex) {
-              client.close();
             LOGGER.warn("ExecutorService throws OutOfMemoryError "+ ex.getMessage() + (++rejections) +
                 " times(s)", ex);
             try {


### PR DESCRIPTION
THRIFT-2551 OutOfMemoryError "unable to create new native thread" kills serve thread.

If executor can not create new thread (because of exceed descriptors limit for example) it throws OutOfMemoryError. This case is same as if RejectedExecutionException is thrown from executor: we can wait and retry.
