### PR TITLE
cmake // build // fixed java library build enabler

### DIFF
--- a/cmake/DefineOptions.cmake
+++ b/cmake/DefineOptions.cmake
@@ -69,8 +69,9 @@ CMAKE_DEPENDENT_OPTION(WITH_C_GLIB "Build C (GLib) library" ON
                        "BUILD_LIBRARIES;GLIB_FOUND" OFF)
 # Java
 find_package(Java QUIET)
+find_package(Ant QUIET)
 CMAKE_DEPENDENT_OPTION(WITH_JAVA "Build Java library" ON
-                       "BUILD_LIBRARIES;JAVA_FOUND" OFF)
+                       "BUILD_LIBRARIES;JAVA_FOUND;Ant_FOUND" OFF)
 
 # Common library options
 option(WITH_SHARED_LIB "Build shared libraries" ON)

--- a/lib/java/CMakeLists.txt
+++ b/lib/java/CMakeLists.txt
@@ -20,9 +20,6 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-# Find required packages
-find_package(Ant REQUIRED)
-
 if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
     set(JAVA_INSTALL_DIR "${LIB_INSTALL_DIR}/java")
 else()


### PR DESCRIPTION
Hello, 

Here the fix for case when jdk is installed, but no Ant tool present.
Since Ant is required to build java library, I move Ant search to  cmake/DefineOptions.cmake and add dependency for WITH_JAVA option.

Without those changes we'll pass JAVA_FOUND test and will fail later in find_package(Ant REQUIRED)