### PR TITLE
THRIFT-2777: move erlang test files into .eunit scratch dir

### DIFF
--- a/lib/erl/test/test_disklog.erl
+++ b/lib/erl/test/test_disklog.erl
@@ -26,7 +26,7 @@ disklog_test() ->
   {ok, TransportFactory} =
     thrift_disk_log_transport:new_transport_factory(
       test_disklog,
-      [{file, "/tmp/test_log"},
+      [{file, "./test_log"},
        {size, {1024*1024, 10}}]),
   {ok, ProtocolFactory} =
     thrift_binary_protocol:new_protocol_factory( TransportFactory, []),
@@ -49,9 +49,9 @@ disklog_test() ->
   io:format("Client closed~n"),
   
   lists:foreach(fun(File) -> file:delete(File) end, [
-    "/tmp/test_log.1",
-    "/tmp/test_log.idx",
-    "/tmp/test_log.siz"
+    "./test_log.1",
+    "./test_log.idx",
+    "./test_log.siz"
   ]),
   io:format("Cleaning up test files~n"),
 
@@ -61,7 +61,7 @@ disklog_base64_test() ->
   {ok, TransportFactory} =
     thrift_disk_log_transport:new_transport_factory(
       test_disklog,
-      [{file, "/tmp/test_b64_log"},
+      [{file, "./test_b64_log"},
        {size, {1024*1024, 10}}]),
   {ok, B64Factory} =
     thrift_base64_transport:new_transport_factory(TransportFactory),
@@ -88,9 +88,9 @@ disklog_base64_test() ->
   io:format("Client closed~n"),
 
   lists:foreach(fun(File) -> file:delete(File) end, [
-    "/tmp/test_b64_log.1",
-    "/tmp/test_b64_log.idx",
-    "/tmp/test_b64_log.siz"
+    "./test_b64_log.1",
+    "./test_b64_log.idx",
+    "./test_b64_log.siz"
   ]),
   io:format("Cleaning up test files~n"),
 


### PR DESCRIPTION
client: erlang
patch: alisdair sullivan

tests could fail with eaccess error if run as an account with
innapropriate permissions
