### PR TITLE
Update thrift.js

### DIFF
--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -138,9 +138,13 @@ var TProtocolExceptionType = exports.TProtocolExceptionType = {
 
 
 var TProtocolException = exports.TProtocolException = function(type, message) {
-  Error.call(this, message);
+  e = Error.call(this, message);
   this.name = 'TProtocolException';
   this.type = type;
+  this.message = e.message;
+  Object.defineProperty(this, 'stack', {
+    get: function() { return e.stack }
+  })
 };
 util.inherits(TProtocolException, Error);
 


### PR DESCRIPTION
Error.message and stack are non-enumerable properties, which cannot be inherited by util.inherits. It is annoying that an Exception object doesn't contain a message, so it is a critical bug I think.