### PR TITLE
THRIFT-2578 Moving 'make cross' from test.sh to test.py

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -60,14 +60,16 @@ def runServiceTest(test_name, server_lib, server_executable, server_extra_args, 
   server_args = []
   cli_args = []
   if server_lib == 'java':
-    server_executable[2] = relfile(server_executable[2])
-    server_args.extend(server_executable)
+    server_args.append(server_executable[0])
+    server_args.append(server_executable[1])
+    server_args.append(relfile(server_executable[2]))
     server_args.extend(['-Dtestargs','\"'])
   else:
     server_args = [relfile(server_executable)]
   if client_lib == 'java':
-    client_executable[2] = relfile(client_executable[2])
-    cli_args.extend(client_executable)
+    cli_args.append(client_executable[0])
+    cli_args.append(client_executable[1])
+    cli_args.append(relfile(client_executable[2]))
     cli_args.extend(['-Dtestargs','\"'])
   else:
     cli_args = [relfile(client_executable)]
@@ -90,14 +92,18 @@ def runServiceTest(test_name, server_lib, server_executable, server_extra_args, 
 #      which.append('-v')
   if server_lib == 'java':
     server_args.append('\"')
+  elif server_lib == 'py':
+    server_args.append('--genpydir=' + relfile('py/gen-py'))
   if client_lib == 'java':
     cli_args.append('\"')
+  elif client_lib == 'py':
+    cli_args.append('--genpydir=' + relfile('py/gen-py'))
 
   server_args.extend(server_extra_args)
   cli_args.extend(client_extra_args)
 
-  server_log=open("log/" + test_name + "_server.log","a")
-  client_log=open("log/" + test_name + "_client.log","a")
+  server_log=open(relfile("log/" + test_name + "_server.log"),"a")
+  client_log=open(relfile("log/" + test_name + "_client.log"),"a")
 
   try:
     if options.verbose > 0:
@@ -169,8 +175,8 @@ def runServiceTest(test_name, server_lib, server_executable, server_extra_args, 
              'processes to terminate via alarm'
              % (protocol, use_zlib, use_ssl, extra_sleep))
       time.sleep(extra_sleep)
-    os.kill(serverproc.pid, signal.SIGKILL)
-    serverproc.wait()
+    os.kill(serverproc.pid, signal.SIGTERM)
+    #serverproc.wait()
   client_log.flush()
   server_log.flush()
   client_log.close()
@@ -178,14 +184,15 @@ def runServiceTest(test_name, server_lib, server_executable, server_extra_args, 
 
 test_count = 0
 failed = 0
+hard_fail_count = 0
 platform = platform.system()
-if os.path.exists('log'): shutil.rmtree('log')
-os.makedirs('log')
-if os.path.exists('results.json'): os.remove('results.json')
-results_json = open("results.json","a")
+if os.path.exists(relfile('log')): shutil.rmtree(relfile('log'))
+os.makedirs(relfile('log'))
+if os.path.exists(relfile('results.json')): os.remove(relfile('results.json'))
+results_json = open(relfile("results.json"),"a")
 results_json.write("[\n")
 
-with open('tests.json') as data_file:
+with open(relfile('tests.json')) as data_file:
     data = json.load(data_file)
 
 #subprocess.call("export NODE_PATH=../lib/nodejs/test:../lib/nodejs/lib:${NODE_PATH}")
@@ -217,6 +224,8 @@ for server in data["server"]:
                   ret = runServiceTest(test_name, server_lib, server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, protocol, transport, 9090, 0, sock)
                   if ret != None:
                     failed += 1
+                    if client["exit"] == "hard" and server["exit"] == "hard":
+                      hard_fail_count +=1
                     print "Error: %s" % ret
                     print "Using"
                     print (' Server: %s --protocol=%s --transport=%s %s %s'
@@ -240,6 +249,8 @@ for server in data["server"]:
 
                   if ret != None:
                     failed += 1
+                    if client["exit"] == "hard" and server["exit"] == "hard":
+                      hard_fail_count +=1
                     print "Error: %s" % ret
                     print "Using"
                     print (' Server: %s --protocol=%s --transport=%s %s %s'
@@ -262,6 +273,8 @@ for server in data["server"]:
                   ret = runServiceTest(test_name, server_lib,server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, 'binary', transport, 9090, 0, sock)
                   if ret != None:
                     failed += 1
+                    if client["exit"] == "hard" and server["exit"] == "hard":
+                      hard_fail_count +=1
                     print "Error: %s" % ret
                     print "Using"
                     print (' Server: %s --protocol=%s --transport=%s %s %s'
@@ -277,3 +290,4 @@ results_json.write("\n]")
 results_json.flush()
 results_json.close()
 print '%s failed of %s tests in total' % (failed, test_count)
+sys.exit(hard_fail_count)

--- a/test/tests.json
+++ b/test/tests.json
@@ -4,7 +4,7 @@
             "description": "Python TestClient",
             "lib": "py",
             "executable": "py/TestClient.py",
-            "extra_args":  ["--genpydir=py/gen-py"],
+            "exit": "hard",
             "protocols": [
                 "binary",
                 "compact",
@@ -27,6 +27,7 @@
             "description": "C++ TestClient",
             "lib": "cpp",
             "executable": "cpp/TestClient",
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -50,6 +51,7 @@
             "description": "Nodejs TestClient",
             "lib": "nodejs",
             "executable": "../lib/nodejs/test/client.js",
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -71,6 +73,7 @@
             "description": "Ruby TestClient",
             "lib": "ruby",
             "executable": "rb/integration/TestClient.rb",
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -93,6 +96,7 @@
             "lib": "java",
             "executable": ["ant","-f","../lib/java/build.xml","-Dno-gen-thrift=\"\""],
             "extra_args": ["run-testclient"],
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -118,8 +122,9 @@
             "description": "Python TSimpleServer",
             "lib": "py",
             "executable": "py/TestServer.py",
-            "extra_args": ["--genpydir=py/gen-py", "TSimpleServer"],
+            "extra_args": ["TSimpleServer"],
             "extra_delay": 0,
+            "exit": "hard",
             "protocols": [
                 "binary",
                 "compact",
@@ -142,6 +147,7 @@
             "description": "C++ TestServer",
             "lib": "cpp",
             "executable": "cpp/TestServer",
+            "exit": "hard",
             "protocols": [
                 "binary",
                 "compact",
@@ -165,6 +171,7 @@
             "description": "Ruby TestServer",
             "lib": "ruby",
             "executable": "rb/integration/TestServer.rb",
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -186,6 +193,7 @@
             "description": "Nodejs TestServer",
             "lib": "nodejs",
             "executable": "../lib/nodejs/test/server.js",
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",
@@ -208,6 +216,7 @@
             "lib": "java",
             "executable": ["ant","-f","../lib/java/build.xml","-Dno-gen-thrift=\"\""],
             "extra_args": ["run-testserver"],
+            "exit": "soft",
             "protocols": [
                 "binary",
                 "compact",


### PR DESCRIPTION
Added "exit" feature to tests.json.
Py server, py client and cpp server "exit" is "hard" while others are "soft".
py server - py client and cpp server - py client are the only combination which has all tests running success.
cpp server - cpp server fails when using domain socket.
