### PR TITLE
THRIFT-3047: Fixing indentation for generated cocoa sources

### DIFF
--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -1516,8 +1516,6 @@ void t_cocoa_generator::generate_cocoa_service_client_implementation(ofstream& o
     out << endl;
   }
 
-  indent_down();
-
   out << "@end" << endl << endl;
 }
 
@@ -1530,7 +1528,6 @@ void t_cocoa_generator::generate_cocoa_service_client_implementation(ofstream& o
 void t_cocoa_generator::generate_cocoa_service_server_implementation(ofstream& out,
                                                                      t_service* tservice) {
   out << "@implementation " << cocoa_prefix_ << tservice->get_name() << "Processor" << endl;
-  indent_up();
 
   // initializer
   out << endl;
@@ -1680,8 +1677,6 @@ void t_cocoa_generator::generate_cocoa_service_server_implementation(ofstream& o
   out << indent() << "[super dealloc_stub];" << endl;
   scope_down(out);
   out << endl;
-
-  indent_down();
 
   out << "@end" << endl << endl;
 }


### PR DESCRIPTION
indent_down was called one extra time when generating the client which gave us an indentation level of -1, then to combat this, we indented the server implementation an extra level. This appeared as if everything was fine unless you generated more than one service in a thrift file, in which case the indentation would get progressively worse.