### PR TITLE
Unignore /aclocal files required for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 *_ReSharper*
 *.opensdf
 *.swp
-*.m4
 *~
 
 .*project
@@ -25,6 +24,8 @@ junit*.properties
 gen-*
 Makefile
 Makefile.in
+aclocal.m4
+acinclude.m4
 autom4te.cache
 node_modules
 compile
@@ -35,6 +36,8 @@ test-driver
 .svn
 
 /contrib/.vagrant/
+/aclocal/libtool.m4
+/aclocal/lt*.m4
 /autoscan.log
 /autoscan-*.log
 /compiler/cpp/Debug


### PR DESCRIPTION
Commit https://github.com/apache/thrift/commit/7fff60ff79398e32b5f4824cabd97d216aad35db ignored a few too many files, excluding the aclocal macros needed for the build.
