### PR TITLE
PHP: do not generate validator code for service *_result classes

### DIFF
--- a/lib/php/test/Test/Thrift/TestValidators.php
+++ b/lib/php/test/Test/Thrift/TestValidators.php
@@ -96,6 +96,10 @@ assert_has_no_write_validator('ThriftTest\EmptyStruct');
 // Unions should not get write validators
 assert_has_no_write_validator('TestValidators\UnionOfStrings');
 
+// Service _result classes should not get any validators
+assert_has_no_read_validator('TestValidators\TestService_test_result');
+assert_has_no_write_validator('TestValidators\TestService_test_result');
+
 function assert_has_a_read_validator($class) {
     my_assert(has_read_validator_method($class),
               $class . ' class should have a read validator');

--- a/lib/php/test/TestValidators.thrift
+++ b/lib/php/test/TestValidators.thrift
@@ -26,3 +26,6 @@ union UnionOfStrings {
   2: string bb; 
 } 
 
+service TestService {
+    void test() throws(1: ThriftTest.Xception xception);
+}


### PR DESCRIPTION
When generating service code with --gen php:validate, the generated code has validators that effectively require all declared exceptions to be thrown at the same time.
