### PR TITLE
THRIFT-2893 CMake build fails with boost thread or std thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,26 @@ matrix:
        - make check -j2;
 
     - env:
+        - TEST_NAME="C++/boost-threads (gcc, CMake)"
+          CONFIG="-DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_BOOSTTHREADS=ON"
+      compiler: gcc
+      before_install:
+       - sh contrib/installCXXDependencies.sh;
+       - sh contrib/installDependencies.sh 1> /dev/null;
+      script:
+       - mkdir build_cmake && cd build_cmake && cmake $CONFIG .. && make -j4 && cd ..;
+
+    - env:
+        - TEST_NAME="C++/std-threads (gcc, CMake)"
+          CONFIG="-DCMAKE_CXX_FLAGS=-std=c++11 -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_STDTHREADS=ON"
+      compiler: gcc
+      before_install:
+       - sh contrib/installCXXDependencies.sh;
+       - sh contrib/installDependencies.sh 1> /dev/null;
+      script:
+       - mkdir build_cmake && cd build_cmake && cmake $CONFIG .. && make -j4 && cd ..;
+
+    - env:
         - TEST_NAME="all (gcc, CMake + CPack)"
           CONFIG=""
       compiler: gcc

--- a/contrib/installCXXDependencies.sh
+++ b/contrib/installCXXDependencies.sh
@@ -25,5 +25,5 @@
 # General dependencies
 sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
 sudo apt-get update -qq
-sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make libqt4-dev git debhelper bc 
+sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make libqt4-dev git debhelper bc
 dpkg -S /usr/include/boost/version.hpp

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -21,7 +21,11 @@
 cmake_minimum_required(VERSION 2.8)
 
 # Find required packages
-find_package(Boost 1.53.0 REQUIRED)
+if(WITH_BOOSTTHREADS)
+  find_package(Boost 1.53.0 REQUIRED COMPONENTS system thread)
+else()
+  find_package(Boost 1.53.0 REQUIRED)
+endif()
 include_directories("${Boost_INCLUDE_DIR}")
 
 include_directories(src)
@@ -98,9 +102,9 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
     list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
 endif()
 
-# WITH_*THREADS selects whicht threading library to use
+# WITH_*THREADS selects which threading library to use
 if(WITH_BOOSTTHREADS)
-    set( USE_BOOST_THREAD 1)
+    add_definitions("-DUSE_BOOST_THREAD=1")
     set( thriftcpp_threads_SOURCES
         src/thrift/concurrency/BoostThreadFactory.cpp
         src/thrift/concurrency/BoostMonitor.cpp
@@ -115,7 +119,11 @@ elseif(UNIX AND NOT WITH_STDTHREADS)
         src/thrift/concurrency/Monitor.cpp
     )
 else()
