### PR TITLE
THRIFT-2998: Set Content-Type for HTTP request in Node.js wrapper. Done similar to th...

### DIFF
--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -214,10 +214,13 @@ util.inherits(HttpConnection, EventEmitter);
  */
 HttpConnection.prototype.write = function(data) {
   var self = this;
-  self.nodeOptions.headers["Content-length"] = data.length;
+  var opts = self.nodeOptions;
+  opts.headers["Content-length"] = data.length;
+  if (!opts.headers["Content-Type"])
+    opts.headers["Content-Type"] = "application/x-thrift";  
   var req = (self.https) ?
-      https.request(self.nodeOptions, self.responseCallback) :
-      http.request(self.nodeOptions, self.responseCallback);
+      https.request(opts, self.responseCallback) :
+      http.request(opts, self.responseCallback);
   req.on('error', function(err) {
     self.emit("error", err);
   });


### PR DESCRIPTION
...e Python wrapper here: 
https://github.com/apache/thrift/blob/master/lib/py/src/transport/THttpClient.py#L127
Without this header, connecting to some servers results in error response. (THRIFT-2998)
