### PR TITLE
fix bug for: BadYieldError: yielded unknown object

### DIFF
--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -174,7 +174,7 @@ class TTornadoServer(tcpserver.TCPServer):
                 frame = yield trans.readFrame()
                 tr = TMemoryBuffer(frame)
                 iprot = self._iprot_factory.getProtocol(tr)
-                yield self._processor.process(iprot, oprot)
+                self._processor.process(iprot, oprot)
         except Exception:
             logger.exception('thrift exception in handle_stream')
             trans.close()


### PR DESCRIPTION
2015-02-09 14:03:00,410 ERROR    handle_stream:183 thrift exception in handle_stream
Traceback (most recent call last):
    File "/home/adsame/.virtualenvs/gooseService/local/lib/python2.7/site-packages/thrift/TTornado.py", line 178, in handle_stream
    yield self._processor.process(iprot, oprot)
    File "/home/adsame/.virtualenvs/gooseService/local/lib/python2.7/site-packages/tornado/gen.py", line 628, in run
    value = future.result()
    File "/home/adsame/.virtualenvs/gooseService/local/lib/python2.7/site-packages/tornado/concurrent.py", line 111, in result
    raise self._exception
    BadYieldError: yielded unknown object True
