### PR TITLE
THRIFT-2919 Haxe test server timeout too large

### DIFF
--- a/lib/haxe/src/org/apache/thrift/TBase.hx
+++ b/lib/haxe/src/org/apache/thrift/TBase.hx
@@ -19,6 +19,13 @@
 
 package org.apache.thrift;
 
+// Make sure we use at least 3.1.3
+// Some Linux platforms have waaaay too old packages in their repos
+// Pro Tip: Look at http://openfl.com for a good Linux install script
+#if( haxe_ver < 3.103)
+#error Haxe 3.1.3 or newer required, sorry!
+#end
+
 import org.apache.thrift.protocol.TProtocol;
 
   /**

--- a/test/haxe/Makefile.am
+++ b/test/haxe/Makefile.am
@@ -46,9 +46,10 @@ clean-local:
 	$(RM) -r gen-haxe bin
 
 check: $(BIN_CPP)
-	timeout 120 $(BIN_CPP) server &
+	timeout 10 $(BIN_CPP) server &
 	sleep 1
 	$(BIN_CPP) client
+	sleep 10
 
 EXTRA_DIST = \
              src \


### PR DESCRIPTION
Client: Haxe
Patch: Jens Geyer
- reduced timeout and made sure the test script waits appropriately
- added test to make sure Haxe >= 3.1.3 is used
