### PR TITLE
THRIFT-2652 THRIFT_TEST_PORT variable via to run tests in parallel

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -231,7 +231,7 @@ for server in data["server"]:
                     count = 1
                     results_json.write("\t[\n\t\t\"" + server_lib + "\",\n\t\t\"" + client_lib + "\",\n\t\t\"" + protocol + "\",\n\t\t\"" + transport + "-" + sock + "\",\n" )
                     test_name = server_lib + "_" + client_lib + "_" + protocol + "_" + transport + "_" + sock
-                    ret = runServiceTest(test_name, server_lib, server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, protocol, transport, 9090, 0, sock)
+                    ret = runServiceTest(test_name, server_lib, server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, protocol, transport, options.port, 0, sock)
                     if ret != None:
                       failed += 1
                       if client["exit"] == "hard" and server["exit"] == "hard":
@@ -255,7 +255,7 @@ for server in data["server"]:
                     count = 1
                     results_json.write("\t[\n\t\t\"" + server_lib + "\",\n\t\t\"" + client_lib + "\",\n\t\t\"accel-binary\",\n\t\t\"" + transport + "-" + sock + "\",\n" )
                     test_name = server_lib + "_" + client_lib + "_accel-binary_" + transport + "_" + sock
-                    ret = runServiceTest(test_name, server_lib,server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, 'accel', transport, 9090, 0, sock)
+                    ret = runServiceTest(test_name, server_lib,server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, 'accel', transport, options.port, 0, sock)
 
                     if ret != None:
                       failed += 1
@@ -280,7 +280,7 @@ for server in data["server"]:
                     count = 1
                     results_json.write("\t[\n\t\t\"" + server_lib + "\",\n\t\t\"" + client_lib + "\",\n\t\t\"binary-accel\",\n\t\t\"" + transport + "-" + sock + "\",\n" )
                     test_name = server_lib + "_" + client_lib + "_binary-accel_" + transport + "_" + sock
-                    ret = runServiceTest(test_name, server_lib,server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, 'binary', transport, 9090, 0, sock)
+                    ret = runServiceTest(test_name, server_lib,server_executable, server_extra_args, client_lib, client_executable, client_extra_args, protocol, 'binary', transport, options.port, 0, sock)
                     if ret != None:
                       failed += 1
                       if client["exit"] == "hard" and server["exit"] == "hard":

--- a/test/test.sh
+++ b/test/test.sh
@@ -116,14 +116,14 @@ do_test () {
     server_exec=$5
     client_timeout=$6
     server_startup_time=$7
-    
+
     testname=${client_server}_${protocol}_${transport}
     server_timeout=$(echo "(${server_startup_time}+${client_timeout})" | bc)
     printf "%-16s %-13s %-17s" ${client_server} ${protocol} ${transport}
-    
+
     timeout $server_timeout $server_exec > log/${testname}_server.log 2>&1 &
     server_pid=$!
-    
+
     sleep $server_startup_time
     timeout $client_timeout $client_exec > log/${testname}_client.log 2>&1
 
@@ -165,6 +165,11 @@ EOF
 }
 
 echo "Apache Thrift - integration test suite"
+if [ "$#" -eq "0" ]; then
+  THRIFT_TEST_PORT=9090
+else
+  THRIFT_TEST_PORT=$1
+fi
 date
 
 
@@ -221,8 +226,8 @@ for proto in $java_protocols; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-java" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testserver" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "5" "1"
     done
   done
@@ -238,8 +243,8 @@ for proto in $cpp_protocols; do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "cpp-cpp"   "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "2" "0.1"
     done
   done
@@ -256,8 +261,8 @@ for proto in $(intersection "${java_protocols}" "${cpp_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-cpp" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}"\
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}"\
               "5" "0.1"
     done
   done
@@ -272,8 +277,8 @@ for proto in $(intersection "${cpp_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-java" "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans}  ${extraparam}\" run-testserver" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT}  ${extraparam}\" run-testserver" \
               "5" "1"
     done
   done
@@ -291,8 +296,8 @@ for proto in ${nodejs_protocols}; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-nodejs" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "0.2"
     done
   done
