### PR TITLE
Directly link libboost_unit_test_framework.a.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,7 @@ have_cpp=no
 if test "$with_cpp" = "yes";  then
   AX_BOOST_BASE([1.54.0])
   if test "x$succeeded" = "xyes" ; then
+    AC_SUBST([BOOST_LIB_DIR], [$(echo "$BOOST_LDFLAGS" | sed -e 's/^\-L//')])
     have_cpp="yes"
   fi
 

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -100,7 +100,7 @@ endif
 
 UnitTests_LDADD = \
   libtestgencpp.la \
-  -l:libboost_unit_test_framework.a
+  $(BOOST_LIB_DIR)/libboost_unit_test_framework.a
 
 TransportTest_SOURCES = \
 	TransportTest.cpp
@@ -108,7 +108,7 @@ TransportTest_SOURCES = \
 TransportTest_LDADD = \
   libtestgencpp.la \
   $(top_builddir)/lib/cpp/libthriftz.la \
-  -l:libboost_unit_test_framework.a \
+  $(BOOST_LIB_DIR)/libboost_unit_test_framework.a \
   -lz
 
 ZlibTest_SOURCES = \
@@ -117,7 +117,7 @@ ZlibTest_SOURCES = \
 ZlibTest_LDADD = \
   libtestgencpp.la \
   $(top_builddir)/lib/cpp/libthriftz.la \
-  -l:libboost_unit_test_framework.a \
+  $(BOOST_LIB_DIR)/libboost_unit_test_framework.a \
   -lz
 
 EnumTest_SOURCES = \
@@ -125,14 +125,14 @@ EnumTest_SOURCES = \
 
 EnumTest_LDADD = \
   libtestgencpp.la \
-  -l:libboost_unit_test_framework.a
+  $(BOOST_LIB_DIR)/libboost_unit_test_framework.a
 
 TFileTransportTest_SOURCES = \
 	TFileTransportTest.cpp
 
 TFileTransportTest_LDADD = \
   libtestgencpp.la \
-  -l:libboost_unit_test_framework.a
+  $(BOOST_LIB_DIR)/libboost_unit_test_framework.a
 
 #
 # TFDTransportTest
@@ -188,9 +188,9 @@ TNonblockingServerTest_SOURCES = TNonblockingServerTest.cpp
 TNonblockingServerTest_LDADD = libprocessortest.la \
                                $(top_builddir)/lib/cpp/libthrift.la \
                                $(top_builddir)/lib/cpp/libthriftnb.la \
+                               $(BOOST_LIB_DIR)/libboost_unit_test_framework.a \
                                $(BOOST_LDFLAGS) \
-                               -levent \
-                               -l:libboost_unit_test_framework.a
+                               -levent
 
 #
 # OptionalRequiredTest
@@ -241,16 +241,16 @@ processor_test_SOURCES = \
 processor_test_LDADD = libprocessortest.la \
                        $(top_builddir)/lib/cpp/libthrift.la \
                        $(top_builddir)/lib/cpp/libthriftnb.la \
+                       $(BOOST_LIB_DIR)/libboost_unit_test_framework.a \
                        $(BOOST_LDFLAGS) \
-                       -levent \
-                       -l:libboost_unit_test_framework.a
+                       -levent
 
 OpenSSLManualInitTest_SOURCES = \
 	OpenSSLManualInitTest.cpp
 
 OpenSSLManualInitTest_LDADD = \
 	$(top_builddir)/lib/cpp/libthrift.la \
-	-l:libboost_unit_test_framework.a
+	$(BOOST_LIB_DIR)/libboost_unit_test_framework.a
 
 #
 # Common thrift code generation rules


### PR DESCRIPTION
Not all linkers support the `-l:libfoo.a` syntax (notably ld(1) on Mac
OS X).  For full compatibility, we want to link directly against the
static library using its full path.

(We can't link the dynamic version of this library because of the way
that the `_main()` symbol is defined and used by the Thrift unit tests.)

Unfortunately, AX_BOOST_BASE doesn't expose the selected library path
as a variable, so we derive BOOST_LIB_DIR from BOOST_LDPATH instead.
That variable is defined conditionally on C++ and Boost support.

Lastly, I looked at the GNU AX_BOOST_UNIT_TEST_FRAMEWORK macro.  It
unfortunately prefers the dynamic library over the static one (see
above), so it's not suitable for our use case.  That macro could be
extended to take an argument (e.g. 'static') which would force the use
of the static library, but that felt unnecessary here.

Fixes [THRIFT-2906](https://issues.apache.org/jira/browse/THRIFT-2906)
