### PR TITLE
bower.json: fix "main" path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Apache Thrift <dev@thrift.apache.org>"
   ],
   "description": "Apache Thrift",
-  "main": "lib/js/thrift.js",
+  "main": "lib/js/src/thrift.js",
   "keywords": [
     "thrift"
   ],


### PR DESCRIPTION
The path "lib/js/thrift.js" is broken. "lib/js/src/thrift.js" seems to be valid.

With this fix I can include the thrift.js lib via wiredep again.