### PR TITLE
THRIFT-2843:Fixes typo in Automake configuration for checking java variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ if test "$with_java" = "yes";  then
   AX_CHECK_ANT_VERSION($ANT, 1.7)
   AC_SUBST(CLASSPATH)
   AC_SUBST(ANT_FLAGS)
-  if test "x$JAVAC" != "x" && test "x$JAVAC" != "x" && test "x$ANT" != "x" ; then
+  if test "x$JAVA" != "x" && test "x$JAVAC" != "x" && test "x$ANT" != "x" ; then
     have_java="yes"
   fi
 fi


### PR DESCRIPTION
The current code is checking that $JAVAC is defined twice.
