### PR TITLE
Allowing use of buffered sockets in go server

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -33,6 +33,10 @@ type TServerSocket struct {
 	// Protects the interrupted value to make it thread safe.
 	mu          sync.RWMutex
 	interrupted bool
+
+	//Size of buffer to use for socket. Defaults to 1024.
+	//Set to 0 to disable bufferring server transport altogether.
+	BufferSize int
 }
 
 func NewTServerSocket(listenAddr string) (*TServerSocket, error) {
@@ -44,7 +48,7 @@ func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*T
 	if err != nil {
 		return nil, err
 	}
-	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout, BufferSize: 1024}, nil
 }
 
 func (p *TServerSocket) Listen() error {
@@ -74,7 +78,12 @@ func (p *TServerSocket) Accept() (TTransport, error) {
 	if err != nil {
 		return nil, NewTTransportExceptionFromError(err)
 	}
-	return NewTSocketFromConnTimeout(conn, p.clientTimeout), nil
+	var trans TTransport
+	trans = NewTSocketFromConnTimeout(conn, p.clientTimeout)
+	if p.BufferSize != 0 {
+		trans = NewTBufferedTransport(trans, p.BufferSize)
+	}
+	return trans, nil
 }
 
 // Checks whether the socket is listening.


### PR DESCRIPTION
There is currently no way in a go server to use buffered sockets. Failing to do so decreases performance significantly in my tests. 

I added an option on TServerSocket to set the buffer size to use. This will default to 1024 bytes, but can be disabled if desired to get back to the original behavior by setting BufferSize to 0.
