### PR TITLE
Always use bit field or BitSet for isSetXXX

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -141,7 +141,7 @@ public:
   std::string get_cap_name(std::string name);
   std::string generate_isset_check(t_field* field);
   std::string generate_isset_check(std::string field);
-  void generate_isset_set(ofstream& out, t_field* field, std::string prefix);
+  void generate_isset_set(ofstream& out, t_field* field, std::string prefix, bool value);
   std::string isset_field_id(t_field* field);
 
   void generate_service_interface (t_service* tservice);
@@ -276,7 +276,7 @@ public:
 
   std::string make_valid_java_filename( std::string const & fromName);
   std::string make_valid_java_identifier( std::string const & fromName);
-  
+
   bool type_can_be_null(t_type* ttype) {
     ttype = get_true_type(ttype);
 
@@ -359,7 +359,7 @@ string t_java_generator::java_type_imports() {
   string hash_builder;
   string tree_set_and_map;
   if (sorted_containers_) {
-    tree_set_and_map = string() + 
+    tree_set_and_map = string() +
       "import java.util.TreeSet;\n" +
       "import java.util.TreeMap;\n";
   }
@@ -385,7 +385,7 @@ string t_java_generator::java_type_imports() {
     "import java.util.Set;\n" +
     "import java.util.HashSet;\n" +
     "import java.util.EnumSet;\n" +
-    tree_set_and_map + 
+    tree_set_and_map +
     "import java.util.Collections;\n" +
     "import java.util.BitSet;\n" +
     "import java.nio.ByteBuffer;\n"
@@ -433,7 +433,7 @@ void t_java_generator::generate_enum(t_enum* tenum) {
 
   // Add java imports
   f_enum << string() +
-    "import java.util.Map;\n" + 
+    "import java.util.Map;\n" +
     "import java.util.HashMap;\n" +
     "import org.apache.thrift.TEnum;" << endl << endl;
 
@@ -491,7 +491,7 @@ void t_java_generator::generate_enum(t_enum* tenum) {
   }
 
   indent(f_enum) << "default:" << endl;
-  indent(f_enum) << "  return null;" << endl;  
+  indent(f_enum) << "  return null;" << endl;
 
   indent_down();
 
@@ -688,7 +688,7 @@ string t_java_generator::render_const_value(ofstream& out, t_type* type, t_const
 }
 
 /**
- * Generates a struct definition for a thrift data type. This will be a org.apache.thrift.TBase 
+ * Generates a struct definition for a thrift data type. This will be a org.apache.thrift.TBase
  * implementor.
  *
  * @param tstruct The struct definition
@@ -905,7 +905,7 @@ void t_java_generator::generate_union_getters_and_setters(ofstream& out, t_struc
       indent(out) << "  if (getSetField() == _Fields." << constant_name(field->get_name()) << ") {" << endl;
       indent(out) << "    return (" << type_name(field->get_type(), true) << ")getFieldValue();" << endl;
       indent(out) << "  } else {" << endl;
-      indent(out) << "    throw new RuntimeException(\"Cannot get field '" << field->get_name() 
+      indent(out) << "    throw new RuntimeException(\"Cannot get field '" << field->get_name()
         << "' because union is currently set to \" + getFieldDesc(getSetField()).name);" << endl;
       indent(out) << "  }" << endl;
       indent(out) << "}" << endl;
@@ -992,8 +992,8 @@ void t_java_generator::generate_check_type(ofstream& out, t_struct* tstruct) {
     indent(out) << "  if (value instanceof " << type_name(field->get_type(), true, false, true) << ") {" << endl;
     indent(out) << "    break;" << endl;
     indent(out) << "  }" << endl;
-    indent(out) << "  throw new ClassCastException(\"Was expecting value of type " 
-      << type_name(field->get_type(), true, false) << " for field '" << field->get_name() 
+    indent(out) << "  throw new ClassCastException(\"Was expecting value of type "
+      << type_name(field->get_type(), true, false) << " for field '" << field->get_name()
       << "', but got \" + value.getClass().getSimpleName());" << endl;
     // do the real check here
   }
@@ -1049,7 +1049,7 @@ void t_java_generator::generate_standard_scheme_read_value(ofstream& out, t_stru
 
   indent_down();
   indent(out) << "} else {" << endl;
-  indent_up();  
+  indent_up();
   indent(out) << "org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);" << endl;
   indent(out) << "return null;" << endl;
   indent_down();
@@ -1076,7 +1076,7 @@ void t_java_generator::generate_standard_scheme_write_value(ofstream& out, t_str
 
     indent(out) << "case " << constant_name(field->get_name()) << ":" << endl;
     indent_up();
-    indent(out) << type_name(field->get_type(), true, false) << " " << field->get_name() 
+    indent(out) << type_name(field->get_type(), true, false) << " " << field->get_name()
       << " = (" <<  type_name(field->get_type(), true, false) << ")value_;" << endl;
     generate_serialize_field(out, field, "");
     indent(out) << "return;" << endl;
@@ -1097,21 +1097,21 @@ void t_java_generator::generate_standard_scheme_write_value(ofstream& out, t_str
 void t_java_generator::generate_tuple_scheme_read_value(ofstream& out, t_struct* tstruct) {
   indent(out) << "@Override" << endl;
   indent(out) << "protected Object tupleSchemeReadValue(org.apache.thrift.protocol.TProtocol iprot, short fieldID) throws org.apache.thrift.TException {" << endl;
-  
+
   indent_up();
-  
+
   indent(out) << "_Fields setField = _Fields.findByThriftId(fieldID);" << endl;
   indent(out) << "if (setField != null) {" << endl;
   indent_up();
   indent(out) << "switch (setField) {" << endl;
   indent_up();
-  
+
   const vector<t_field*>& members = tstruct->get_members();
   vector<t_field*>::const_iterator m_iter;
-  
+
   for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
     t_field* field = (*m_iter);
-    
+
     indent(out) << "case " << constant_name(field->get_name()) << ":" << endl;
     indent_up();
     indent(out) << type_name(field->get_type(), true, false) << " " << field->get_name() << ";" << endl;
@@ -1119,13 +1119,13 @@ void t_java_generator::generate_tuple_scheme_read_value(ofstream& out, t_struct*
     indent(out) << "return " << field->get_name() << ";" << endl;
     indent_down();
   }
-  
+
   indent(out) << "default:" << endl;
   indent(out) << "  throw new IllegalStateException(\"setField wasn't null, but didn't match any of the case statements!\");" << endl;
-  
+
   indent_down();
   indent(out) << "}" << endl;
-  
+
   indent_down();
   indent(out) << "} else {" << endl;
   indent_up();
@@ -1139,35 +1139,35 @@ void t_java_generator::generate_tuple_scheme_read_value(ofstream& out, t_struct*
 void t_java_generator::generate_tuple_scheme_write_value(ofstream& out, t_struct* tstruct) {
   indent(out) << "@Override" << endl;
   indent(out) << "protected void tupleSchemeWriteValue(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {" << endl;
-  
+
   indent_up();
-  
+
   indent(out) << "switch (setField_) {" << endl;
   indent_up();
-  
+
   const vector<t_field*>& members = tstruct->get_members();
   vector<t_field*>::const_iterator m_iter;
-  
+
   for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
     t_field* field = (*m_iter);
-    
+
     indent(out) << "case " << constant_name(field->get_name()) << ":" << endl;
     indent_up();
-    indent(out) << type_name(field->get_type(), true, false) << " " << field->get_name() 
+    indent(out) << type_name(field->get_type(), true, false) << " " << field->get_name()
     << " = (" <<  type_name(field->get_type(), true, false) << ")value_;" << endl;
     generate_serialize_field(out, field, "");
     indent(out) << "return;" << endl;
     indent_down();
   }
-  
+
   indent(out) << "default:" << endl;
   indent(out) << "  throw new IllegalStateException(\"Cannot write union with unknown field \" + setField_);" << endl;
-  
+
   indent_down();
   indent(out) << "}" << endl;
-  
+
   indent_down();
-  
+
   indent(out) << "}" << endl;
 }
 
@@ -1332,11 +1332,9 @@ void t_java_generator::generate_java_struct_definition(ofstream &out,
       if ((*m_iter)->get_req() == t_field::T_OPTIONAL) {
         optionals++;
       }
-      if (!type_can_be_null((*m_iter)->get_type())) {
-        indent(out) << "private static final int " << isset_field_id(*m_iter)
-          << " = " << i << ";" <<  endl;
-        i++;
-      }
+      indent(out) << "private static final int " << isset_field_id(*m_iter)
+        << " = " << i << ";" <<  endl;
+      i++;
     }
 
     std::string primitiveType;
@@ -1414,7 +1412,7 @@ void t_java_generator::generate_java_struct_definition(ofstream &out,
           indent(out) << "this." << (*m_iter)->get_name() << " = "
             << (*m_iter)->get_name() << ";" << endl;
         }
-        generate_isset_set(out, (*m_iter), "");
+        generate_isset_set(out, (*m_iter), "", true);
       }
     }
 
@@ -1437,7 +1435,7 @@ void t_java_generator::generate_java_struct_definition(ofstream &out,
     break;
   case ISSET_BITSET:
     indent(out) << "__isset_bit_vector.clear();" << endl;
-    indent(out) << "__isset_bit_vector.or(other.__isset_bit_vector);" << endl;    
+    indent(out) << "__isset_bit_vector.or(other.__isset_bit_vector);" << endl;
     break;
   }
 
@@ -1664,7 +1662,7 @@ void t_java_generator::generate_java_struct_reader(ofstream& out,
   (void) tstruct;
   indent(out) << "public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {" << endl;
   indent_up();
-  indent(out) << "schemes.get(iprot.getScheme()).getScheme().read(iprot, this);" << endl; 
+  indent(out) << "schemes.get(iprot.getScheme()).getScheme().read(iprot, this);" << endl;
   indent_down();
   indent(out) << "}" << endl <<
   endl;
@@ -1744,7 +1742,7 @@ void t_java_generator::generate_java_struct_result_writer(ofstream& out,
   indent(out) << "public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {" << endl;
   indent_up();
   indent(out) << "schemes.get(oprot.getScheme()).getScheme().write(oprot, this);" << endl;
-  
+
   indent_down();
   indent(out) << "  }" << endl << endl;
 }
@@ -1990,6 +1988,14 @@ void t_java_generator::generate_java_bean_boilerplate(ofstream& out,
     }
     out << " set" << cap_name << "(" << type_name(type) << " " << field_name << ") {" << endl;
     indent_up();
+    if (type_can_be_null(type)) {
+      indent(out) << "if (" << field_name << " == null) {" << endl;
+      indent_up();
+      generate_isset_set(out, field, "", false);
+      indent(out) << "return this;" << endl;
+      indent_down();
+      indent(out) << "}" << endl;
+    }
     indent(out) << "this." << field_name << " = ";
     if (type->is_base_type() && ((t_base_type*)type)->is_binary()) {
       out << "org.apache.thrift.TBaseHelper.copyBinary(" << field_name << ")";
@@ -1997,11 +2003,10 @@ void t_java_generator::generate_java_bean_boilerplate(ofstream& out,
       out << field_name;
     }
     out << ";" << endl;
-    generate_isset_set(out, field, "");
+    generate_isset_set(out, field, "", true);
     if (!bean_style_) {
       indent(out) << "return this;" << endl;
     }
-
     indent_down();
     indent(out) << "}" << endl << endl;
 
@@ -2010,7 +2015,8 @@ void t_java_generator::generate_java_bean_boilerplate(ofstream& out,
     indent_up();
     if (type_can_be_null(type)) {
       indent(out) << "this." << field_name << " = null;" << endl;
-    } else if(issetType == ISSET_PRIMITIVE) {
+    }
+    if(issetType == ISSET_PRIMITIVE) {
       indent(out) << "__isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, " << isset_field_id(field) << ");" << endl;
     } else {
       indent(out) << "__isset_bit_vector.clear(" << isset_field_id(field) << ");" << endl;
@@ -2022,9 +2028,7 @@ void t_java_generator::generate_java_bean_boilerplate(ofstream& out,
     indent(out) << "/** Returns true if field " << field_name << " is set (has been assigned a value) and false otherwise */" << endl;
     indent(out) << "public boolean is" << get_cap_name("set") << cap_name << "() {" << endl;
     indent_up();
-    if (type_can_be_null(type)) {
-      indent(out) << "return this." << field_name << " != null;" << endl;
-    } else if(issetType == ISSET_PRIMITIVE) {
+    if(issetType == ISSET_PRIMITIVE) {
       indent(out) << "return EncodingUtils.testBit(__isset_bitfield, " << isset_field_id(field) << ");" << endl;
     } else {
       indent(out) << "return __isset_bit_vector.get(" << isset_field_id(field) << ");" << endl;
@@ -2038,13 +2042,14 @@ void t_java_generator::generate_java_bean_boilerplate(ofstream& out,
       indent(out) << "if (!value) {" << endl;
       indent(out) << "  this." << field_name << " = null;" << endl;
       indent(out) << "}" << endl;
-    } else if(issetType == ISSET_PRIMITIVE) {
+    }
+    if(issetType == ISSET_PRIMITIVE) {
       indent(out) << "__isset_bitfield = EncodingUtils.setBit(__isset_bitfield, " << isset_field_id(field) << ", value);" << endl;
     } else {
       indent(out) << "__isset_bit_vector.set(" << isset_field_id(field) << ", value);" << endl;
     }
     indent_down();
-    indent(out) << "}" << endl << endl; 
+    indent(out) << "}" << endl << endl;
   }
 }
 
@@ -2158,7 +2163,7 @@ void t_java_generator::generate_java_meta_data_map(ofstream& out,
   indent(out) << "}" << endl << endl;
 }
 
-/** 
+/**
  * Returns a string with the java representation of the given thrift type
  * (e.g. for the type struct it returns "org.apache.thrift.protocol.TType.STRUCT")
  */
@@ -2201,12 +2206,12 @@ void t_java_generator::generate_field_value_meta_data(std::ofstream& out, t_type
   } else if (type->is_container()){
     if (type->is_list()){
       indent(out) << "new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, ";
-      t_type* elem_type = ((t_list*)type)->get_elem_type();    
-      generate_field_value_meta_data(out, elem_type);   
+      t_type* elem_type = ((t_list*)type)->get_elem_type();
+      generate_field_value_meta_data(out, elem_type);
     } else if (type->is_set()){
       indent(out) << "new org.apache.thrift.meta_data.SetMetaData(org.apache.thrift.protocol.TType.SET, ";
-      t_type* elem_type = ((t_list*)type)->get_elem_type();    
-      generate_field_value_meta_data(out, elem_type); 
+      t_type* elem_type = ((t_list*)type)->get_elem_type();
+      generate_field_value_meta_data(out, elem_type);
     } else{ // map
       indent(out) << "new org.apache.thrift.meta_data.MapMetaData(org.apache.thrift.protocol.TType.MAP, ";
       t_type* key_type = ((t_map*)type)->get_key_type();
@@ -2508,7 +2513,7 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
   indent(f_service_) << "  private org.apache.thrift.async.TAsyncClientManager clientManager;" << endl;
   indent(f_service_) << "  private org.apache.thrift.protocol.TProtocolFactory protocolFactory;" << endl;
   indent(f_service_) << "  public Factory(org.apache.thrift.async.TAsyncClientManager clientManager, org.apache.thrift.protocol.TProtocolFactory protocolFactory) {" << endl;
-  indent(f_service_) << "    this.clientManager = clientManager;" << endl; 
+  indent(f_service_) << "    this.clientManager = clientManager;" << endl;
   indent(f_service_) << "    this.protocolFactory = protocolFactory;" << endl;
   indent(f_service_) << "  }" << endl;
   indent(f_service_) << "  public AsyncClient getAsyncClient(org.apache.thrift.transport.TNonblockingTransport transport) {" << endl;
@@ -2534,7 +2539,7 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
     string args_name = (*f_iter)->get_name() + "_args";
     string result_name = (*f_iter)->get_name() + "_result";
 
-    // Main method body   
+    // Main method body
     indent(f_service_) << "public " << function_signature_async(*f_iter, false) << " throws org.apache.thrift.TException {" << endl;
     indent(f_service_) << "  checkReady();" << endl;
     indent(f_service_) << "  " << funclassname << " method_call = new " + funclassname + "(" << async_argument_list(*f_iter, arg_struct, ret_type) << ", this, ___protocolFactory, ___transport);" << endl;
@@ -2572,7 +2577,7 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
 
     // Serialize request
     // NOTE we are leaving seqid as 0, for now (see above)
-    f_service_ << 
+    f_service_ <<
       indent() << "prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage(\"" << funname << "\", org.apache.thrift.protocol.TMessageType.CALL, 0));" << endl <<
       indent() << args_name << " args = new " << args_name << "();" << endl;
 
@@ -2580,14 +2585,14 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
       f_service_ << indent() << "args.set" << get_cap_name((*fld_iter)->get_name()) << "(" << (*fld_iter)->get_name() << ");" << endl;
     }
 
-    f_service_ << 
+    f_service_ <<
       indent() << "args.write(prot);" << endl <<
       indent() << "prot.writeMessageEnd();" << endl;
 
     indent_down();
     indent(f_service_) << "}" << endl << endl;
 
-    // Return method  
+    // Return method
     indent(f_service_) << "public " + type_name(ret_type) + " getResult() throws ";
     vector<t_field*>::const_iterator x_iter;
     for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
@@ -2605,7 +2610,7 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
     if (!(*f_iter)->is_oneway()) {
       indent(f_service_);
       if (!ret_type->is_void()) {
-        f_service_ << "return "; 
+        f_service_ << "return ";
       }
       f_service_ << "(new Client(prot)).recv_" + funname + "();" << endl;
     }
@@ -3137,13 +3142,13 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
   } else {
     // Declare variables, read header
     if (ttype->is_map()) {
-      indent(out) << "org.apache.thrift.protocol.TMap " << obj << " = new org.apache.thrift.protocol.TMap(" << 
+      indent(out) << "org.apache.thrift.protocol.TMap " << obj << " = new org.apache.thrift.protocol.TMap(" <<
       type_to_enum(((t_map*)ttype)->get_key_type()) << ", " << type_to_enum(((t_map*)ttype)->get_val_type()) << ", " << "iprot.readI32());" << endl;
     } else if (ttype->is_set()) {
-      indent(out) << "org.apache.thrift.protocol.TSet " << obj << " = new org.apache.thrift.protocol.TSet(" << 
+      indent(out) << "org.apache.thrift.protocol.TSet " << obj << " = new org.apache.thrift.protocol.TSet(" <<
       type_to_enum(((t_set*)ttype)->get_elem_type()) << ", iprot.readI32());" << endl;
     } else if (ttype->is_list()) {
-      indent(out) << "org.apache.thrift.protocol.TList " << obj << " = new org.apache.thrift.protocol.TList(" << 
+      indent(out) << "org.apache.thrift.protocol.TList " << obj << " = new org.apache.thrift.protocol.TList(" <<
       type_to_enum(((t_set*)ttype)->get_elem_type()) << ", iprot.readI32());" << endl;
     }
   }
@@ -3153,8 +3158,8 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
     indent_up();
   }
 
-  out << 
-      indent() << prefix << " = new " << type_name(ttype, false, true); 
+  out <<
+      indent() << prefix << " = new " << type_name(ttype, false, true);
 
   // size the collection correctly
   if (sorted_containers_ && (ttype->is_map() || ttype->is_set())) {
@@ -3201,7 +3206,7 @@ void t_java_generator::generate_deserialize_container(ofstream& out,
  */
 void t_java_generator::generate_deserialize_map_element(ofstream& out,
                                                         t_map* tmap,
-                                                        string prefix, 
+                                                        string prefix,
                                                         string obj, bool has_metadata) {
   string key = tmp("_key");
   string val = tmp("_val");
@@ -3217,7 +3222,7 @@ void t_java_generator::generate_deserialize_map_element(ofstream& out,
        "for (int " << i << " = 0; " <<
           i << " < " << obj << ".size" << "; " <<
           "++" << i << ")" << endl;
-  
+
   scope_up(out);
 
   generate_deserialize_field(out, &fkey, "", has_metadata);
@@ -3231,7 +3236,7 @@ void t_java_generator::generate_deserialize_map_element(ofstream& out,
  */
 void t_java_generator::generate_deserialize_set_element(ofstream& out,
                                                         t_set* tset,
-                                                        string prefix, 
+                                                        string prefix,
                                                         string obj, bool has_metadata) {
   string elem = tmp("_elem");
   t_field felem(tset->get_elem_type(), elem);
@@ -3245,7 +3250,7 @@ void t_java_generator::generate_deserialize_set_element(ofstream& out,
           i << " < " << obj << ".size" << "; " <<
           "++" << i << ")" << endl;
   scope_up(out);
-  
+
   generate_deserialize_field(out, &felem, "", has_metadata);
 
   indent(out) << prefix << ".add(" << elem << ");" << endl;
@@ -3257,7 +3262,7 @@ void t_java_generator::generate_deserialize_set_element(ofstream& out,
  */
 void t_java_generator::generate_deserialize_list_element(ofstream& out,
                                                          t_list* tlist,
-                                                         string prefix, 
+                                                         string prefix,
                                                          string obj, bool has_metadata) {
   string elem = tmp("_elem");
   t_field felem(tlist->get_elem_type(), elem);
@@ -3271,7 +3276,7 @@ void t_java_generator::generate_deserialize_list_element(ofstream& out,
           i << " < " << obj << ".size" << "; " <<
           "++" << i << ")" << endl;
   scope_up(out);
- 
+
   generate_deserialize_field(out, &felem, "", has_metadata);
 
   indent(out) << prefix << ".add(" << elem << ");" << endl;
@@ -3308,7 +3313,7 @@ void t_java_generator::generate_serialize_field(ofstream& out,
     indent(out) << "oprot.";
 
     if (type->is_base_type()) {
-      t_base_type::t_base tbase = ((t_base_type*)type)->get_base();  
+      t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
       switch (tbase) {
         case t_base_type::TYPE_VOID:
           throw "compiler error: cannot serialize void field in a struct: " + name;
@@ -3514,7 +3519,7 @@ string t_java_generator::type_name(t_type* ttype, bool in_container, bool in_ini
     if (in_init) {
       if (sorted_containers_) {
         prefix = "TreeSet";
-      } else { 
+      } else {
         prefix = "HashSet";
       }
     } else {
@@ -3804,7 +3809,7 @@ std::string t_java_generator::make_valid_java_identifier( std::string const & fr
 
     // tests rely on this
     assert( ('A' < 'Z') && ('a' < 'z') && ('0' < '9'));
-    
+
     // if the first letter is a number, we add an additional underscore in front of it
     char c = str.at(0);
     if( ('0' <= c) && (c <= '9')) {
@@ -3813,10 +3818,10 @@ std::string t_java_generator::make_valid_java_identifier( std::string const & fr
 
     // following chars: letter, number or underscore
     for( size_t i = 0;  i < str.size();  ++i) {
-        c = str.at(i);        
-        if( (('A' > c) || (c > 'Z')) && 
-            (('a' > c) || (c > 'z')) && 
-            (('0' > c) || (c > '9')) && 
+        c = str.at(i);
+        if( (('A' > c) || (c > 'Z')) &&
+            (('a' > c) || (c > 'z')) &&
+            (('0' > c) || (c > '9')) &&
             ('_' != c) ) {
             str.replace( i, 1, "_");
         }
@@ -3885,7 +3890,7 @@ void t_java_generator::generate_deep_copy_container(ofstream &out, std::string s
     source_name = source_name_p1;
   else
     source_name = source_name_p1 + "." + source_name_p2;
-  
+
   bool copy_construct_container;
   if (container->is_map()) {
     t_map *tmap = (t_map *)container;
@@ -4017,10 +4022,9 @@ std::string t_java_generator::generate_isset_check(std::string field_name) {
   return "is" + get_cap_name("set") + get_cap_name(field_name) + "()";
 }
 
-void t_java_generator::generate_isset_set(ofstream& out, t_field* field, string prefix) {
-  if (!type_can_be_null(field->get_type())) {
-    indent(out) << prefix << "set" << get_cap_name(field->get_name()) << get_cap_name("isSet") << "(true);" << endl;
-  }
+void t_java_generator::generate_isset_set(ofstream& out, t_field* field, string prefix, bool value) {
+  indent(out) << prefix << "set" << get_cap_name(field->get_name()) << get_cap_name("isSet") <<
+    "(" << (value ? "true":"false") << ");" << endl;
 }
 
 void t_java_generator::generate_struct_desc(ofstream& out, t_struct* tstruct) {
@@ -4044,8 +4048,8 @@ void t_java_generator::generate_field_descs(ofstream& out, t_struct* tstruct) {
 void t_java_generator::generate_scheme_map(ofstream& out, t_struct* tstruct) {
   indent(out) << "private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();" << endl;
   indent(out) << "static {" << endl;
-  indent(out) << "  schemes.put(StandardScheme.class, new " << tstruct->get_name() << "StandardSchemeFactory());" << endl;  
-  indent(out) << "  schemes.put(TupleScheme.class, new " << tstruct->get_name() << "TupleSchemeFactory());" << endl;  
+  indent(out) << "  schemes.put(StandardScheme.class, new " << tstruct->get_name() << "StandardSchemeFactory());" << endl;
+  indent(out) << "  schemes.put(TupleScheme.class, new " << tstruct->get_name() << "TupleSchemeFactory());" << endl;
   indent(out) << "}" << endl;
 }
 
@@ -4139,14 +4143,7 @@ void t_java_generator::generate_field_name_constants(ofstream& out, t_struct* ts
 
 t_java_generator::isset_type t_java_generator::needs_isset(t_struct* tstruct, std::string *outPrimitiveType) {
   const vector<t_field*>& members = tstruct->get_members();
-  vector<t_field*>::const_iterator m_iter;
-
-  int count = 0;
-  for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-    if (!type_can_be_null(get_true_type((*m_iter)->get_type()))) {
-      count++;
-    }
-  }
+  int count = members.size();
   if(count == 0) {
     return ISSET_NONE;
   } else if(count <= 64) {
@@ -4345,7 +4342,7 @@ void t_java_generator::generate_standard_reader(ofstream& out, t_struct* tstruct
 void t_java_generator::generate_standard_writer(ofstream& out, t_struct* tstruct, bool is_result) {
   indent_up();
   out <<
-    indent() << "public void write(org.apache.thrift.protocol.TProtocol oprot, " << 
+    indent() << "public void write(org.apache.thrift.protocol.TProtocol oprot, " <<
     tstruct->get_name() << " struct) throws org.apache.thrift.TException {" << endl;
   indent_up();
   const vector<t_field*>& fields = tstruct->get_sorted_members();
@@ -4387,7 +4384,7 @@ void t_java_generator::generate_standard_writer(ofstream& out, t_struct* tstruct
     }
   }
   // Write the struct map
-  out << 
+  out <<
     indent() << "oprot.writeFieldStop();" << endl <<
     indent() << "oprot.writeStructEnd();" << endl;
 
@@ -4452,7 +4449,7 @@ void t_java_generator::generate_java_struct_tuple_reader(ofstream& out, t_struct
     }
   }
   indent_down();
-  indent(out) << "}" << endl;  
+  indent(out) << "}" << endl;
 }
 
 void t_java_generator::generate_java_struct_tuple_writer(ofstream& out, t_struct* tstruct) {


### PR DESCRIPTION
This is to address the issue: https://issues.apache.org/jira/browse/THRIFT-1827
Due to the the inconsistent behavior of isSet for primitive field and nullable field (e.g.., enum), enums with defaults will always have isSetAnyEnumField() as true when the class is initialized. Example:

enum Gender {
    UNSPECIFIED = 0,
    FEMALE = 1,
    MALE = 2,
}

struct User {
    1: optional Gender gender = Gender.UNSPECIFIED,
    2: optional i32 age = 0;
}

With this change, the generated code will look like this:

  public User setGender(Gender gender) {
    if (gender == null) {
      setGenderIsSet(false);
      return this;
    }
    this.gender = gender;
    setGenderIsSet(true);
    return this;
  }

  public void unsetGender() {
    this.gender = null;
    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __GENDER_ISSET_ID);
  }

  /*\* Returns true if field gender is set (has been assigned a value) and false otherwise */
  public boolean isSetGender() {
    return EncodingUtils.testBit(__isset_bitfield, __GENDER_ISSET_ID);
  }

  public void setGenderIsSet(boolean value) {
    if (!value) {
      this.gender = null;
    }
    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __GENDER_ISSET_ID, value);
  }

I haven't tested this but just want to see if this the desired direction. If so I will do more testing and make sure it works.
