### PR TITLE
erl lib: add recv_timeout configuration for client tcp connection

### DIFF
--- a/lib/erl/src/thrift_client_util.erl
+++ b/lib/erl/src/thrift_client_util.erl
@@ -40,6 +40,7 @@ split_options([Opt = {OptKey, _} | Rest], ProtoIn, TransIn)
 split_options([Opt = {OptKey, _} | Rest], ProtoIn, TransIn)
   when OptKey =:= framed;
        OptKey =:= connect_timeout;
+       OptKey =:= recv_timeout;
        OptKey =:= sockopts ->
     split_options(Rest, ProtoIn, [Opt | TransIn]).
 


### PR DESCRIPTION
Tcp recv timeout is only used in server socket but in client, and thus client could block there to wait for the server response, which is not satisfied in time-critical situations.