@@ -307,8 +312,8 @@ for proto in $(intersection "${nodejs_protocols}" "${cpp_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-cpp" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "0.2"
     done
   done
@@ -323,8 +328,8 @@ for proto in $(intersection "${nodejs_protocols}" "${cpp_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-nodejs" "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "2"
     done
   done
@@ -339,8 +344,8 @@ for proto in $(intersection "${nodejs_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-java" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testserver" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "5" "1"
     done
   done
@@ -355,8 +360,8 @@ for proto in $(intersection "${nodejs_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-nodejs" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "2"
     done
   done
@@ -371,8 +376,8 @@ for proto in ${py_protocols}; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-py" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport={trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "py/TestServer.py --protocol=${proto} --transport={trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "py/TestClient.py --protocol=${proto} --transport={trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "py/TestServer.py --protocol=${proto} --transport={trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -385,12 +390,12 @@ for trans in ${py_transports}; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-py" "accel-binary" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "py/TestServer.py --protocol=binary --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "py/TestServer.py --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
       do_test "py-py" "binary-accel" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=binary --transport={trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "py/TestServer.py --protocol=accel --transport={trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "py/TestClient.py --protocol=binary --transport={trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "py/TestServer.py --protocol=accel --transport={trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -404,8 +409,8 @@ for proto in $(intersection "${cpp_protocols}" "${py_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-cpp" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "2"
     done
   done
@@ -418,8 +423,8 @@ for trans in $(intersection "${cpp_transports}" "${py_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-cpp" "accel-binary" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "cpp/TestServer --protocol=binary --transport=${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "cpp/TestServer --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "2"
     done
   done
@@ -433,8 +438,8 @@ for proto in $(intersection "${cpp_protocols}" "${py_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-py" "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -447,8 +452,8 @@ for trans in $(intersection "${cpp_transports}" "${py_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-py" "binary-accel" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=binary --transport=${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=accel --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "cpp/TestClient --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -462,8 +467,8 @@ for proto in $(intersection "${py_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-java" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testserver" \
+              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "15" "2"
     done
   done
@@ -476,8 +481,8 @@ for trans in $(intersection "${py_transports}" "${java_server_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-java" "accel-binary" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} ${extraparam}\" run-testserver" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "15" "2"
     done
   done
@@ -491,8 +496,8 @@ for proto in $(intersection "${py_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-py" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "5"
     done
   done
@@ -505,8 +510,8 @@ for trans in $(intersection "${py_transports}" "${java_client_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-py" "binary-accel" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} ${extraparam}\" run-testclient" \
-              "py/TestServer.py --protocol=accel --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "py/TestServer.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "5"
     done
   done
@@ -520,8 +525,8 @@ for proto in $(intersection "${py_protocols}" "${nodejs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-nodejs" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "15" "2"
     done
   done
@@ -534,8 +539,8 @@ for trans in $(intersection "${py_transports}" "${nodejs_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-nodejs" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "node ${NODE_TEST_DIR}/server.js -p binary -t ${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p binary -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "15" "2"
     done
   done
@@ -549,8 +554,8 @@ for proto in $(intersection "${py_protocols}" "${nodejs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-py" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -563,8 +568,8 @@ for trans in $(intersection "${py_transports}" "${nodejs_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-py" "binary-accel" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p binary -t ${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=accel --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "node ${NODE_TEST_DIR}/client.js -p binary -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -578,8 +583,8 @@ for proto in ${ruby_protocols}; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-ruby" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=9091" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=9091" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -592,12 +597,12 @@ for trans in ${ruby_transports}; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-ruby" "accel-binary" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=9091" \
-              "ruby rb/integration/TestServer.rb --protocol=binary --transport=${trans} --port=9091" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
       do_test "ruby-ruby" "binary-accel" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=binary --transport=${trans} --port=9091" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=9091" \
+              "ruby rb/integration/TestClient.rb --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -611,8 +616,8 @@ for proto in $(intersection "${cpp_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-cpp" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans}" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -625,8 +630,8 @@ for trans in $(intersection "${cpp_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-cpp" "accel-binary" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans}" \
-              "cpp/TestServer --protocol=binary --transport=${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "cpp/TestServer --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -640,8 +645,8 @@ for proto in $(intersection "${cpp_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-ruby" "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans}" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -654,8 +659,8 @@ for trans in $(intersection "${cpp_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "cpp-ruby" "binary-accel" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=binary --transport=${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans}" \
+              "cpp/TestClient --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -669,8 +674,8 @@ for proto in $(intersection "${ruby_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-java" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testserver" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "15" "5"
     done
   done
@@ -683,8 +688,8 @@ for trans in $(intersection "${ruby_transports}" "${java_server_transports}"); d
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-java" "accel-binary" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} ${extraparam}\" run-testserver" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "15" "5"
     done
   done
@@ -698,8 +703,8 @@ for proto in $(intersection "${ruby_protocols}" "${java_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-ruby" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "5"
     done
   done
@@ -712,8 +717,8 @@ for trans in $(intersection "${ruby_transports}" "${java_client_transports}"); d
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "java-ruby" "binary-accel" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} ${extraparam}\" run-testclient" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "5"
     done
   done
@@ -727,8 +732,8 @@ for proto in $(intersection "${ruby_protocols}" "${nodejs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-nodejs" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans}" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "2"
     done
   done
@@ -741,8 +746,8 @@ for trans in $(intersection "${ruby_transports}" "${nodejs_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-nodejs" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans}" \
-              "node ${NODE_TEST_DIR}/server.js -p binary -t ${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p binary -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "2"
     done
   done
@@ -756,8 +761,8 @@ for proto in $(intersection "${ruby_protocols}" "${nodejs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-ruby" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans}" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "5"
     done
   done
@@ -770,8 +775,8 @@ for trans in $(intersection "${ruby_transports}" "${nodejs_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-ruby" "binary-accel" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p binary -t ${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans}" \
+              "node ${NODE_TEST_DIR}/client.js -p binary -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "2"
     done
   done
@@ -785,8 +790,8 @@ for proto in $(intersection "${py_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-ruby" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans}" \
+              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "15" "5"
     done
   done
@@ -799,12 +804,12 @@ for trans in $(intersection "${py_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-ruby" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=binary --transport=${trans}" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "15" "5"
       do_test "py-ruby" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=binary --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans}" \
+              "py/TestClient.py --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "15" "5"
     done
   done
@@ -818,8 +823,8 @@ for proto in $(intersection "${py_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-py" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans}" \
-              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "5" "2"
     done
   done
@@ -832,12 +837,12 @@ for trans in $(intersection "${py_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-py" "binary-accel" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=binary --transport=${trans}" \
-              "py/TestServer.py --protocol=accel --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "5" "2"
       do_test "ruby-py" "accel-binary" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans}" \
-              "py/TestServer.py --protocol=binary --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "5" "2"
     done
   done
@@ -852,8 +857,8 @@ for proto in $hs_protocols; do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "hs-hs"   "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "2" "0.1"
     done
   done
@@ -869,8 +874,8 @@ for proto in $(intersection "${hs_protocols}" "${cpp_protocols}"); do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "hs-cpp"   "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "cpp/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "cpp/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "2" "0.1"
     done
   done
@@ -886,8 +891,8 @@ for proto in $(intersection "${hs_protocols}" "${cpp_protocols}"); do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "cpp-hs"   "${proto}" "${trans}-${sock}" \
-              "cpp/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "cpp/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "2" "0.1"
     done
   done
@@ -903,8 +908,8 @@ for proto in $(intersection "${hs_protocols}" "${java_protocols}"); do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "hs-java" "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-        "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testserver" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+        "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testserver" \
               "5" "1"
     done
   done
@@ -920,8 +925,8 @@ for proto in $(intersection "${hs_protocols}" "${java_protocols}"); do
        "domain" ) extraparam="--domain-socket=/tmp/ThriftTest.thrift";;
       esac
       do_test "java-hs" "${proto}" "${trans}-${sock}" \
-              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} ${extraparam}\" run-testclient" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "ant -f  ../lib/java/build.xml -Dno-gen-thrift=\"\" -Dtestargs \"--protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --port=${THRIFT_TEST_PORT} ${extraparam}\" run-testclient" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "1"
     done
   done
@@ -936,8 +941,8 @@ for proto in $(intersection "${hs_protocols}" "${py_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-hs" "${proto}" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "2"
     done
   done
@@ -950,8 +955,8 @@ for trans in $(intersection "${hs_transports}" "${py_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "py-hs" "accel-binary" "${trans}-${sock}" \
-              "py/TestClient.py --protocol=accel --transport=${trans} --port=9090 --host=localhost --genpydir=gen-py ${extraparam}" \
-              "hs/TestServer --protocol=binary --transport=${trans} ${extraparam}" \
+              "py/TestClient.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --host=localhost --genpydir=gen-py ${extraparam}" \
+              "hs/TestServer --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "10" "2"
     done
   done
@@ -965,8 +970,8 @@ for proto in $(intersection "${hs_protocols}" "${py_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "hs-py" "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -979,8 +984,8 @@ for trans in $(intersection "${hs_transports}" "${py_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "hs-py" "binary-accel" "${trans}-${sock}" \
-              "hs/TestClient --protocol=binary --transport=${trans} ${extraparam}" \
-              "py/TestServer.py --protocol=accel --transport=${trans} --port=9090 --genpydir=gen-py TSimpleServer ${extraparam}" \
+              "hs/TestClient --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "py/TestServer.py --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} --genpydir=gen-py TSimpleServer ${extraparam}" \
               "10" "2"
     done
   done
@@ -994,8 +999,8 @@ for proto in $(intersection "${nodejs_protocols}" "${hs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "nodejs-hs" "${proto}" "${trans}-${sock}" \
-              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} ${extraparam}" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/client.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "0.2"
     done
   done
@@ -1010,8 +1015,8 @@ for proto in $(intersection "${nodejs_protocols}" "${hs_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "hs-nodejs" "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} ${extraparam}" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "node ${NODE_TEST_DIR}/server.js -p ${proto} -t ${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "2"
     done
   done
@@ -1026,8 +1031,8 @@ for proto in $(intersection "${hs_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-hs" "${proto}" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans}" \
-              "hs/TestServer --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "hs/TestServer --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -1040,8 +1045,8 @@ for trans in $(intersection "${hs_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "ruby-cpp" "accel-binary" "${trans}-${sock}" \
-              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans}" \
-              "hs/TestServer --protocol=binary --transport=${trans} ${extraparam}" \
+              "ruby rb/integration/TestClient.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam} ${extraparam}" \
+              "hs/TestServer --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -1055,8 +1060,8 @@ for proto in $(intersection "${hs_protocols}" "${ruby_protocols}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "hs-ruby" "${proto}" "${trans}-${sock}" \
-              "hs/TestClient --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans}" \
+              "hs/TestClient --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -1069,8 +1074,8 @@ for trans in $(intersection "${hs_transports}" "${ruby_transports}"); do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "hs-ruby" "binary-accel" "${trans}-${sock}" \
-              "hs/TestClient --protocol=binary --transport=${trans} ${extraparam}" \
-              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans}" \
+              "hs/TestClient --protocol=binary --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "ruby rb/integration/TestServer.rb --protocol=accel --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "5"
     done
   done
@@ -1089,8 +1094,8 @@ for proto in $csharp_protocols; do
         "ip-ssl" ) extraparam="--ssl";;
       esac
       do_test "csharp-csharp"   "${proto}" "${trans}-${sock}" \
-              "../lib/csharp/test/ThriftTest/TestClientServer.exe client --protocol=${proto} --transport=${trans} ${extraparam}" \
-              "../lib/csharp/test/ThriftTest/TestClientServer.exe server --protocol=${proto} --transport=${trans} ${extraparam}" \
+              "../lib/csharp/test/ThriftTest/TestClientServer.exe client --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
+              "../lib/csharp/test/ThriftTest/TestClientServer.exe server --protocol=${proto} --transport=${trans} --port=${THRIFT_TEST_PORT} ${extraparam}" \
               "5" "1"
     done
   done
@@ -1102,11 +1107,11 @@ do_test "js-java"   "json"  "http-ip" \
         "2" "2"
 do_test "perl-cpp"  "binary" "buffered-ip" \
         "perl -I perl/gen-perl/ -I../lib/perl/lib/ perl/TestClient.pl" \
-        "cpp/TestServer" \
+        "cpp/TestServer  --port=${THRIFT_TEST_PORT}" \
         "10" "2"
 do_test "php-cpp"  "binary" "buffered-ip" \
         "make -C php/ client" \
-        "cpp/TestServer" \
+        "cpp/TestServer --port=${THRIFT_TEST_PORT}" \
         "10" "2"
 
 echo " failed tests are logged to test/log/error.log"


### PR DESCRIPTION
python test.py --port=9091
./test.sh 9090
