### PR TITLE
THRIFT-2676 Avoid 'i386' name collision in generated Cocoa/objc code

### DIFF
--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -2098,7 +2098,7 @@ void t_cocoa_generator::generate_serialize_container(ofstream& out,
     indent(out) << "id " << key << ";" << endl;
     indent(out) << "while ((" << key << " = [" << iter << " nextObject]))" << endl;
   } else if (ttype->is_list()) {
-    key = tmp("i");
+    key = tmp("idx");
     indent(out) << "int " << key << ";" << endl;
     indent(out) <<
       "for (" << key << " = 0; " << key << " < [" << fieldName << " count]; " << key << "++)" << endl;


### PR DESCRIPTION
[THRIFT-2676](https://issues.apache.org/jira/browse/THRIFT-2676)

This fixes a bug in the cocoa code generator where the variable
used by a for-loop can conflict with a built-in symbol when the
temporary variable counter is equal to 386. The generated variable
name, 'i386', conflicts with a macro built-in to the compiler.

I can reproduce this bug on Xcode 5 as well as Xcode 6. It appears
to only affect iOS projects, not OS X projects.

My fix simply prefixes the generated variable with 'idx' instead of 'i'.

This test code demonstrates the problem, regardless of Thrift codegen.

```
int i386 = 42;
printf("foobar %d\n", i386);
```

Which results in the following compiler error:

```
/Users/keith/Desktop/ReservedSymbolTest/ReservedSymbolTest/ViewController.m:22:7: error: expected identifier or '('
  int i386 = 42;
      ^
<built-in>:143:14: note: expanded from here
             ^
1 error generated.
```
