### PR TITLE
THRIFT-2869: Run JSON schema validator from test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -659,6 +659,8 @@ AC_CONFIG_FILES([
   lib/hs/Makefile
   lib/java/Makefile
   lib/js/test/Makefile
+  lib/json/Makefile
+  lib/json/test/Makefile
   lib/nodejs/Makefile
   lib/perl/Makefile
   lib/perl/test/Makefile

--- a/lib/json/Makefile.am
+++ b/lib/json/Makefile.am
@@ -17,77 +17,13 @@
 # under the License.
 #
 
-SUBDIRS = json
-
-if WITH_CPP
-SUBDIRS += cpp
-endif
-
-if WITH_C_GLIB
-SUBDIRS += c_glib
-endif
-
-if WITH_MONO
-SUBDIRS += csharp
-endif
+SUBDIRS =
 
 if WITH_JAVA
-SUBDIRS += java
-# JavaScript unit test depends on java
-# so test only if java, ant & co is available
-SUBDIRS += js/test
+# Schema validation test depends on java
+SUBDIRS += test
 endif
 
-if WITH_PYTHON
-SUBDIRS += py
-endif
-
-if WITH_ERLANG
-SUBDIRS += erl
-endif
-
-if WITH_RUBY
-SUBDIRS += rb
-endif
-
-if WITH_HASKELL
-SUBDIRS += hs
-endif
-
-if WITH_PERL
-SUBDIRS += perl
-endif
-
-if WITH_PHP
-SUBDIRS += php
-endif
-
-if WITH_GO
-SUBDIRS += go
-endif
-
-if WITH_D
-SUBDIRS += d
-endif
-
-if WITH_NODEJS
-SUBDIRS += nodejs
-endif
-
-if WITH_LUA
-SUBDIRS += lua
-endif
-
-# All of the libs that don't use Automake need to go in here
-# so they will end up in our release tarballs.
 EXTRA_DIST = \
-	as3 \
-	cocoa \
-	d \
-	delphi \
-	haxe \
-	javame \
-	js \
-	ocaml \
-	st \
-	ts
+    json-schema.json \
+    test

--- a/lib/json/schema.json
+++ b/lib/json/schema.json
@@ -1,11 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
 
-  "id": "http://thrift.apache.org/program-schema#",
+  "id": "http://thrift.apache.org/schema.json#",
   "description": "Schema for Apache Thrift protocol descriptors",
 
   "definitions": {
     "type-id": {
+      "title": "Any type id (name)",
       "enum": [
         "void",
         "string",
@@ -20,66 +21,78 @@
         "map",
         "union",
         "struct",
-        "exception",
         "binary"
       ]
     },
     "base-type": {
-      "title": "Base types",
+      "title": "Base type schema",
       "type": "object",
       "properties": {
         "typeId": {
-          "enum": [ "void", "string", "bool", "byte", "i16", "i32", "i64", "double", "binary" ]
+          "enum": ["void", "string", "bool", "byte", "i16", "i32", "i64", "double", "binary" ]
         }
       },
       "required": [ "typeId" ]
     },
     "list-type": {
-      "title": "List and set types",
+      "title": "List and set schema",
       "type": "object",
       "properties": {
-        "typeId": { "enum": [ "list", "set" ] },
-        "elemTypeId": { "$ref": "#/definitions/type-id" },
-        "elemType": { "$ref": "#/definitions/type-spec" }
+        "typeId": {
+          "enum": [ "list", "set" ]
+        }
       },
-      "required": [ "typeId", "elemTypeId", "elemType" ]
+      "required": [ "typeId", "elemTypeId" ]
     },
     "map-type": {
-      "title": "Map type",
+      "title": "Map schema",
       "type": "object",
       "properties": {
-        "typeId":      { "enum": [ "map" ] },
-        "keyTypeId":   { "$ref": "#/definitions/type-id" },
-        "keyType":     { "$ref": "#/definitions/type-spec" },
-        "valueTypeId": { "$ref": "#/definitions/type-id" },
-        "valueType":   { "$ref": "#/definitions/type-spec" }
+        "typeId": {
+          "enum": [ "map" ]
+        }
       },
       "required": [ "typeId", "keyTypeId", "valueTypeId" ]
     },
-    "struct-spec": {
-      "title": "Struct and union types",
+    "struct-type": {
+      "title": "Struct, union and exception schema",
       "type": "object",
       "properties": {
-        "typeId": { "enum": [ "union", "struct" ] },
-        "class": { "type": "string" }
+        "typeId": {
+          "enum": [ "union", "struct", "exception" ]
+        }
       },
       "required": [ "typeId", "class" ]
     },
-    "type-spec": {
+    "type-desc": {
+      "title": "Type descriptor schema",
       "allOf": [
-        { "type": "object" },
+        {
+            "type": "object",
+            "properties": {
+                "typeId":      { "type": "string" },
+                "keyTypeId":   { "$ref": "#/definitions/type-id" },
+                "keyType":     { "$ref": "#/definitions/type-desc" },
+                "valueTypeId": { "$ref": "#/definitions/type-id" },
+                "valueType":   { "$ref": "#/definitions/type-desc" },
+                "class":       { "type": "string" },
+                "elemTypeId":  { "$ref": "#/definitions/type-id" },
+                "elemType":    { "$ref": "#/definitions/type-desc" }
+            }
+        },
         {
           "oneOf":
           [
             { "$ref": "#/definitions/base-type" },
             { "$ref": "#/definitions/list-type" },
             { "$ref": "#/definitions/map-type" },
-            { "$ref": "#/definitions/struct-spec" }
+            { "$ref": "#/definitions/struct-type" }
           ]
         }
       ]
     },
     "name-and-doc": {
+      "title": "Name and documentation sub-schema",
       "type": "object",
       "properties": {
         "name": { "type": "string" },
@@ -88,6 +101,7 @@
       "required": [ "name" ]
     },
     "enum": {
+      "title": "Thrift 'enum' definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
@@ -110,23 +124,25 @@
       ]
     },
     "typedef": {
+      "title": "Thrift typedef definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
         {
           "properties": {
             "typeId": { "$ref": "#/definitions/type-id" },
-            "type": { "$ref": "#/definitions/type-spec" }
+            "type": { "$ref": "#/definitions/type-desc" }
           },
           "required": [ "typeId" ]
         }
       ]
     },
     "constant": {
+      "title": "Thrift constant definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
-        { "$ref": "#/definitions/type-spec" },
+        { "$ref": "#/definitions/type-desc" },
         {
           "properties": {
             "value": {
@@ -143,10 +159,10 @@
       ]
     },
     "field": {
+      "title": "Thrift struct field definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
-        { "$ref": "#/definitions/type-spec" },
         {
           "properties": {
             "key": {
@@ -157,6 +173,8 @@
             "required": {
               "enum": [ "required", "optional", "req_out" ]
             },
+            "typeId": { "$ref": "#/definitions/type-id" },
+            "type": { "$ref": "#/definitions/type-desc" },
             "default": {
               "oneOf": [
                 { "type": "string" },
@@ -171,6 +189,7 @@
       ]
     },
     "struct": {
+      "title": "Thrift struct definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
@@ -190,45 +209,46 @@
       ]
     },
     "union": {
+      "title": "Thrift union definition schema",
       "$ref": "#/definitions/struct"
     },
     "exception": {
-      "$ref": "#/definitions/struct"
+      "title": "Thrift exception definition schema",
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "name": { "type": "string" },
+        "typeId": { "enum": [ "exception" ] },
+        "type": { "$ref": "#/definitions/struct-type" }
+      },
+      "required": [ "key", "name", "typeId" ]
     },
     "function": {
+      "title": "Thrift service function definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
         {
-          "oneOf": [
-            {
-              "properties": { "oneway": { "type": "boolean" } },
-              "required": [ "oneway" ]
-            },
-            {
-              "properties": { "returnType": { "$ref": "#/definitions/type-spec" } },
-              "required": [ "returnType" ]
-            }
-          ]
-        },
-        {
           "properties": {
+            "oneway": {
+              "type": "boolean"
+            },
+            "returnType": {
+              "$ref": "#/definitions/type-desc"
+            },
             "arguments": {
               "type": "array",
               "items": {
-                "allOf": [
-                  { "$ref": "#/definitions/field" },
-                  {
-                    "properties": { }
-                  }
-                ]
+                "$ref": "#/definitions/field"
               }
             },
             "exceptions": {
               "type": "array",
-              "items": {
-                "$ref": "#/definitions/exception"
-              }
+              "items": { "$ref": "#/definitions/exception" }
             }
           },
           "required": [ "oneway", "arguments", "exceptions" ]
@@ -236,6 +256,7 @@
       ]
     },
     "service": {
+      "title": "Thrift service definition schema",
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
@@ -257,8 +278,6 @@
   "type": "object",
   "required": [
     "name",
-    "namespaces",
-    "includes",
     "enums",
     "typedefs",
     "structs",

--- a/lib/json/test/Makefile.am
+++ b/lib/json/test/Makefile.am
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+check:
+	$(ANT) $(ANT_FLAGS) test
+
+# Make sure this doesn't fail if ant is not configured.
+clean-local:
+	ANT=$(ANT) ; if test -z "$$ANT" ; then ANT=: ; fi ; \
+	$$ANT $(ANT_FLAGS) clean

--- a/lib/json/test/build.properties
+++ b/lib/json/test/build.properties
@@ -1,0 +1,10 @@
+# Jar versions 
+mvn.ant.task.version=2.1.3
+
+# Dependency versions
+json-schema-validator.version=2.2.6
+
+# Maven dependency download locations
+mvn.repo=http://repo1.maven.org/maven2
+mvn.ant.task.url=${mvn.repo}/org/apache/maven/maven-ant-tasks/${mvn.ant.task.version}
+mvn.ant.task.jar=maven-ant-tasks-${mvn.ant.task.version}.jar

--- a/lib/json/test/build.xml
+++ b/lib/json/test/build.xml
@@ -1,0 +1,143 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<project name="JSON Schema Test" default="test" basedir="."
+  xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+
+  <description>JSON Schema Validation Test</description>
+
+  <property name="build.dir" location="${basedir}/build" />
+  <property name="json.dir" location="${basedir}/.." />
+  <property name="gen.json.dir" location="${build.dir}/gen-json" />
+  <property name="json.schema" location="${json.dir}/schema.json" />
+  <property name="build.tools.dir" location="${build.dir}/tools"/>
+  <property name="build.lib.dir" location="${build.dir}/lib"/>
+
+  <!-- the root directory, where you unpack thrift distibution (e.g. thrift-0.x.x.tar.gz) -->
+  <property name="thrift.dir" location="../../../" />
+  <property name="thrift.test.dir" location="${thrift.dir}/test" />
+  <property name="thrift.compiler" location="${thrift.dir}/compiler/cpp/thrift" />
+
+  <!-- Get maven dependency versions from here -->
+  <property file="${basedir}/build.properties" />
+
+  <path id="test.classpath">
+    <fileset dir="${build.lib.dir}">
+      <include name="*.jar" />
+    </fileset>
+  </path>
+
+  <target name="compiler.check">
+    <fail>
+      <condition>
+        <not>
+          <resourcecount count="1">
+            <fileset id="fs" file="${thrift.compiler}"/>
+          </resourcecount>
+        </not>
+      </condition>
+      Thrift compiler is missing !
+    </fail>
+  </target>
+
+  <target name="init" depends="compiler.check, mkdirs, mvn.init">
+    <tstamp />
+  </target>
+
+  <target name="mkdirs">
+    <mkdir dir="${build.dir}"/>
+    <mkdir dir="${build.lib.dir}"/>
+    <mkdir dir="${build.tools.dir}"/>
+    <mkdir dir="${gen.json.dir}"/>
+  </target>
+
+  <target name="generate" depends="init">
+    <exec executable="${thrift.compiler}" failonerror="true">
+      <arg line="--gen json"/>
+      <arg line="-out ${gen.json.dir}"/>
+      <arg line="${thrift.test.dir}/ThriftTest.thrift"/>
+    </exec>
+    <exec executable="${thrift.compiler}" failonerror="true">
+      <arg line="--gen json:merge"/>
+      <arg line="-out ${gen.json.dir}"/>
+      <arg line="${thrift.test.dir}/Include.thrift"/>
+    </exec>
+  </target>
+
+  <target name="test" description="run schema validation"
+          depends="validate-schema, validate-generated-json"/>
+
+  <target name="validate-schema" depends="init">
+    <java classname="com.github.fge.jsonschema.main.cli.Main"
+          classpathref="test.classpath">
+      <arg value="--syntax"/>
+      <arg value="${json.schema}"/>
+    </java>
+  </target>
+
+  <target name="validate-generated-json" depends="init, generate">
+    <validate-json file="${gen.json.dir}/ThriftTest.json"/>
+    <validate-json file="${gen.json.dir}/Include.json"/>
+  </target>
+
+  <target name="clean">
+    <delete dir="${build.dir}" />
+    <delete dir="${gen.json.dir}" />
+  </target>
+
+  <target name="mvn.ant.tasks.download" depends="mkdirs,mvn.ant.tasks.check" unless="mvn.ant.tasks.found">
+    <get src="${mvn.ant.task.url}/${mvn.ant.task.jar}" dest="${build.tools.dir}/${mvn.ant.task.jar}" usetimestamp="true"/>
+  </target>
+
+  <target name="mvn.ant.tasks.check">
+    <condition property="mvn.ant.tasks.found">
+      <typefound uri="antlib:org.apache.maven.artifact.ant" name="artifact"/>
+    </condition>
+  </target> 
+
+  <target name="mvn.init" depends="mvn.ant.tasks.download" unless="mvn.finished">
+    <typedef uri="antlib:org.apache.maven.artifact.ant" classpath="${build.tools.dir}/${mvn.ant.task.jar}"/>
+
+    <artifact:dependencies filesetId="test.dependency.jars">
+      <dependency groupId="com.github.fge" artifactId="json-schema-validator" version="${json-schema-validator.version}"/>
+    </artifact:dependencies>
+
+    <!-- Copy the dependencies to the build/lib dir -->
+    <copy todir="${build.lib.dir}">
+      <fileset refid="test.dependency.jars"/>
+      <mapper type="flatten"/>
+    </copy>
+    
+    <property name="mvn.finished" value="true"/>
+  </target>
+
+  <macrodef name="validate-json">
+    <attribute name="file" default=""/>
+    <sequential>
+      <java fork="true"
+            dir="${json.dir}"
+            classname="com.github.fge.jsonschema.main.cli.Main"
+            classpathref="test.classpath">
+        <arg line="--fakeroot http://thrift.apache.org/"/>
+        <arg value="${json.schema}"/>
+        <arg value="@{file}"/>
+      </java>
+    </sequential>
+  </macrodef>
+
+</project>


### PR DESCRIPTION
This patch makes "make check" test the JSON generator by running a schema validator on generated files.
Jira: THRIFT-2869
