### PR TITLE
THRIFT-3000: Issue with IPv6 an IPv4 on windows machines

### DIFF
--- a/lib/csharp/ThriftMSBuildTask/Properties/AssemblyInfo.cs
+++ b/lib/csharp/ThriftMSBuildTask/Properties/AssemblyInfo.cs
@@ -56,5 +56,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.*")]
-[assembly: AssemblyFileVersion("0.9.0.*")]
+[assembly: AssemblyVersion("0.9.0.*")]//Generates AssemblyFileVersion accordingly.

--- a/lib/csharp/ThriftMSBuildTask/ThriftMSBuildTask.csproj
+++ b/lib/csharp/ThriftMSBuildTask/ThriftMSBuildTask.csproj
@@ -28,7 +28,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ThriftMSBuildTask</RootNamespace>
     <AssemblyName>ThriftMSBuildTask</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -49,6 +49,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,6 +60,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,6 +70,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />

--- a/lib/csharp/src/Thrift.csproj
+++ b/lib/csharp/src/Thrift.csproj
@@ -112,6 +112,7 @@
     <Compile Include="TException.cs" />
     <Compile Include="TApplicationException.cs" />
     <Compile Include="TProcessor.cs" />
+    <Compile Include="Transport\SocketVersionizer.cs" />
     <Compile Include="Transport\TBufferedTransport.cs" />
     <Compile Include="Transport\TFramedTransport.cs" />
     <Compile Include="Transport\THttpClient.cs" />

--- a/lib/csharp/src/Thrift.csproj
+++ b/lib/csharp/src/Thrift.csproj
@@ -27,7 +27,7 @@
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
     <AssemblyName>Thrift</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <RootNamespace>Thrift</RootNamespace>
     <FileUpgradeFlags>
