### PR TITLE
THRIFT-3050 TLS Client cert validation TLS C#

### DIFF
--- a/lib/csharp/src/Transport/TTLSServerSocket.cs
+++ b/lib/csharp/src/Transport/TTLSServerSocket.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 
@@ -53,6 +54,10 @@ namespace Thrift.Transport
         /// </summary>
         private X509Certificate serverCertificate;
 
+        /// <summary>
+        /// The function to validate the client certificate.
+        /// </summary>
+        private RemoteCertificateValidationCallback clientCertValidator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TTLSServerSocket" /> class.
@@ -82,7 +87,8 @@ namespace Thrift.Transport
         /// <param name="clientTimeout">Send/receive timeout.</param>
         /// <param name="useBufferedSockets">If set to <c>true</c> [use buffered sockets].</param>
         /// <param name="certificate">The certificate object.</param>
-        public TTLSServerSocket(int port, int clientTimeout, bool useBufferedSockets, X509Certificate2 certificate)
+        /// <param name="clientCertValidator">The certificate validator.</param>
+        public TTLSServerSocket(int port, int clientTimeout, bool useBufferedSockets, X509Certificate2 certificate, RemoteCertificateValidationCallback clientCertValidator = null)
         {
             if (!certificate.HasPrivateKey)
             {
@@ -92,6 +98,7 @@ namespace Thrift.Transport
             this.port = port;
             this.serverCertificate = certificate;
             this.useBufferedSockets = useBufferedSockets;
+            this.clientCertValidator = clientCertValidator;
             try
             {
                 // Create server socket
@@ -143,7 +150,7 @@ namespace Thrift.Transport
                 client.SendTimeout = client.ReceiveTimeout = this.clientTimeout;
 
                 //wrap the client in an SSL Socket passing in the SSL cert
-                TTLSSocket socket = new TTLSSocket(client, this.serverCertificate, true);
+                TTLSSocket socket = new TTLSSocket(client, this.serverCertificate, true, this.clientCertValidator);
 
                 socket.setupTLS();
 


### PR DESCRIPTION
This plumbs the remote certificate validation callback down
to the server side authentication code. When the callback is
set, we set the client certificate required flag. In practice, the
validation callback still gets called even when the client
doesn't supply a certificate.

I've taken the liberty of using slightly more modern C# syntax
to shorten up the affected method.