### PR TITLE
Go Library - Make remote socket address accessible

### DIFF
--- a/lib/go/thrift/socket.go
+++ b/lib/go/thrift/socket.go
@@ -126,6 +126,11 @@ func (p *TSocket) Close() error {
 	return nil
 }
 
+//Returns the remote address of the socket.
+func (p *TSocket) Addr() net.Addr {
+	return p.addr
+}
+
 func (p *TSocket) Read(buf []byte) (int, error) {
 	if !p.IsOpen() {
 		return 0, NewTTransportException(NOT_OPEN, "Connection not open")


### PR DESCRIPTION
In my server I would like to log the remote ip address of incoming connections. This patch makes the addr available on TSocket via an accessor, so my server implementation can read it and log it or do other things with it.
