### PR TITLE
THRIFT-2180: Cocoa-Library: addresses integer type issues on 64-bit platforms

### DIFF
--- a/lib/cocoa/src/protocol/TBinaryProtocol.m
+++ b/lib/cocoa/src/protocol/TBinaryProtocol.m
@@ -230,10 +230,9 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
   return (short)
     (((buff[0] & 0xff) << 8) |
      ((buff[1] & 0xff)));
-  return 0;
 }
 
-- (int64_t) readI64;
+- (int64_t) readI64
 {
   uint8_t i64rd[8];
   [mTransport readAll: i64rd offset: 0 length: 8];
@@ -248,7 +247,7 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
     ((int64_t)(i64rd[7] & 0xff));
 }
 
-- (double) readDouble;
+- (double) readDouble
 {
   // FIXME - will this get us into trouble on PowerPC?
   int64_t ieee754 = [self readI64];

--- a/lib/cocoa/src/protocol/TBinaryProtocol.m
+++ b/lib/cocoa/src/protocol/TBinaryProtocol.m
@@ -24,6 +24,50 @@
 int32_t VERSION_1 = 0x80010000;
 int32_t VERSION_MASK = 0xffff0000;
 
+NS_INLINE size_t
+CheckedCastInt32ToSizeT(int32_t size)
+{
+  if (size < 0) {
+    NSString *reason = [NSString stringWithFormat:
+                        @"%s: refusing to read data with negative size: %"PRId32,
+                        __func__, size];
+    @throw [TProtocolException
+            exceptionWithName: @"TProtocolException"
+            reason: reason];
+  }
+  size_t checkedSize = (size_t)size;
+  return checkedSize;
+}
+
+NS_INLINE int32_t
+CheckedCastSizeTToInt32(size_t size)
+{
+  if (size > INT32_MAX) {
+    NSString *reason = [NSString stringWithFormat:
+                        @"%s: data size exceeds values representable by a 32-bit signed integer: %zu",
+                        __func__, size];
+    @throw [TProtocolException
+            exceptionWithName: @"TProtocolException"
+            reason: reason];
+  }
+  int32_t checkedSize = (int32_t)size;
+  return checkedSize;
+}
+
+NS_INLINE uint8_t
+CheckedCastIntToUInt8(int size)
+{
+  if (size > UINT8_MAX) {
+    NSString *reason = [NSString stringWithFormat:
+                        @"%s: data size exceeds values representable by a 8-bit unsigned integer: %d",
+                        __func__, size];
+    @throw [TProtocolException
+            exceptionWithName: @"TProtocolException"
+            reason: reason];
+  }
+  uint8_t checkedSize = (uint8_t)size;
+  return checkedSize;
+}
 
 static TBinaryProtocolFactory * gSharedFactory = nil;
 

--- a/lib/cocoa/src/protocol/TBinaryProtocol.m
+++ b/lib/cocoa/src/protocol/TBinaryProtocol.m
@@ -263,7 +263,7 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
 
 - (NSString *) readString
 {
-  int size = [self readI32];
+  int32_t size = [self readI32];
   return [self readStringBody: size];
 }
 

--- a/lib/cocoa/src/server/TSocketServer.m
+++ b/lib/cocoa/src/server/TSocketServer.m
@@ -49,7 +49,9 @@ NSString * const kTSockerServer_TransportKey = @"TSockerServer_Transport";
   int fd = -1;
   CFSocketRef socket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL);
   if (socket) {
-    CFSocketSetSocketFlags(socket, CFSocketGetSocketFlags(socket) & ~kCFSocketCloseOnInvalidate);
+    CFOptionFlags flagsToClear = kCFSocketCloseOnInvalidate;
+    CFSocketSetSocketFlags(socket,  CFSocketGetSocketFlags(socket) & ~flagsToClear);
+
     fd = CFSocketGetNative(socket);
     int yes = 1;
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
@@ -137,6 +139,7 @@ NSString * const kTSockerServer_TransportKey = @"TSockerServer_Transport";
             } while (result);
         }
         @catch (TTransportException * te) {
+            (void)te;
             //NSLog(@"Caught transport exception, abandoning client connection: %@", te);
         }
         

