### PR TITLE
autotools // Use Boost C++ >= 1.53.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ fi
 AX_THRIFT_LIB(cpp, [C++], yes)
 have_cpp=no
 if test "$with_cpp" = "yes";  then
-  AX_BOOST_BASE([1.54.0])
+  AX_BOOST_BASE([1.53.0])
   if test "x$succeeded" = "xyes" ; then
     AC_SUBST([BOOST_LIB_DIR], [$(echo "$BOOST_LDFLAGS" | sed -e 's/^\-L//')])
     AC_SUBST([BOOST_TEST_LDADD], [$(echo "$BOOST_LIB_DIR/libboost_unit_test_framework.a")])

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -3,7 +3,7 @@
 * A relatively POSIX-compliant *NIX system
     * Cygwin or MinGW can be used on Windows
 * g++ 4.2
-* boost 1.54.0
+* boost 1.53.0
 * Runtime libraries for lex and yacc might be needed for the compiler.
 
 ## Requirements for building from source

--- a/doc/install/centos.md
+++ b/doc/install/centos.md
@@ -54,11 +54,11 @@ If you will be developing Apache Thrift clients/servers in C++ you will also nee
 
 	sudo yum -y install libevent-devel zlib-devel openssl-devel
 
-### Upgrade Boost 
+### Upgrade Boost >= 1.53
 
-	wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz
-	tar xvf boost_1_55_0.tar.gz
-	cd boost_1_55_0
+	wget http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.gz
+	tar xvf boost_1_53_0.tar.gz
+	cd boost_1_53_0
 	./bootstrap.sh
 	sudo ./b2 install
 

--- a/doc/install/windows.md
+++ b/doc/install/windows.md
@@ -123,7 +123,7 @@ Make sure you add -lfl in your cxxflags in Makefile, also try adding -Lc:/cygwin
 #### boost is not found
 Try and change the include dir to use the windows path from c like this: Edit compiler/cpp/Makefile, look for the declaration of BOOST_CPPFLAGS, change that line for
 
-	BOOST_CPPFLAGS = -Ic:/cygwin/usr/include/boost-1_33_1
+	BOOST_CPPFLAGS = -Ic:/cygwin/usr/include/boost-1_53_0
 	
 #### realpath is not found
 add -DMINGW -mno-cygwin to the CXXDEFS variable in Makefile

--- a/lib/cpp/test/TypedefTest.cpp
+++ b/lib/cpp/test/TypedefTest.cpp
@@ -22,6 +22,6 @@
 
 #include "gen-cpp/TypedefTest_types.h"
 
-BOOST_STATIC_ASSERT(boost::is_same<int32_t, thrift::test::MyInt32>::value);
-BOOST_STATIC_ASSERT(boost::is_same<std::string, thrift::test::MyString>::value);
-BOOST_STATIC_ASSERT(boost::is_same<thrift::test::TypedefTestStruct, thrift::test::MyStruct>::value);
+BOOST_STATIC_ASSERT((boost::is_same<int32_t, thrift::test::MyInt32>::value));
+BOOST_STATIC_ASSERT((boost::is_same<std::string, thrift::test::MyString>::value));
+BOOST_STATIC_ASSERT((boost::is_same<thrift::test::TypedefTestStruct, thrift::test::MyStruct>::value));


### PR DESCRIPTION
- Updated autotools to search Boost C++ version equal to 1.53.0 or higher.
- Updated docs to reflect this change
- Fixed compilation issue with BOOST_STATIC_ASSERT (appears on both cmake & autotools build)

Used CentOS 7.
