### PR TITLE
THRIFT-2885: Add a 'fullcamel' option for obj-c

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  java:
+    version: oraclejdk8
+
+dependencies:
+  pre:
+    - sudo apt-get update; sudo apt-get install build-essential mono-gmcs python-dev ant mono-devel libmono-system-web2.0-cil erlang-base autoconf automake pkg-config libtool bison flex libboost-dev  python-all python-all-dev python-all-dbg libboost-test-dev libevent-dev php5 php5-dev libglib2.0-dev libqt4-dev ruby ruby-dev
+
+deployment:
+  production:
+    branch: dwnld
+    commands:
+      - dpkg-buildpackage -us -uc -d
+      - cd ~/ && curl -F package=@$(ls thrift-compiler*.deb) https://$GEMFURY_DEPLOY_KEY@push.fury.io/dwnld/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+thrift (1.0.0-THRIFT-2885) stable; urgency=low
+  * update version
+  * fix libthrift0.install
+
+ -- Roger Meier <roger@apache.org>  Tue, 08 Jan 2013 22:40:12 +0100
+
 thrift (1.0.0-dev) stable; urgency=low
   * update version
   * fix libthrift0.install

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,7 @@
-thrift (1.0.0-THRIFT-2885) stable; urgency=low
-  * update version
-  * fix libthrift0.install
+thrift (1.0.0-dwnld-0) stable; urgency=low
+  * dwnld features
 
- -- Roger Meier <roger@apache.org>  Tue, 08 Jan 2013 22:40:12 +0100
+ -- Anatoly Fayngelerin <anatoly@dwnld.me>  Tue, 09 Jun 2015 22:40:12 +0100
 
 thrift (1.0.0-dev) stable; urgency=low
   * update version


### PR DESCRIPTION
This allows you to write your idl files in snake_case and have your objective c code be in the (stylistic) camelCase. It makes the java option of the same name.

It also fixes a minor warning about isEqual methods with no members (which caused an unused variable "other").

Tested by reading and compiling generated code for tutorial; didn't see any tests for compiler outputs.
