### PR TITLE
THRIFT-2949: fix typo in compiler/cpp/README.md

### DIFF
--- a/compiler/cpp/README.md
+++ b/compiler/cpp/README.md
@@ -30,8 +30,8 @@ In order to build on windows a few additional steps are necessary:
 1. Download winflexbison from http://sourceforge.net/projects/winflexbison/
 2. Extract the winflex bison files to for e.g. C:\winflexbison
 3. Make the CMake variables point to the correct binaries.
-  * FLEX_EXECUTBALE = C:/winbuild/win_flex.exe
-  * BISON_EXECUTBALE = C:/winbuild/win_bison.exe
+  * FLEX_EXECUTABLE = C:/winbuild/win_flex.exe
+  * BISON_EXECUTABLE = C:/winbuild/win_bison.exe
 
 
 ### Create a Visual Studio project


### PR DESCRIPTION
fix typo in compiler/cpp/README.md
* EXECUTBALE -> EXECUTABLE