### PR TITLE
THRIFT-2883 Fix dict changed size during iteration exception

### DIFF
--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -93,7 +93,7 @@ class ThriftClientProtocol(basic.Int32StringReceiver):
                 _, v = self.client._reqs.popitem()
                 v.errback(tex)
             del self.client._reqs
-            del self.client
+            self.client = None
 
     def stringReceived(self, frame):
         tr = TTransport.TMemoryBuffer(frame)


### PR DESCRIPTION
During the notification of outstanding requests via errback that the connection has failed, new requests can be attempted which change the size of the client._reqs dict.
This change pulls individual requests from the dict until the dict is empty. Also, the exception is augmented to include the reason the connection was lost.