### PR TITLE
[THRIFT-3071] check minimum required version of automake in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,6 +38,13 @@ else
   exit 1
 fi
 
+# we require automake 1.13 or later
+AUTOMAKE_VERSION=`automake --version | head -n1 | rev | sed -e 's/\s.*$//' | rev`
+if [ "$AUTOMAKE_VERSION" \< "1.13" ]; then
+  echo >&2 "automake version $AUTOMAKE_VERSION is too old (need 1.13 or later)"
+  exit 1
+fi
+
 autoscan
 $LIBTOOLIZE --copy --automake
 aclocal -I ./aclocal

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,6 +39,7 @@ else
 fi
 
 # we require automake 1.13 or later
+# check must happen externally due to use of newer macro
 AUTOMAKE_VERSION=`automake --version | head -n1 | rev | sed -e 's/\s.*$//' | rev`
 if [ "$AUTOMAKE_VERSION" \< "1.13" ]; then
   echo >&2 "automake version $AUTOMAKE_VERSION is too old (need 1.13 or later)"

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@
 #
 
 AC_PREREQ(2.65)
+AC_CONFIG_MACRO_DIR([./aclocal])
 
 AC_INIT([thrift], [1.0.0-dev])
 
@@ -595,6 +596,7 @@ AC_CHECK_FUNCS([memset])
 AC_CHECK_FUNCS([mkdir])
 AC_CHECK_FUNCS([realpath])
 AC_CHECK_FUNCS([select])
+AC_CHECK_FUNCS([setlocale])
 AC_CHECK_FUNCS([socket])
 AC_CHECK_FUNCS([strchr])
 AC_CHECK_FUNCS([strdup])


### PR DESCRIPTION
~/thrift$ sh bootstrap.sh 
automake version 1.11.3 is too old (need 1.13 or later)
