### PR TITLE
Thrift-1857: Python 3 support, redux

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -802,7 +802,7 @@ void t_py_generator::generate_py_struct_definition(ofstream& out,
     out <<
       indent() << "def __repr__(self):" << endl <<
       indent() << "  L = ['%s=%r' % (key, value)" << endl <<
-      indent() << "    for key, value in self.__dict__.iteritems()]" << endl <<
+      indent() << "    for key, value in self.__dict__.items()]" << endl <<
       indent() << "  return '%s(%s)' % (self.__class__.__name__, ', '.join(L))" << endl <<
       endl;
 
@@ -2202,7 +2202,7 @@ void t_py_generator::generate_deserialize_container(ofstream &out,
   // For loop iterates over elements
   string i = tmp("_i");
   indent(out) <<
-    "for " << i << " in xrange(" << size << "):" << endl;
+    "for " << i << " in range(" << size << "):" << endl;
 
     indent_up();
 

--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -1987,7 +1987,7 @@ void t_py_generator::generate_process_function(t_service* tservice,
       indent_down();
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
         f_service_ <<
-          indent() << "except " << type_name((*x_iter)->get_type()) << ", " << (*x_iter)->get_name() << ":" << endl;
+          indent() << "except " << type_name((*x_iter)->get_type()) << " as " << (*x_iter)->get_name() << ":" << endl;
         if (!tfunction->is_oneway()) {
           indent_up();
           f_service_ <<

--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -373,7 +373,7 @@ void t_py_generator::init_generator() {
   f_consts_ <<
     py_autogen_comment() << endl <<
     py_imports() << endl <<
-    "from ttypes import *" << endl <<
+    "from .ttypes import *" << endl <<
     endl;
 }
 
@@ -1044,7 +1044,7 @@ void t_py_generator::generate_service(t_service* tservice) {
   }
 
   f_service_ <<
-    "from ttypes import *" << endl <<
+    "from .ttypes import *" << endl <<
     "from thrift.Thrift import TProcessor" << endl <<
     render_fastbinary_includes() << endl;
 
@@ -1516,7 +1516,10 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
     py_autogen_comment() << endl <<
     "import sys" << endl <<
     "import pprint" << endl <<
-    "from urlparse import urlparse" << endl <<
+    "if sys.version_info[0] == 3:" << endl <<
+    "  from urllib.parse import urlparse" << endl <<
+    "else:" << endl <<
+    "  from urlparse import urlparse" << endl <<
     "from thrift.transport import TTransport" << endl <<
     "from thrift.transport import TSocket" << endl <<
     "from thrift.transport import TSSLSocket" << endl <<
@@ -1907,7 +1910,7 @@ void t_py_generator::generate_process_function(t_service* tservice,
         indent() << "  error.raiseException()" << endl;
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
         f_service_ <<
-          indent() << "except " << type_name((*x_iter)->get_type()) << ", " << (*x_iter)->get_name() << ":" << endl;
+          indent() << "except " << type_name((*x_iter)->get_type()) << " as " << (*x_iter)->get_name() << ":" << endl;
         if (!tfunction->is_oneway()) {
           indent_up();
           f_service_ <<
@@ -2046,7 +2049,7 @@ void t_py_generator::generate_process_function(t_service* tservice,
       indent_down();
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
         f_service_ <<
-          indent() << "except " << type_name((*x_iter)->get_type()) << ", " << (*x_iter)->get_name() << ":" << endl;
+          indent() << "except " << type_name((*x_iter)->get_type()) << " as " << (*x_iter)->get_name() << ":" << endl;
         if (!tfunction->is_oneway()) {
           indent_up();
           f_service_ <<

--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -1252,7 +1252,7 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       indent() << "    try:" << endl <<
       indent() << "      frame = yield self._transport.readFrame()" << endl <<
       indent() << "    except TTransport.TTransportException as e:" << endl <<
-      indent() << "      for future in self._reqs.itervalues():" << endl <<
+      indent() << "      for future in self._reqs.values():" << endl <<
       indent() << "        future.set_exception(e)" << endl <<
       indent() << "      self._reqs = {}" << endl <<
       indent() << "      return" << endl <<

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -77,6 +77,7 @@ def run_setup(with_binary):
         author_email = 'dev@thrift.apache.org',
         url = 'http://thrift.apache.org',
         license = 'Apache License 2.0',
+        install_requires=['six>=1.7.2'],
         packages = [
             'thrift',
             'thrift.protocol',
@@ -90,6 +91,7 @@ def run_setup(with_binary):
             'Intended Audience :: Developers',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 3',
             'Topic :: Software Development :: Libraries',
             'Topic :: System :: Networking'
         ],

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -19,6 +19,7 @@
 # under the License.
 #
 
+import platform
 import sys
 try:
     from setuptools import setup, Extension
@@ -69,7 +70,7 @@ def run_setup(with_binary):
         )
     else:
         extensions = dict()
-        
+
     setup(name = 'thrift',
         version = '1.0.0-dev',
         description = 'Python bindings for the Apache Thrift RPC system',
@@ -95,12 +96,16 @@ def run_setup(with_binary):
             'Topic :: Software Development :: Libraries',
             'Topic :: System :: Networking'
         ],
-        use_2to3 = True,
         **extensions
     )
 
 try:
-    run_setup(True)
+    with_binary = False
+    # Don't even try to build the C module unless we're on CPython 2.x.
+    # TODO: fix it for CPython 3.x
+    if platform.python_implementation() == 'CPython' and sys.version_info < (3,):
+        with_binary = True
+    run_setup(with_binary)
 except BuildFailed:
     print()
     print('*' * 80)

--- a/lib/py/src/TSCons.py
+++ b/lib/py/src/TSCons.py
@@ -19,6 +19,8 @@
 
 from os import path
 from SCons.Builder import Builder
+from six.moves import map
+from six.moves import zip
 
 
 def scons_env(env, add=''):

--- a/lib/py/src/TSerialization.py
+++ b/lib/py/src/TSerialization.py
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-from protocol import TBinaryProtocol
-from transport import TTransport
+from .protocol import TBinaryProtocol
+from .transport import TTransport
 
 
 def serialize(thrift_object,

--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -22,7 +22,7 @@ import logging
 import socket
 import struct
 
-from .thrift.transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
+from .transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
 
 from io import BytesIO
 from collections import deque

--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -22,7 +22,7 @@ import logging
 import socket
 import struct
 
-from thrift.transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
+from .thrift.transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
 
 from io import BytesIO
 from collections import deque

--- a/lib/py/src/protocol/TBase.py
+++ b/lib/py/src/protocol/TBase.py
@@ -74,8 +74,8 @@ class TExceptionBase(Exception):
   #  This can't inherit from TBase because of that limitation.
   __slots__ = []
 
-  __repr__ = TBase.__repr__.im_func
-  __eq__ = TBase.__eq__.im_func
-  __ne__ = TBase.__ne__.im_func
-  read = TBase.read.im_func
-  write = TBase.write.im_func
+  __repr__ = TBase.__repr__.__func__
+  __eq__ = TBase.__eq__.__func__
+  __ne__ = TBase.__ne__.__func__
+  read = TBase.read.__func__
+  write = TBase.write.__func__

--- a/lib/py/src/protocol/TBase.py
+++ b/lib/py/src/protocol/TBase.py
@@ -69,13 +69,5 @@ class TBase(object):
     oprot.writeStruct(self, self.thrift_spec)
 
 
-class TExceptionBase(Exception):
-  # old style class so python2.4 can raise exceptions derived from this
-  #  This can't inherit from TBase because of that limitation.
+class TExceptionBase(TBase, Exception):
   __slots__ = []
-
-  __repr__ = TBase.__repr__.__func__
-  __eq__ = TBase.__eq__.__func__
-  __ne__ = TBase.__ne__.__func__
-  read = TBase.read.__func__
-  write = TBase.write.__func__

--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -119,8 +119,9 @@ class TBinaryProtocol(TProtocolBase):
     self.trans.write(buff)
 
   def writeString(self, str):
-    self.writeI32(len(bytearray(str,'utf-8')))
-    self.trans.write(bytearray(str,'utf-8'))
+    encoded = bytearray(str, 'utf-8')
+    self.writeI32(len(encoded))
+    self.trans.write(encoded)
 
   def readMessageBegin(self):
     sz = self.readI32()

--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from TProtocol import *
+from .TProtocol import *
 from struct import pack, unpack
 
 
@@ -119,8 +119,8 @@ class TBinaryProtocol(TProtocolBase):
     self.trans.write(buff)
 
   def writeString(self, str):
-    self.writeI32(len(str))
-    self.trans.write(str)
+    self.writeI32(len(bytearray(str,'utf-8')))
+    self.trans.write(bytearray(str,'utf-8'))
 
   def readMessageBegin(self):
     sz = self.readI32()
@@ -219,7 +219,7 @@ class TBinaryProtocol(TProtocolBase):
 
   def readString(self):
     len = self.readI32()
-    str = self.trans.readAll(len)
+    str = self.trans.readAll(len).decode('utf-8')
     return str
 
 

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -17,8 +17,10 @@
 # under the License.
 #
 
-from TProtocol import *
+from .TProtocol import *
 from struct import pack, unpack
+from six.moves import map
+from six.moves import zip
 
 __all__ = ['TCompactProtocol', 'TCompactProtocolFactory']
 

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -63,7 +63,7 @@ def writeVarint(trans, n):
     else:
       out.append((n & 0xff) | 0x80)
       n = n >> 7
-  trans.write(''.join(map(chr, out)))
+  trans.write(bytearray(out))
 
 
 def readVarint(trans):
@@ -255,8 +255,9 @@ class TCompactProtocol(TProtocolBase):
     self.trans.write(pack('<d', dub))
 
   def __writeString(self, s):
-    self.__writeSize(len(s))
-    self.trans.write(s)
+    b = s.encode('utf8')
+    self.__writeSize(len(b))
+    self.trans.write(b)
   writeString = writer(__writeString)
 
   def readFieldBegin(self):
@@ -390,7 +391,7 @@ class TCompactProtocol(TProtocolBase):
 
   def __readString(self):
     len = self.__readSize()
-    return self.trans.readAll(len)
+    return self.trans.readAll(len).decode('utf8')
   readString = reader(__readString)
 
   def __getTType(self, byte):

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -241,7 +241,10 @@ class TJSONProtocolBase(TProtocolBase):
                                      "Expected control char")
           character = ESCAPE_CHARS[character]
       else:
-        character = character.decode('ascii')
+        utf8_bytes = bytearray([ord(character)])
+        while utf8_bytes[-1] >= 0x80:
+          utf8_bytes.append(ord(self.reader.read()))
+        character = utf8_bytes.decode('utf8')
       string.append(character)
     return u('').join(string)
 

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -29,20 +29,20 @@ __all__ = ['TJSONProtocol',
 
 VERSION = 1
 
-COMMA = ','
-COLON = ':'
-LBRACE = '{'
-RBRACE = '}'
-LBRACKET = '['
-RBRACKET = ']'
-QUOTE = '"'
-BACKSLASH = '\\'
-ZERO = '0'
+COMMA = b','
+COLON = b':'
+LBRACE = b'{'
+RBRACE = b'}'
+LBRACKET = b'['
+RBRACKET = b']'
+QUOTE = b'"'
+BACKSLASH = b'\\'
+ZERO = b'0'
 
-ESCSEQ = '\\u00'
-ESCAPE_CHAR = '"\\bfnrt'
-ESCAPE_CHAR_VALS = ['"', '\\', '\b', '\f', '\n', '\r', '\t']
-NUMERIC_CHAR = '+-.0123456789Ee'
+ESCSEQ = b'\\u00'
+ESCAPE_CHAR = b'"\\bfnrt'
+ESCAPE_CHAR_VALS = [b'"', b'\\', b'\b', b'\f', b'\n', b'\r', b'\t']
+NUMERIC_CHAR = b'+-.0123456789Ee'
 
 CTYPES = {TType.BOOL:       'tf',
           TType.BYTE:       'i8',

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from TProtocol import TType, TProtocolBase, TProtocolException
+from .TProtocol import TType, TProtocolBase, TProtocolException
 import base64
 import json
 import math

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -69,7 +69,7 @@ class JSONBaseContext(object):
 
   def doIO(self, function):
     pass
-  
+
   def write(self):
     pass
 
@@ -84,7 +84,7 @@ class JSONBaseContext(object):
 
 
 class JSONListContext(JSONBaseContext):
-    
+
   def doIO(self, function):
     if self.first is True:
       self.first = False
@@ -99,7 +99,7 @@ class JSONListContext(JSONBaseContext):
 
 
 class JSONPairContext(JSONBaseContext):
-  
+
   def __init__(self, protocol):
     super(JSONPairContext, self).__init__(protocol)
     self.colon = True
@@ -429,12 +429,12 @@ class TJSONProtocol(TJSONProtocolBase):
   def writeMapEnd(self):
     self.writeJSONObjectEnd()
     self.writeJSONArrayEnd()
-    
+
   def writeListBegin(self, etype, size):
     self.writeJSONArrayStart()
     self.writeJSONString(CTYPES[etype])
     self.writeJSONNumber(size)
-    
+
   def writeListEnd(self):
     self.writeJSONArrayEnd()
 
@@ -442,7 +442,7 @@ class TJSONProtocol(TJSONProtocolBase):
     self.writeJSONArrayStart()
     self.writeJSONString(CTYPES[etype])
     self.writeJSONNumber(size)
-    
+
   def writeSetEnd(self):
     self.writeJSONArrayEnd()
 
@@ -461,7 +461,7 @@ class TJSONProtocol(TJSONProtocolBase):
 
   def writeString(self, string):
     self.writeJSONString(string)
-    
+
   def writeBinary(self, binary):
     self.writeJSONBase64(binary)
 
@@ -474,49 +474,49 @@ class TJSONProtocolFactory:
 
 class TSimpleJSONProtocol(TJSONProtocolBase):
     """Simple, readable, write-only JSON protocol.
-    
+
     Useful for interacting with scripting languages.
     """
 
     def readMessageBegin(self):
         raise NotImplementedError()
-    
+
     def readMessageEnd(self):
         raise NotImplementedError()
-    
+
     def readStructBegin(self):
         raise NotImplementedError()
-    
+
     def readStructEnd(self):
         raise NotImplementedError()
-    
+
     def writeMessageBegin(self, name, request_type, seqid):
         self.resetWriteContext()
-    
+
     def writeMessageEnd(self):
         pass
-    
+
     def writeStructBegin(self, name):
         self.writeJSONObjectStart()
-    
+
     def writeStructEnd(self):
         self.writeJSONObjectEnd()
-      
+
     def writeFieldBegin(self, name, ttype, fid):
         self.writeJSONString(name)
-    
+
     def writeFieldEnd(self):
         pass
-    
+
     def writeMapBegin(self, ktype, vtype, size):
         self.writeJSONObjectStart()
-    
+
     def writeMapEnd(self):
         self.writeJSONObjectEnd()
-    
+
     def _writeCollectionBegin(self, etype, size):
         self.writeJSONArrayStart()
-    
+
     def _writeCollectionEnd(self):
         self.writeJSONArrayEnd()
     writeListBegin = _writeCollectionBegin
@@ -530,16 +530,16 @@ class TSimpleJSONProtocol(TJSONProtocolBase):
     writeI16 = writeInteger
     writeI32 = writeInteger
     writeI64 = writeInteger
-    
+
     def writeBool(self, boolean):
         self.writeJSONNumber(1 if boolean is True else 0)
 
     def writeDouble(self, dbl):
         self.writeJSONNumber(dbl)
-    
+
     def writeString(self, string):
         self.writeJSONString(string)
-      
+
     def writeBinary(self, binary):
         self.writeJSONBase64(binary)
 

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -18,6 +18,7 @@
 #
 
 from thrift.Thrift import *
+import six
 
 
 class TProtocolException(TException):
@@ -187,18 +188,18 @@ class TProtocolBase:
       self.readStructEnd()
     elif ttype == TType.MAP:
       (ktype, vtype, size) = self.readMapBegin()
-      for i in xrange(size):
+      for i in range(size):
         self.skip(ktype)
         self.skip(vtype)
       self.readMapEnd()
     elif ttype == TType.SET:
       (etype, size) = self.readSetBegin()
-      for i in xrange(size):
+      for i in range(size):
         self.skip(etype)
       self.readSetEnd()
     elif ttype == TType.LIST:
       (etype, size) = self.readListBegin()
-      for i in xrange(size):
+      for i in range(size):
         self.skip(etype)
       self.readListEnd()
 
@@ -246,13 +247,13 @@ class TProtocolBase:
     (list_type, list_len) = self.readListBegin()
     if tspec is None:
       # list values are simple types
-      for idx in xrange(list_len):
+      for idx in range(list_len):
         results.append(reader())
     else:
       # this is like an inlined readFieldByTType
       container_reader = self._TTYPE_HANDLERS[list_type][0]
       val_reader = getattr(self, container_reader)
-      for idx in xrange(list_len):
+      for idx in range(list_len):
         val = val_reader(tspec)
         results.append(val)
     self.readListEnd()
@@ -266,12 +267,12 @@ class TProtocolBase:
     (set_type, set_len) = self.readSetBegin()
     if tspec is None:
       # set members are simple types
-      for idx in xrange(set_len):
+      for idx in range(set_len):
         results.add(reader())
     else:
       container_reader = self._TTYPE_HANDLERS[set_type][0]
       val_reader = getattr(self, container_reader)
-      for idx in xrange(set_len):
+      for idx in range(set_len):
         results.add(val_reader(tspec))
     self.readSetEnd()
     return results
@@ -292,7 +293,7 @@ class TProtocolBase:
     key_reader = getattr(self, self._TTYPE_HANDLERS[key_ttype][0])
     val_reader = getattr(self, self._TTYPE_HANDLERS[val_ttype][0])
     # list values are simple types
-    for idx in xrange(map_len):
+    for idx in range(map_len):
       if key_spec is None:
         k_val = key_reader()
       else:
@@ -363,7 +364,7 @@ class TProtocolBase:
     k_writer = getattr(self, ktype_name)
     v_writer = getattr(self, vtype_name)
     self.writeMapBegin(k_type, v_type, len(val))
-    for m_key, m_val in val.iteritems():
+    for m_key, m_val in six.iteritems(val):
       if not k_is_container:
         k_writer(m_key)
       else:

--- a/lib/py/src/server/THttpServer.py
+++ b/lib/py/src/server/THttpServer.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import BaseHTTPServer
+from six.moves import BaseHTTPServer
 
 from thrift.server import TServer
 from thrift.transport import TTransport

--- a/lib/py/src/server/THttpServer.py
+++ b/lib/py/src/server/THttpServer.py
@@ -73,7 +73,7 @@ class THttpServer(TServer.TServer):
         oprot = thttpserver.outputProtocolFactory.getProtocol(otrans)
         try:
           thttpserver.processor.process(iprot, oprot)
-        except ResponseException, exn:
+        except ResponseException as exn:
           exn.handler(self)
         else:
           self.send_response(200)

--- a/lib/py/src/server/TNonblockingServer.py
+++ b/lib/py/src/server/TNonblockingServer.py
@@ -250,7 +250,7 @@ class TNonblockingServer:
         if self.prepared:
             return
         self.socket.listen()
-        for _ in xrange(self.threads):
+        for _ in range(self.threads):
             thread = Worker(self.tasks)
             thread.setDaemon(True)
             thread.start()
@@ -330,7 +330,7 @@ class TNonblockingServer:
 
     def close(self):
         """Closes the server."""
-        for _ in xrange(self.threads):
+        for _ in range(self.threads):
             self.tasks.put([None, None, None, None, None])
         self.socket.close()
         self.prepared = False

--- a/lib/py/src/server/TProcessPoolServer.py
+++ b/lib/py/src/server/TProcessPoolServer.py
@@ -21,7 +21,7 @@
 import logging
 from multiprocessing import  Process, Value, Condition, reduction
 
-from TServer import TServer
+from .TServer import TServer
 from thrift.transport.TTransport import TTransportException
 
 
@@ -61,7 +61,7 @@ class TProcessPoolServer(TServer):
                 self.serveClient(client)
             except (KeyboardInterrupt, SystemExit):
                 return 0
-            except Exception, x:
+            except Exception as x:
                 logging.exception(x)
 
     def serveClient(self, client):
@@ -74,9 +74,9 @@ class TProcessPoolServer(TServer):
         try:
             while True:
                 self.processor.process(iprot, oprot)
-        except TTransportException, tx:
+        except TTransportException as tx:
             pass
-        except Exception, x:
+        except Exception as x:
             logging.exception(x)
 
         itrans.close()
@@ -97,7 +97,7 @@ class TProcessPoolServer(TServer):
                 w.daemon = True
                 w.start()
                 self.workers.append(w)
-            except Exception, x:
+            except Exception as x:
                 logging.exception(x)
 
         # wait until the condition is set by stop()
@@ -108,7 +108,7 @@ class TProcessPoolServer(TServer):
                 break
             except (SystemExit, KeyboardInterrupt):
                 break
-            except Exception, x:
+            except Exception as x:
                 logging.exception(x)
 
         self.isRunning.value = False

--- a/lib/py/src/server/TServer.py
+++ b/lib/py/src/server/TServer.py
@@ -248,7 +248,7 @@ class TForkingServer(TServer):
             try:
               while True:
                 self.processor.process(iprot, oprot)
-            except TTransport.TTransportException as tx:
+            except TTransport.TTransportException:
               pass
             except Exception as e:
               logging.exception(e)
@@ -259,7 +259,7 @@ class TForkingServer(TServer):
 
           os._exit(ecode)
 
-      except TTransport.TTransportException as tx:
+      except TTransport.TTransportException:
         pass
       except Exception as x:
         logging.exception(x)

--- a/lib/py/src/server/TServer.py
+++ b/lib/py/src/server/TServer.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import Queue
+from six.moves import queue
 import logging
 import os
 import sys
@@ -84,9 +84,9 @@ class TSimpleServer(TServer):
       try:
         while True:
           self.processor.process(iprot, oprot)
-      except TTransport.TTransportException, tx:
+      except TTransport.TTransportException as tx:
         pass
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
       itrans.close()
@@ -112,7 +112,7 @@ class TThreadedServer(TServer):
         t.start()
       except KeyboardInterrupt:
         raise
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
   def handle(self, client):
@@ -123,9 +123,9 @@ class TThreadedServer(TServer):
     try:
       while True:
         self.processor.process(iprot, oprot)
-    except TTransport.TTransportException, tx:
+    except TTransport.TTransportException as tx:
       pass
-    except Exception, x:
+    except Exception as x:
       logging.exception(x)
 
     itrans.close()
@@ -137,7 +137,7 @@ class TThreadPoolServer(TServer):
 
   def __init__(self, *args, **kwargs):
     TServer.__init__(self, *args)
-    self.clients = Queue.Queue()
+    self.clients = queue.Queue()
     self.threads = 10
     self.daemon = kwargs.get("daemon", False)
 
@@ -151,7 +151,7 @@ class TThreadPoolServer(TServer):
       try:
         client = self.clients.get()
         self.serveClient(client)
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
   def serveClient(self, client):
@@ -163,9 +163,9 @@ class TThreadPoolServer(TServer):
     try:
       while True:
         self.processor.process(iprot, oprot)
-    except TTransport.TTransportException, tx:
+    except TTransport.TTransportException as tx:
       pass
-    except Exception, x:
+    except Exception as x:
       logging.exception(x)
 
     itrans.close()
@@ -178,7 +178,7 @@ class TThreadPoolServer(TServer):
         t = threading.Thread(target=self.serveThread)
         t.setDaemon(self.daemon)
         t.start()
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
     # Pump the socket for clients
@@ -189,7 +189,7 @@ class TThreadPoolServer(TServer):
         if not client:
           continue
         self.clients.put(client)
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
 
@@ -214,7 +214,7 @@ class TForkingServer(TServer):
     def try_close(file):
       try:
         file.close()
-      except IOError, e:
+      except IOError as e:
         logging.warning(e, exc_info=True)
 
     self.serverTransport.listen()
@@ -248,9 +248,9 @@ class TForkingServer(TServer):
             try:
               while True:
                 self.processor.process(iprot, oprot)
-            except TTransport.TTransportException, tx:
+            except TTransport.TTransportException as tx:
               pass
-            except Exception, e:
+            except Exception as e:
               logging.exception(e)
               ecode = 1
           finally:
@@ -259,9 +259,9 @@ class TForkingServer(TServer):
 
           os._exit(ecode)
 
-      except TTransport.TTransportException, tx:
+      except TTransport.TTransportException as tx:
         pass
-      except Exception, x:
+      except Exception as x:
         logging.exception(x)
 
   def collect_children(self):

--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+from io import StringIO
 import os
 import socket
 import sys
@@ -25,7 +26,6 @@ import warnings
 
 from six.moves.urllib import parse as urlparse
 from six.moves import http_client
-from six.moves import StringIO
 
 from .TTransport import *
 import six

--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -17,17 +17,18 @@
 # under the License.
 #
 
-import httplib
 import os
 import socket
 import sys
 import urllib
-import urlparse
 import warnings
 
-from cStringIO import StringIO
+from six.moves.urllib import parse as urlparse
+from six.moves import http_client
+from six.moves import StringIO
 
-from TTransport import *
+from .TTransport import *
+import six
 
 
 class THttpClient(TTransportBase):
@@ -133,7 +134,7 @@ class THttpClient(TTransportBase):
       self.__http.putheader('User-Agent', user_agent)
 
     if self.__custom_headers:
-        for key, val in self.__custom_headers.iteritems():
+        for key, val in six.iteritems(self.__custom_headers):
             self.__http.putheader(key, val)
 
     self.__http.endheaders()

--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -17,14 +17,13 @@
 # under the License.
 #
 
-from io import StringIO
+from io import BytesIO
 import os
 import socket
 import sys
-import urllib
 import warnings
 
-from six.moves.urllib import parse as urlparse
+from six.moves import urllib
 from six.moves import http_client
 
 from .TTransport import *
@@ -53,31 +52,33 @@ class THttpClient(TTransportBase):
       self.path = path
       self.scheme = 'http'
     else:
-      parsed = urlparse.urlparse(uri_or_host)
+      parsed = urllib.parse.urlparse(uri_or_host)
       self.scheme = parsed.scheme
       assert self.scheme in ('http', 'https')
       if self.scheme == 'http':
-        self.port = parsed.port or httplib.HTTP_PORT
+        self.port = parsed.port or http_client.HTTP_PORT
       elif self.scheme == 'https':
-        self.port = parsed.port or httplib.HTTPS_PORT
+        self.port = parsed.port or http_client.HTTPS_PORT
       self.host = parsed.hostname
       self.path = parsed.path
       if parsed.query:
         self.path += '?%s' % parsed.query
-    self.__wbuf = StringIO()
+    self.__wbuf = BytesIO()
     self.__http = None
+    self.__http_response = None
     self.__timeout = None
     self.__custom_headers = None
 
   def open(self):
     if self.scheme == 'http':
-      self.__http = httplib.HTTP(self.host, self.port)
+      self.__http = http_client.HTTPConnection(self.host, self.port)
     else:
-      self.__http = httplib.HTTPS(self.host, self.port)
+      self.__http = http_client.HTTPSConnection(self.host, self.port)
 
   def close(self):
     self.__http.close()
     self.__http = None
+    self.__http_response = None
 
   def isOpen(self):
     return self.__http is not None
@@ -95,7 +96,7 @@ class THttpClient(TTransportBase):
     self.__custom_headers = headers
 
   def read(self, sz):
-    return self.__http.file.read(sz)
+    return self.__http_response.read(sz)
 
   def write(self, buf):
     self.__wbuf.write(buf)
@@ -116,13 +117,12 @@ class THttpClient(TTransportBase):
 
     # Pull data out of buffer
     data = self.__wbuf.getvalue()
-    self.__wbuf = StringIO()
+    self.__wbuf = BytesIO()
 
     # HTTP request
     self.__http.putrequest('POST', self.path)
 
     # Write headers
-    self.__http.putheader('Host', self.host)
     self.__http.putheader('Content-Type', 'application/x-thrift')
     self.__http.putheader('Content-Length', str(len(data)))
 
@@ -130,7 +130,7 @@ class THttpClient(TTransportBase):
       user_agent = 'Python/THttpClient'
       script = os.path.basename(sys.argv[0])
       if script:
-        user_agent = '%s (%s)' % (user_agent, urllib.quote(script))
+        user_agent = '%s (%s)' % (user_agent, urllib.parse.quote(script))
       self.__http.putheader('User-Agent', user_agent)
 
     if self.__custom_headers:
@@ -143,7 +143,10 @@ class THttpClient(TTransportBase):
     self.__http.send(data)
 
     # Get reply to flush the request
-    self.code, self.message, self.headers = self.__http.getreply()
+    self.__http_response = self.__http.getresponse()
+    self.code = self.__http_response.status
+    self.message = self.__http_response.reason
+    self.headers = self.__http_response.msg
 
   # Decorate if we know how to timeout
   if hasattr(socket, 'getdefaulttimeout'):

--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -96,13 +96,13 @@ class TSSLSocket(TSocket.TSocket):
         self.handle.settimeout(self._timeout)
         try:
           self.handle.connect(ip_port)
-        except socket.error, e:
+        except socket.error as e:
           if res is not res0[-1]:
             continue
           else:
             raise e
         break
-    except socket.error, e:
+    except socket.error as e:
       if self._unix_socket:
         message = 'Could not connect to secure socket %s: %s' \
                 % (self._unix_socket, e)
@@ -200,7 +200,7 @@ class TSSLServerSocket(TSocket.TServerSocket):
     try:
       client = ssl.wrap_socket(plain_client, certfile=self.certfile,
                       server_side=True, ssl_version=self.SSL_VERSION)
-    except ssl.SSLError, ssl_exc:
+    except ssl.SSLError as ssl_exc:
       # failed handshake/ssl wrap, close socket to client
       plain_client.close()
       # raise ssl_exc

--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -58,7 +58,7 @@ class TSSLSocket(TSocket.TSocket):
     @type keyfile: str
     @param certfile: The cert file
     @type certfile: str
-    
+
     Raises an IOError exception if validate is True and the ca_certs file is
     None, not present or unreadable.
     """
@@ -200,10 +200,10 @@ class TSSLServerSocket(TSocket.TServerSocket):
     try:
       client = ssl.wrap_socket(plain_client, certfile=self.certfile,
                       server_side=True, ssl_version=self.SSL_VERSION)
-    except ssl.SSLError as ssl_exc:
+    except ssl.SSLError:
       # failed handshake/ssl wrap, close socket to client
       plain_client.close()
-      # raise ssl_exc
+      # raise
       # We can't raise the exception, because it kills most TServer derived
       # serve() methods.
       # Instead, return None, and let the TServer instance deal with it in

--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -22,7 +22,7 @@ import os
 import socket
 import sys
 
-from TTransport import *
+from .TTransport import *
 
 
 class TSocketBase(TTransportBase):
@@ -86,13 +86,13 @@ class TSocket(TSocketBase):
         self.handle.settimeout(self._timeout)
         try:
           self.handle.connect(res[4])
-        except socket.error, e:
+        except socket.error as e:
           if res is not res0[-1]:
             continue
           else:
             raise e
         break
-    except socket.error, e:
+    except socket.error as e:
       if self._unix_socket:
         message = 'Could not connect to socket %s' % self._unix_socket
       else:
@@ -103,7 +103,7 @@ class TSocket(TSocketBase):
   def read(self, sz):
     try:
       buff = self.handle.recv(sz)
-    except socket.error, e:
+    except socket.error as e:
       if (e.args[0] == errno.ECONNRESET and
           (sys.platform == 'darwin' or sys.platform.startswith('freebsd'))):
         # freebsd and Mach don't follow POSIX semantic of recv
@@ -161,7 +161,7 @@ class TServerSocket(TSocketBase, TServerTransportBase):
       tmp = socket.socket(res[0], res[1])
       try:
         tmp.connect(res[4])
-      except socket.error, err:
+      except socket.error as err:
         eno, message = err.args
         if eno == errno.ECONNREFUSED:
           os.unlink(res[4])

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -18,6 +18,7 @@
 #
 
 from io import BytesIO
+from cStringIO import StringIO as BytesIO
 from struct import pack, unpack
 from thrift.Thrift import TException
 
@@ -139,7 +140,7 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
   def __init__(self, trans, rbuf_size=DEFAULT_BUFFER):
     self.__trans = trans
     self.__wbuf = BytesIO()
-    self.__rbuf = BytesIO(b"")
+    self.__rbuf = BytesIO()
     self.__rbuf_size = rbuf_size
 
   def isOpen(self):

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from cStringIO import StringIO
+from six import BytesIO
 from struct import pack, unpack
 from thrift.Thrift import TException
 
@@ -52,7 +52,7 @@ class TTransportBase:
     pass
 
   def readAll(self, sz):
-    buff = ''
+    buff = b''
     have = 0
     while (have < sz):
       chunk = self.read(sz - have)
@@ -76,14 +76,14 @@ class CReadableTransport:
   """base class for transports that are readable from C"""
 
   # TODO(dreiss): Think about changing this interface to allow us to use
-  #               a (Python, not c) StringIO instead, because it allows
+  #               a (Python, not c) BytesIO instead, because it allows
   #               you to write after reading.
 
   # NOTE: This is a classic class, so properties will NOT work
   #       correctly for setting.
   @property
   def cstringio_buf(self):
-    """A cStringIO buffer that contains the current chunk we are reading."""
+    """A cBytesIO buffer that contains the current chunk we are reading."""
     pass
 
   def cstringio_refill(self, partialread, reqlen):
@@ -138,8 +138,8 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
 
   def __init__(self, trans, rbuf_size=DEFAULT_BUFFER):
     self.__trans = trans
-    self.__wbuf = StringIO()
-    self.__rbuf = StringIO("")
+    self.__wbuf = BytesIO()
+    self.__rbuf = BytesIO(b"")
     self.__rbuf_size = rbuf_size
 
   def isOpen(self):
@@ -155,8 +155,7 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
     ret = self.__rbuf.read(sz)
     if len(ret) != 0:
       return ret
-
-    self.__rbuf = StringIO(self.__trans.read(max(sz, self.__rbuf_size)))
+    self.__rbuf = BytesIO(self.__trans.read(max(sz, self.__rbuf_size)))
     return self.__rbuf.read(sz)
 
   def write(self, buf):
@@ -165,7 +164,7 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
   def flush(self):
     out = self.__wbuf.getvalue()
     # reset wbuf before write/flush to preserve state on underlying failure
-    self.__wbuf = StringIO()
+    self.__wbuf = BytesIO()
     self.__trans.write(out)
     self.__trans.flush()
 
@@ -184,12 +183,12 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
     if len(retstring) < reqlen:
       retstring += self.__trans.readAll(reqlen - len(retstring))
 
-    self.__rbuf = StringIO(retstring)
+    self.__rbuf = BytesIO(retstring)
     return self.__rbuf
 
 
 class TMemoryBuffer(TTransportBase, CReadableTransport):
-  """Wraps a cStringIO object as a TTransport.
+  """Wraps a cBytesIO object as a TTransport.
 
   NOTE: Unlike the C++ version of this class, you cannot write to it
         then immediately read from it.  If you want to read from a
@@ -203,9 +202,9 @@ class TMemoryBuffer(TTransportBase, CReadableTransport):
     If value is set, this will be a transport for reading,
     otherwise, it is for writing"""
     if value is not None:
-      self._buffer = StringIO(value)
+      self._buffer = BytesIO(value)
     else:
-      self._buffer = StringIO()
+      self._buffer = BytesIO()
 
   def isOpen(self):
     return not self._buffer.closed
@@ -251,8 +250,8 @@ class TFramedTransport(TTransportBase, CReadableTransport):
 
   def __init__(self, trans,):
     self.__trans = trans
-    self.__rbuf = StringIO()
-    self.__wbuf = StringIO()
+    self.__rbuf = BytesIO()
+    self.__wbuf = BytesIO()
 
   def isOpen(self):
     return self.__trans.isOpen()
@@ -274,7 +273,7 @@ class TFramedTransport(TTransportBase, CReadableTransport):
   def readFrame(self):
     buff = self.__trans.readAll(4)
     sz, = unpack('!i', buff)
-    self.__rbuf = StringIO(self.__trans.readAll(sz))
+    self.__rbuf = BytesIO(self.__trans.readAll(sz))
 
   def write(self, buf):
     self.__wbuf.write(buf)
@@ -283,7 +282,7 @@ class TFramedTransport(TTransportBase, CReadableTransport):
     wout = self.__wbuf.getvalue()
     wsz = len(wout)
     # reset wbuf before write/flush to preserve state on underlying failure
-    self.__wbuf = StringIO()
+    self.__wbuf = BytesIO()
     # N.B.: Doing this string concatenation is WAY cheaper than making
     # two separate calls to the underlying socket object. Socket writes in
     # Python turn out to be REALLY expensive, but it seems to do a pretty
@@ -304,7 +303,7 @@ class TFramedTransport(TTransportBase, CReadableTransport):
     while len(prefix) < reqlen:
       self.readFrame()
       prefix += self.__rbuf.getvalue()
-    self.__rbuf = StringIO(prefix)
+    self.__rbuf = BytesIO(prefix)
     return self.__rbuf
 
 
@@ -358,8 +357,8 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     self.transport = transport
     self.sasl = SASLClient(host, service, mechanism, **sasl_kwargs)
 
-    self.__wbuf = StringIO()
-    self.__rbuf = StringIO()
+    self.__wbuf = BytesIO()
+    self.__rbuf = BytesIO()
 
   def open(self):
     if not self.transport.isOpen():
@@ -404,7 +403,7 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     encoded = self.sasl.wrap(data)
     self.transport.write(''.join((pack("!i", len(encoded)), encoded)))
     self.transport.flush()
-    self.__wbuf = StringIO()
+    self.__wbuf = BytesIO()
 
   def read(self, sz):
     ret = self.__rbuf.read(sz)
@@ -418,7 +417,7 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     header = self.transport.readAll(4)
     length, = unpack('!i', header)
     encoded = self.transport.readAll(length)
-    self.__rbuf = StringIO(self.sasl.unwrap(encoded))
+    self.__rbuf = BytesIO(self.sasl.unwrap(encoded))
 
   def close(self):
     self.sasl.dispose()
@@ -436,6 +435,6 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     while len(prefix) < reqlen:
       self._read_frame()
       prefix += self.__rbuf.getvalue()
-    self.__rbuf = StringIO(prefix)
+    self.__rbuf = BytesIO(prefix)
     return self.__rbuf
 

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from six import BytesIO
+from io import BytesIO
 from struct import pack, unpack
 from thrift.Thrift import TException
 
@@ -331,7 +331,7 @@ class TFileObjectTransport(TTransportBase):
 
 class TSaslClientTransport(TTransportBase, CReadableTransport):
   """
-  SASL transport 
+  SASL transport
   """
 
   START = 1

--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -29,6 +29,7 @@ from twisted.protocols import basic
 from twisted.web import server, resource, http
 
 from thrift.transport import TTransport
+import six
 
 
 class TMessageSenderTransport(TTransport.TTransportBase):
@@ -82,7 +83,7 @@ class ThriftClientProtocol(basic.Int32StringReceiver):
         self.started.callback(self.client)
 
     def connectionLost(self, reason=connectionDone):
-        for k, v in self.client._reqs.iteritems():
+        for k, v in six.iteritems(self.client._reqs):
             tex = TTransport.TTransportException(
                 type=TTransport.TTransportException.END_OF_FILE,
                 message='Connection closed')

--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -17,8 +17,8 @@
 # under the License.
 #
 
+from io import BytesIO
 import struct
-from cStringIO import StringIO
 
 from zope.interface import implements, Interface, Attribute
 from twisted.internet.protocol import ServerFactory, ClientFactory, \
@@ -35,14 +35,14 @@ import six
 class TMessageSenderTransport(TTransport.TTransportBase):
 
     def __init__(self):
-        self.__wbuf = StringIO()
+        self.__wbuf = BytesIO()
 
     def write(self, buf):
         self.__wbuf.write(buf)
 
     def flush(self):
         msg = self.__wbuf.getvalue()
-        self.__wbuf = StringIO()
+        self.__wbuf = BytesIO()
         self.sendMessage(msg)
 
     def sendMessage(self, message):

--- a/lib/py/src/transport/TZlibTransport.py
+++ b/lib/py/src/transport/TZlibTransport.py
@@ -24,7 +24,7 @@ data compression.
 
 from __future__ import division
 import zlib
-from cStringIO import StringIO
+from io import BytesIO
 from .TTransport import TTransportBase, CReadableTransport
 
 
@@ -88,17 +88,17 @@ class TZlibTransport(TTransportBase, CReadableTransport):
     """
     self.__trans = trans
     self.compresslevel = compresslevel
-    self.__rbuf = StringIO()
-    self.__wbuf = StringIO()
+    self.__rbuf = BytesIO()
+    self.__wbuf = BytesIO()
     self._init_zlib()
     self._init_stats()
 
   def _reinit_buffers(self):
-    """Internal method to initialize/reset the internal StringIO objects
+    """Internal method to initialize/reset the internal BytesIO objects
     for read and write buffers.
     """
-    self.__rbuf = StringIO()
-    self.__wbuf = StringIO()
+    self.__rbuf = BytesIO()
+    self.__wbuf = BytesIO()
 
   def _init_stats(self):
     """Internal method to reset the internal statistics counters
@@ -195,7 +195,7 @@ class TZlibTransport(TTransportBase, CReadableTransport):
 
   def readComp(self, sz):
     """Read compressed data from the underlying transport, then
-    decompress it and append it to the internal StringIO read buffer
+    decompress it and append it to the internal BytesIO read buffer
     """
     zbuf = self.__trans.read(sz)
     zbuf = self._zcomp_read.unconsumed_tail + zbuf
@@ -203,7 +203,7 @@ class TZlibTransport(TTransportBase, CReadableTransport):
     self.bytes_in += len(zbuf)
     self.bytes_in_comp += len(buf)
     old = self.__rbuf.read()
-    self.__rbuf = StringIO(old + buf)
+    self.__rbuf = BytesIO(old + buf)
     if len(old) + len(buf) == 0:
       return False
     return True
@@ -228,7 +228,7 @@ class TZlibTransport(TTransportBase, CReadableTransport):
     ztail = self._zcomp_write.flush(zlib.Z_SYNC_FLUSH)
     self.bytes_out_comp += len(ztail)
     if (len(zbuf) + len(ztail)) > 0:
-      self.__wbuf = StringIO()
+      self.__wbuf = BytesIO()
       self.__trans.write(zbuf + ztail)
     self.__trans.flush()
 
@@ -244,5 +244,5 @@ class TZlibTransport(TTransportBase, CReadableTransport):
       retstring += self.read(self.DEFAULT_BUFFSIZE)
     while len(retstring) < reqlen:
       retstring += self.read(reqlen - len(retstring))
-    self.__rbuf = StringIO(retstring)
+    self.__rbuf = BytesIO(retstring)
     return self.__rbuf

--- a/lib/py/src/transport/TZlibTransport.py
+++ b/lib/py/src/transport/TZlibTransport.py
@@ -25,7 +25,7 @@ data compression.
 from __future__ import division
 import zlib
 from cStringIO import StringIO
-from TTransport import TTransportBase, CReadableTransport
+from .TTransport import TTransportBase, CReadableTransport
 
 
 class TZlibTransportFactory(object):

--- a/lib/py/src/transport/TZlibTransport.py
+++ b/lib/py/src/transport/TZlibTransport.py
@@ -25,6 +25,7 @@ data compression.
 from __future__ import division
 import zlib
 from io import BytesIO
+from cStringIO import StringIO as BytesIO
 from .TTransport import TTransportBase, CReadableTransport
 
 

--- a/test/py.tornado/test_suite.py
+++ b/test/py.tornado/test_suite.py
@@ -28,7 +28,7 @@ import unittest
 
 basepath = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, basepath+'/gen-py.tornado')
-sys.path.insert(0, glob.glob(os.path.join(basepath, '../../lib/py/build/lib.*'))[0])
+sys.path.insert(0, glob.glob(os.path.join(basepath, '../../lib/py/build/lib*'))[0])
 
 try:
     __import__('tornado')

--- a/test/py.tornado/test_suite.py
+++ b/test/py.tornado/test_suite.py
@@ -185,7 +185,7 @@ class ThriftTestCase(AsyncTestCase):
         self.assertEqual(y.i64_thing, -5)
 
     def test_oneway(self):
-        self.client.testOneway(0.5)
+        self.client.testOneway(0)
         start, end, seconds = self.wait(timeout=1)
         self.assertAlmostEqual(seconds, (end - start), places=3)
 

--- a/test/py.tornado/test_suite.py
+++ b/test/py.tornado/test_suite.py
@@ -33,7 +33,7 @@ sys.path.insert(0, glob.glob(os.path.join(basepath, '../../lib/py/build/lib*'))[
 try:
     __import__('tornado')
 except ImportError:
-    print "module `tornado` not found, skipping test"
+    print("module `tornado` not found, skipping test")
     sys.exit(0)
 
 from tornado import gen
@@ -187,7 +187,7 @@ class ThriftTestCase(AsyncTestCase):
     def test_oneway(self):
         self.client.testOneway(0.5)
         start, end, seconds = self.wait(timeout=1)
-        self.assertAlmostEquals(seconds, (end - start), places=3)
+        self.assertAlmostEqual(seconds, (end - start), places=3)
 
     @gen_test
     def test_map(self):

--- a/test/py.twisted/test_suite.py
+++ b/test/py.twisted/test_suite.py
@@ -19,7 +19,7 @@
 
 import sys, glob, time
 sys.path.insert(0, './gen-py.twisted')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from ThriftTest import ThriftTest
 from ThriftTest.ttypes import Xception, Xtruct

--- a/test/py.twisted/test_suite.py
+++ b/test/py.twisted/test_suite.py
@@ -164,7 +164,7 @@ class ThriftTestCase(unittest.TestCase):
         try:
             yield self.client.testException('Xception')
             self.fail("should have gotten exception")
-        except Xception, x:
+        except Xception as x:
             self.assertEquals(x.errorCode, 1001)
             self.assertEquals(x.message, 'Xception')
 

--- a/test/py/RunClientServer.py
+++ b/test/py/RunClientServer.py
@@ -20,6 +20,7 @@
 #
 
 from __future__ import division
+from __future__ import print_function
 import time
 import socket
 import subprocess
@@ -78,13 +79,13 @@ SERVERS = [
 try:
   import multiprocessing
 except:
-  print 'Warning: the multiprocessing module is unavailable. Skipping tests for TProcessPoolServer'
+  print('Warning: the multiprocessing module is unavailable. Skipping tests for TProcessPoolServer')
   SERVERS.remove('TProcessPoolServer')
 
 try:
   import ssl
 except:
-  print 'Warning, no ssl module available. Skipping all SSL tests.'
+  print('Warning, no ssl module available. Skipping all SSL tests.')
   SKIP_SSL.extend(SERVERS)
 
 # commandline permits a single class name to be specified to override SERVERS=[...]
@@ -92,7 +93,7 @@ if len(args) == 1:
   if args[0] in SERVERS:
     SERVERS = args
   else:
-    print 'Unavailable server type "%s", please choose one of: %s' % (args[0], SERVERS)
+    print('Unavailable server type "%s", please choose one of: %s' % (args[0], SERVERS))
     sys.exit(0)
 
 
@@ -103,7 +104,7 @@ def runScriptTest(genpydir, script):
   script_args = [sys.executable, relfile(script) ]
   script_args.append('--genpydir=%s' % genpydir)
   serverproc = subprocess.Popen(script_args)
-  print '\nTesting script: %s\n----' % (' '.join(script_args))
+  print('\nTesting script: %s\n----' % (' '.join(script_args)))
   ret = subprocess.call(script_args)
   if ret != 0:
     raise Exception("Script subprocess failed, retcode=%d, args: %s" % (ret, ' '.join(script_args)))
@@ -134,12 +135,12 @@ def runServiceTest(genpydir, server_class, proto, port, use_zlib, use_ssl):
   if server_class == 'THttpServer':
     cli_args.append('--http=/')
   if options.verbose > 0:
-    print 'Testing server %s: %s' % (server_class, ' '.join(server_args))
+    print('Testing server %s: %s' % (server_class, ' '.join(server_args)))
   serverproc = subprocess.Popen(server_args)
 
   def ensureServerAlive():
     if serverproc.poll() is not None:
-      print ('FAIL: Server process (%s) failed with retcode %d'
+      print(('FAIL: Server process (%s) failed with retcode %d')
              % (' '.join(server_args), serverproc.returncode))
       raise Exception('Server subprocess %s died, args: %s'
                       % (server_class, ' '.join(server_args)))
@@ -162,7 +163,7 @@ def runServiceTest(genpydir, server_class, proto, port, use_zlib, use_ssl):
 
   try:
     if options.verbose > 0:
-      print 'Testing client: %s' % (' '.join(cli_args))
+      print('Testing client: %s' % (' '.join(cli_args)))
     ret = subprocess.call(cli_args)
     if ret != 0:
       raise Exception("Client subprocess failed, retcode=%d, args: %s" % (ret, ' '.join(cli_args)))
@@ -171,7 +172,7 @@ def runServiceTest(genpydir, server_class, proto, port, use_zlib, use_ssl):
     ensureServerAlive()
     extra_sleep = EXTRA_DELAY.get(server_class, 0)
     if extra_sleep > 0 and options.verbose > 0:
-      print ('Giving %s (proto=%s,zlib=%s,ssl=%s) an extra %d seconds for child'
+      print('Giving %s (proto=%s,zlib=%s,ssl=%s) an extra %d seconds for child'
              'processes to terminate via alarm'
              % (server_class, proto, use_zlib, use_ssl, extra_sleep))
       time.sleep(extra_sleep)
@@ -180,22 +181,22 @@ def runServiceTest(genpydir, server_class, proto, port, use_zlib, use_ssl):
 
 test_count = 0
 # run tests without a client/server first
-print '----------------'
-print ' Executing individual test scripts with various generated code directories'
-print ' Directories to be tested: ' + ', '.join(generated_dirs)
-print ' Scripts to be tested: ' + ', '.join(SCRIPTS)
-print '----------------'
+print('----------------')
+print(' Executing individual test scripts with various generated code directories')
+print(' Directories to be tested: ' + ', '.join(generated_dirs))
+print(' Scripts to be tested: ' + ', '.join(SCRIPTS))
+print('----------------')
 for genpydir in generated_dirs:
   for script in SCRIPTS:
     runScriptTest(genpydir, script)
 
-print '----------------'
-print ' Executing Client/Server tests with various generated code directories'
-print ' Servers to be tested: ' + ', '.join(SERVERS)
-print ' Directories to be tested: ' + ', '.join(generated_dirs)
-print ' Protocols to be tested: ' + ', '.join(PROTOS)
-print ' Options to be tested: ZLIB(yes/no), SSL(yes/no)'
-print '----------------'
+print('----------------')
+print(' Executing Client/Server tests with various generated code directories')
+print(' Servers to be tested: ' + ', '.join(SERVERS))
+print(' Directories to be tested: ' + ', '.join(generated_dirs))
+print(' Protocols to be tested: ' + ', '.join(PROTOS))
+print(' Options to be tested: ZLIB(yes/no), SSL(yes/no)')
+print('----------------')
 for try_server in SERVERS:
   for genpydir in generated_dirs:
     for try_proto in PROTOS:
@@ -209,7 +210,7 @@ for try_server in SERVERS:
             continue
           test_count += 1
           if options.verbose > 0:
-            print '\nTest run #%d:  (includes %s) Server=%s,  Proto=%s,  zlib=%s,  SSL=%s' % (test_count, genpydir, try_server, try_proto, with_zlib, with_ssl)
+            print('\nTest run #%d:  (includes %s) Server=%s,  Proto=%s,  zlib=%s,  SSL=%s' % (test_count, genpydir, try_server, try_proto, with_zlib, with_ssl))
           runServiceTest(genpydir, try_server, try_proto, options.port, with_zlib, with_ssl)
           if options.verbose > 0:
-            print 'OK: Finished (includes %s)  %s / %s proto / zlib=%s / SSL=%s.   %d combinations tested.' % (genpydir, try_server, try_proto, with_zlib, with_ssl, test_count)
+            print('OK: Finished (includes %s)  %s / %s proto / zlib=%s / SSL=%s.   %d combinations tested.' % (genpydir, try_server, try_proto, with_zlib, with_ssl, test_count))

--- a/test/py/SerializationTest.py
+++ b/test/py/SerializationTest.py
@@ -26,7 +26,7 @@ parser.add_option('--genpydir', type='string', dest='genpydir', default='gen-py'
 options, args = parser.parse_args()
 del sys.argv[1:] # clean up hack so unittest doesn't complain
 sys.path.insert(0, options.genpydir)
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from ThriftTest.ttypes import *
 from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty

--- a/test/py/SerializationTest.py
+++ b/test/py/SerializationTest.py
@@ -336,14 +336,14 @@ class SerializersTest(unittest.TestCase):
     objcopy = Bools()
     deserialize(objcopy, serialize(obj))
     self.assertEquals(obj, objcopy)
-    
+
     # test enums
     for num, name in Numberz._VALUES_TO_NAMES.iteritems():
       obj = Bonk(message='enum Numberz value %d is string %s' % (num, name), type=num)
       objcopy = Bonk()
       deserialize(objcopy, serialize(obj))
       self.assertEquals(obj, objcopy)
-  
+
 
 def suite():
   suite = unittest.TestSuite()

--- a/test/py/SerializationTest.py
+++ b/test/py/SerializationTest.py
@@ -295,7 +295,7 @@ class AcceleratedFramedTest(unittest.TestCase):
     prot.writeString(bigstring)
     prot.writeI16(24)
     data = databuf.getvalue()
-    cutpoint = len(data)/2
+    cutpoint = len(data) // 2
     parts = [ data[:cutpoint], data[cutpoint:] ]
 
     framed_buffer = TTransport.TMemoryBuffer()
@@ -338,7 +338,7 @@ class SerializersTest(unittest.TestCase):
     self.assertEquals(obj, objcopy)
 
     # test enums
-    for num, name in Numberz._VALUES_TO_NAMES.iteritems():
+    for num, name in Numberz._VALUES_TO_NAMES.items():
       obj = Bonk(message='enum Numberz value %d is string %s' % (num, name), type=num)
       objcopy = Bonk()
       deserialize(objcopy, serialize(obj))

--- a/test/py/TSimpleJSONProtocolTest.py
+++ b/test/py/TSimpleJSONProtocolTest.py
@@ -66,7 +66,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
 
   def testWriteOnly(self):
     self.assertRaises(NotImplementedError,
-                      self._deserialize, VersioningTestV1, '{}')
+                      self._deserialize, VersioningTestV1, b'{}')
 
   def testSimpleMessage(self):
       v1obj = VersioningTestV1(
@@ -76,7 +76,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
       expected = dict(begin_in_both=v1obj.begin_in_both,
                       old_string=v1obj.old_string,
                       end_in_both=v1obj.end_in_both)
-      actual = json.loads(self._serialize(v1obj))
+      actual = json.loads(self._serialize(v1obj).decode('ascii'))
 
       self._assertDictEqual(expected, actual)
 
@@ -110,7 +110,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
 
       # Need to load/dump because map keys get escaped.
       expected = json.loads(json.dumps(expected))
-      actual = json.loads(self._serialize(v2obj))
+      actual = json.loads(self._serialize(v2obj).decode('ascii'))
       self._assertDictEqual(expected, actual)
 
 

--- a/test/py/TSimpleJSONProtocolTest.py
+++ b/test/py/TSimpleJSONProtocolTest.py
@@ -27,7 +27,7 @@ parser.add_option('--genpydir', type='string', dest='genpydir', default='gen-py'
 options, args = parser.parse_args()
 del sys.argv[1:] # clean up hack so unittest doesn't complain
 sys.path.insert(0, options.genpydir)
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from ThriftTest.ttypes import *
 from thrift.protocol import TJSONProtocol

--- a/test/py/TSimpleJSONProtocolTest.py
+++ b/test/py/TSimpleJSONProtocolTest.py
@@ -45,7 +45,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
       # assertDictEqual only in Python 2.7. Depends on your machine.
       self.assertDictEqual(a, b, msg)
       return
-    
+
     # Substitute implementation not as good as unittest library's
     self.assertEquals(len(a), len(b), msg)
     for k, v in a.iteritems():
@@ -79,7 +79,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
       actual = json.loads(self._serialize(v1obj))
 
       self._assertDictEqual(expected, actual)
-     
+
   def testComplicated(self):
       v2obj = VersioningTestV2(
           begin_in_both=12345,
@@ -107,7 +107,7 @@ class SimpleJSONProtocolTest(unittest.TestCase):
                       newmap=v2obj.newmap,
                       newstring=v2obj.newstring,
                       end_in_both=v2obj.end_in_both)
-      
+
       # Need to load/dump because map keys get escaped.
       expected = json.loads(json.dumps(expected))
       actual = json.loads(self._serialize(v2obj))

--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -20,7 +20,7 @@
 #
 
 import sys, glob, os
-sys.path.insert(0, glob.glob(os.path.join(os.path.dirname(__file__),'../../lib/py/build/lib.*'))[0])
+sys.path.insert(0, glob.glob(os.path.join(os.path.dirname(__file__),'../../lib/py/build/lib*'))[0])
 
 import unittest
 import time

--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -182,7 +182,7 @@ class AbstractTest(unittest.TestCase):
     try:
       self.client.testException('Xception')
       self.fail("should have gotten exception")
-    except Xception, x:
+    except Xception as x:
       self.assertEqual(x.errorCode, 1001)
       self.assertEqual(x.message, 'Xception')
       # TODO ensure same behavior for repr within generated python variants

--- a/test/py/TestEof.py
+++ b/test/py/TestEof.py
@@ -99,7 +99,7 @@ class TestEof(unittest.TestCase):
     # TODO: we should make sure this covers more of the code paths
 
     data = self.make_data(pfactory)
-    for i in xrange(0, len(data) + 1):
+    for i in range(0, len(data) + 1):
       trans = TTransport.TMemoryBuffer(data[0:i])
       prot = pfactory.getProtocol(trans)
       try:

--- a/test/py/TestEof.py
+++ b/test/py/TestEof.py
@@ -26,7 +26,7 @@ parser.add_option('--genpydir', type='string', dest='genpydir', default='gen-py'
 options, args = parser.parse_args()
 del sys.argv[1:] # clean up hack so unittest doesn't complain
 sys.path.insert(0, options.genpydir)
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from ThriftTest import ThriftTest
 from ThriftTest.ttypes import *

--- a/test/py/TestServer.py
+++ b/test/py/TestServer.py
@@ -20,7 +20,7 @@
 #
 from __future__ import division
 import sys, glob, time, os
-sys.path.insert(0, glob.glob(os.path.join(os.path.dirname(__file__),'../../lib/py/build/lib.*'))[0])
+sys.path.insert(0, glob.glob(os.path.join(os.path.dirname(__file__),'../../lib/py/build/lib*'))[0])
 from optparse import OptionParser
 
 parser = OptionParser()

--- a/test/py/TestServer.py
+++ b/test/py/TestServer.py
@@ -19,6 +19,7 @@
 # under the License.
 #
 from __future__ import division
+from __future__ import print_function
 import sys, glob, time, os
 sys.path.insert(0, glob.glob(os.path.join(os.path.dirname(__file__),'../../lib/py/build/lib*'))[0])
 from optparse import OptionParser
@@ -69,46 +70,46 @@ class TestHandler:
 
   def testVoid(self):
     if options.verbose > 1:
-      print 'testVoid()'
+      print('testVoid()')
 
   def testString(self, str):
     if options.verbose > 1:
-      print 'testString(%s)' % str
+      print('testString(%s)' % str)
     return str
 
   def testByte(self, byte):
     if options.verbose > 1:
-      print 'testByte(%d)' % byte
+      print('testByte(%d)' % byte)
     return byte
 
   def testI16(self, i16):
     if options.verbose > 1:
-      print 'testI16(%d)' % i16
+      print('testI16(%d)' % i16)
     return i16
 
   def testI32(self, i32):
     if options.verbose > 1:
-      print 'testI32(%d)' % i32
+      print('testI32(%d)' % i32)
     return i32
 
   def testI64(self, i64):
     if options.verbose > 1:
-      print 'testI64(%d)' % i64
+      print('testI64(%d)' % i64)
     return i64
 
   def testDouble(self, dub):
     if options.verbose > 1:
-      print 'testDouble(%f)' % dub
+      print('testDouble(%f)' % dub)
     return dub
 
   def testStruct(self, thing):
     if options.verbose > 1:
-      print 'testStruct({%s, %d, %d, %d})' % (thing.string_thing, thing.byte_thing, thing.i32_thing, thing.i64_thing)
+      print('testStruct({%s, %d, %d, %d})' % (thing.string_thing, thing.byte_thing, thing.i32_thing, thing.i64_thing))
     return thing
 
   def testException(self, arg):
     #if options.verbose > 1:
-    print 'testException(%s)' % arg
+    print('testException(%s)' % arg)
     if arg == 'Xception':
       raise Xception(errorCode=1001, message=arg)
     elif arg == 'TException':
@@ -116,7 +117,7 @@ class TestHandler:
 
   def testMultiException(self, arg0, arg1):
     if options.verbose > 1:
-      print 'testMultiException(%s, %s)' % (arg0, arg1)
+      print('testMultiException(%s, %s)' % (arg0, arg1))
     if arg0 == 'Xception':
       raise Xception(errorCode=1001, message='This is an Xception')
     elif arg0 == 'Xception2':
@@ -127,54 +128,54 @@ class TestHandler:
 
   def testOneway(self, seconds):
     if options.verbose > 1:
-      print 'testOneway(%d) => sleeping...' % seconds
+      print('testOneway(%d) => sleeping...' % seconds)
     time.sleep(seconds / 3) # be quick
     if options.verbose > 1:
-      print 'done sleeping'
+      print('done sleeping')
 
   def testNest(self, thing):
     if options.verbose > 1:
-      print 'testNest(%s)' % thing
+      print('testNest(%s)' % thing)
     return thing
 
   def testMap(self, thing):
     if options.verbose > 1:
-      print 'testMap(%s)' % thing
+      print('testMap(%s)' % thing)
     return thing
 
   def testSet(self, thing):
     if options.verbose > 1:
-      print 'testSet(%s)' % thing
+      print('testSet(%s)' % thing)
     return thing
 
   def testList(self, thing):
     if options.verbose > 1:
-      print 'testList(%s)' % thing
+      print('testList(%s)' % thing)
     return thing
 
   def testEnum(self, thing):
     if options.verbose > 1:
-      print 'testEnum(%s)' % thing
+      print('testEnum(%s)' % thing)
     return thing
 
   def testTypedef(self, thing):
     if options.verbose > 1:
-      print 'testTypedef(%s)' % thing
+      print('testTypedef(%s)' % thing)
     return thing
 
   def testMapMap(self, thing):
     if options.verbose > 1:
-      print 'testMapMap(%s)' % thing
+      print('testMapMap(%s)' % thing)
     return {thing: {thing: thing}}
 
   def testInsanity(self, argument):
     if options.verbose > 1:
-      print 'testInsanity(%s)' % argument
+      print('testInsanity(%s)' % argument)
     return {123489: {Numberz.ONE:argument}}
 
   def testMulti(self, arg0, arg1, arg2, arg3, arg4, arg5):
     if options.verbose > 1:
-      print 'testMulti(%s)' % [arg0, arg1, arg2, arg3, arg4, arg5]
+      print('testMulti(%s)' % [arg0, arg1, arg2, arg3, arg4, arg5])
     return Xtruct(string_thing='Hello2',
                   byte_thing=arg0, i32_thing=arg1, i64_thing=arg2)
 
@@ -237,10 +238,10 @@ elif server_type == "TProcessPoolServer":
     def clean_shutdown(signum, frame):
       for worker in server.workers:
         if options.verbose > 0:
-          print 'Terminating worker: %s' % worker
+          print('Terminating worker: %s' % worker)
         worker.terminate()
       if options.verbose > 0:
-        print 'Requesting server to stop()'
+        print('Requesting server to stop()')
       try:
         server.stop()
       except:

--- a/test/py/TestSocket.py
+++ b/test/py/TestSocket.py
@@ -41,7 +41,7 @@ from optparse import OptionParser
 
 class TimeoutTest(unittest.TestCase):
     def setUp(self):
-        for i in xrange(50):
+        for i in range(50):
             try:
                 # find a port we can use
                 self.listen_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -58,7 +58,7 @@ class TimeoutTest(unittest.TestCase):
 
         try:
             leaky = []
-            for i in xrange(100):
+            for i in range(100):
                 socket = TSocket.TSocket('localhost', self.port)
                 socket.setTimeout(10)
                 socket.open()

--- a/test/py/TestSocket.py
+++ b/test/py/TestSocket.py
@@ -26,7 +26,7 @@ parser.add_option('--genpydir', type='string', dest='genpydir', default='gen-py'
 options, args = parser.parse_args()
 del sys.argv[1:] # clean up hack so unittest doesn't complain
 sys.path.insert(0, options.genpydir)
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from ThriftTest import ThriftTest
 from ThriftTest.ttypes import *

--- a/test/py/TestSyntax.py
+++ b/test/py/TestSyntax.py
@@ -26,7 +26,7 @@ parser.add_option('--genpydir', type='string', dest='genpydir', default='gen-py'
 options, args = parser.parse_args()
 del sys.argv[1:] # clean up hack so unittest doesn't complain
 sys.path.insert(0, options.genpydir)
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 # Just import these generated files to make sure they are syntactically valid
 from DebugProtoTest import EmptyService

--- a/tutorial/py.tornado/PythonClient.py
+++ b/tutorial/py.tornado/PythonClient.py
@@ -56,21 +56,21 @@ def communicate(callback=None):
 
     # ping
     yield gen.Task(client.ping)
-    print "ping()"
+    print("ping()")
 
     # add
     sum_ = yield gen.Task(client.add, 1, 1)
-    print "1 + 1 = {}".format(sum_)
+    print("1 + 1 = {}".format(sum_))
 
     # make a oneway call without a callback (schedule the write and continue
     # without blocking)
     client.zip()
-    print "zip() without callback"
+    print("zip() without callback")
 
     # make a oneway call with a callback (we'll wait for the stream write to
     # complete before continuing)
     yield gen.Task(client.zip)
-    print "zip() with callback"
+    print("zip() with callback")
 
     # calculate 1/0
     work = Work()
@@ -80,9 +80,9 @@ def communicate(callback=None):
 
     try:
         quotient = yield gen.Task(client.calculate, 1, work)
-        print "Whoa? You know how to divide by zero?"
+        print("Whoa? You know how to divide by zero?")
     except InvalidOperation as io:
-        print "InvalidOperation: {}".format(io)
+        print("InvalidOperation: {}".format(io))
 
     # calculate 15-10
     work.op = Operation.SUBTRACT
@@ -90,11 +90,11 @@ def communicate(callback=None):
     work.num2 = 10
 
     diff = yield gen.Task(client.calculate, 1, work)
-    print "15 - 10 = {}".format(diff)
+    print("15 - 10 = {}".format(diff))
 
     # getStruct
     log = yield gen.Task(client.getStruct, 1)
-    print "Check log: {}".format(log.value)
+    print("Check log: {}".format(log.value))
 
     # close the transport
     client._transport.close()

--- a/tutorial/py.tornado/PythonClient.py
+++ b/tutorial/py.tornado/PythonClient.py
@@ -22,7 +22,7 @@
 import sys
 import glob
 sys.path.append('gen-py.tornado')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 import logging
 

--- a/tutorial/py.tornado/PythonServer.py
+++ b/tutorial/py.tornado/PythonServer.py
@@ -22,7 +22,7 @@
 import sys
 import glob
 sys.path.append('gen-py.tornado')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from tutorial import Calculator
 from tutorial.ttypes import Operation, InvalidOperation

--- a/tutorial/py.tornado/PythonServer.py
+++ b/tutorial/py.tornado/PythonServer.py
@@ -43,15 +43,15 @@ class CalculatorHandler(object):
         self.log = {}
 
     def ping(self, callback):
-        print "ping()"
+        print("ping()")
         callback()
 
     def add(self, n1, n2, callback):
-        print "add({}, {})".format(n1, n2)
+        print("add({}, {})".format(n1, n2))
         callback(n1 + n2)
 
     def calculate(self, logid, work, callback):
-        print "calculate({}, {})".format(logid, work)
+        print("calculate({}, {})".format(logid, work))
 
         if work.op == Operation.ADD:
             val = work.num1 + work.num2
@@ -79,11 +79,11 @@ class CalculatorHandler(object):
         callback(val)
 
     def getStruct(self, key, callback):
-        print "getStruct({})".format(key)
+        print("getStruct({})".format(key))
         callback(self.log[key])
 
     def zip(self, callback):
-        print "zip()"
+        print("zip()")
         callback()
 
 
@@ -93,11 +93,11 @@ def main():
     pfactory = TBinaryProtocol.TBinaryProtocolFactory()
     server = TTornado.TTornadoServer(processor, pfactory)
 
-    print "Starting the server..."
+    print("Starting the server...")
     server.bind(9090)
     server.start(1)
     ioloop.IOLoop.instance().start()
-    print "done."
+    print("done.")
 
 
 if __name__ == "__main__":

--- a/tutorial/py.twisted/PythonClient.py
+++ b/tutorial/py.twisted/PythonClient.py
@@ -37,10 +37,10 @@ from thrift.protocol import TBinaryProtocol
 @inlineCallbacks
 def main(client):
   yield client.ping()
-  print 'ping()'
+  print('ping()')
 
   sum = yield client.add(1,1)
-  print '1+1=%d' % (sum)
+  print(('1+1=%d' % (sum)))
 
   work = Work()
 
@@ -50,19 +50,19 @@ def main(client):
 
   try:
     quotient = yield client.calculate(1, work)
-    print 'Whoa? You know how to divide by zero?'
-  except InvalidOperation, io:
-    print 'InvalidOperation: %r' % io
+    print('Whoa? You know how to divide by zero?')
+  except InvalidOperation as e:
+    print(('InvalidOperation: %r' % e))
 
   work.op = Operation.SUBTRACT
   work.num1 = 15
   work.num2 = 10
 
   diff = yield client.calculate(1, work)
-  print '15-10=%d' % (diff)
+  print(('15-10=%d' % (diff)))
 
   log = yield client.getStruct(1)
-  print 'Check log: %s' % (log.value)
+  print(('Check log: %s' % (log.value)))
   reactor.stop()
 
 if __name__ == '__main__':

--- a/tutorial/py.twisted/PythonClient.py
+++ b/tutorial/py.twisted/PythonClient.py
@@ -21,7 +21,7 @@
 
 import sys, glob
 sys.path.append('gen-py.twisted')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from tutorial import Calculator
 from tutorial.ttypes import *

--- a/tutorial/py.twisted/PythonServer.py
+++ b/tutorial/py.twisted/PythonServer.py
@@ -41,14 +41,14 @@ class CalculatorHandler:
     self.log = {}
 
   def ping(self):
-    print 'ping()'
+    print('ping()')
 
   def add(self, n1, n2):
-    print 'add(%d,%d)' % (n1, n2)
+    print('add(%d,%d)' % (n1, n2))
     return n1+n2
 
   def calculate(self, logid, work):
-    print 'calculate(%d, %r)' % (logid, work)
+    print('calculate(%d, %r)' % (logid, work))
 
     if work.op == Operation.ADD:
       val = work.num1 + work.num2
@@ -77,11 +77,11 @@ class CalculatorHandler:
     return val
 
   def getStruct(self, key):
-    print 'getStruct(%d)' % (key)
+    print('getStruct(%d)' % (key))
     return self.log[key]
 
   def zip(self):
-    print 'zip()'
+    print('zip()')
 
 if __name__ == '__main__':
     handler = CalculatorHandler()

--- a/tutorial/py.twisted/PythonServer.py
+++ b/tutorial/py.twisted/PythonServer.py
@@ -21,7 +21,7 @@
 
 import sys, glob
 sys.path.append('gen-py.twisted')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from tutorial import Calculator
 from tutorial.ttypes import *
@@ -36,7 +36,7 @@ from thrift.protocol import TBinaryProtocol
 from thrift.server import TServer
 
 class CalculatorHandler:
-  implements(Calculator.Iface)  
+  implements(Calculator.Iface)
   def __init__(self):
     self.log = {}
 

--- a/tutorial/py.twisted/PythonServer.tac
+++ b/tutorial/py.twisted/PythonServer.tac
@@ -24,7 +24,7 @@ from thrift.transport import TTwisted
 
 import sys, glob
 sys.path.append('gen-py.twisted')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 from tutorial import Calculator
 from tutorial.ttypes import *
 from PythonServer import CalculatorHandler

--- a/tutorial/py/PythonClient.py
+++ b/tutorial/py/PythonClient.py
@@ -21,7 +21,7 @@
 
 import sys, glob
 sys.path.append('gen-py')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from tutorial import Calculator
 from tutorial.ttypes import *

--- a/tutorial/py/PythonClient.py
+++ b/tutorial/py/PythonClient.py
@@ -49,10 +49,10 @@ try:
   transport.open()
 
   client.ping()
-  print 'ping()'
+  print('ping()')
 
   sum = client.add(1,1)
-  print '1+1=%d' % (sum)
+  print(('1+1=%d' % (sum)))
 
   work = Work()
 
@@ -62,22 +62,22 @@ try:
 
   try:
     quotient = client.calculate(1, work)
-    print 'Whoa? You know how to divide by zero?'
-  except InvalidOperation, io:
-    print 'InvalidOperation: %r' % io
+    print('Whoa? You know how to divide by zero?')
+  except InvalidOperation as e:
+    print(('InvalidOperation: %r' % e))
 
   work.op = Operation.SUBTRACT
   work.num1 = 15
   work.num2 = 10
 
   diff = client.calculate(1, work)
-  print '15-10=%d' % (diff)
+  print(('15-10=%d' % (diff)))
 
   log = client.getStruct(1)
-  print 'Check log: %s' % (log.value)
+  print(('Check log: %s' % (log.value)))
 
   # Close!
   transport.close()
 
-except Thrift.TException, tx:
-  print '%s' % (tx.message)
+except Thrift.TException as tx:
+  print(('%s' % (tx.message)))

--- a/tutorial/py/PythonServer.py
+++ b/tutorial/py/PythonServer.py
@@ -21,7 +21,7 @@
 
 import sys, glob
 sys.path.append('gen-py')
-sys.path.insert(0, glob.glob('../../lib/py/build/lib.*')[0])
+sys.path.insert(0, glob.glob('../../lib/py/build/lib*')[0])
 
 from tutorial import Calculator
 from tutorial.ttypes import *

--- a/tutorial/py/PythonServer.py
+++ b/tutorial/py/PythonServer.py
@@ -38,14 +38,14 @@ class CalculatorHandler:
     self.log = {}
 
   def ping(self):
-    print 'ping()'
+    print('ping()')
 
   def add(self, n1, n2):
-    print 'add(%d,%d)' % (n1, n2)
+    print('add(%d,%d)' % (n1, n2))
     return n1+n2
 
   def calculate(self, logid, work):
-    print 'calculate(%d, %r)' % (logid, work)
+    print('calculate(%d, %r)' % (logid, work))
 
     if work.op == Operation.ADD:
       val = work.num1 + work.num2
@@ -74,11 +74,11 @@ class CalculatorHandler:
     return val
 
   def getStruct(self, key):
-    print 'getStruct(%d)' % (key)
+    print('getStruct(%d)' % (key))
     return self.log[key]
 
   def zip(self):
-    print 'zip()'
+    print('zip()')
 
 handler = CalculatorHandler()
 processor = Calculator.Processor(handler)
@@ -92,6 +92,6 @@ server = TServer.TSimpleServer(processor, transport, tfactory, pfactory)
 #server = TServer.TThreadedServer(processor, transport, tfactory, pfactory)
 #server = TServer.TThreadPoolServer(processor, transport, tfactory, pfactory)
 
-print 'Starting the server...'
+print('Starting the server...')
 server.serve()
-print 'done.'
+print('done.')


### PR DESCRIPTION
As mentioned on [the Jira ticket](https://issues.apache.org/jira/browse/THRIFT-1857?focusedCommentId=14104848&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14104848), there are still some minor problems with `fastbinary.c`, which uses a private API that no longer exists in Python 3.  I think it's worth just removing outright.

But the test suite passes completely on Python 3, now.

----

FYI: I left the company I worked for and no longer have any need for Thrift, so I won't be working on this further.  Anyone else, feel free to pick it up.  Anyone who desperately needs Thrift on Python 3 may want to try [thriftpy](https://github.com/eleme/thriftpy), which is pure-Python, works everywhere, has a similar API, and doesn't require a manual code generation step.