### PR TITLE
py.twisted: Avoid synchronous exceptions

### DIFF
--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -42,7 +42,7 @@ class TMessageSenderTransport(TTransport.TTransportBase):
     def flush(self):
         msg = self.__wbuf.getvalue()
         self.__wbuf = StringIO()
-        self.sendMessage(msg)
+        return self.sendMessage(msg)
 
     def sendMessage(self, message):
         raise NotImplementedError
@@ -55,7 +55,7 @@ class TCallbackTransport(TMessageSenderTransport):
         self.func = func
 
     def sendMessage(self, message):
-        self.func(message)
+        return self.func(message)
 
 
 class ThriftClientProtocol(basic.Int32StringReceiver):


### PR DESCRIPTION
This is an update of the patch posted to:
https://issues.apache.org/jira/browse/THRIFT-585
and a re-write of 8345772

Patch: Mattias de Zalenski, James Broadhead

Jira: THRIFT-585
