### PR TITLE
THRIFT-2928 Rename the erlang test_server module

### DIFF
--- a/lib/erl/test/test_thrift_server.erl
+++ b/lib/erl/test/test_thrift_server.erl
@@ -17,7 +17,7 @@
 %% under the License.
 %%
 
--module(test_server).
+-module(test_thrift_server).
 
 -export([go/0, go/1, start_link/2, handle_function/2]).
 


### PR DESCRIPTION
Submitted the fix for the issue I filed earlier today.

Avoiding clashes with the in-built erlang app bundled since November '09
Used git mv, then renamed the module in the source.
Verified that git blame continues to work as expected.

More Details on Jira/THRIFT-2928