### PR TITLE
THRIFT-227 Pretty print binary collections in Java

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2423,6 +2423,16 @@ void t_java_generator::generate_java_struct_tostring(ofstream& out, t_struct* ts
     if (field->get_type()->is_base_type() && ((t_base_type*)(field->get_type()))->is_binary()) {
       indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
                   << endl;
+    } else if ((field->get_type()->is_set()) &&
+               (((t_set*) field->get_type())->get_elem_type()->is_base_type()) &&
+               (((t_base_type*) ((t_set*) field->get_type())->get_elem_type())->is_binary())) {
+      indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
+                  << endl;
+    } else if ((field->get_type()->is_list()) &&
+               (((t_list*) field->get_type())->get_elem_type()->is_base_type()) &&
+               (((t_base_type*) ((t_list*) field->get_type())->get_elem_type())->is_binary())) {
+      indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
+                  << endl;
     } else {
       indent(out) << "sb.append(this." << (*f_iter)->get_name() << ");" << endl;
     }

--- a/lib/java/src/org/apache/thrift/TBaseHelper.java
+++ b/lib/java/src/org/apache/thrift/TBaseHelper.java
@@ -28,6 +28,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.Collection;
 
 public final class TBaseHelper {
 
@@ -217,6 +218,25 @@ public final class TBaseHelper {
         return compareTo((byte[])oA, (byte[])oB);
       } else {
         return compareTo((Comparable)oA, (Comparable)oB);
+      }
+    }
+  }
+
+  public static void toString(Collection<ByteBuffer> bbs, StringBuilder sb) {
+    Iterator<ByteBuffer> it = bbs.iterator();
+    if (!it.hasNext()) {
+      sb.append("[]");
+    } else {
+      sb.append("[");
+      while (true) {
+        ByteBuffer bb = it.next();
+        org.apache.thrift.TBaseHelper.toString(bb, sb);
+        if (!it.hasNext()) {
+          sb.append("]");
+          return;
+        } else {
+          sb.append(", ");
+        }
       }
     }
   }


### PR DESCRIPTION
`set<binary>` and `list<binary>` don't have pretty printers corresponding to `binary`. This adds them.