### PR TITLE
Service inheritance does not work with namespaced Ruby code.

### DIFF
--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -749,8 +749,13 @@ void t_rb_generator::generate_service(t_service* tservice) {
   f_service_ << rb_autogen_comment() << endl << render_require_thrift();
 
   if (tservice->get_extends() != NULL) {
-    f_service_ << "require '" << require_prefix_ << underscore(tservice->get_extends()->get_name())
-               << "'" << endl;
+    if (namespaced_) {
+      f_service_ << "require '" << rb_namespace_to_path_prefix(tservice->get_extends()->get_program()->get_namespace("rb")) << underscore(tservice->get_extends()->get_name())
+	         << "'" << endl;
+    } else {
+      f_service_ << "require '" << require_prefix_ << underscore(tservice->get_extends()->get_name())
+	         << "'" << endl;
+    }
   }
 
   f_service_ << "require '" << require_prefix_ << underscore(program_name_) << "_types'" << endl

--- a/lib/rb/Rakefile
+++ b/lib/rb/Rakefile
@@ -48,6 +48,8 @@ namespace :'gen-rb' do
   task :'namespaced_spec' do
     dir = File.dirname(__FILE__) + '/spec'
     sh THRIFT, '--gen', 'rb:namespaced', '-recurse', '-o', dir, "#{dir}/ThriftNamespacedSpec.thrift"
+    sh THRIFT, '--gen', 'rb:namespaced', '-recurse', '-o', dir, "#{dir}/BaseService.thrift"
+    sh THRIFT, '--gen', 'rb:namespaced', '-recurse', '-o', dir, "#{dir}/ExtendedService.thrift"
   end
 
   task :'benchmark' do

--- a/lib/rb/spec/BaseService.thrift
+++ b/lib/rb/spec/BaseService.thrift
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+namespace rb Base
+
+struct Hello {
+  1: string greeting = "hello world"
+}
+
+service BaseService {
+  Hello greeting(1:bool english)
+}

--- a/lib/rb/spec/ExtendedService.thrift
+++ b/lib/rb/spec/ExtendedService.thrift
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+namespace rb Extended
+
+include "BaseService.thrift"
+
+service ExtendedService extends BaseService.BaseService {
+  void ping()
+}

--- a/lib/rb/spec/namespaced_spec.rb
+++ b/lib/rb/spec/namespaced_spec.rb
@@ -59,4 +59,9 @@ describe 'namespaced generation' do
   it "required an included file" do
     defined?(OtherNamespace::SomeEnum).should be_true
   end
+
+  it "extended a service" do
+    require "extended/extended_service"
+  end
+
 end


### PR DESCRIPTION
This PR fixes `thrift --gen rb:namespaced` to work with inheritance.

See also #140 and #363.