### PR TITLE
Support negative hex literals in IDL

### DIFF
--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -104,7 +104,7 @@ void unexpected_token(char* text) {
  */
 
 intconstant   ([+-]?[0-9]+)
-hexconstant   ("0x"[0-9A-Fa-f]+)
+hexconstant   ([+-]?"0x"[0-9A-Fa-f]+)
 dubconstant   ([+-]?[0-9]*(\.[0-9]+)?([eE][+-]?[0-9]+)?)
 identifier    ([a-zA-Z_](\.[a-zA-Z_0-9]|[a-zA-Z_0-9])*)
 whitespace    ([ \t\r\n]*)
@@ -305,7 +305,12 @@ literal_begin (['\"])
 
 {hexconstant} {
   errno = 0;
-  yylval.iconst = strtoll(yytext+2, NULL, 16);
+  char sign = yytext[0];
+  int shift = sign == '0' ? 2 : 3;
+  yylval.iconst = strtoll(yytext+shift, NULL, 16);
+  if (sign == '-') {
+    yylval.iconst = -yylval.iconst;
+  }
   if (errno == ERANGE) {
     integer_overflow(yytext);
   }

--- a/test/ConstantsDemo.thrift
+++ b/test/ConstantsDemo.thrift
@@ -40,6 +40,7 @@ const myIntType myInt = 3
 //const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
 
 const i32 hex_const = 0x0001F
+const i32 negative_hex_constant = -0x0001F
 
 const i32 GEN_ME = -3523553
 const double GEn_DUB = 325.532


### PR DESCRIPTION
As it is now, the parser doesn't allow hex constant values to be negative (it throws a 'bad syntax' error).
The change updates the regex and the code that parses the hex value from the string read from the IDL file to support negative values.

Jira issue: https://issues.apache.org/jira/browse/THRIFT-233