### PR TITLE
THRIFT-2824

### DIFF
--- a/compiler/cpp/src/generate/t_html_generator.cc
+++ b/compiler/cpp/src/generate/t_html_generator.cc
@@ -64,6 +64,10 @@ class t_html_generator : public t_generator {
     iter = parsed_options.find("standalone");
     standalone_ = (iter != parsed_options.end());
 
+	iter = parsed_options.find("noescape");
+	unsafe_ = (iter != parsed_options.end());
+
+
     escape_.clear();
     escape_['&']  = "&amp;";
     escape_['<']  = "&lt;";
@@ -112,6 +116,7 @@ class t_html_generator : public t_generator {
   input_type input_type_;
   std::map<std::string, int> allowed_markup;
   bool standalone_;
+  bool unsafe_;
 };
 
 
@@ -399,7 +404,8 @@ std::string t_html_generator::make_file_link( std::string filename) {
  */
 void t_html_generator::print_doc(t_doc* tdoc) {
   if (tdoc->has_doc()) {
-    f_out_ << escape_html(tdoc->get_doc()) << "<br/>";
+	if (unsafe_)f_out_ << tdoc->get_doc() << "<br/>";
+    else f_out_ << escape_html(tdoc->get_doc()) << "<br/>";
   }
 }
 
@@ -1079,4 +1085,5 @@ void t_html_generator::generate_service(t_service* tservice) {
 THRIFT_REGISTER_GENERATOR(html, "HTML",
 "    standalone:      Self-contained mode, includes all CSS in the HTML files.\n"
 "                     Generates no style.css file, but HTML files will be larger.\n"
+"    noescape:        Do not escape html in doc text.\n"
 )


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-2824

We use the html generator to create and publish documentation for our services. We primarily use the program level doctext to insert html documentation for the entire service.
We would like to add richer content up top, but are limited by the escaping performed by the html generator on doctexts.
This patch adds the "noescape" flag to simply render doctexts as-is.
