### PR TITLE
Backout

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -44,7 +44,7 @@ func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*T
 	if err != nil {
 		return nil, err
 	}
-	return &TServerSocket{addr: addr, clientTimeout: clientTimeout, BufferSize: 1024}, nil
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
 }
 
 func (p *TServerSocket) Listen() error {


### PR DESCRIPTION
It has been pointed out to me that https://github.com/apache/thrift/pull/249 was wrong. It was not needed to allow server sockets to use buffering. The correct way is to pass in a TBufferedTransportFactory to the server. This will create buffered sockets as the processor starts up.

This change creates extra buffering, and is actually a real pain to deactivate. Sorry. 
