### PR TITLE
Removed reference to nonexisting tests from cabal file

### DIFF
--- a/lib/hs/Thrift.cabal
+++ b/lib/hs/Thrift.cabal
@@ -69,13 +69,3 @@ Library
     RecordWildCards,
     ScopedTypeVariables,
     TypeSynonymInstances
-
-Test-Suite tests
-  Type:
-    exitcode-stdio-1.0
-  Hs-Source-Dirs:
-    tests
-  Build-Depends:
-    base, QuickCheck, binary, bytestring, thrift, split
-  Main-Is:
-    JSONTests.hs


### PR DESCRIPTION
Fix for reference in cabal file for the Haskell example. The Cabal file referred a test that didn't exist anymore. From the discussion in the ticket it seemed best to just remove it, as cabal will complain about not finding a test when you're trying to build.
