### PR TITLE
THRIFT-1857: Added some missing leading periods for the ttypes import

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -341,7 +341,7 @@ void t_py_generator::init_generator() {
   f_types_ << py_autogen_comment() << endl << py_imports() << endl << render_includes() << endl
            << render_fastbinary_includes() << endl << endl;
 
-  f_consts_ << py_autogen_comment() << endl << py_imports() << endl << "from ttypes import *"
+  f_consts_ << py_autogen_comment() << endl << py_imports() << endl << "from .ttypes import *"
             << endl << endl;
 }
 
@@ -945,7 +945,7 @@ void t_py_generator::generate_service(t_service* tservice) {
                << tservice->get_extends()->get_name() << endl;
   }
 
-  f_service_ << "from ttypes import *" << endl << "from thrift.Thrift import TProcessor" << endl
+  f_service_ << "from .ttypes import *" << endl << "from thrift.Thrift import TProcessor" << endl
              << render_fastbinary_includes() << endl;
 
   if (gen_twisted_) {


### PR DESCRIPTION
This should fix the ttypes import.