### PR TITLE
THRIFT-2925 CMake build does not work with OpenSSL nor anything installe...

### DIFF
--- a/cmake/DefineOptions.cmake
+++ b/cmake/DefineOptions.cmake
@@ -59,7 +59,7 @@ if(${WITH_QT4} AND ${WITH_QT5} AND ${CMAKE_MAJOR_VERSION} LESS 3)
 endif()
 find_package(OpenSSL QUIET)
 CMAKE_DEPENDENT_OPTION(WITH_OPENSSL "Build with OpenSSL support" ON
-                       "OpenSSL_FOUND" OFF)
+                       "OPENSSL_FOUND" OFF)
 option(WITH_BOOSTTHREADS "Build with Boost thread support" OFF)
 option(WITH_STDTHREADS "Build with C++ std::thread support" OFF)
 

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ if(WITH_BOOSTTHREADS)
 else()
   find_package(Boost 1.53.0 REQUIRED)
 endif()
-include_directories("${Boost_INCLUDE_DIR}")
+include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 
 include_directories(src)
 
@@ -98,7 +98,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
        src/thrift/transport/TSSLSocket.cpp
        src/thrift/transport/TSSLServerSocket.cpp
     )
-    include_directories("${OPENSSL_INCLUDE_DIR}")
+    include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
     list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
 endif()
 
@@ -158,15 +158,15 @@ TARGET_LINK_LIBRARIES_THRIFT(thrift ${SYSLIBS})
 
 if(WITH_LIBEVENT)
     find_package(Libevent REQUIRED)  # Libevent comes with CMake support form upstream
-    include_directories(${Libevent_INCLUDE_DIR})
+    include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftnb ${thriftcppnb_SOURCES})
-    TARGET_LINK_LIBRARIES_THRIFT(thriftnb ${SYSLIBS} ${Libevent_LIBRARIES})
+    TARGET_LINK_LIBRARIES_THRIFT(thriftnb ${SYSLIBS} ${LIBEVENT_LIBRARIES})
 endif()
 
 if(WITH_ZLIB)
     find_package(ZLIB REQUIRED)
-    include_directories(${ZLIB_INCLUDE_DIR})
+    include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftz ${thriftcppz_SOURCES})
     TARGET_LINK_LIBRARIES_THRIFT(thriftz ${SYSLIBS} ${ZLIB_LIBRARIES})

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Find required packages
 set(Boost_USE_STATIC_LIBS ON) # Force the use of static boost test framework
 find_package(Boost 1.53.0 REQUIRED COMPONENTS unit_test_framework)
-include_directories("${Boost_INCLUDE_DIR}")
+include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 
 #Make sure gen-cpp files can be included
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
...d in non-system location

This diff fixes them by correcting invalid CMake variable names:
* OPENSSL_... rather than OpenSSL_...
* LIBEVENT_... rather than Libevent_...
* Boost_INCLUDE_DIRS rather than Boost_INCLUDE_DIR
* LIBEVENT_INCLUDE_DIRS rather than LIBEVENT_INCLUDE_DIR
* ZLIB_INCLUDE_DIRS rather than ZLIB_INCLUDE_DIR

Note:
* OPENSSL_INCLUDE_DIR is correct (rather than ..._DIRS)
* Boost_INCLUDE_DIR exists and actually works for most cases but
  Boost_INCLUDE_DIRS is the one desinged to be included

Also, library headers are now included as SYSTEM headers.