### PR TITLE
Make Transport.Empty externally available in the Haskell Thrift Library

### DIFF
--- a/lib/hs/Thrift.cabal
+++ b/lib/hs/Thrift.cabal
@@ -54,6 +54,7 @@ Library
     Thrift.Protocol.JSON,
     Thrift.Server,
     Thrift.Transport,
+    Thrift.Transport.Empty,
     Thrift.Transport.Framed,
     Thrift.Transport.Handle,
     Thrift.Transport.HttpClient,


### PR DESCRIPTION
The Haskell Thrift library contains an "Empty" transport. It looks to me that this is the easiest way to use Thrift in Haskell for serialization-only purposes, but it is currently not exposed to users of the library. It is not used internally either, so I think this is just an oversight, and I would suggest to add it to the exported modules.
