### PR TITLE
Update TForkingServer.php

### DIFF
--- a/lib/php/lib/Thrift/Server/TForkingServer.php
+++ b/lib/php/lib/Thrift/Server/TForkingServer.php
@@ -84,7 +84,7 @@ class TForkingServer extends TServer {
       $outputTransport = $this->outputTransportFactory_->getTransport($transport);
       $inputProtocol = $this->inputProtocolFactory_->getProtocol($inputTransport);
       $outputProtocol = $this->outputProtocolFactory_->getProtocol($outputTransport);
-      while ($this->processor_->process($inputProtocol, $outputProtocol)) { }
+      $this->processor_->process($inputProtocol, $outputProtocol);
       @$transport->close();
     }
     catch (TTransportException $e) { }


### PR DESCRIPTION
The while() statement was causing the forked children to handle one request and then just spin without doing anything. By connecting to the server multiple times, you would end up with lots of children processes that wouldn't exit, but consume processor time. 
The fix is to handle one request per child and then exit.
