### PR TITLE
Node.js: Fixed retry delay

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -41,6 +41,7 @@ var Connection = exports.Connection = function(stream, options) {
   this.protocol = this.options.protocol || TBinaryProtocol;
   this.offline_queue = [];
   this.connected = false;
+  this.initialize_retry_vars();
 
   this._debug = this.options.debug || false;
   if (this.options.max_attempts &&
@@ -209,10 +210,9 @@ Connection.prototype.connection_gone = function () {
   this.connected = false;
   this.ready = false;
 
+  this.retry_delay = Math.floor(this.retry_delay * this.retry_backoff);
   if (this.retry_max_delay !== null && this.retry_delay > this.retry_max_delay) {
     this.retry_delay = this.retry_max_delay;
-  } else {
-    this.retry_delay = Math.floor(this.retry_delay * this.retry_backoff);
   }
 
   if (self._debug) {


### PR DESCRIPTION
- Call `initialize_retry_vars()` in `Connection`'s constructor, so that `retry_delay` does not become `NaN` after multiplying two `null` values. This resulted in the retry delay always being instant, since calling `setTimeout()` with `NaN` is equivalent to calling it with 0 ms.
- Fixed `retry_max_delay` logic: The max value should be applied after calculating the next `retry_delay`. Previously, the connection would allow one delay to be greater than the max. And after that every second delay would be greater than the max, since the code was using `>` to compare the last retry delay (which was the max) and the max, which would always be false.