### PR TITLE
THRIFT-2975 Graceful handling of server-side errors in Python

### DIFF
--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -195,7 +195,7 @@ class AbstractTest(unittest.TestCase):
     try:
       self.client.testException("throw_undeclared")
       self.fail("should have thrown exception")
-    except Exception: # type is undefined
+    except TApplicationException: # type is undefined
       pass
 
   def testOneway(self):

--- a/test/py/TestServer.py
+++ b/test/py/TestServer.py
@@ -118,6 +118,8 @@ class TestHandler:
       raise Xception(errorCode=1001, message=arg)
     elif arg == 'TException':
       raise TException(message='This is a TException')
+    elif arg == 'throw_undeclared':
+      raise ValueError('foo')
 
   def testMultiException(self, arg0, arg1):
     if options.verbose > 1:


### PR DESCRIPTION
Change `process_*` functions to handle unexpected exceptions from
user-supplied handlers by throwing a `TApplicationException(INTERNAL_ERROR)`
to the client.