### PR TITLE
THRIFT-3098 Print binary typedefs the same way we do binary fields

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2420,17 +2420,17 @@ void t_java_generator::generate_java_struct_tostring(ofstream& out, t_struct* ts
       indent_up();
     }
 
-    if (field->get_type()->is_base_type() && ((t_base_type*)(field->get_type()))->is_binary()) {
+    if (get_true_type(field->get_type())->is_base_type() && ((t_base_type*)(get_true_type(field->get_type())))->is_binary()) {
       indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
                   << endl;
     } else if ((field->get_type()->is_set()) &&
-               (((t_set*) field->get_type())->get_elem_type()->is_base_type()) &&
-               (((t_base_type*) ((t_set*) field->get_type())->get_elem_type())->is_binary())) {
+               (get_true_type(((t_set*) field->get_type())->get_elem_type())->is_base_type()) &&
+               (((t_base_type*) get_true_type(((t_set*) field->get_type())->get_elem_type()))->is_binary())) {
       indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
                   << endl;
     } else if ((field->get_type()->is_list()) &&
-               (((t_list*) field->get_type())->get_elem_type()->is_base_type()) &&
-               (((t_base_type*) ((t_list*) field->get_type())->get_elem_type())->is_binary())) {
+               (get_true_type(((t_list*) field->get_type())->get_elem_type())->is_base_type()) &&
+               (((t_base_type*) get_true_type(((t_list*) field->get_type())->get_elem_type()))->is_binary())) {
       indent(out) << "org.apache.thrift.TBaseHelper.toString(this." << field->get_name() << ", sb);"
                   << endl;
     } else {


### PR DESCRIPTION
Now

```
typedef BinType binary
struct BinHolder {
 1: binary bin_field
 2: BinType typedef_field
}
```

generates

```
 sb.append("bin_field:");
    if (this.bin_field == null) {
      sb.append("null");
    } else {
      org.apache.thrift.TBaseHelper.toString(this.bin_field, sb);
    }
    first = false;
    if (!first) sb.append(", ");
    sb.append("typedef_field:");
    if (this.typedef_field == null) {
      sb.append("null");
    } else {
      org.apache.thrift.TBaseHelper.toString(this.typedef_field, sb);
    }
```