### PR TITLE
THRIFT-2655 CPP tests should not use relative path when accessing ssh related files

### DIFF
--- a/contrib/installCXXDependencies.sh
+++ b/contrib/installCXXDependencies.sh
@@ -25,5 +25,5 @@
 # General dependencies
 sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
 sudo apt-get update -qq
-sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make libqt4-dev git debhelper bc 
+sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make libqt4-dev git debhelper bc 
 dpkg -S /usr/include/boost/version.hpp

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -59,7 +59,7 @@ TestServer_LDADD = \
 	$(top_builddir)/lib/cpp/libthrift.la \
 	$(top_builddir)/lib/cpp/libthriftz.la \
 	$(top_builddir)/lib/cpp/libthriftnb.la \
-	-levent -lboost_program_options
+	-levent -lboost_program_options -lboost_system -lboost_filesystem
 
 TestClient_SOURCES = \
 	src/TestClient.cpp
@@ -69,7 +69,7 @@ TestClient_LDADD = \
 	$(top_builddir)/lib/cpp/libthrift.la \
 	$(top_builddir)/lib/cpp/libthriftz.la \
 	$(top_builddir)/lib/cpp/libthriftnb.la \
-	-levent -lboost_program_options
+	-levent -lboost_program_options -lboost_system -lboost_filesystem
 
 StressTest_SOURCES = \
 	src/StressTest.cpp

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -33,6 +33,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
 #include <thrift/cxxfunctional.h>
 #if _WIN32
    #include <thrift/windows/TWinsockSingleton.h>
@@ -46,6 +47,9 @@ using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
 using namespace thrift::test;
 using namespace apache::thrift::async;
+
+// Length of argv[0] - Length of script dir
+#define EXECUTABLE_FILE_NAME_LENGTH 19
 
 //extern uint32_t g_socket_syscalls;
 
@@ -92,6 +96,8 @@ static void testVoid_clientReturn(const char* host, int port, event_base *base, 
 }
 
 int main(int argc, char** argv) {
+  string file_path = boost::filesystem::system_complete(argv[0]).string();
+  string dir_path = file_path.substr(0, file_path.size()-EXECUTABLE_FILE_NAME_LENGTH);
 #if _WIN32
   transport::TWinsockSingleton::create();
 #endif
@@ -155,7 +161,7 @@ int main(int argc, char** argv) {
   if (vm.count("ssl")) {
     ssl = true;
   }
-  
+
   if (vm.count("noinsane")) {
     noinsane = true;
   }
@@ -169,7 +175,7 @@ int main(int argc, char** argv) {
   if (ssl) {
     factory = boost::shared_ptr<TSSLSocketFactory>(new TSSLSocketFactory());
     factory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
-    factory->loadTrustedCertificates("keys/CA.pem");
+    factory->loadTrustedCertificates((dir_path + "../keys/CA.pem").c_str());
     factory->authenticate(true);
     socket = factory->createSocket(host, port);
   } else {

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -45,6 +45,7 @@
 #include <sstream>
 
 #include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
 #include <thrift/cxxfunctional.h>
 
 #include <signal.h>
@@ -62,6 +63,9 @@ using namespace apache::thrift::server;
 using namespace apache::thrift::async;
 
 using namespace thrift::test;
+
+// Length of argv[0] - Length of script dir
+#define EXECUTABLE_FILE_NAME_LENGTH 19
 
 class TestHandler : public ThriftTestIf {
  public:
@@ -494,7 +498,11 @@ protected:
 
 
 int main(int argc, char **argv) {
-#if _WIN32
+
+  string file_path = boost::filesystem::system_complete(argv[0]).string();
+  string dir_path = file_path.substr(0, file_path.size()-EXECUTABLE_FILE_NAME_LENGTH);
+
+  #if _WIN32
   transport::TWinsockSingleton::create();
 #endif
   int port = 9090;
@@ -600,8 +608,8 @@ int main(int argc, char **argv) {
 
   if (ssl) {
     sslSocketFactory = boost::shared_ptr<TSSLSocketFactory>(new TSSLSocketFactory());
-    sslSocketFactory->loadCertificate("keys/server.crt");
-    sslSocketFactory->loadPrivateKey("keys/server.key");
+    sslSocketFactory->loadCertificate((dir_path + "../keys/server.crt").c_str());
+    sslSocketFactory->loadPrivateKey((dir_path + "../keys/server.key").c_str());
     sslSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
     serverSocket = boost::shared_ptr<TServerSocket>(new TSSLServerSocket(port, sslSocketFactory));
   } else {


### PR DESCRIPTION
Need a doc update for http://thrift.apache.org/docs/install/debian . 
