### PR TITLE
THRIFT-2930 erlang module thriftTest_thrift referenced instead of thrift...

### DIFF
--- a/lib/erl/README.md
+++ b/lib/erl/README.md
@@ -31,7 +31,7 @@ old naming conventions (for backwards compatibility) use the compiler option
 
 Example session using thrift_client:
 
-1> {ok, C0} = thrift_client_util:new("localhost", 9090, thriftTest_thrift, []), ok.
+1> {ok, C0} = thrift_client_util:new("localhost", 9090, thrift_test_thrift, []), ok.
 ok
 2> {C1, R1} = thrift_client:call(C0, testVoid, []), R1.
 {ok,ok}

--- a/lib/erl/test/test_server.erl
+++ b/lib/erl/test/test_server.erl
@@ -52,7 +52,7 @@ go(Args) ->
 
 start_link(Port, ServerOpts) ->
     thrift_socket_server:start([{handler, ?MODULE},
-                                {service, thriftTest_thrift},
+                                {service, thrift_test_thrift},
                                 {port, Port}] ++
                                ServerOpts).
 


### PR DESCRIPTION
..._test_thrift

I was unable to find thriftTest_thrift in master. I did find references to a 5 year old version of that file online.

Replace thriftTest_thrift with thrift_test_thrift in a test and the Readme, within the erlang library.

More details on JIRA/THRIFT-2930
