### PR TITLE
THRIFT-3060: NodeJS Client - Fix connection retry logic

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -32,6 +32,20 @@ var binary = require('./binary');
 
 var Connection = exports.Connection = function(stream, options) {
   var self = this;
+  var connectHandler = function () {
+    self.connected = true;
+
+    this.setTimeout(self.options.timeout || 0);
+    this.setNoDelay();
+    this.frameLeft = 0;
+    this.framePos = 0;
+    this.frame = null;
+    self.initialize_retry_vars();
+
+    self.flushQueue();
+    self.emit("connect");
+  };
+
   EventEmitter.call(this);
 
   this.seqId2Service = {};
@@ -41,6 +55,7 @@ var Connection = exports.Connection = function(stream, options) {
   this.protocol = this.options.protocol || TBinaryProtocol;
   this.offline_queue = [];
   this.connected = false;
+  this.initialize_retry_vars();
 
   this._debug = this.options.debug || false;
   if (this.options.max_attempts &&
@@ -60,41 +75,9 @@ var Connection = exports.Connection = function(stream, options) {
       this.options.connect_timeout > 0) {
      this.connect_timeout = +this.options.connect_timeout;
   }
-  this.connection.addListener("connect", function() {
-    self.connected = true;
 
-    this.setTimeout(self.options.timeout || 0);
-    this.setNoDelay();
-    this.frameLeft = 0;
-    this.framePos = 0;
-    this.frame = null;
-    self.initialize_retry_vars();
-
-    self.offline_queue.forEach(function(data) {
-      self.connection.write(data);
-    });
-
-    self.emit("connect");
-  });
-
-  this.connection.addListener("secureConnect", function() {
-    self.connected = true;
-
-    this.setTimeout(self.options.timeout || 0);
-    this.setNoDelay();
-    this.frameLeft = 0;
-    this.framePos = 0;
-    this.frame = null;
-    self.initialize_retry_vars();
-
-    self.offline_queue.forEach(function(data) {
-      self.connection.write(data);
-    });
-
-    self.emit("connect");
-  });
-
-
+  this.connection.addListener("connect", connectHandler);
+  this.connection.addListener("secureConnect", connectHandler);
   this.connection.addListener("error", function(err) {
     // Only emit the error if no-one else is listening on the connection
     // or if someone is listening on us
@@ -110,6 +93,11 @@ var Connection = exports.Connection = function(stream, options) {
   // Add a close listener
   this.connection.addListener("close", function() {
     self.connection_gone(); // handle close event. try to reconnect
+  });
+
+  // Add an end listener
+  this.connection.addListener("end", function() {
+    self.connection_gone(); // handle end event. try to reconnect
   });
 
   this.connection.addListener("timeout", function() {
@@ -182,8 +170,16 @@ Connection.prototype.initialize_retry_vars = function () {
   this.retry_timer = null;
   this.retry_totaltime = 0;
   this.retry_delay = 150;
-  this.retry_backoff = 1.7;
+  this.retry_backoff = 1.5;
   this.attempts = 0;
+};
+
+Connection.prototype.flushQueue = function () {
+  var current_queue = this.offline_queue.slice();
+  this.offline_queue = [];
+  current_queue.forEach(function(data) {
+    this.write(data);
+  });
 };
 
 Connection.prototype.write = function(data) {
@@ -209,10 +205,9 @@ Connection.prototype.connection_gone = function () {
   this.connected = false;
   this.ready = false;
 
+  this.retry_delay = Math.floor(this.retry_delay * this.retry_backoff);
   if (this.retry_max_delay !== null && this.retry_delay > this.retry_max_delay) {
     this.retry_delay = this.retry_max_delay;
-  } else {
-    this.retry_delay = Math.floor(this.retry_delay * this.retry_backoff);
   }
 
   if (self._debug) {
@@ -316,6 +311,11 @@ var StdIOConnection = exports.StdIOConnection = function(command, options) {
   // Add a close listener
   this.connection.addListener("close", function() {
     self.emit("close");
+  });
+
+  // Add an end listener
+  this.connection.addListener("end", function() {
+    self.emit("end");
   });
 
   child.stdout.addListener("data", self.transport.receiver(function(transport_with_data) {


### PR DESCRIPTION
**Fix**: Retry variables were not initialized until after the connection succeeded. This fix properly calculates the retry timer even when the initial connection cannot be made.

**Fix**: The `offline_queue` array never gets cleared.  On reconnect, if requests ended up in the offline_queue, they would be sent again on each reconnect. This fix flushes the queue after the requests have been written to the connection.

**Change**: both connect handlers use the same code, so I pulled out the function and pass it into both the `connect` and `secureConnect` event listeners.

**Change**: Add an on "end" listener for cases where the connection may be closed by the server and left in a half-open state.
