### PR TITLE
Thrift 3113 c++11 check issue

### DIFF
--- a/aclocal/ax_lib_event.m4
+++ b/aclocal/ax_lib_event.m4
@@ -75,7 +75,7 @@ AC_DEFUN([AX_LIB_EVENT_DO_CHECK],
           AC_LANG_PUSH([C])
           dnl This can be changed to AC_LINK_IFELSE if you are cross-compiling,
           dnl but then the version cannot be checked.
-          AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+          AC_LINK_IFELSE([AC_LANG_PROGRAM([[
           #include <sys/types.h>
           #include <event.h>
           ]], [[

--- a/aclocal/ax_lib_zlib.m4
+++ b/aclocal/ax_lib_zlib.m4
@@ -73,7 +73,7 @@ AC_DEFUN([AX_LIB_ZLIB_DO_CHECK],
           #   (defined in the library).
           AC_LANG_PUSH([C])
           dnl This can be changed to AC_LINK_IFELSE if you are cross-compiling.
-          AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+          AC_LINK_IFELSE([AC_LANG_PROGRAM([[
           #include <zlib.h>
           #if ZLIB_VERNUM >= 0x$WANT_ZLIB_VERSION
           #else

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_PROG_AWK
 AC_PROG_RANLIB
 
 AC_LANG([C++])
-AX_CXX_COMPILE_STDCXX_11([noext])
+AX_CXX_COMPILE_STDCXX_11([noext], [optional])
 
 AM_EXTRA_RECURSIVE_TARGETS([style])
 AC_SUBST(CPPSTYLE_CMD, 'find . -type f \( -iname "*.h" -or -iname "*.cpp" -or -iname "*.cc" -or -iname "*.tcc" \) -printf "Reformatting: %h/%f\n" -exec clang-format -i {} \;')


### PR DESCRIPTION
The ax_cxx_compile_stdcxx_11 macro bundled in thrift package is broken [1] and out of date. Since Thrift actually doesn't use that particular C+11 feature, make C+11 support optional.
Also, add two patches added by Gustavo Zacarias used to cross-compile thrift.
[1] https://savannah.gnu.org/patch/index.php?8287
