### PR TITLE
THRIFT-2994: Fix TJsonProtocol for nodejs

### DIFF
--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -89,6 +89,7 @@ TJSONProtocol.RType.set = Type.SET;
 TJSONProtocol.Version = 1;
 
 TJSONProtocol.prototype.flush = function() {
+  this.writeToTransportIfStackIsFlushable();
   return this.trans.flush();
 };
 
@@ -119,6 +120,7 @@ TJSONProtocol.prototype.writeMessageEnd = function() {
 
   this.wbuf = '[' + this.wobj.join(',') + ']';
 
+  // we assume there is nothing more to come so we write
   this.trans.write(this.wbuf);
 };
 
@@ -151,6 +153,8 @@ TJSONProtocol.prototype.writeStructEnd = function() {
 
   str += '}';
   this.tstack[p] = str;
+
+  this.writeToTransportIfStackIsFlushable();
 };
 
 /**
@@ -181,6 +185,8 @@ TJSONProtocol.prototype.writeFieldEnd = function() {
       fieldInfo.fieldType + ':' + value + '}';
   }
   this.tpos.pop();
+
+  this.writeToTransportIfStackIsFlushable();
 };
 
 /**
@@ -237,6 +243,8 @@ TJSONProtocol.prototype.writeMapEnd = function() {
 
   this.tstack[p].push(map);
   this.tstack[p] = '[' + this.tstack[p].join(',') + ']';
+
+  this.writeToTransportIfStackIsFlushable();
 };
 
 /**
@@ -262,6 +270,8 @@ TJSONProtocol.prototype.writeListEnd = function() {
   }
 
   this.tstack[p] = '[' + this.tstack[p].join(',') + ']';
+
+  this.writeToTransportIfStackIsFlushable();
 };
 
 /**
@@ -287,6 +297,8 @@ TJSONProtocol.prototype.writeSetEnd = function() {
   }
 
   this.tstack[p] = '[' + this.tstack[p].join(',') + ']';
+
+  this.writeToTransportIfStackIsFlushable();
 };
 
 /** Serializes a boolean */

--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -92,6 +92,12 @@ TJSONProtocol.prototype.flush = function() {
   return this.trans.flush();
 };
 
+TJSONProtocol.prototype.writeToTransportIfStackIsFlushable = function() {
+  if (this.tstack.length === 1) {
+    this.trans.write(this.tstack.pop());
+  }
+};
+
 /**
  * Serializes the beginning of a Thrift RPC message.
  * @param {string} name - The service method to call.

--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -99,9 +99,6 @@ TJSONProtocol.prototype.flush = function() {
  * @param {number} seqid - The sequence number of this call (always 0 in Apache Thrift).
  */
 TJSONProtocol.prototype.writeMessageBegin = function(name, messageType, seqid) {
-  this.tstack = [];
-  this.tpos = [];
-
   this.tstack.push([TJSONProtocol.Version, '"' + name + '"', messageType, seqid]);
 };
 


### PR DESCRIPTION
this fixes: https://issues.apache.org/jira/browse/THRIFT-2994 (not sure if that is the correct way to link a jira ticket :smile: )

It initializes the arrays used to build up the json on construct and writes to transport whenever a `writeEnd` method is encountered and the stack length is 1, assuming its finished now.

