### PR TITLE
Fix for Python Thrift client when it encounters an exception on write

### DIFF
--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -160,7 +160,12 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
     return self.__rbuf.read(sz)
 
   def write(self, buf):
-    self.__wbuf.write(buf)
+    try:
+      self.__wbuf.write(buf)
+    except Exception as e:
+      # on exception reset wbuf so it doesn't contain a partial function call
+      self.__wbuf = StringIO()
+      raise e
 
   def flush(self):
     out = self.__wbuf.getvalue()


### PR DESCRIPTION
Make sure we clear wbuf on exception, so it doesn't contain a partial function call.

As the branch name suggests, this is for https://issues.apache.org/jira/browse/THRIFT-2825. This is my first time contributing to Thrift, so let me know if there's something I should be doing differently!
