### PR TITLE
THRIFT-2987: returns message/struct/field names directly

### DIFF
--- a/lib/cocoa/src/TApplicationException.m
+++ b/lib/cocoa/src/TApplicationException.m
@@ -77,12 +77,12 @@
   int fieldType;
   int fieldID;
 
-  [protocol readStructBeginReturningName: NULL];
+  (void)[protocol readStructBegin];
 
   while (true) {
-    [protocol readFieldBeginReturningName: NULL
-              type: &fieldType
-              fieldID: &fieldID];
+    (void)[protocol
+           readFieldBeginReturningType: &fieldType
+           fieldID: &fieldID];
     if (fieldType == TType_STOP) {
       break;
     }

--- a/lib/cocoa/src/protocol/TBinaryProtocol.m
+++ b/lib/cocoa/src/protocol/TBinaryProtocol.m
@@ -158,9 +158,8 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
 }
 
 
-- (void) readMessageBeginReturningName: (NSString **) name
-                                  type: (int *) type
-                            sequenceID: (int *) sequenceID
+- (NSString *) readMessageBeginReturningType: (int *) type
+                                  sequenceID: (int *) sequenceID
 {
   int32_t size = [self readI32];
   if (size < 0) {
@@ -178,13 +177,11 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
       *type = size & 0x00FF;
     }
     NSString * messageName = [self readString];
-    if (name != NULL) {
-      *name = messageName;
-    }
     int seqID = [self readI32];
     if (sequenceID != NULL) {
       *sequenceID = seqID;
     }
+    return messageName;
   } else {
     if (mStrictRead) {
       @throw [TProtocolException exceptionWithName: @"TProtocolException"
@@ -197,9 +194,6 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
                                                      size]];
     }
     NSString * messageName = [self readStringBody: size];
-    if (name != NULL) {
-      *name = messageName;
-    }
     int messageType = [self readByte];
     if (type != NULL) {
       *type = messageType;
@@ -208,6 +202,7 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
     if (sequenceID != NULL) {
       *sequenceID = seqID;
     }
+    return messageName;
   }
 }
 
@@ -215,24 +210,18 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
 - (void) readMessageEnd {}
 
 
-- (void) readStructBeginReturningName: (NSString **) name
+- (NSString *) readStructBegin
 {
-  if (name != NULL) {
-    *name = nil;
-  }
+  return nil;
 }
 
 
 - (void) readStructEnd {}
 
 
-- (void) readFieldBeginReturningName: (NSString **) name
-                                type: (int *) fieldType
-                             fieldID: (int *) fieldID
+- (NSString *) readFieldBeginReturningType: (int *) fieldType
+                                   fieldID: (int *) fieldID
 {
-  if (name != NULL) {
-    *name = nil;
-  }
   int ft = [self readByte];
   if (fieldType != NULL) {
     *fieldType = ft;
@@ -243,6 +232,7 @@ static TBinaryProtocolFactory * gSharedFactory = nil;
       *fieldID = fid;
     }
   }
+  return nil;
 }
 
 

--- a/lib/cocoa/src/protocol/TProtocol.h
+++ b/lib/cocoa/src/protocol/TProtocol.h
@@ -50,17 +50,15 @@ enum {
 
 - (id <TTransport>) transport;
 
-- (void) readMessageBeginReturningName: (NSString **) name
-                                  type: (int *) type
-                            sequenceID: (int *) sequenceID;
+- (NSString *) readMessageBeginReturningType: (int *) type
+                                  sequenceID: (int *) sequenceID;
 - (void) readMessageEnd;
 
-- (void) readStructBeginReturningName: (NSString **) name;
+- (NSString *) readStructBegin;
 - (void) readStructEnd;
 
-- (void) readFieldBeginReturningName: (NSString **) name
-                                type: (int *) fieldType
-                             fieldID: (int *) fieldID;
+- (NSString *) readFieldBeginReturningType: (int *) fieldType
+                                   fieldID: (int *) fieldID;
 - (void) readFieldEnd;
 
 - (NSString *) readString;

--- a/lib/cocoa/src/protocol/TProtocolDecorator.m
+++ b/lib/cocoa/src/protocol/TProtocolDecorator.m
@@ -36,13 +36,13 @@
     return [mConcreteProtocol transport];
 }
 
-- (void) readMessageBeginReturningName: (NSString **) name
-                                  type: (int *) type
-                            sequenceID: (int *) sequenceID
+- (NSString *) readMessageBeginReturningType: (int *) type
+                                  sequenceID: (int *) sequenceID
 {
-    [mConcreteProtocol readMessageBeginReturningName:name
-                                                type:type
-                                          sequenceID:sequenceID];
+    NSString *name = [mConcreteProtocol
+                      readMessageBeginReturningType:type
+                      sequenceID:sequenceID];
+    return name;
 }
 
 - (void) readMessageEnd
@@ -50,9 +50,10 @@
     [mConcreteProtocol readMessageEnd];
 }
 
-- (void) readStructBeginReturningName: (NSString **) name
+- (NSString *) readStructBegin
 {
-    [mConcreteProtocol readStructBeginReturningName:name];
+    NSString *name = [mConcreteProtocol readStructBegin];
+    return name;
 }
 
 - (void) readStructEnd
@@ -60,13 +61,13 @@
     [mConcreteProtocol readStructEnd];
 }
 
-- (void) readFieldBeginReturningName: (NSString **) name
-                                type: (int *) fieldType
-                             fieldID: (int *) fieldID
+- (NSString *) readFieldBeginReturningType: (int *) fieldType
+                                   fieldID: (int *) fieldID
 {
-    [mConcreteProtocol readFieldBeginReturningName:name
-                                              type:fieldType
-                                           fieldID:fieldID];
+    NSString *name = [mConcreteProtocol
+                      readFieldBeginReturningType:fieldType
+                      fieldID:fieldID];
+    return name;
 }
 - (void) readFieldEnd
 {

--- a/lib/cocoa/src/protocol/TProtocolUtil.m
+++ b/lib/cocoa/src/protocol/TProtocolUtil.m
@@ -46,10 +46,10 @@
     [protocol readString];
     break;
   case TType_STRUCT:
-    [protocol readStructBeginReturningName: NULL];
+    (void)[protocol readStructBegin];
     while (true) {
       int fieldType;
-      [protocol readFieldBeginReturningName: nil type: &fieldType fieldID: nil];
+      (void)[protocol readFieldBeginReturningType: &fieldType fieldID: nil];
       if (fieldType == TType_STOP) {
         break;
       }


### PR DESCRIPTION
Returning byref was triggering a warning from ARC.
