### PR TITLE
Fix PHP TJSONProtocol encode unicode into UTF8 instead of UCS-4LE

### DIFF
--- a/lib/php/lib/Thrift/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Thrift/Protocol/TJSONProtocol.php
@@ -209,6 +209,12 @@ class TJSONProtocol extends TProtocol
         return dechex($val);
     }
 
+    private function json_encode_utf8($str) {
+      return preg_replace("/\\\\u([a-f0-9]{4})/e",
+        "iconv('UCS-4LE','UTF-8',pack('V', hexdec('U$1')))",
+        json_encode($str));
+    }
+
     private function writeJSONString($b) {
         $this->context_->write();
 
@@ -216,7 +222,7 @@ class TJSONProtocol extends TProtocol
             $this->trans_->write(self::QUOTE);
         }
 
-        $this->trans_->write(json_encode($b));
+        $this->trans_->write(json_encode_utf8($b));
 
         if (is_numeric($b) && $this->context_->escapeNum()) {
             $this->trans_->write(self::QUOTE);


### PR DESCRIPTION
fix THRIFT-2779.
JSON_UNESCAPED_UNICODE option is only available for PHP 5.4+.
