### PR TITLE
THRIFT-3085: thrift_reconnecting_client never try to reconnect

### DIFF
--- a/lib/erl/src/thrift_reconnecting_client.erl
+++ b/lib/erl/src/thrift_reconnecting_client.erl
@@ -156,6 +156,9 @@ handle_cast( _Msg, State ) ->
 %%                                       {stop, Reason, State}
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
+handle_info( try_connect, State ) ->
+  { noreply, try_connect( State ) };
+
 handle_info( _Info, State ) ->
   { noreply, State }.
 


### PR DESCRIPTION
gen_server does not handle message try_connect after unsuccessful connection, and gen_server always return {error, noconn}

THRIFT-3085