### PR TITLE
Add getOrigin() function to TTransport

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -126,7 +126,6 @@ class TBufferBase : public TVirtualTransport<TBufferBase> {
     }
   }
 
-
  protected:
 
   /// Slow path read.
@@ -253,6 +252,12 @@ class TBufferedTransport
 
   void flush();
 
+  /**
+   * Returns the origin of the underlying transport
+   */
+  virtual const std::string getOrigin() {
+    return transport_->getOrigin();
+  }
 
   /**
    * The following behavior is currently implemented by TBufferedTransport,
@@ -391,6 +396,13 @@ class TFramedTransport
    */
   uint32_t readAll(uint8_t* buf, uint32_t len) {
     return TBufferBase::readAll(buf,len);
+  }
+
+  /**
+   * Returns the origin of the underlying transport
+   */
+  virtual const std::string getOrigin() {
+    return transport_->getOrigin();
   }
 
  protected:

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -49,6 +49,8 @@ void THttpServer::parseHeader(char* header) {
   } else if (strncmp(header, "Content-Length", sz) == 0) {
     chunked_ = false;
     contentLength_ = atoi(value);
+  } else if (strncmp(header, "X-Forwarded-For", sz) == 0) {
+    origin_ = value;
   }
 }
 

--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <sstream>
+
 #include <thrift/transport/THttpTransport.h>
 
 namespace apache { namespace thrift { namespace transport {
@@ -29,6 +31,7 @@ const int THttpTransport::CRLF_LEN = 2;
 
 THttpTransport::THttpTransport(boost::shared_ptr<TTransport> transport) :
   transport_(transport),
+  origin_(""),
   readHeaders_(true),
   chunked_(false),
   chunkedDone_(false),
@@ -247,6 +250,15 @@ void THttpTransport::readHeaders() {
 
 void THttpTransport::write(const uint8_t* buf, uint32_t len) {
   writeBuffer_.write(buf, len);
+}
+
+const std::string THttpTransport::getOrigin() {
+  std::ostringstream oss;
+  if ( !origin_.empty()) {
+    oss << origin_ << ", ";
+  }
+  oss << transport_->getOrigin();
+  return oss.str();
 }
 
 }}}

--- a/lib/cpp/src/thrift/transport/THttpTransport.h
+++ b/lib/cpp/src/thrift/transport/THttpTransport.h
@@ -62,9 +62,12 @@ class THttpTransport : public TVirtualTransport<THttpTransport> {
 
   virtual void flush() = 0;
 
+  virtual const std::string getOrigin();
+
  protected:
 
   boost::shared_ptr<TTransport> transport_;
+  std::string origin_;
 
   TMemoryBuffer writeBuffer_;
   TMemoryBuffer readBuffer_;

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -841,4 +841,10 @@ bool TSocket::getUseLowMinRto() {
   return useLowMinRto_;
 }
 
+const std::string TSocket::getOrigin() {
+  std::ostringstream oss;
+  oss << getPeerHost() << ":" << getPeerPort();
+  return oss.str();
+}
+
 }}} // apache::thrift::transport

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -235,6 +235,13 @@ class TSocket : public TVirtualTransport<TSocket> {
   static bool getUseLowMinRto();
 
   /**
+   * Get the origin the socket is connected to
+   *
+   * @return string peer host identifier and port
+   */
+  virtual const std::string getOrigin();
+
+  /**
    * Constructor to create socket from raw UNIX handle.
    */
   TSocket(THRIFT_SOCKET socket);

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -237,6 +237,18 @@ class TTransport {
                               "Base TTransport cannot consume.");
   }
 
+  /**
+   * Returns the origin of the transports call. The value depends on the
+   * transport used. An IP based transport for example will return the
+   * IP address of the client making the request.
+   * If the transport doesn't know the origin Unknown is returned.
+   *
+   * The returned value can be used in a log message for example
+   */
+  virtual const std::string getOrigin() {
+    return "Unknown";
+  }
+
  protected:
   /**
    * Simple constructor.


### PR DESCRIPTION
getOrigin returns the origin of a request, the value depends on the transport used

See: THRIFT-2672
