### PR TITLE
THRIFT-2911 fix c++ version zeromq transport, the old version cannot work

### DIFF
--- a/contrib/zeromq/Makefile
+++ b/contrib/zeromq/Makefile
@@ -1,6 +1,4 @@
 THRIFT = thrift
-CXXFLAGS = `pkg-config --cflags libzmq thrift`
-LDLIBS = `pkg-config --libs libzmq thrift`
 
 CXXFLAGS += -g3 -O0
 
@@ -16,9 +14,13 @@ PROGS =  test-client test-server test-sender test-receiver
 all: $(PYLIBS) $(PROGS)
 
 test-client: test-client.o TZmqClient.o $(GENOBJS)
+	$(CXX) $^ -o $@ -lzmq -lthrift
 test-server: test-server.o TZmqServer.o $(GENOBJS)
+	$(CXX) $^ -o $@ -lzmq -lthrift
 test-sender: test-sender.o TZmqClient.o $(GENOBJS)
+	$(CXX) $^ -o $@ -lzmq -lthrift
 test-receiver: test-receiver.o TZmqServer.o $(GENOBJS)
+	$(CXX) $^ -o $@ -lzmq -lthrift
 
 test-client.o test-server.o test-sender.o test-receiver.o: $(GENSRCS)
 

--- a/contrib/zeromq/TZmqClient.cpp
+++ b/contrib/zeromq/TZmqClient.cpp
@@ -22,7 +22,7 @@
 
 namespace apache { namespace thrift { namespace transport {
 
-uint32_t TZmqClient::read(uint8_t* buf, uint32_t len) {
+uint32_t TZmqClient::read_virt(uint8_t* buf, uint32_t len) {
   if (rbuf_.available_read() == 0) {
     (void)sock_.recv(&msg_);
     rbuf_.resetBuffer((uint8_t*)msg_.data(), msg_.size());
@@ -30,11 +30,11 @@ uint32_t TZmqClient::read(uint8_t* buf, uint32_t len) {
   return rbuf_.read(buf, len);
 }
 
-void TZmqClient::write(const uint8_t* buf, uint32_t len) {
+void TZmqClient::write_virt(const uint8_t* buf, uint32_t len) {
   return wbuf_.write(buf, len);
 }
 
-void TZmqClient::writeEnd() {
+uint32_t TZmqClient::writeEnd() {
   uint8_t* buf;
   uint32_t size;
   wbuf_.getBuffer(&buf, &size);
@@ -42,6 +42,7 @@ void TZmqClient::writeEnd() {
   std::memcpy(msg.data(), buf, size);
   (void)sock_.send(msg);
   wbuf_.resetBuffer(true);
+  return size;
 }
 
 }}} // apache::thrift::transport

--- a/contrib/zeromq/TZmqClient.h
+++ b/contrib/zeromq/TZmqClient.h
@@ -45,15 +45,15 @@ class TZmqClient : public TTransport {
     }
   }
 
-  uint32_t read(uint8_t* buf, uint32_t len);
+  uint32_t read_virt(uint8_t* buf, uint32_t len);
 
-  void write(const uint8_t* buf, uint32_t len);
+  void write_virt(const uint8_t* buf, uint32_t len);
 
-  void writeEnd();
+  uint32_t writeEnd();
 
  protected:
-  std::string endpoint_;
   zmq::socket_t sock_;
+  std::string endpoint_;
   TMemoryBuffer wbuf_;
   TMemoryBuffer rbuf_;
   zmq::message_t msg_;

--- a/contrib/zeromq/TZmqServer.cpp
+++ b/contrib/zeromq/TZmqServer.cpp
@@ -27,7 +27,6 @@ using apache::thrift::protocol::TProtocol;
 
 namespace apache { namespace thrift { namespace server {
 
-
 bool TZmqServer::serveOne(int recv_flags) {
   zmq::message_t msg;
   bool received = sock_.recv(&msg, recv_flags);
@@ -40,8 +39,9 @@ bool TZmqServer::serveOne(int recv_flags) {
       inputProtocolFactory_->getProtocol(inputTransport));
   shared_ptr<TProtocol> outputProtocol(
       outputProtocolFactory_->getProtocol(outputTransport));
+  shared_ptr<TMemoryBuffer> transport(new TMemoryBuffer);
 
-  processor_->process(inputProtocol, outputProtocol);
+  processor_->process(inputProtocol, outputProtocol, NULL);
 
   if (zmq_type_ == ZMQ_REP) {
     uint8_t* buf;

--- a/contrib/zeromq/TZmqServer.h
+++ b/contrib/zeromq/TZmqServer.h
@@ -31,6 +31,7 @@ class TZmqServer : public TServer {
       boost::shared_ptr<TProcessor> processor,
       zmq::context_t& ctx, const std::string& endpoint, int type)
     : TServer(processor)
+    , processor_(processor)
     , zmq_type_(type)
     , sock_(ctx, type)
   {
@@ -55,6 +56,7 @@ class TZmqServer : public TServer {
   }
 
  private:
+  boost::shared_ptr<TProcessor> processor_;
   int zmq_type_;
   zmq::socket_t sock_;
 };


### PR DESCRIPTION
* Fix TTransport inheritance made by TZmqClient is indeed incorrect, TZmqClient override nothing