--- a/lib/cocoa/src/server/TSocketServer.m
+++ b/lib/cocoa/src/server/TSocketServer.m
@@ -37,7 +37,7 @@ NSString * const kTSockerServer_TransportKey = @"TSockerServer_Transport";
 
 - (id) initWithPort: (int) port
     protocolFactory: (id <TProtocolFactory>) protocolFactory
-   processorFactory: (id <TProcessorFactory>) processorFactory;
+   processorFactory: (id <TProcessorFactory>) processorFactory
 {
   self = [super init];
 

--- a/lib/cocoa/src/transport/TFramedTransport.m
+++ b/lib/cocoa/src/transport/TFramedTransport.m
@@ -78,7 +78,7 @@
     [writeBuffer appendBytes:data+offset length:length];
 }
 
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
     if (readBuffer == nil) {
         [self readFrame];

--- a/lib/cocoa/src/transport/TFramedTransport.m
+++ b/lib/cocoa/src/transport/TFramedTransport.m
@@ -73,12 +73,13 @@
     [writeBuffer appendBytes:dummy_header length:HEADER_SIZE];
 }
 
-- (void)write:(const uint8_t *)data offset:(unsigned int)offset length:(unsigned int)length
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
     [writeBuffer appendBytes:data+offset length:length];
 }
 
-- (int)readAll:(uint8_t *)buf offset:(int)off length:(int)len {
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+{
     if (readBuffer == nil) {
         [self readFrame];
     }

--- a/lib/cocoa/src/transport/THTTPClient.h
+++ b/lib/cocoa/src/transport/THTTPClient.h
@@ -25,7 +25,7 @@
   NSMutableURLRequest * mRequest;
   NSMutableData * mRequestData;
   NSData * mResponseData;
-  int mResponseDataOffset;
+  size_t mResponseDataOffset;
   NSString * mUserAgent;
   int mTimeout;
 }

--- a/lib/cocoa/src/transport/THTTPClient.m
+++ b/lib/cocoa/src/transport/THTTPClient.m
@@ -147,8 +147,8 @@
   NSHTTPURLResponse * httpResponse = (NSHTTPURLResponse *) response;
   if ([httpResponse statusCode] != 200) {
     @throw [TTransportException exceptionWithName: @"TTransportException"
-                                           reason: [NSString stringWithFormat: @"Bad response from HTTP server: %d",
-                                                    [httpResponse statusCode]]];
+                                           reason: [NSString stringWithFormat: @"Bad response from HTTP server: %ld",
+                                                    (long)[httpResponse statusCode]]];
   }
 
   // phew!

--- a/lib/cocoa/src/transport/THTTPClient.m
+++ b/lib/cocoa/src/transport/THTTPClient.m
@@ -102,7 +102,7 @@
 }
 
 
-- (int) readAll: (uint8_t *) buf offset: (int) off length: (int) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
 {
   NSRange r;
   r.location = mResponseDataOffset;
@@ -115,7 +115,7 @@
 }
 
 
-- (void) write: (const uint8_t *) data offset: (unsigned int) offset length: (unsigned int) length
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
   [mRequestData appendBytes: data+offset length: length];
 }

--- a/lib/cocoa/src/transport/THTTPClient.m
+++ b/lib/cocoa/src/transport/THTTPClient.m
@@ -102,16 +102,16 @@
 }
 
 
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
   NSRange r;
   r.location = mResponseDataOffset;
-  r.length = len;
+  r.length = length;
 
-  [mResponseData getBytes: buf+off range: r];
-  mResponseDataOffset += len;
+  [mResponseData getBytes: buf+offset range: r];
+  mResponseDataOffset += length;
 