-    set( USE_STD_THREAD 1)
+    add_definitions("-DUSE_STD_THREAD=1")
+    if(UNIX)
+        # need pthread for multi-thread support
+        list(APPEND SYSLIBS pthread)
+    endif()
     set( thriftcpp_threads_SOURCES
         src/thrift/concurrency/StdThreadFactory.cpp
         src/thrift/concurrency/StdMutex.cpp

--- a/lib/cpp/src/thrift/concurrency/BoostThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/BoostThreadFactory.cpp
@@ -19,7 +19,7 @@
 
 #include <thrift/thrift-config.h>
 
-#ifdef USE_BOOST_THREAD
+#if USE_BOOST_THREAD
 
 #include <thrift/concurrency/BoostThreadFactory.h>
 #include <thrift/concurrency/Exception.h>

--- a/lib/cpp/src/thrift/concurrency/PlatformThreadFactory.h
+++ b/lib/cpp/src/thrift/concurrency/PlatformThreadFactory.h
@@ -36,7 +36,7 @@ namespace thrift {
 namespace concurrency {
 
 // clang-format off
-#ifdef USE_BOOST_THREAD
+#if USE_BOOST_THREAD
   typedef BoostThreadFactory PlatformThreadFactory;
 #elif USE_STD_THREAD
   typedef StdThreadFactory PlatformThreadFactory;

--- a/lib/cpp/src/thrift/concurrency/StdThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/StdThreadFactory.cpp
@@ -19,7 +19,7 @@
 
 #include <thrift/thrift-config.h>
 
-#ifdef USE_STD_THREAD
+#if USE_STD_THREAD
 
 #include <thrift/concurrency/StdThreadFactory.h>
 #include <thrift/concurrency/Exception.h>

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -1215,7 +1215,7 @@ void TNonblockingServer::registerEvents(event_base* user_event_base) {
   // Launch all the secondary IO threads in separate threads
   if (ioThreads_.size() > 1) {
     ioThreadFactory_.reset(new PlatformThreadFactory(
-#if !defined(USE_BOOST_THREAD) && !defined(USE_STD_THREAD)
+#if !USE_BOOST_THREAD && !USE_STD_THREAD
         PlatformThreadFactory::OTHER,  // scheduler
         PlatformThreadFactory::NORMAL, // priority
         1,                             // stack size (MB)

--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -63,7 +63,7 @@ protected:
   int startServer(int port) {
     boost::scoped_ptr<concurrency::ThreadFactory> threadFactory(
         new concurrency::PlatformThreadFactory(
-#if !defined(USE_BOOST_THREAD) && !defined(USE_STD_THREAD)
+#if !USE_BOOST_THREAD && !USE_STD_THREAD
             concurrency::PlatformThreadFactory::OTHER,
             concurrency::PlatformThreadFactory::NORMAL,
             1,

--- a/lib/cpp/test/concurrency/ThreadManagerTests.h
+++ b/lib/cpp/test/concurrency/ThreadManagerTests.h
@@ -106,7 +106,7 @@ public:
     shared_ptr<PlatformThreadFactory> threadFactory
         = shared_ptr<PlatformThreadFactory>(new PlatformThreadFactory());
 
-#ifndef USE_BOOST_THREAD
+#if !USE_BOOST_THREAD && !USE_STD_THREAD
     threadFactory->setPriority(PosixThreadFactory::HIGHEST);
 #endif
     threadManager->threadFactory(threadFactory);
@@ -253,7 +253,7 @@ public:
       shared_ptr<PlatformThreadFactory> threadFactory
           = shared_ptr<PlatformThreadFactory>(new PlatformThreadFactory());
 
-#ifndef USE_BOOST_THREAD
+#if !USE_BOOST_THREAD && !USE_STD_THREAD
       threadFactory->setPriority(PosixThreadFactory::HIGHEST);
 #endif
       threadManager->threadFactory(threadFactory);

--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -25,7 +25,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <thrift/concurrency/PosixThreadFactory.h>
+#include <thrift/concurrency/PlatformThreadFactory.h>
 #include <thrift/concurrency/Monitor.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TThreadedServer.h>
@@ -94,7 +94,7 @@ public:
       const boost::shared_ptr<TProtocolFactory>& protocolFactory) {
     boost::shared_ptr<TServerSocket> socket(new TServerSocket(port));
 
-    boost::shared_ptr<PosixThreadFactory> threadFactory(new PosixThreadFactory);
+    boost::shared_ptr<PlatformThreadFactory> threadFactory(new PlatformThreadFactory);
     boost::shared_ptr<ThreadManager> threadManager = ThreadManager::newSimpleThreadManager(8);
     threadManager->threadFactory(threadFactory);
     threadManager->start();
@@ -122,7 +122,7 @@ public:
       throw TException("TNonblockingServer must use TFramedTransport");
     }
 
-    boost::shared_ptr<PosixThreadFactory> threadFactory(new PosixThreadFactory);
+    boost::shared_ptr<PlatformThreadFactory> threadFactory(new PlatformThreadFactory);
     boost::shared_ptr<ThreadManager> threadManager = ThreadManager::newSimpleThreadManager(8);
     threadManager->threadFactory(threadFactory);
     threadManager->start();

--- a/lib/cpp/test/processor/ServerThread.cpp
+++ b/lib/cpp/test/processor/ServerThread.cpp
@@ -21,7 +21,7 @@
 
 #include "ServerThread.h"
 
-#include <thrift/concurrency/PosixThreadFactory.h>
+#include <thrift/concurrency/PlatformThreadFactory.h>
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/server/TThreadPoolServer.h>
 #include <thrift/transport/TBufferTransports.h>
@@ -36,7 +36,7 @@ void ServerThread::start() {
   running_ = true;
 
   // Start the other thread
-  concurrency::PosixThreadFactory threadFactory;
+  concurrency::PlatformThreadFactory threadFactory;
   threadFactory.setDetached(false);
   thread_ = threadFactory.newThread(helper_);
 


### PR DESCRIPTION
Following changes are made to fix the build
- Add USE_..._THREAD compiler definitions correctly
- Link to boost_thread and boost_system when configured with boost thread
- Use PlatformThreadFactory in test code
