### PR TITLE
THRIFT-2880 Read the network address from the listener if available.

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -96,6 +96,9 @@ func (p *TServerSocket) Open() error {
 }
 
 func (p *TServerSocket) Addr() net.Addr {
+	if p.listener != nil {
+		return p.listener.Addr()
+	}
 	return p.addr
 }
 


### PR DESCRIPTION
Often in tests, the listening port of a test server is automatically
selected by passing the zero port in the host, as in "127.0.0.1:0".
An example of such behaviour is in the "httptest" package of the
standard library:

https://github.com/golang/go/blob/master/src/net/http/httptest/server.go#L65

As such, it is necessary to read from the listener itself to retrieve
the actually listening port, as in

https://github.com/golang/go/blob/master/src/net/http/httptest/server.go#L107
