### PR TITLE
C# - reduce number of server exceptions

### DIFF
--- a/lib/csharp/src/Server/TSimpleServer.cs
+++ b/lib/csharp/src/Server/TSimpleServer.cs
@@ -118,6 +118,7 @@ namespace Thrift.Server
                   //Process client requests until client disconnects
                   while (true)
                   {
+                    if (!inputTransport.Peek()) break;
                     //Fire processContext server event
                     //N.B. This is the pattern implemented in C++ and the event fires provisionally.
                     //That is to say it may be many minutes between the event firing and the client request

--- a/lib/csharp/src/Server/TThreadPoolServer.cs
+++ b/lib/csharp/src/Server/TThreadPoolServer.cs
@@ -172,6 +172,7 @@ namespace Thrift.Server
         //Process client requests until client disconnects
         while (true)
         {
+          if (!inputTransport.Peek()) break;
           //Fire processContext server event
           //N.B. This is the pattern implemented in C++ and the event fires provisionally.
           //That is to say it may be many minutes between the event firing and the client request

--- a/lib/csharp/src/Server/TThreadedServer.cs
+++ b/lib/csharp/src/Server/TThreadedServer.cs
@@ -204,6 +204,7 @@ namespace Thrift.Server
             //Process client requests until client disconnects
             while (true)
             {
+              if (!inputTransport.Peek()) break;
               //Fire processContext server event
               //N.B. This is the pattern implemented in C++ and the event fires provisionally.
               //That is to say it may be many minutes between the event firing and the client request

--- a/lib/csharp/src/Transport/TTransport.cs
+++ b/lib/csharp/src/Transport/TTransport.cs
@@ -32,10 +32,24 @@ namespace Thrift.Transport
 			get;
 		}
 
-		public bool Peek()
-		{
-			return IsOpen;
-		}
+		private byte[] _peekBuffer = new byte[1];
+        private bool _hasPeekByte = false;
+
+        public bool Peek()
+        {
+            //If we already have a byte read but not consumed, do nothing.
+            if (_hasPeekByte) return true;
+            //If transport closed we can't peek.
+            if (!IsOpen) return false;
+            //Try to read one byte. If succeeds we will need to store it for the next read.
+            int bytes = Read(_peekBuffer, 0, 1);
+            if (bytes == 0)
+            {
+                return false;
+            }
+            _hasPeekByte = true;
+            return true;
+        }
 
 		public abstract void Open();
 
@@ -46,21 +60,25 @@ namespace Thrift.Transport
 		public int ReadAll(byte[] buf, int off, int len)
 		{
 			int got = 0;
-			int ret = 0;
 
-			while (got < len)
-			{
-				ret = Read(buf, off + got, len - got);
-				if (ret <= 0)
-				{
-					throw new TTransportException(
-						TTransportException.ExceptionType.EndOfFile,
-						"Cannot read, Remote side has closed");
-				}
-				got += ret;
-			}
-
-			return got;
+            //If we previously peeked a byte, we need to use that first.
+            if (_hasPeekByte)
+            {
+                buf[off + got++] = _peekBuffer[0];
+                _hasPeekByte = false;
+            }
+            while (got < len)
+            {
+                int ret = Read(buf, off + got, len - got);
+                if (ret <= 0)
+                {
+                    throw new TTransportException(
+                        TTransportException.ExceptionType.EndOfFile,
+                        "Cannot read, Remote side has closed");
+                }
+                got += ret;
+            }
+            return got;
 		}
 
 		public virtual void Write(byte[] buf) 


### PR DESCRIPTION
The current server implementation reads in a loop until the client closes, at which point an exception is thrown by the processor/transport and caught by the server.

I solve this by creating a smarter peek functionality in TTransport which reads and caches a byte from the underlying transport and reinserts it in ReadAll.  
