### PR TITLE
THRIFT-585 Wrap py:twisted calls in maybeDeferred

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -1279,18 +1279,22 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << "self._seqid += 1" << endl;
       if (!(*f_iter)->is_oneway()) {
         indent(f_service_) <<
-          "d = self._reqs[self._seqid] = defer.Deferred()" << endl;
+          "self._reqs[self._seqid] = defer.Deferred()" << endl;
+        indent(f_service_) <<
+          "d = defer.maybeDeferred(self.send_" << funname << ",";
       }
     } else if (gen_tornado_) {
       indent(f_service_) << "self._seqid += 1" << endl;
       if (!(*f_iter)->is_oneway()) {
         indent(f_service_) <<
           "self._reqs[self._seqid] = callback" << endl;
+        indent(f_service_) <<
+          "self.send_" << funname << "(";
       }
+    } else {
+      indent(f_service_) <<
+        "self.send_" << funname << "(";
     }
-
-    indent(f_service_) <<
-      "self.send_" << funname << "(";
 
     bool first = true;
     for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
@@ -1314,26 +1318,57 @@ void t_py_generator::generate_service_client(t_service* tservice) {
     f_service_ << ")" << endl;
 
     if (!(*f_iter)->is_oneway()) {
-      f_service_ << indent();
+
       if (gen_twisted_) {
-        f_service_ << "return d" << endl;
+        indent(f_service_) << "d.addCallbacks(self.cb_send_" << funname << "," << endl <<
+          indent() << indent() << "errback=self.eb_send_" << funname << "," << endl <<
+          indent() << indent() << "callbackArgs=(self._seqid,)," << endl <<
+          indent() << indent() << "errbackArgs=(self._seqid,))" << endl;
+        indent(f_service_) << "return d" << endl;
+
       } else if (gen_tornado_) {
+        f_service_ << indent();
         f_service_ << "self.recv_dispatch()" << endl;
       } else {
+        f_service_ << indent();
         if (!(*f_iter)->get_returntype()->is_void()) {
           f_service_ << "return ";
         }
         f_service_ <<
           "self.recv_" << funname << "()" << endl;
       }
-    } else {
-      if (gen_twisted_) {
-        f_service_ <<
-          indent() << "return defer.succeed(None)" << endl;
-      }
     }
+
     indent_down();
     f_service_ << endl;
+
+    if (gen_twisted_) {
+      indent(f_service_) <<
+        "def cb_send_" << funname << "(self, _, seqid):" << endl;
+      indent_up();
+      if ((*f_iter)->is_oneway()) {
+        f_service_ <<
+          indent() << "d = self._reqs.pop(seqid)" << endl <<
+          indent() << "d.callback(None)" << endl;
+      } else {
+        f_service_ <<
+          indent() << "d = self._reqs[seqid]" << endl;
+      }
+      f_service_ << indent() << "return d" << endl;
+      indent_down();
+
+      f_service_ << endl;
+
+      indent(f_service_) <<
+        "def eb_send_" << funname << "(self, e, seqid):" << endl;
+      indent_up();
+      f_service_ <<
+        indent() << "d = self._reqs.pop(seqid)" << endl <<
+        indent() << "d.errback(e)" << endl <<
+        indent() << "return d" << endl;
+      indent_down();
+      f_service_ << endl;
+    }
 
     indent(f_service_) <<
       "def send_" << function_signature(*f_iter, false, MANDATORY_FOR_ONEWAY_ELSE_NONE) << ":" << endl;
@@ -1367,7 +1402,7 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       f_service_ <<
         indent() << "args.write(oprot)" << endl <<
         indent() << "oprot.writeMessageEnd()" << endl <<
-        indent() << "oprot.trans.flush()" << endl;
+        indent() << "return oprot.trans.flush()" << endl;
     } else if (gen_tornado_) {
       f_service_ <<
         indent() << "args.write(oprot)" << endl <<

--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -42,7 +42,7 @@ class TMessageSenderTransport(TTransport.TTransportBase):
     def flush(self):
         msg = self.__wbuf.getvalue()
         self.__wbuf = StringIO()
-        self.sendMessage(msg)
+        return defer.maybeDeferred(self.sendMessage, msg)
 
     def sendMessage(self, message):
         raise NotImplementedError
@@ -55,7 +55,7 @@ class TCallbackTransport(TMessageSenderTransport):
         self.func = func
 
     def sendMessage(self, message):
-        self.func(message)
+        return self.func(message)
 
 
 class ThriftClientProtocol(basic.Int32StringReceiver):


### PR DESCRIPTION
This avoids synchronous exceptions from the client libraries.
This is an update of the patch posted to: 
https://issues.apache.org/jira/browse/THRIFT-585

Patch: Mattias de Zalenski, James Broadhead

Testing: 
- Compiled with --gen py, --gen py:tornado, --gen py:twisted for 3 projects and visually compared results. 
- py and py:tornado output was unaffected. 
- All output has equivalent pyflakes/pylint success. 
  (we have been running with the original version of this patch for 2 years. cf. https://github.com/jamesbroadhead/thrift/commit/91f5b3370cf34afab2511b972113197e2fe8a9c6)
