### PR TITLE
THRIFT-2881 Handle errors from Accept() correctly

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -120,15 +120,14 @@ func (p *TSimpleServer) Listen() error {
 
 func (p *TSimpleServer) AcceptLoop() error {
 	for {
-		select {
-		case <-p.quit:
-			return nil
-		default:
-		}
-
 		client, err := p.serverTransport.Accept()
 		if err != nil {
-			log.Println("Accept err: ", err)
+			select {
+			case <-p.quit:
+				return nil
+			default:
+			}
+			return err
 		}
 		if client != nil {
 			go func() {


### PR DESCRIPTION
Often in tests, servers are started and closed when a test case is
finished, as in the standard library's "httptest" package.

http://golang.org/pkg/net/http/httptest/#example_Server

However, currently the "p.quit" channel of TSimpleServer does not
correctly handle the case when the listener socket is Closed, resulting
in spurious logs with the text "Accept err: ...".
For details of handling closed listener sockets, see

https://code.google.com/p/go/issues/detail?id=4373
http://zhen.org/blog/graceful-shutdown-of-go-net-dot-listeners/
http://stackoverflow.com/a/13419724/2182406