-  return len;
+  return length;
 }
 
 

--- a/lib/cocoa/src/transport/TMemoryBuffer.m
+++ b/lib/cocoa/src/transport/TMemoryBuffer.m
@@ -40,18 +40,18 @@
 	return self;
 }
 
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
-	if ([mBuffer length] - mOffset < len) {
+	if ([mBuffer length] - mOffset < length) {
 		@throw [TTransportException exceptionWithReason:@"Not enough bytes remain in buffer"];
 	}
-	[mBuffer getBytes:buf range:NSMakeRange(mOffset, len)];
-	mOffset += len;
+	[mBuffer getBytes:buf range:NSMakeRange(mOffset, length)];
+	mOffset += length;
 	if (mOffset >= GARBAGE_BUFFER_SIZE) {
 		[mBuffer replaceBytesInRange:NSMakeRange(0, mOffset) withBytes:NULL length:0];
 		mOffset = 0;
 	}
-	return len;
+	return length;
 }
 
 - (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length

--- a/lib/cocoa/src/transport/TMemoryBuffer.m
+++ b/lib/cocoa/src/transport/TMemoryBuffer.m
@@ -25,7 +25,7 @@
 
 @implementation TMemoryBuffer
 - (id)init {
-	if (self = [super init]) {
+	if ((self = [super init])) {
 		mBuffer = [[NSMutableData alloc] init];
 		mOffset = 0;
 	}
@@ -33,7 +33,7 @@
 }
 
 - (id)initWithData:(NSData *)data {
-	if (self = [super init]) {
+	if ((self = [super init])) {
 		mBuffer = [data mutableCopy];
 		mOffset = 0;
 	}

--- a/lib/cocoa/src/transport/TMemoryBuffer.m
+++ b/lib/cocoa/src/transport/TMemoryBuffer.m
@@ -40,7 +40,8 @@
 	return self;
 }
 
-- (int)readAll:(uint8_t *)buf offset:(int)off length:(int)len {
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+{
 	if ([mBuffer length] - mOffset < len) {
 		@throw [TTransportException exceptionWithReason:@"Not enough bytes remain in buffer"];
 	}
@@ -53,7 +54,8 @@
 	return len;
 }
 
-- (void)write:(const uint8_t *)data offset:(unsigned int)offset length:(unsigned int)length {
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
+{
 	[mBuffer appendBytes:data+offset length:length];
 }
 

--- a/lib/cocoa/src/transport/TNSFileHandleTransport.m
+++ b/lib/cocoa/src/transport/TNSFileHandleTransport.m
@@ -51,7 +51,7 @@
 }
 
 
-- (int) readAll: (uint8_t *) buf offset: (int) off length: (int) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
 {
   int got = 0;
   while (got < len) {
@@ -67,7 +67,7 @@
 }
 
 
-- (void) write: (const uint8_t *) data offset: (unsigned int) offset length: (unsigned int) length
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
   void *pos = (void *) data + offset;
   NSData * dataObject = [[NSData alloc] initWithBytesNoCopy: pos // data+offset

--- a/lib/cocoa/src/transport/TNSFileHandleTransport.m
+++ b/lib/cocoa/src/transport/TNSFileHandleTransport.m
@@ -51,11 +51,11 @@
 }
 
 
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
   int got = 0;
-  while (got < len) {
-    NSData * d = [mInputFileHandle readDataOfLength: len-got];
+  while (got < length) {
+    NSData * d = [mInputFileHandle readDataOfLength: length-got];
     if ([d length] == 0) {
       @throw [TTransportException exceptionWithName: @"TTransportException"
                                   reason: @"Cannot read. No more data."];

--- a/lib/cocoa/src/transport/TNSFileHandleTransport.m
+++ b/lib/cocoa/src/transport/TNSFileHandleTransport.m
@@ -53,24 +53,24 @@
 
 - (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
-  int got = 0;
-  while (got < length) {
-    NSData * d = [mInputFileHandle readDataOfLength: length-got];
-    if ([d length] == 0) {
+  size_t totalBytesRead = 0;
+  while (totalBytesRead < length) {
+    NSData * data = [mInputFileHandle readDataOfLength: length-totalBytesRead];
+    if ([data length] == 0) {
       @throw [TTransportException exceptionWithName: @"TTransportException"
                                   reason: @"Cannot read. No more data."];
     }
-    [d getBytes: buf+got];
-    got += [d length];
+    [data getBytes: buf+totalBytesRead];
+    totalBytesRead += [data length];
   }
-  return got;
+  return totalBytesRead;
 }
 
 
 - (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
-  void *pos = (void *) data + offset;
-  NSData * dataObject = [[NSData alloc] initWithBytesNoCopy: pos // data+offset
+  const void *pos = data + offset;
+  NSData * dataObject = [[NSData alloc] initWithBytesNoCopy: (void *)pos
                                                      length: length
                                                freeWhenDone: NO];
 

--- a/lib/cocoa/src/transport/TNSStreamTransport.m
+++ b/lib/cocoa/src/transport/TNSStreamTransport.m
@@ -53,32 +53,38 @@
 
 - (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
-  int got = 0;
-  int ret = 0;
-  while (got < length) {
-    ret = [self.mInput read: buf+offset+got maxLength: length-got];
-    if (ret <= 0) {
+  size_t totalBytesRead = 0;
+  ssize_t bytesRead = 0;
+  while (totalBytesRead < length) {
+    bytesRead = [self.mInput read: buf+offset+totalBytesRead maxLength: length-totalBytesRead];
+
+    BOOL encounteredErrorOrEOF = (bytesRead <= 0);
+    if (encounteredErrorOrEOF) {
       @throw [TTransportException exceptionWithReason: @"Cannot read. Remote side has closed."];
+    } else {
+        /* bytesRead is guaranteed to be positive and within the range representable by size_t. */
+        totalBytesRead += (size_t)bytesRead;
     }
-    got += ret;
   }
-  return got;
+  return totalBytesRead;
 }
 
 
 - (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
-  int got = 0;
-  int result = 0;
-  while (got < length) {
-    result = [self.mOutput write: data+offset+got maxLength: length-got];
-    if (result == -1) {
+  size_t totalBytesWritten = 0;
+  ssize_t bytesWritten = 0;
+  while (totalBytesWritten < length) {
+    bytesWritten = [self.mOutput write: data+offset+totalBytesWritten maxLength: length-totalBytesWritten];
+    if (bytesWritten < 0) {
       @throw [TTransportException exceptionWithReason: @"Error writing to transport output stream."
                                                 error: [self.mOutput streamError]];
-    } else if (result == 0) {
+    } else if (bytesWritten == 0) {
       @throw [TTransportException exceptionWithReason: @"End of output stream."];
+    } else {
+        /* bytesWritten is guaranteed to be positive and within the range representable by size_t. */
+        totalBytesWritten += (size_t)bytesWritten;
     }
-    got += result;
   }
 }
 

--- a/lib/cocoa/src/transport/TNSStreamTransport.m
+++ b/lib/cocoa/src/transport/TNSStreamTransport.m
@@ -51,12 +51,12 @@
 }
 
 
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length
 {
   int got = 0;
   int ret = 0;
-  while (got < len) {
-    ret = [self.mInput read: buf+off+got maxLength: len-got];
+  while (got < length) {
+    ret = [self.mInput read: buf+offset+got maxLength: length-got];
     if (ret <= 0) {
       @throw [TTransportException exceptionWithReason: @"Cannot read. Remote side has closed."];
     }

--- a/lib/cocoa/src/transport/TNSStreamTransport.m
+++ b/lib/cocoa/src/transport/TNSStreamTransport.m
@@ -51,7 +51,7 @@
 }
 
 
-- (int) readAll: (uint8_t *) buf offset: (int) off length: (int) len
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len
 {
   int got = 0;
   int ret = 0;
@@ -66,7 +66,7 @@
 }
 
 
-- (void) write: (const uint8_t *) data offset: (unsigned int) offset length: (unsigned int) length
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length
 {
   int got = 0;
   int result = 0;

--- a/lib/cocoa/src/transport/TSSLSocketClient.m
+++ b/lib/cocoa/src/transport/TSSLSocketClient.m
@@ -59,10 +59,10 @@
             break;
         }
     }
-    
+
     memset (&pin, 0, sizeof(pin));
     pin.sin_family = AF_INET;
-    pin.sin_addr.s_addr = ((struct in_addr *) (hp->h_addr))->s_addr;
+    memcpy(&pin.sin_addr, hp->h_addr, sizeof(struct in_addr));
     pin.sin_port = htons (port);
     
     /* create the socket */

--- a/lib/cocoa/src/transport/TSSLSocketClient.m
+++ b/lib/cocoa/src/transport/TSSLSocketClient.m
@@ -199,8 +199,6 @@
         }
         case NSStreamEventEndEncountered:
             break;
-        default:
-            break;
     }
 }
 

--- a/lib/cocoa/src/transport/TSocketClient.h
+++ b/lib/cocoa/src/transport/TSocketClient.h
@@ -28,7 +28,7 @@
 }
 
 - (id) initWithHostname: (NSString *) hostname
-                   port: (int) port;
+                   port: (UInt32) port;
 
 @end
 

--- a/lib/cocoa/src/transport/TSocketClient.m
+++ b/lib/cocoa/src/transport/TSocketClient.m
@@ -35,7 +35,7 @@
 @implementation TSocketClient
 
 - (id) initWithHostname: (NSString *) hostname
-                   port: (int) port
+                   port: (UInt32) port
 {
 	inputStream = NULL;
 	outputStream = NULL;

--- a/lib/cocoa/src/transport/TTransport.h
+++ b/lib/cocoa/src/transport/TTransport.h
@@ -28,9 +28,9 @@
    * @return The number of bytes actually read, which must be equal to len
    * @throws TTransportException if there was an error reading data
    */
-- (int) readAll: (uint8_t *) buf offset: (int) off length: (int) len;
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len;
 
-- (void) write: (const uint8_t *) data offset: (unsigned int) offset length: (unsigned int) length;
+- (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length;
 
 - (void) flush;
 @end

--- a/lib/cocoa/src/transport/TTransport.h
+++ b/lib/cocoa/src/transport/TTransport.h
@@ -23,12 +23,12 @@
    * Guarantees that all of len bytes are read
    *
    * @param buf Buffer to read into
-   * @param off Index in buffer to start storing bytes at
-   * @param len Maximum number of bytes to read
+   * @param offset Index in buffer to start storing bytes at
+   * @param length Maximum number of bytes to read
    * @return The number of bytes actually read, which must be equal to len
    * @throws TTransportException if there was an error reading data
    */
-- (size_t) readAll: (uint8_t *) buf offset: (size_t) off length: (size_t) len;
+- (size_t) readAll: (uint8_t *) buf offset: (size_t) offset length: (size_t) length;
 
 - (void) write: (const uint8_t *) data offset: (size_t) offset length: (size_t) length;
 


### PR DESCRIPTION
No easy way to test, since there's no shared Xcode project to generate warnings. For reference, I was building for iOS and for Mac with flags:

    OTHER_CFLAGS = -Wall -Wextra -Weverything -Wno-objc-missing-property-synthesis -Wno-unused-parameter -Wno-auto-import -Wno-documentation-unknown-command -Wno-direct-ivar-access -Wno-objc-interface-ivars

The remaining warnings should be addressed by issues THRIFT-2982 through THRIFT-2987.