### PR TITLE
THRIFT-2827: Remove unused tr1/functional include

### DIFF
--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -23,7 +23,6 @@
  * implementations.
  */
 
-#include <tr1/functional>
 #include <boost/test/unit_test.hpp>
 
 #include <thrift/concurrency/PosixThreadFactory.h>


### PR DESCRIPTION
This appears unused and is causing compilation issues on OS X.
