### PR TITLE
[THRIFT-3088] TThreadPoolServer with Sasl auth may leak CLOSE_WAIT socket

### DIFF
--- a/lib/java/src/org/apache/thrift/server/TThreadPoolServer.java
+++ b/lib/java/src/org/apache/thrift/server/TThreadPoolServer.java
@@ -303,6 +303,10 @@ public class TThreadPoolServer extends TServer {
       if (outputTransport != null) {
         outputTransport.close();
       }
+
+      if (client_.isOpen()) {
+        client_.close();
+      }
     }
   }
 }


### PR DESCRIPTION
Start TThreadPoolServer to server with TSaslServerTransport.Factory as transportFactory. While using nc to test the specified port whether reachable, it will leak CLOSE_WAIT socket.That's because nc will close socket at once while successful connect TThreadPoolServer, but the server still try using sasl protocol to build an inputTransport which of course failed at once. However inputTransport is null which makes it can't close socket properly which lead to CLOSE_WAIT socket.
