### PR TITLE
add go json annotation 'omitempty' on optionals

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -1121,7 +1121,12 @@ void t_go_generator::generate_go_struct_definition(ofstream& out,
 
       t_type* fieldType = (*m_iter)->get_type();
       string goType = type_to_go_type_with_opt(fieldType, is_pointer_field(*m_iter));
-      string gotag("json:\"" + escape_string((*m_iter)->get_name()) + "\"");
+      string gotag;
+      if ((*m_iter)->get_req() == t_field::T_OPTIONAL) {
+        gotag = "json:\"" + escape_string((*m_iter)->get_name()) + ",omitempty\"";
+      } else {
+        gotag = "json:\"" + escape_string((*m_iter)->get_name()) + "\"";
+      }
       std::map<string, string>::iterator it = (*m_iter)->annotations_.find("go.tag");
       if (it != (*m_iter)->annotations_.end()) {
         gotag = it->second;

--- a/lib/go/test/GoTagTest.thrift
+++ b/lib/go/test/GoTagTest.thrift
@@ -19,5 +19,6 @@
 
 struct tagged {
     1: string string_thing,
-    2: i64 int_thing (go.tag = "json:\"int_thing,string\"")
+    2: i64 int_thing (go.tag = "json:\"int_thing,string\""),
+    3: optional i64 optional_int_thing
 }

--- a/lib/go/test/tests/gotag_test.go
+++ b/lib/go/test/tests/gotag_test.go
@@ -42,3 +42,12 @@ func TestCustomTag(t *testing.T) {
 		t.Error("Unexpected custom tag value")
 	}
 }
+
+func TestOptionalTag(t *testing.T) {
+	s := gotagtest.Tagged{}
+	st := reflect.TypeOf(s)
+	field, ok := st.FieldByName("OptionalIntThing")
+	if !ok || field.Tag.Get("json") != "optional_int_thing,omitempty" {
+		t.Error("Unexpected default tag value for optional field")
+	}
+}


### PR DESCRIPTION
if a field is optional, we shouldn't need to assert its nullness when
serializing to json. this additionally matches protobuf behavior.