### PR TITLE
THRIFT-2788: enable TCP keep alive for sockets in java lib.

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TNonblockingSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TNonblockingSocket.java
@@ -85,6 +85,7 @@ public class TNonblockingSocket extends TNonblockingTransport {
     Socket socket = socketChannel.socket();
     socket.setSoLinger(false, 0);
     socket.setTcpNoDelay(true);
+    socket.setKeepAlive(true);
     setTimeout(timeout);
   }
 

--- a/lib/java/src/org/apache/thrift/transport/TSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TSocket.java
@@ -68,6 +68,7 @@ public class TSocket extends TIOStreamTransport {
     try {
       socket_.setSoLinger(false, 0);
       socket_.setTcpNoDelay(true);
+      socket_.setKeepAlive(true);
     } catch (SocketException sx) {
       LOGGER.warn("Could not configure socket.", sx);
     }
@@ -117,6 +118,7 @@ public class TSocket extends TIOStreamTransport {
     try {
       socket_.setSoLinger(false, 0);
       socket_.setTcpNoDelay(true);
+      socket_.setKeepAlive(true);
       socket_.setSoTimeout(timeout_);
     } catch (SocketException sx) {
       LOGGER.error("Could not configure socket.", sx);


### PR DESCRIPTION
Both client and server sockets in Java were not enable tcp keepalive.

This is important for reap dead tcp connections. If not enabled, the process can not be notified appropriately while remote peer crashed or connection interrupted.