@@ -49,6 +49,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,6 +60,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,6 +70,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/lib/csharp/src/Thrift.sln
+++ b/lib/csharp/src/Thrift.sln
@@ -1,38 +1,37 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift", "Thrift.csproj", "{499EB63C-D74C-47E8-AE48-A2FC94538E9D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThriftTest", "..\test\ThriftTest\ThriftTest.csproj", "{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}"
-    ProjectSection(ProjectDependencies) = postProject
-        {499EB63C-D74C-47E8-AE48-A2FC94538E9D} = {499EB63C-D74C-47E8-AE48-A2FC94538E9D}
-    EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThriftMSBuildTask", "..\ThriftMSBuildTask\ThriftMSBuildTask.csproj", "{EC0A0231-66EA-4593-A792-C6CA3BB8668E}"
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Any CPU = Debug|Any CPU
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Release|Any CPU.Build.0 = Release|Any CPU
-        {48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Release|Any CPU.Build.0 = Release|Any CPU
-        {EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Release|Any CPU.Build.0 = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(MonoDevelopProperties) = preSolution
-        StartupItem = Thrift.csproj
-    EndGlobalSection
-    GlobalSection(SolutionProperties) = preSolution
-        HideSolutionNode = FALSE
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{499EB63C-D74C-47E8-AE48-A2FC94538E9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC0A0231-66EA-4593-A792-C6CA3BB8668E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		        StartupItem = Thrift.csproj
+	EndGlobalSection
 EndGlobal

--- a/lib/csharp/src/Transport/SocketVersionizer.cs
+++ b/lib/csharp/src/Transport/SocketVersionizer.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Thrift.Transport
+{
+	/**
+	* PropertyInfo for the DualMode property of the System.Net.Sockets.Socket class. Used to determine if the sockets are capable of
+	* automatic IPv4 and IPv6 handling. If DualMode is present the sockets automatically handle IPv4 and IPv6 connections.
+	* If the DualMode is not available the system configuration determines whether IPv4 or IPv6 is used.
+	*/
+	internal static class SocketVersionizer
+	{
+		/*
+		* PropertyInfo for the DualMode property of System.Net.Sockets.Socket.
+		*/
+		private static PropertyInfo DualModeProperty = typeof(Socket).GetProperty("DualMode");
+
+		/*
+		* Indicates whether the used framework supports DualMode on sockets or not.
+		*/
+		internal static Boolean SupportsDualMode
+		{
+			get
+			{
+				return SocketVersionizer.DualModeProperty != null;
+			}
+		}
+
+		/*
+		* Creates a TcpClient according to the capabilitites of the used framework
+		*/
+		internal static TcpClient CreateTcpClient()
+		{
+			TcpClient client = null;
+
+			if (SocketVersionizer.SupportsDualMode)
+			{
+				client = new TcpClient(AddressFamily.InterNetworkV6);
+				SocketVersionizer.DualModeProperty.SetValue(client.Client, true);
+			}
+			else
+			{
+				client = new TcpClient(AddressFamily.InterNetwork);
+			}
+
+			return client;
+		}
+
+		/*
+		* Creates a TcpListener according to the capabilitites of the used framework
+		*/
+		internal static TcpListener CreateTcpListener(Int32 port)
+		{
+			TcpListener listener = null;
+
+			if (SocketVersionizer.SupportsDualMode)
+			{
+				listener = new TcpListener(System.Net.IPAddress.IPv6Any, port);
+				SocketVersionizer.DualModeProperty.SetValue(listener.Server, true);
+			}
+			else
+			{
+				listener = new TcpListener(System.Net.IPAddress.Any, port);
+			}
+
+			return listener;
+		}
+	}
+}

--- a/lib/csharp/src/Transport/TServerSocket.cs
+++ b/lib/csharp/src/Transport/TServerSocket.cs
@@ -90,7 +90,8 @@ namespace Thrift.Transport
             try
             {
                 // Make server socket
-                server = new TcpListener(System.Net.IPAddress.Any, this.port);
+                server = new TcpListener(System.Net.IPAddress.IPv6Any, this.port);
+				server.Server.DualMode = true;
                 server.Server.NoDelay = true;
             }
             catch (Exception)

--- a/lib/csharp/src/Transport/TServerSocket.cs
+++ b/lib/csharp/src/Transport/TServerSocket.cs
@@ -23,155 +23,155 @@
 
 using System;
 using System.Net.Sockets;
+using System.Reflection;
 
 
 namespace Thrift.Transport
 {
-    public class TServerSocket : TServerTransport
-    {
+	public class TServerSocket : TServerTransport
+	{
         /**
         * Underlying server with socket
         */
-        private TcpListener server = null;
+		private TcpListener server = null;
 
-        /**
-         * Port to listen on
-         */
-        private int port = 0;
+		/**
+		 * Port to listen on
+		 */
+		private int port = 0;
 
-        /**
-         * Timeout for client sockets from accept
-         */
-        private int clientTimeout = 0;
+		/**
+		 * Timeout for client sockets from accept
+		 */
+		private int clientTimeout = 0;
 
-        /**
-         * Whether or not to wrap new TSocket connections in buffers
-         */
-        private bool useBufferedSockets = false;
+		/**
+		 * Whether or not to wrap new TSocket connections in buffers
+		 */
+		private bool useBufferedSockets = false;
 
-        /**
-         * Creates a server socket from underlying socket object
-         */
-        public TServerSocket(TcpListener listener)
-            :this(listener, 0)
-        {
-        }
+		/**
+		 * Creates a server socket from underlying socket object
+		 */
+		public TServerSocket(TcpListener listener)
+			: this(listener, 0)
+		{
+		}
 
-        /**
-         * Creates a server socket from underlying socket object
-         */
-        public TServerSocket(TcpListener listener, int clientTimeout)
-        {
-            this.server = listener;
-            this.clientTimeout = clientTimeout;
-        }
+		/**
+		 * Creates a server socket from underlying socket object
+		 */
+		public TServerSocket(TcpListener listener, int clientTimeout)
+		{
+			this.server = listener;
+			this.clientTimeout = clientTimeout;
+		}
 
-        /**
-         * Creates just a port listening server socket
-         */
-        public TServerSocket(int port)
-            : this(port, 0)
-        {
-        }
+		/**
+		 * Creates just a port listening server socket
+		 */
+		public TServerSocket(int port)
+			: this(port, 0)
+		{
+		}
 
-        /**
-         * Creates just a port listening server socket
-         */
-        public TServerSocket(int port, int clientTimeout)
-            :this(port, clientTimeout, false)
-        {
-        }
+		/**
+		 * Creates just a port listening server socket
+		 */
+		public TServerSocket(int port, int clientTimeout)
+			: this(port, clientTimeout, false)
+		{
+		}
 
-        public TServerSocket(int port, int clientTimeout, bool useBufferedSockets)
-        {
-            this.port = port;
-            this.clientTimeout = clientTimeout;
-            this.useBufferedSockets = useBufferedSockets;
-            try
-            {
-                // Make server socket
-                server = new TcpListener(System.Net.IPAddress.IPv6Any, this.port);
-				server.Server.DualMode = true;
-                server.Server.NoDelay = true;
-            }
-            catch (Exception)
-            {
-                server = null;
-                throw new TTransportException("Could not create ServerSocket on port " + port + ".");
-            }
-        }
+		public TServerSocket(int port, int clientTimeout, bool useBufferedSockets)
+		{
+			this.port = port;
+			this.clientTimeout = clientTimeout;
+			this.useBufferedSockets = useBufferedSockets;
+			try
+			{
+				// Make server socket
+				this.server = SocketVersionizer.CreateTcpListener(port);
+				this.server.Server.NoDelay = true;
+			}
+			catch (Exception)
+			{
+				server = null;
+				throw new TTransportException("Could not create ServerSocket on port " + port + ".");
+			}
+		}
 
-        public override void Listen()
-        {
-            // Make sure not to block on accept
-            if (server != null)
-            {
-                try
-                {
-                    server.Start();
-                }
-                catch (SocketException sx)
-                {
-                    throw new TTransportException("Could not accept on listening socket: " + sx.Message);
-                }
-            }
-        }
+		public override void Listen()
+		{
+			// Make sure not to block on accept
+			if (server != null)
+			{
+				try
+				{
+					server.Start();
+				}
+				catch (SocketException sx)
+				{
+					throw new TTransportException("Could not accept on listening socket: " + sx.Message);
+				}
+			}
+		}
 
-        protected override TTransport AcceptImpl()
-        {
-            if (server == null)
-            {
-                throw new TTransportException(TTransportException.ExceptionType.NotOpen, "No underlying server socket.");
-            }
-            try
-            {
-                TSocket result2 = null;
-                TcpClient result = server.AcceptTcpClient();
-                try
-                {
-                    result2 = new TSocket(result);
-                    result2.Timeout = clientTimeout;
-                    if (useBufferedSockets)
-                    {
-                        TBufferedTransport result3 = new TBufferedTransport(result2);
-                        return result3;
-                    }
-                    else
-                    {
-                        return result2;
-                    }
-                }
-                catch (System.Exception)
-                {
-                    // If a TSocket was successfully created, then let
-                    // it do proper cleanup of the TcpClient object.
-                    if (result2 != null)
-                        result2.Dispose();
-                    else //  Otherwise, clean it up ourselves.
-                        ((IDisposable)result).Dispose();
-                    throw;
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new TTransportException(ex.ToString());
-            }
-        }
+		protected override TTransport AcceptImpl()
+		{
+			if (server == null)
+			{
+				throw new TTransportException(TTransportException.ExceptionType.NotOpen, "No underlying server socket.");
+			}
+			try
+			{
+				TSocket result2 = null;
+				TcpClient result = server.AcceptTcpClient();
+				try
+				{
+					result2 = new TSocket(result);
+					result2.Timeout = clientTimeout;
+					if (useBufferedSockets)
+					{
+						TBufferedTransport result3 = new TBufferedTransport(result2);
+						return result3;
+					}
+					else
+					{
+						return result2;
+					}
+				}
+				catch (System.Exception)
+				{
+					// If a TSocket was successfully created, then let
+					// it do proper cleanup of the TcpClient object.
+					if (result2 != null)
+						result2.Dispose();
+					else //  Otherwise, clean it up ourselves.
+						((IDisposable)result).Dispose();
+					throw;
+				}
+			}
+			catch (Exception ex)
+			{
+				throw new TTransportException(ex.ToString());
+			}
+		}
 
-        public override void Close()
-        {
-            if (server != null)
-            {
-                try
-                {
-                    server.Stop();
-                }
-                catch (Exception ex)
-                {
-                    throw new TTransportException("WARNING: Could not close server socket: " + ex);
-                }
-                server = null;
-            }
-        }
-    }
+		public override void Close()
+		{
+			if (server != null)
+			{
+				try
+				{
+					server.Stop();
+				}
+				catch (Exception ex)
+				{
+					throw new TTransportException("WARNING: Could not close server socket: " + ex);
+				}
+				server = null;
+			}
+		}
+	}
 }

--- a/lib/csharp/src/Transport/TServerTransport.cs
+++ b/lib/csharp/src/Transport/TServerTransport.cs
@@ -22,22 +22,25 @@
  */
 
 using System;
+using System.Net.Sockets;
+using System.Reflection;
 
 namespace Thrift.Transport
 {
-    public abstract class TServerTransport
-    {
-        public abstract void Listen();
-        public abstract void Close();
-        protected abstract TTransport AcceptImpl();
+	public abstract class TServerTransport
+	{
+		public abstract void Listen();
+		public abstract void Close();
+		protected abstract TTransport AcceptImpl();
 
-        public TTransport Accept()
-        {
-            TTransport transport = AcceptImpl();
-            if (transport == null) {
-              throw new TTransportException("accept() may not return NULL");
-            }
-            return transport;
-         }
-    }
+		public TTransport Accept()
+		{
+			TTransport transport = AcceptImpl();
+			if (transport == null)
+			{
+				throw new TTransportException("accept() may not return NULL");
+			}
+			return transport;
+		}
+	}
 }

--- a/lib/csharp/src/Transport/TSocket.cs
+++ b/lib/csharp/src/Transport/TSocket.cs
@@ -26,217 +26,220 @@ using System.Net.Sockets;
 
 namespace Thrift.Transport
 {
-    public class TSocket : TStreamTransport
-    {
-        private TcpClient client = null;
-        private string host = null;
-        private int port = 0;
-        private int timeout = 0;
+	public class TSocket : TStreamTransport
+	{
+		private TcpClient client = null;
+		private string host = null;
+		private int port = 0;
+		private int timeout = 0;
 
-        public TSocket(TcpClient client)
-        {
-            this.client = client;
+		public TSocket(TcpClient client)
+		{
+			this.client = client;
 
-            if (IsOpen)
-            {
-                inputStream = client.GetStream();
-                outputStream = client.GetStream();
-            }
-        }
+			if (IsOpen)
+			{
+				inputStream = client.GetStream();
+				outputStream = client.GetStream();
+			}
+		}
 
-        public TSocket(string host, int port)
-            : this(host, port, 0)
-        {
-        }
+		public TSocket(string host, int port)
+			: this(host, port, 0)
+		{
+		}
 
-        public TSocket(string host, int port, int timeout)
-        {
-            this.host = host;
-            this.port = port;
-            this.timeout = timeout;
+		public TSocket(string host, int port, int timeout)
+		{
+			this.host = host;
+			this.port = port;
+			this.timeout = timeout;
 
-            InitSocket();
-        }
+			InitSocket();
+		}
 
-        private void InitSocket()
-        {
-            client = new TcpClient(AddressFamily.InterNetworkV6);
-			client.Client.DualMode = true;
-            client.ReceiveTimeout = client.SendTimeout = timeout;
-            client.Client.NoDelay = true;
-        }
+		private void InitSocket()
+		{
+			this.client = SocketVersionizer.CreateTcpClient();
+			this.client.ReceiveTimeout = client.SendTimeout = timeout;
+			this.client.Client.NoDelay = true;
+		}
 
-        public int Timeout
-        {
-            set
-            {
-                client.ReceiveTimeout = client.SendTimeout = timeout = value;
-            }
-        }
+		public int Timeout
+		{
+			set
+			{
+				client.ReceiveTimeout = client.SendTimeout = timeout = value;
+			}
+		}
 
-        public TcpClient TcpClient
-        {
-            get
-            {
-                return client;
-            }
-        }
+		public TcpClient TcpClient
+		{
+			get
+			{
+				return client;
+			}
+		}
 
-        public string Host
-        {
-            get
-            {
-                return host;
-            }
-        }
+		public string Host
+		{
+			get
+			{
+				return host;
+			}
+		}
 
-        public int Port
-        {
-            get
-            {
-                return port;
-            }
-        }
+		public int Port
+		{
+			get
+			{
+				return port;
+			}
+		}
 
-        public override bool IsOpen
-        {
-            get
-            {
-                if (client == null)
-                {
-                    return false;
-                }
+		public override bool IsOpen
+		{
+			get
+			{
+				if (client == null)
+				{
+					return false;
+				}
 
-                return client.Connected;
-            }
-        }
+				return client.Connected;
+			}
+		}
 
-        public override void Open()
-        {
-            if (IsOpen)
-            {
-                throw new TTransportException(TTransportException.ExceptionType.AlreadyOpen, "Socket already connected");
-            }
+		public override void Open()
+		{
+			if (IsOpen)
+			{
+				throw new TTransportException(TTransportException.ExceptionType.AlreadyOpen, "Socket already connected");
+			}
 
-            if (String.IsNullOrEmpty(host))
-            {
-                throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open null host");
-            }
+			if (String.IsNullOrEmpty(host))
+			{
+				throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open null host");
+			}
 
-            if (port <= 0)
-            {
-                throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open without port");
-            }
+			if (port <= 0)
+			{
+				throw new TTransportException(TTransportException.ExceptionType.NotOpen, "Cannot open without port");
+			}
 
-            if (client == null)
-            {
-                InitSocket();
-            }
+			if (client == null)
+			{
+				InitSocket();
+			}
 
-            if( timeout == 0)            // no timeout -> infinite
-            {
-                client.Connect(host, port);
-            }
-            else                        // we have a timeout -> use it
-            {
-                ConnectHelper hlp = new ConnectHelper(client);
-                IAsyncResult asyncres = client.BeginConnect(host, port, new AsyncCallback(ConnectCallback), hlp);
-                bool bConnected = asyncres.AsyncWaitHandle.WaitOne(timeout) && client.Connected;
-                if (!bConnected)
-                {
-                    lock (hlp.Mutex)
-                    {
-                        if( hlp.CallbackDone)
-                        {
-                            asyncres.AsyncWaitHandle.Close();
-                            client.Close();
-                        }
-                        else
-                        {
-                            hlp.DoCleanup = true;
-                            client = null;
-                        }
-                    }
-                    throw new TTransportException(TTransportException.ExceptionType.TimedOut, "Connect timed out");
-                }
-            }
+			if (timeout == 0)            // no timeout -> infinite
+			{
+				client.Connect(host, port);
+			}
+			else                        // we have a timeout -> use it
+			{
+				ConnectHelper hlp = new ConnectHelper(client);
+				IAsyncResult asyncres = client.BeginConnect(host, port, new AsyncCallback(ConnectCallback), hlp);
+				bool bConnected = asyncres.AsyncWaitHandle.WaitOne(timeout) && client.Connected;
+				if (!bConnected)
+				{
+					lock (hlp.Mutex)
+					{
+						if (hlp.CallbackDone)
+						{
+							asyncres.AsyncWaitHandle.Close();
+							client.Close();
+						}
+						else
+						{
+							hlp.DoCleanup = true;
+							client = null;
+						}
+					}
+					throw new TTransportException(TTransportException.ExceptionType.TimedOut, "Connect timed out");
+				}
+			}
 
-            inputStream = client.GetStream();
-            outputStream = client.GetStream();
-        }
+			inputStream = client.GetStream();
+			outputStream = client.GetStream();
+		}
 
 
-        static void ConnectCallback(IAsyncResult asyncres)
-        {
-            ConnectHelper hlp = asyncres.AsyncState as ConnectHelper;
-            lock (hlp.Mutex)
-            {
-                hlp.CallbackDone = true;
+		static void ConnectCallback(IAsyncResult asyncres)
+		{
+			ConnectHelper hlp = asyncres.AsyncState as ConnectHelper;
+			lock (hlp.Mutex)
+			{
+				hlp.CallbackDone = true;
 
-                try
-                {
-                    if( hlp.Client.Client != null)
-                        hlp.Client.EndConnect(asyncres);
-                }
-                catch (Exception)
-                {
-                    // catch that away
-                }
+				try
+				{
+					if (hlp.Client.Client != null)
+						hlp.Client.EndConnect(asyncres);
+				}
+				catch (Exception)
+				{
+					// catch that away
+				}
 
-                if (hlp.DoCleanup)
-                {
-                    try {
-                        asyncres.AsyncWaitHandle.Close();
-                    } catch (Exception) {}
+				if (hlp.DoCleanup)
+				{
+					try
+					{
+						asyncres.AsyncWaitHandle.Close();
+					}
+					catch (Exception) { }
 
-                    try {
-                        if (hlp.Client is IDisposable)
-                            ((IDisposable)hlp.Client).Dispose();
-                    } catch (Exception) {}
-                    hlp.Client = null;
-                }
-            }
-        }
+					try
+					{
+						if (hlp.Client is IDisposable)
+							((IDisposable)hlp.Client).Dispose();
+					}
+					catch (Exception) { }
+					hlp.Client = null;
+				}
+			}
+		}
 
-        private class ConnectHelper
-        {
-            public object Mutex = new object();
-            public bool DoCleanup = false;
-            public bool CallbackDone = false;
-            public TcpClient Client;
-            public ConnectHelper(TcpClient client)
-            {
-                Client = client;
-            }
-        }
+		private class ConnectHelper
+		{
+			public object Mutex = new object();
+			public bool DoCleanup = false;
+			public bool CallbackDone = false;
+			public TcpClient Client;
+			public ConnectHelper(TcpClient client)
+			{
+				Client = client;
+			}
+		}
 
-        public override void Close()
-        {
-            base.Close();
-            if (client != null)
-            {
-                client.Close();
-                client = null;
-            }
-        }
+		public override void Close()
+		{
+			base.Close();
+			if (client != null)
+			{
+				client.Close();
+				client = null;
+			}
+		}
 
-    #region " IDisposable Support "
-    private bool _IsDisposed;
+		#region " IDisposable Support "
+		private bool _IsDisposed;
 
-    // IDisposable
-    protected override void Dispose(bool disposing)
-    {
-      if (!_IsDisposed)
-      {
-        if (disposing)
-        {
-          if (client != null)
-            ((IDisposable)client).Dispose();
-          base.Dispose(disposing);
-        }
-      }
-      _IsDisposed = true;
-    }
-    #endregion
-  }
+		// IDisposable
+		protected override void Dispose(bool disposing)
+		{
+			if (!_IsDisposed)
+			{
+				if (disposing)
+				{
+					if (client != null)
+						((IDisposable)client).Dispose();
+					base.Dispose(disposing);
+				}
+			}
+			_IsDisposed = true;
+		}
+		#endregion
+	}
 }

--- a/lib/csharp/src/Transport/TSocket.cs
+++ b/lib/csharp/src/Transport/TSocket.cs
@@ -60,7 +60,8 @@ namespace Thrift.Transport
 
         private void InitSocket()
         {
-            client = new TcpClient();
+            client = new TcpClient(AddressFamily.InterNetworkV6);
+			client.Client.DualMode = true;
             client.ReceiveTimeout = client.SendTimeout = timeout;
             client.Client.NoDelay = true;
         }

--- a/lib/csharp/src/Transport/TTLSServerSocket.cs
+++ b/lib/csharp/src/Transport/TTLSServerSocket.cs
@@ -95,9 +95,8 @@ namespace Thrift.Transport
             try
             {
                 // Create server socket
-                server = new TcpListener(System.Net.IPAddress.IPv6Any, this.port);
-				server.Server.DualMode = true;
-                server.Server.NoDelay = true;
+				this.server = SocketVersionizer.CreateTcpListener(port);
+                this.server.Server.NoDelay = true;
             }
             catch (Exception)
             {

--- a/lib/csharp/src/Transport/TTLSServerSocket.cs
+++ b/lib/csharp/src/Transport/TTLSServerSocket.cs
@@ -95,7 +95,8 @@ namespace Thrift.Transport
             try
             {
                 // Create server socket
-                server = new TcpListener(System.Net.IPAddress.Any, this.port);
+                server = new TcpListener(System.Net.IPAddress.IPv6Any, this.port);
+				server.Server.DualMode = true;
                 server.Server.NoDelay = true;
             }
             catch (Exception)

--- a/lib/csharp/src/Transport/TTLSSocket.cs
+++ b/lib/csharp/src/Transport/TTLSSocket.cs
@@ -138,7 +138,8 @@ namespace Thrift.Transport
         /// </summary>
         private void InitSocket()
         {
-            this.client = new TcpClient();
+			client = new TcpClient(AddressFamily.InterNetworkV6);
+			client.Client.DualMode = true;
             client.ReceiveTimeout = client.SendTimeout = timeout;
             client.Client.NoDelay = true;
         }

--- a/lib/csharp/src/Transport/TTLSSocket.cs
+++ b/lib/csharp/src/Transport/TTLSSocket.cs
@@ -138,8 +138,7 @@ namespace Thrift.Transport
         /// </summary>
         private void InitSocket()
         {
-			client = new TcpClient(AddressFamily.InterNetworkV6);
-			client.Client.DualMode = true;
+			this.client = SocketVersionizer.CreateTcpClient();
             client.ReceiveTimeout = client.SendTimeout = timeout;
             client.Client.NoDelay = true;
         }

--- a/lib/csharp/test/ThriftTest/ThriftTest.csproj
+++ b/lib/csharp/test/ThriftTest/ThriftTest.csproj
@@ -28,7 +28,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ThriftTest</RootNamespace>
     <AssemblyName>ThriftTest</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <FileUpgradeFlags>
@@ -49,6 +49,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,6 +60,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,6 +70,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -120,6 +123,9 @@
       <Name>Thrift</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -136,6 +142,6 @@ SET THRIFT_FILE=$(ProjectDir)\..\..\..\..\test\ThriftTest.thrift
 for %25%25I in ("%25OUTPUT_DIR%25") do set SHORT_DIR=%25%25~fsI
 for %25%25I in ("%25THRIFT_FILE%25") do set THRIFT_SHORT=%25%25~fsI
 "$(ProjectDir)\..\..\..\..\compiler\cpp\thrift.exe" --gen csharp -o %25SHORT_DIR%25 %25THRIFT_SHORT%25
-$(MSBuildToolsPath)\Csc.exe /t:library /out:"$(ProjectDir)ThriftImpl.dll" /recurse:"$(ProjectDir)gen-csharp"\* /reference:"$(ProjectDir)..\..\src\bin\Debug\Thrift.dll"</PreBuildEvent>
+"$(MSBuildToolsPath)\Csc.exe" /t:library /out:"$(ProjectDir)ThriftImpl.dll" /recurse:"$(ProjectDir)gen-csharp"\* /reference:"$(ProjectDir)..\..\src\bin\Debug\Thrift.dll"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/lib/csharp/test/ThriftTest/app.config
+++ b/lib/csharp/test/ThriftTest/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>


### PR DESCRIPTION
When using TcpListener and TcpClient it depends on the network configuration if IPv4 or IPv6 is used. By upgrading the framework to .NET 4.5 the DualMode can be set on the sockets of the listener and the client. The sockets then try to estabild IPv6 sockets before they fallback to IPv4. For example IPv4 is preferred on Windows 7 machines while on Windows 8 and 8.1 machines IPv6 is preferred. This patch works on Window 7, 8 and 8.1.

Additionally the AssemblyFileVersion must not contain an asterix. By removing the AssemblyFileVersion it alsways corresponds the the generated value of AsemblyVersion

In the PreBuild command of the ThriftTest project I added "" around the MSBuildToolPath to make the script work on english windows machine wheren the folder equals to sth like "C:\program files\....."
