### PR TITLE
JavaScript: set Accept: and Content-Type: headers in request

### DIFF
--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -327,7 +327,11 @@ Thrift.TXHRTransport.prototype = {
         var xreq = this.getXmlHttpRequestObject();
 
         if (xreq.overrideMimeType) {
-            xreq.overrideMimeType('application/json');
+            xreq.overrideMimeType('application/vnd.apache.thrift.json; charset=utf-8');
+        }
+        if (xreq.setRequestHeader) {
+            xreq.setRequestHeader('Accept', 'application/vnd.apache.thrift.json; charset=utf-8');
+            xreq.setRequestHeader('Content-Type', 'application/vnd.apache.thrift.json; charset=utf-8');
         }
 
         if (callback) {
@@ -387,7 +391,7 @@ Thrift.TXHRTransport.prototype = {
             data: postData,
             type: 'POST',
             cache: false,
-            contentType: 'application/json',
+            contentType: 'application/vnd.apache.thrift.json; charset=utf-8',
             dataType: 'text thrift',
             converters: {
                 'text thrift' : function(responseData) {


### PR DESCRIPTION
When a JS client communicates with a backend supporting several encodings, knowing which protocol to use is a bit kludgy. This patch tries to fix that by always setting the Accept: and Content-Type: request headers to "application/json".