### PR TITLE
THRIFT-2912 Autotool build for C++ Qt library is invalid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,8 +153,10 @@ if test "$with_cpp" = "yes";  then
     PKG_CHECK_MODULES([QT], [QtCore >= 4.3, QtNetwork >= 4.3], have_qt=yes, have_qt=no)
   fi
   if test "$have_qt" = "yes"; then
-    AC_PATH_PROGS([QT_MOC], [moc-qt4 moc])
-    have_qt=$success
+    AC_PATH_PROGS([QT_MOC], [moc-qt4 moc], "fail")
+    if test "$QT_MOC" = "fail"; then
+      have_qt=no
+    fi
   fi
 
   AX_THRIFT_LIB(qt5, [Qt5], yes)
@@ -166,8 +168,10 @@ if test "$with_cpp" = "yes";  then
                       [have_qt5=no])
   fi
   if test "$have_qt5" = "yes"; then
-    AC_PATH_PROGS([QT5_MOC], [moc-qt5 moc])
-    have_qt5=$success
+    AC_PATH_PROGS([QT5_MOC], [moc-qt5 moc], "fail")
+    if test "$QT5_MOC" = "fail"; then
+      have_qt5=no
+    fi
   fi
 fi
 AM_CONDITIONAL([WITH_CPP], [test "$have_cpp" = "yes"])

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -114,16 +114,16 @@ libthriftnb_la_SOURCES = src/thrift/server/TNonblockingServer.cpp \
 libthriftz_la_SOURCES = src/thrift/transport/TZlibTransport.cpp
 
 libthriftqt_la_MOC = src/thrift/qt/moc_TQTcpServer.cpp
-libthriftqt_la_SOURCES = $(libthriftqt_la_MOC) \
-                         src/thrift/qt/TQIODeviceTransport.cpp \
+nodist_libthriftqt_la_SOURCES = $(libthriftqt_la_MOC)
+libthriftqt_la_SOURCES = src/thrift/qt/TQIODeviceTransport.cpp \
                          src/thrift/qt/TQTcpServer.cpp
 CLEANFILES = $(libthriftqt_la_MOC)
 
 libthriftqt5_la_MOC = src/thrift/qt/moc__TQTcpServer.cpp
-libthriftqt5_la_SOURCES = $(libthriftqt5_la_MOC) \
-                         src/thrift/qt/TQIODeviceTransport.cpp \
-                         src/thrift/qt/TQTcpServer.cpp
-CLEANFILES = $(libthriftqt5_la_MOC)
+nodist_libthriftqt5_la_SOURCES = $(libthriftqt5_la_MOC)
+libthriftqt5_la_SOURCES = src/thrift/qt/TQIODeviceTransport.cpp \
+                          src/thrift/qt/TQTcpServer.cpp
+CLEANFILES += $(libthriftqt5_la_MOC)
 
 # Flags for the various libraries
 libthriftnb_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBEVENT_CPPFLAGS)


### PR DESCRIPTION
- Fix incorrect AC_PATH_PROGS usage
- Exclude generated source code from distribution
