### PR TITLE
THRIFT-3027 Ensure common initialisms in generated Go code have consistent case

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -35,7 +35,7 @@
 #include <sys/types.h>
 #include <sstream>
 #include <algorithm>
-#include <boost/algorithm/string.hpp>
+#include <clocale>
 #include "t_generator.h"
 #include "platform.h"
 #include "version.h"
@@ -417,6 +417,7 @@ const std::set<std::string> commonInitialisms = {"API", "ASCII", "CPU", "CSS",
 std::string t_go_generator::camelcase(const std::string& value) {
   
   std::string value2(value);
+  std::setlocale(LC_ALL, "C"); // set locale to classic
   
   // as long as we are changing things, let's change _ followed by lowercase to capital and fix common initialisms
   for (std::string::size_type i = 1; i < value2.size() - 1; ++i) {
@@ -425,10 +426,9 @@ std::string t_go_generator::camelcase(const std::string& value) {
         value2.replace(i, 2, 1, toupper(value2[i + 1]));
       }
       std::string word = value2.substr(i,value2.find('_', i));
-      std::string upper = boost::to_upper_copy(word);
-      
-      if (commonInitialisms.find(upper) != commonInitialisms.end()) {
-        value2.replace(i, word.length(), upper); 
+      std::transform(word.begin(), word.end(), word.begin(), ::toupper);
+      if (commonInitialisms.find(word) != commonInitialisms.end()) {
+        value2.replace(i, word.length(), word); 
       }
     }
   }

--- a/lib/go/test/InitialismsTest.thrift
+++ b/lib/go/test/InitialismsTest.thrift
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+struct InitialismsTest {
+    1: string user_id,
+    2: string server_url,
+}

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -32,7 +32,8 @@ gopath: $(top_srcdir)/compiler/cpp/thrift $(THRIFTTEST) \
 				TypedefFieldTest.thrift \
 				RefAnnotationFieldsTest.thrift \
 				ErrorTest.thrift \
-				NamesTest.thrift
+				NamesTest.thrift \
+				InitialismsTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) -r IncludesTest.thrift
@@ -46,6 +47,7 @@ gopath: $(top_srcdir)/compiler/cpp/thrift $(THRIFTTEST) \
 	$(THRIFT) RefAnnotationFieldsTest.thrift
 	$(THRIFT) ErrorTest.thrift
 	$(THRIFT) NamesTest.thrift
+	$(THRIFT) InitialismsTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get code.google.com/p/gomock/gomock
 	ln -nfs ../../../thrift gopath/src/thrift
 	ln -nfs ../../tests gopath/src/tests
@@ -59,7 +61,8 @@ check: gopath
 				typedeffieldtest \
 				refannotationfieldstest \
 				errortest	\
-				namestest
+				namestest \
+				initialismstest
 	GOPATH=`pwd`/gopath $(GO) test thrift tests
 
 clean-local:
@@ -81,4 +84,5 @@ EXTRA_DIST = \
 	ServicesTest.thrift \
 	TypedefFieldTest.thrift \
 	ErrorTest.thrift \
-	NamesTest.thrift
+	NamesTest.thrift \
+	InitialismsTest.thrift

--- a/lib/go/test/tests/initialisms_test.go
+++ b/lib/go/test/tests/initialisms_test.go
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"initialismstest"
+	"reflect"
+	"testing"
+)
+
+func TestThatCommonInitialismsAreFixed(t *testing.T) {
+	s := initialismstest.InitialismsTest{}
+	st := reflect.TypeOf(s)
+	_, ok := st.FieldByName("UserID")
+	if !ok {
+		t.Error("UserID attribute is missing!")
+	}
+	_, ok = st.FieldByName("ServerURL")
+	if !ok {
+		t.Error("ServerURL attribute is missing!")
+	}
+}


### PR DESCRIPTION
In Go, as per https://github.com/golang/go/wiki/CodeReviewComments#initialisms, words in names that are initialisms or acronyms should have a consistent case.

https://issues.apache.org/jira/browse/THRIFT-3027