### PR TITLE
do not leave the serverSocket_ open if something goes wrong during construction

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TServerSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TServerSocket.java
@@ -105,8 +105,8 @@ public class TServerSocket extends TServerTransport {
       // Bind to listening port
       serverSocket_.bind(args.bindAddr, args.backlog);
     } catch (IOException ioe) {
-      serverSocket_ = null;
-      throw new TTransportException("Could not create ServerSocket on address " + args.bindAddr.toString() + ".");
+      close();
+      throw new TTransportException("Could not create ServerSocket on address " + args.bindAddr.toString() + ":" + ioe.getMessage());
     }
   }
 


### PR DESCRIPTION
If construction of a TServerSocket fails the underlying ServerSocket object may already have been initialized. Since the reference is nullified, we loose the opportunity to properly close it. This fix addresses the issue by always cleaning up after failures during construction.

Additionally, the failure message is added to the exception for improved visibility of what went wrong
