### PR TITLE
Fixed the path to the LICENSE file for Haskell lib.

### DIFF
--- a/lib/hs/Thrift.cabal
+++ b/lib/hs/Thrift.cabal
@@ -27,7 +27,7 @@ Synopsis:       Haskell bindings for the Apache Thrift RPC system
 Homepage:       http://thrift.apache.org
 Bug-Reports:    https://issues.apache.org/jira/browse/THRIFT
 Maintainer:     dev@thrift.apache.org
-License-File:   ../../LICENSE
+License-File:   LICENSE
 
 Description:
   Haskell bindings for the Apache Thrift RPC system. Requires the use of the thrift code generator.


### PR DESCRIPTION
This fixes the path to the LICENSE file for the Haskell library so that it doesn't break when pulling it down from Hackage, currently this means the 0.9.2 release is unusable as a result of this.

In changing the path I've confirmed that the LICENSE file is included as the path being incorrect also resulted in the file not being included in the tarball.
