### PR TITLE
THRIFT-2773: java - fixed oneway support while using TServiceClient

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2674,7 +2674,8 @@ void t_java_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << "args.set" << get_cap_name((*fld_iter)->get_name()) << "(" << (*fld_iter)->get_name() << ");" << endl;
     }
 
-    indent(f_service_) << "sendBase(\"" << funname << "\", args);" << endl;
+    const string sendBaseName = (*f_iter)->is_oneway() ? "sendBaseOneway" : "sendBase";
+    indent(f_service_) << sendBaseName << "(\"" << funname << "\", args);" << endl;
 
     scope_down(f_service_);
     f_service_ << endl;

--- a/lib/java/src/org/apache/thrift/TServiceClient.java
+++ b/lib/java/src/org/apache/thrift/TServiceClient.java
@@ -58,14 +58,22 @@ public abstract class TServiceClient {
     return this.oprot_;
   }
 
-  protected void sendBase(String methodName, TBase args) throws TException {
-    oprot_.writeMessageBegin(new TMessage(methodName, TMessageType.CALL, ++seqid_));
+  protected void sendBase(String methodName, TBase<?,?> args) throws TException {
+    sendBase(methodName, args, TMessageType.CALL);
+  }
+
+  protected void sendBaseOneway(String methodName, TBase<?,?> args) throws TException {
+    sendBase(methodName, args, TMessageType.ONEWAY);
+  }
+
+  private void sendBase(String methodName, TBase<?,?> args, byte type) throws TException {
+    oprot_.writeMessageBegin(new TMessage(methodName, type, ++seqid_));
     args.write(oprot_);
     oprot_.writeMessageEnd();
     oprot_.getTransport().flush();
   }
 
-  protected void receiveBase(TBase result, String methodName) throws TException {
+  protected void receiveBase(TBase<?,?> result, String methodName) throws TException {
     TMessage msg = iprot_.readMessageBegin();
     if (msg.type == TMessageType.EXCEPTION) {
       TApplicationException x = TApplicationException.read(iprot_);


### PR DESCRIPTION
new method for oneway call provided by TServiceClient
and compiler will now use it
