### PR TITLE
THRIFT-2877 Generate hashCode using primitives, static utility methods

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -1874,9 +1874,9 @@ void t_java_generator::generate_java_struct_equality(ofstream& out, t_struct* ts
   scope_down(out);
   out << endl;
 
-  const int MUL = 31; // HashCode multiplier
-  const int B_YES = 1231;
-  const int B_NO = 1237;
+  const int MUL = 8191; // HashCode multiplier
+  const int B_YES = 131071;
+  const int B_NO = 524287;
   out << indent() << "@Override" << endl << indent() << "public int hashCode() {" << endl;
   indent_up();
   indent(out) << "int hashCode = 1;" << endl;
@@ -1889,19 +1889,13 @@ void t_java_generator::generate_java_struct_equality(ofstream& out, t_struct* ts
     bool can_be_null = type_can_be_null(t);
     string name = (*m_iter)->get_name();
 
-    string present = "true";
-
     if (is_optional || can_be_null) {
       indent(out) << "hashCode = hashCode * " << MUL << " + ((" << generate_isset_check(*m_iter)
                   << ") ? " << B_YES << " : " << B_NO << ");" << endl;
-      present += " && (" + generate_isset_check(*m_iter) + ")";
-    } else {
-      indent(out) << "hashCode = hashCode * " << MUL << " + " << B_YES << ";" << endl;
     }
 
     if (is_optional || can_be_null) {
-      indent(out) << "boolean present_" << name << " = " << present << ";" << endl;
-      indent(out) << "if (present_" << name << ")" << endl;
+      indent(out) << "if (" + generate_isset_check(*m_iter) + ")" << endl;
       indent_up();
     }
 
@@ -1909,31 +1903,29 @@ void t_java_generator::generate_java_struct_equality(ofstream& out, t_struct* ts
       indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ".getValue();" << endl;
     } else if (t->is_base_type()) {
       switch(((t_base_type*)t)->get_base()) {
-        case t_base_type::TYPE_VOID:
-          break;
-        case t_base_type::TYPE_STRING:
-          indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ".hashCode();" << endl;
-          break;
-        case t_base_type::TYPE_BOOL:
-          indent(out) << "hashCode = hashCode * " << MUL << " + ((" << name << ") ? "
-                      << B_YES << " : " << B_NO << ");" << endl;
-          break;
-        case t_base_type::TYPE_BYTE:
-          indent(out) << "hashCode = hashCode * " << MUL << " + org.apache.thrift.TBaseHelper.hashCode(" << name << ");" << endl;
-          break;
-        case t_base_type::TYPE_I16:
-        case t_base_type::TYPE_I32:
-          indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ";" << endl;
-          break;
-        case t_base_type::TYPE_I64:
-          indent(out) << "hashCode = hashCode * " << MUL << " + org.apache.thrift.TBaseHelper.hashCode(" << name << ");" << endl;
-          break;
-        case t_base_type::TYPE_DOUBLE:
-          indent(out) << "hashCode = hashCode * " << MUL << " + org.apache.thrift.TBaseHelper.hashCode(" << name << ");" << endl;
-          break;
-        default:
-          throw "compiler error: the following base type has no hashcode generator: " +
-                 t_base_type::t_base_name(((t_base_type*)t)->get_base());
+      case t_base_type::TYPE_STRING:
+        indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ".hashCode();" << endl;
+        break;
+      case t_base_type::TYPE_BOOL:
+        indent(out) << "hashCode = hashCode * " << MUL << " + ((" << name << ") ? "
+                    << B_YES << " : " << B_NO << ");" << endl;
+        break;
+      case t_base_type::TYPE_I8:
+        indent(out) << "hashCode = hashCode * " << MUL << " + (int) (" << name << ");" << endl;
+        break;
+      case t_base_type::TYPE_I16:
+      case t_base_type::TYPE_I32:
+        indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ";" << endl;
+        break;
+      case t_base_type::TYPE_I64:
+      case t_base_type::TYPE_DOUBLE:
+        indent(out) << "hashCode = hashCode * " << MUL << " + org.apache.thrift.TBaseHelper.hashCode(" << name << ");" << endl;
+        break;
+      case t_base_type::TYPE_VOID:
+        throw std::logic_error("compiler error: a struct field cannot be void");
+      default:
+        throw std::logic_error("compiler error: the following base type has no hashcode generator: " +
+               t_base_type::t_base_name(((t_base_type*)t)->get_base()));
       }
     } else {
       indent(out) << "hashCode = hashCode * " << MUL << " + " << name << ".hashCode();" << endl;

--- a/lib/java/src/org/apache/thrift/TBaseHelper.java
+++ b/lib/java/src/org/apache/thrift/TBaseHelper.java
@@ -326,15 +326,12 @@ public final class TBaseHelper {
   }
 
   public static int hashCode(long value) {
-    return (int)(value ^ (value >>> 32));
-  }
-
-  public static int hashCode(byte value) {
-    return (int) value;
+    int low = (int) value;
+    int high = (int) (value >>> 32);
+    return high * 127 + low;
   }
 
   public static int hashCode(double value) {
-    long bits = Double.doubleToLongBits(value);
-    return (int)(bits ^ (bits >>> 32));
+    return hashCode(Double.doubleToRawLongBits(value));
   }
 }

--- a/lib/java/src/org/apache/thrift/TBaseHelper.java
+++ b/lib/java/src/org/apache/thrift/TBaseHelper.java
@@ -324,4 +324,17 @@ public final class TBaseHelper {
     System.arraycopy(orig, 0, copy, 0, orig.length);
     return copy;
   }
+
+  public static int hashCode(long value) {
+    return (int)(value ^ (value >>> 32));
+  }
+
+  public static int hashCode(byte value) {
+    return (int) value;
+  }
+
+  public static int hashCode(double value) {
+    long bits = Double.doubleToLongBits(value);
+    return (int)(bits ^ (bits >>> 32));
+  }
 }


### PR DESCRIPTION
This is pretty much the List.hashCode() except without any list. It takes about a third the time on some rudimentary benchmarks. I tried it out with

```
typedef i32 SomeId
typedef binary BinId
typedef string StringId

struct NonTrue {}

union MaybeAThing {
    1: NonTrue nt
    2: bool bl
}

enum Nomnom {
    EAT=31
    LIVE=515
}

struct AllPrims {
    1: bool boole
    2: byte single_byte
    3: i16 shrt
    4: i32 integ
    5: i64 longue
    6: double f64
    7: string str
    8: binary bin
    9: Nomnom en
    10: NonTrue stru
    11: MaybeAThing un
    12: SomeId intid
    13: BinId binid
    14: StringId strid
}
```

generating [this hashCode()](https://gist.github.com/roshan/7b7fff349e3ed06322c3).

Populating these structs with some values has it match the AbstractList.hashCode() result but maybe we could try a different multiplicative factor.

Sorry about the other one https://github.com/apache/thrift/pull/447. I rebased to one commit, but couldn't seem to reuse the old PR (it compiled locally on gcc but failed on clang).