### PR TITLE
[THRIFT-3048] - Make TCompactProtocol always return an object for i64

### DIFF
--- a/lib/nodejs/lib/thrift/compact_protocol.js
+++ b/lib/nodejs/lib/thrift/compact_protocol.js
@@ -811,8 +811,7 @@ TCompactProtocol.prototype.readVarint64 = function() {
       throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.INVALID_DATA, "Variable-length int over 10 bytes.");
     }
   }
-  var i64 = new Int64(hi, lo);
-  return i64.toNumber();
+  return new Int64(hi, lo);
 };
 
 /**
@@ -826,7 +825,7 @@ TCompactProtocol.prototype.zigzagToI32 = function(n) {
  * Convert from zigzag long to long.
  */
 TCompactProtocol.prototype.zigzagToI64 = function(n) {
-  var zz = new Int64(n);
+  var zz = n;
   var hi = zz.buffer.readUInt32BE(0, true);
   var lo = zz.buffer.readUInt32BE(4, true);
 
@@ -839,7 +838,7 @@ TCompactProtocol.prototype.zigzagToI64 = function(n) {
   hi = (hi >>> 1) ^ (hi_neg);
   lo = ((lo >>> 1) | hi_lo) ^ (lo_neg);
   var i64 = new Int64(hi, lo);
-  return i64.toNumber();
+  return i64;
 };
 
 TCompactProtocol.prototype.skip = function(type) {


### PR DESCRIPTION
This changes the TCompactProtocol to always return an Int64 object in the same way that TBinary and TJSON do.

This is definitely a breaking change and will likely cause application problems for many people using TCompact and i64 types.