### PR TITLE
PHP generator: in jsonSerialize, only skip maps with non-scalar keys

### DIFF
--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -1081,11 +1081,14 @@ void t_php_generator::generate_php_struct_json_serialize(ofstream& out,
       t_field* field = (*f_iter);
       t_type* type = field->get_type();
       const string& name = field->get_name();
-      if (type->is_map() && !((t_map*)type)->get_key_type()->is_base_type()) {
-        // JSON object keys must be strings. PHP's json_encode()
-        // function will convert any scalar key to strings, but
-        // we skip thrift maps with non-scalar keys.
-        continue;
+      if (type->is_map()) {
+        t_type* key_type = ((t_map*)type)->get_key_type();
+        if (!(key_type->is_base_type() || key_type->is_enum())) {
+          // JSON object keys must be strings. PHP's json_encode()
+          // function will convert any scalar key to strings, but
+          // we skip thrift maps with non-scalar keys.
+          continue;
+        }
       }
       indent(out) << "if ($this->" << name << " !== null) {" << endl;
       indent_up();


### PR DESCRIPTION
Previously skipped maps with enum or non-base-type keys. This fixes the original patch in THRIFT-2894.
