### PR TITLE
Thrift 727 - support C++ native exception message

### DIFF
--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -1643,11 +1643,11 @@ void t_cpp_generator::generate_struct_ostream_operator_decl(std::ofstream& out, 
 void t_cpp_generator::generate_exception_what_method_decl(std::ofstream& out,
                                                           t_struct* tstruct,
                                                           bool external) {
-  std::string prefix = "";
+  out << "const char* ";
   if (external) {
-    prefix = string(tstruct->get_name() + "::");
+    out << tstruct->get_name() << "::";
   }
-  out << "const char* " << prefix << "what() const throw()";
+  out << "what() const throw()";
 }
 
 namespace struct_ostream_operator_generator {

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -1124,6 +1124,7 @@ void t_cpp_generator::generate_struct_declaration(ofstream& out,
   
   // std::exception::what()
   if (is_exception) {
+    out << indent() << "mutable std::string _TExceptionMessageHolder;" << endl;
     out << indent();
     generate_exception_what_method_decl(out, tstruct, false);
     out << ";" << endl;
@@ -1732,13 +1733,34 @@ void t_cpp_generator::generate_exception_what_method(std::ofstream& out, t_struc
   out << " {" << endl;
 
   indent_up();
-
+  out << indent() << "bool dump_successful = true;" << endl;
   out << indent() << "std::stringstream ss;" << endl;
+
+  out << indent() << "try {" << endl;
+
+  indent_up();
   out << indent() << "ss << \"TException - service has thrown: \" << *this;" << endl;
-  out << indent() << "return ss.str().c_str();" << endl;
+  indent_down();
+
+  out << indent() << "} catch (const std::exception& e) {" << endl;
+
+  indent_up();
+  out << indent() << "dump_successful = false;" << endl;
+  indent_down();
+
+  out << indent() << "}" << endl;
+  out << indent() << "if (!dump_successful || !ss.good()) {" << endl;
+
+  indent_up();
+  out << indent() << "return \"TException - service has thrown: " << tstruct->get_name() << "\";" << endl;
+  indent_down();
+
+  out << indent() << "}" << endl;
+  out << indent() << "this->_TExceptionMessageHolder = ss.str();" << endl;
+  out << indent() << "return this->_TExceptionMessageHolder.c_str();" << endl;
 
   indent_down();
-  out <<"}" << endl << endl;
+  out << "}" << endl << endl;
 }
 
 /**

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -138,6 +138,7 @@ public:
   void generate_struct_result_writer(std::ofstream& out, t_struct* tstruct, bool pointers = false);
   void generate_struct_swap(std::ofstream& out, t_struct* tstruct);
   void generate_struct_ostream_operator(std::ofstream& out, t_struct* tstruct);
+  void generate_exception_what_method(std::ofstream& out, t_struct* tstruct);
 
   /**
    * Service-level generation functions
@@ -239,6 +240,9 @@ public:
                                    bool include_values);
 
   void generate_struct_ostream_operator_decl(std::ofstream& f, t_struct* tstruct);
+  void generate_exception_what_method_decl(std::ofstream& f,
+                                           t_struct* tstruct,
+                                           bool external = false);
 
   // These handles checking gen_dense_ and checking for duplicates.
   void generate_local_reflection(std::ofstream& out, t_type* ttype, bool is_definition);
@@ -767,6 +771,9 @@ void t_cpp_generator::generate_cpp_struct(t_struct* tstruct, bool is_exception) 
     generate_move_assignment_operator(f_types_impl_, tstruct);
   }
   generate_struct_ostream_operator(f_types_impl_, tstruct);
+  if (is_exception) {
+    generate_exception_what_method(f_types_impl_, tstruct);
+  }
 }
 
 void t_cpp_generator::generate_copy_constructor(ofstream& out,
@@ -1113,7 +1120,14 @@ void t_cpp_generator::generate_struct_declaration(ofstream& out,
   // ostream operator<<
   out << indent() << "friend ";
   generate_struct_ostream_operator_decl(out, tstruct);
-  out << ";" << endl;
+  out << ";" << endl << endl;
+  
+  // std::exception::what()
+  if (is_exception) {
+    out << indent();
+    generate_exception_what_method_decl(out, tstruct, false);
+    out << ";" << endl;
+  }
 
   indent_down();
   indent(out) << "};" << endl << endl;
@@ -1626,6 +1640,16 @@ void t_cpp_generator::generate_struct_ostream_operator_decl(std::ofstream& out, 
   out << "std::ostream& operator<<(std::ostream& out, const " << tstruct->get_name() << "& obj)";
 }
 
+void t_cpp_generator::generate_exception_what_method_decl(std::ofstream& out,
+                                                          t_struct* tstruct,
+                                                          bool external) {
+  std::string prefix = "";
+  if (external) {
+    prefix = string(tstruct->get_name() + "::");
+  }
+  out << "const char* " << prefix << "what() const throw()";
+}
+
 namespace struct_ostream_operator_generator {
 void generate_required_field_value(std::ofstream& out, const t_field* field) {
   out << " << to_string(obj." << field->get_name() << ")";
@@ -1697,6 +1721,24 @@ void t_cpp_generator::generate_struct_ostream_operator(std::ofstream& out, t_str
 
   indent_down();
   out << "}" << endl << endl;
+}
+
+/**                                                                                                                                           
+ * Generates what() method for exceptions                                                                                                     
+ */                                                                                                                                           
+void t_cpp_generator::generate_exception_what_method(std::ofstream& out, t_struct* tstruct) {
+  out << indent();
+  generate_exception_what_method_decl(out, tstruct, true);
+  out << " {" << endl;
+
+  indent_up();
+
+  out << indent() << "std::stringstream ss;" << endl;
+  out << indent() << "ss << \"TException - service has thrown: \" << *this;" << endl;
+  out << indent() << "return ss.str().c_str();" << endl;
+
+  indent_down();
+  out <<"}" << endl << endl;
 }
 
 /**

--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -765,6 +765,9 @@ void testExpectedError() {
     BOOST_FAIL("expected MyError to be thrown");
   } catch (const MyError& e) {
     BOOST_CHECK_EQUAL(message, e.message);
+    // Check if std::exception::what() is handled properly
+    size_t message_pos = std::string(e.what()).find("TException - service has thrown: MyError");
+    BOOST_CHECK_NE(message_pos, std::string::npos);
   }
 
   // Now we should see the events for a normal call finish

--- a/tutorial/c_glib/c_glib_server.c
+++ b/tutorial/c_glib/c_glib_server.c
@@ -231,7 +231,7 @@ tutorial_calculator_handler_calculate (CalculatorIf      *iface,
          setting the corresponding output parameter to a new instance
          of its type and returning FALSE. */
       *ouch = g_object_new (TYPE_INVALID_OPERATION,
-                            "what", op,
+                            "whatOp", op,
                             "why",  g_strdup ("Cannot divide by 0"),
                             NULL);
       result = FALSE;
@@ -249,7 +249,7 @@ tutorial_calculator_handler_calculate (CalculatorIf      *iface,
 
   default:
     *ouch = g_object_new (TYPE_INVALID_OPERATION,
-                          "what", op,
+                          "whatOp", op,
                           "why",  g_strdup ("Invalid Operation"),
                           NULL);
     result = FALSE;

--- a/tutorial/cpp/CppClient.cpp
+++ b/tutorial/cpp/CppClient.cpp
@@ -58,6 +58,7 @@ int main() {
     } catch (InvalidOperation& io) {
       cout << "InvalidOperation: " << io.why << endl;
       // or using generated operator<<: cout << io << endl;
+      // or by using std::exception native method what(): cout << io.what() << endl;
     }
 
     work.op = Operation::SUBTRACT;

--- a/tutorial/cpp/CppServer.cpp
+++ b/tutorial/cpp/CppServer.cpp
@@ -71,7 +71,7 @@ public:
     case Operation::DIVIDE:
       if (work.num2 == 0) {
         InvalidOperation io;
-        io.what_op = work.op;
+        io.whatOp = work.op;
         io.why = "Cannot divide by 0";
         throw io;
       }
@@ -79,7 +79,7 @@ public:
       break;
     default:
       InvalidOperation io;
-      io.what_op = work.op;
+      io.whatOp = work.op;
       io.why = "Invalid Operation";
       throw io;
     }

--- a/tutorial/cpp/CppServer.cpp
+++ b/tutorial/cpp/CppServer.cpp
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
- * under the License.
+w * under the License.
  */
 
 #include <thrift/concurrency/ThreadManager.h>
@@ -71,7 +71,7 @@ public:
     case Operation::DIVIDE:
       if (work.num2 == 0) {
         InvalidOperation io;
-        io.what = work.op;
+        io.what_op = work.op;
         io.why = "Cannot divide by 0";
         throw io;
       }
@@ -79,7 +79,7 @@ public:
       break;
     default:
       InvalidOperation io;
-      io.what = work.op;
+      io.what_op = work.op;
       io.why = "Invalid Operation";
       throw io;
     }

--- a/tutorial/cpp/CppServer.cpp
+++ b/tutorial/cpp/CppServer.cpp
@@ -14,7 +14,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
-w * under the License.
+ * under the License.
  */
 
 #include <thrift/concurrency/ThreadManager.h>

--- a/tutorial/d/server.d
+++ b/tutorial/d/server.d
@@ -62,7 +62,7 @@ class CalculatorHandler : Calculator {
     case Operation.DIVIDE:
       if (work.num2 == 0) {
         auto io = new InvalidOperation();
-        io.what = work.op;
+        io.whatOp = work.op;
         io.why = "Cannot divide by 0";
         throw io;
       }
@@ -70,7 +70,7 @@ class CalculatorHandler : Calculator {
       break;
     default:
       auto io = new InvalidOperation();
-      io.what = work.op;
+      io.whatOp = work.op;
       io.why = "Invalid Operation";
       throw io;
     }

--- a/tutorial/erl/server.erl
+++ b/tutorial/erl/server.erl
@@ -44,12 +44,12 @@ calculate(Logid, Work) ->
         ?tutorial_Operation_MULTIPLY -> Num1 * Num2;
 
         ?tutorial_Operation_DIVIDE when Num2 == 0 ->
-          throw(#invalidOperation{what=Op, why="Cannot divide by 0"});
+          throw(#invalidOperation{whatOp=Op, why="Cannot divide by 0"});
         ?tutorial_Operation_DIVIDE ->
           Num1 div Num2;
 
         _Else ->
-          throw(#invalidOperation{what=Op, why="Invalid operation"})
+          throw(#invalidOperation{whatOp=Op, why="Invalid operation"})
     end.
 
 getStruct(Key) ->

--- a/tutorial/haxe/src/CalculatorHandler.hx
+++ b/tutorial/haxe/src/CalculatorHandler.hx
@@ -67,7 +67,7 @@ class CalculatorHandler implements Calculator {
                 if (work.num2 == 0)
                 {
                     var io = new InvalidOperation();
-                    io.what = work.op;
+                    io.whatOp = work.op;
                     io.why = "Cannot divide by 0";
                     throw io;
                 }
@@ -75,7 +75,7 @@ class CalculatorHandler implements Calculator {
 
             default:
                 var io = new InvalidOperation();
-                io.what = work.op;
+                io.whatOp = work.op;
                 io.why = "Unknown operation";
                 throw io;
         }

--- a/tutorial/hs/HaskellServer.hs
+++ b/tutorial/hs/HaskellServer.hs
@@ -74,7 +74,7 @@ instance Calculator_Iface CalculatorHandler where
                     if num2 work == 0 then
                         throw $
                               InvalidOperation {
-                                 invalidOperation_what = fromIntegral $ fromEnum $ op work,
+                                 invalidOperation_whatOp = fromIntegral $ fromEnum $ op work,
                                  invalidOperation_why = "Cannot divide by 0"
                                             }
                     else

--- a/tutorial/java/src/CalculatorHandler.java
+++ b/tutorial/java/src/CalculatorHandler.java
@@ -58,7 +58,7 @@ public class CalculatorHandler implements Calculator.Iface {
     case DIVIDE:
       if (work.num2 == 0) {
         InvalidOperation io = new InvalidOperation();
-        io.what = work.op.getValue();
+        io.whatOp = work.op.getValue();
         io.why = "Cannot divide by 0";
         throw io;
       }
@@ -66,7 +66,7 @@ public class CalculatorHandler implements Calculator.Iface {
       break;
     default:
       InvalidOperation io = new InvalidOperation();
-      io.what = work.op.getValue();
+      io.whatOp = work.op.getValue();
       io.why = "Unknown operation";
       throw io;
     }

--- a/tutorial/nodejs/NodeServer.js
+++ b/tutorial/nodejs/NodeServer.js
@@ -48,7 +48,7 @@ var server = thrift.createServer(Calculator, {
     } else if (work.op === ttypes.Operation.DIVIDE) {
       if (work.num2 === 0) {
         var x = new ttypes.InvalidOperation();
-        x.what = work.op;
+        x.whatOp = work.op;
         x.why = 'Cannot divide by 0';
         result(x);
         return;
@@ -56,7 +56,7 @@ var server = thrift.createServer(Calculator, {
       val = work.num1 / work.num2;
     } else {
       var x = new ttypes.InvalidOperation();
-      x.what = work.op;
+      x.whatOp = work.op;
       x.why = 'Invalid operation';
       result(x);
       return;

--- a/tutorial/nodejs/NodeServerPromise.js
+++ b/tutorial/nodejs/NodeServerPromise.js
@@ -47,14 +47,14 @@ var server = thrift.createServer(Calculator, {
     } else if (work.op === ttypes.Operation.DIVIDE) {
       if (work.num2 === 0) {
         var x = new ttypes.InvalidOperation();
-        x.what = work.op;
+        x.whatOp = work.op;
         x.why = 'Cannot divide by 0';
 		throw x;
       }
       val = work.num1 / work.num2;
     } else {
       var x = new ttypes.InvalidOperation();
-      x.what = work.op;
+      x.whatOp = work.op;
       x.why = 'Invalid operation';
       throw x;
     }

--- a/tutorial/ocaml/CalcServer.ml
+++ b/tutorial/ocaml/CalcServer.ml
@@ -49,7 +49,7 @@ object (self)
 	| Operation.DIVIDE ->
 	    if w#grab_num2 = Int32.zero then
 	      let io = new invalidOperation in
-		io#set_what (Operation.to_i w#grab_op) ;
+		io#set_whatOp (Operation.to_i w#grab_op) ;
 		io#set_why "Cannot divide by 0" ;
 		raise (InvalidOperation io)
 	    else

--- a/tutorial/perl/PerlServer.pl
+++ b/tutorial/perl/PerlServer.pl
@@ -68,14 +68,14 @@ sub calculate
     if ($num2 == 0)
     {
       my $x = new tutorial::InvalidOperation;
-      $x->what($op);
+      $x->whatOp($op);
       $x->why('Cannot divide by 0');
       die $x;
     }
     $val = $num1 / $num2;
   } else {
     my $x = new tutorial::InvalidOperation;
-    $x->what($op);
+    $x->whatOp($op);
     $x->why('Invalid operation');
     die $x;
   }

--- a/tutorial/php/PhpServer.php
+++ b/tutorial/php/PhpServer.php
@@ -79,7 +79,7 @@ class CalculatorHandler implements \tutorial\CalculatorIf {
       case \tutorial\Operation::DIVIDE:
         if ($w->num2 == 0) {
           $io = new \tutorial\InvalidOperation();
-          $io->what = $w->op;
+          $io->whatOp = $w->op;
           $io->why = "Cannot divide by 0";
           throw $io;
         }
@@ -87,7 +87,7 @@ class CalculatorHandler implements \tutorial\CalculatorIf {
         break;
       default:
         $io = new \tutorial\InvalidOperation();
-        $io->what = $w->op;
+        $io->whatOp = $w->op;
         $io->why = "Invalid Operation";
         throw $io;
     }

--- a/tutorial/py.tornado/PythonServer.py
+++ b/tutorial/py.tornado/PythonServer.py
@@ -62,13 +62,13 @@ class CalculatorHandler(object):
         elif work.op == Operation.DIVIDE:
             if work.num2 == 0:
                 x = InvalidOperation()
-                x.what = work.op
+                x.whatOp = work.op
                 x.why = "Cannot divide by 0"
                 raise x
             val = work.num1 / work.num2
         else:
             x = InvalidOperation()
-            x.what = work.op
+            x.whatOp = work.op
             x.why = "Invalid operation"
             raise x
 

--- a/tutorial/py.twisted/PythonServer.py
+++ b/tutorial/py.twisted/PythonServer.py
@@ -59,13 +59,13 @@ class CalculatorHandler:
     elif work.op == Operation.DIVIDE:
       if work.num2 == 0:
         x = InvalidOperation()
-        x.what = work.op
+        x.whatOp = work.op
         x.why = 'Cannot divide by 0'
         raise x
       val = work.num1 / work.num2
     else:
       x = InvalidOperation()
-      x.what = work.op
+      x.whatOp = work.op
       x.why = 'Invalid operation'
       raise x
 

--- a/tutorial/py/PythonServer.py
+++ b/tutorial/py/PythonServer.py
@@ -56,13 +56,13 @@ class CalculatorHandler:
     elif work.op == Operation.DIVIDE:
       if work.num2 == 0:
         x = InvalidOperation()
-        x.what = work.op
+        x.whatOp = work.op
         x.why = 'Cannot divide by 0'
         raise x
       val = work.num1 / work.num2
     else:
       x = InvalidOperation()
-      x.what = work.op
+      x.whatOp = work.op
       x.why = 'Invalid operation'
       raise x
 

--- a/tutorial/rb/RubyServer.rb
+++ b/tutorial/rb/RubyServer.rb
@@ -52,14 +52,14 @@ class CalculatorHandler
     elsif work.op == Operation::DIVIDE
       if work.num2 == 0
         x = InvalidOperation.new()
-        x.what = work.op
+        x.whatOp = work.op
         x.why = "Cannot divide by 0"
         raise x
       end
       val = work.num1 / work.num2
     else
       x = InvalidOperation.new()
-      x.what = work.op
+      x.whatOp = work.op
       x.why = "Invalid operation"
       raise x
     end

--- a/tutorial/tutorial.thrift
+++ b/tutorial/tutorial.thrift
@@ -113,7 +113,7 @@ struct Work {
  * Structs can also be exceptions, if they are nasty.
  */
 exception InvalidOperation {
-  1: i32 what,
+  1: i32 what_op,
   2: string why
 }
 

--- a/tutorial/tutorial.thrift
+++ b/tutorial/tutorial.thrift
@@ -113,7 +113,7 @@ struct Work {
  * Structs can also be exceptions, if they are nasty.
  */
 exception InvalidOperation {
-  1: i32 what_op,
+  1: i32 whatOp,
   2: string why
 }
 


### PR DESCRIPTION
Added code generating implementation of std::exception::what() function for exceptions.

I needed to modify the tutorial's IDL file, as well as CppClient and CppServer files, because member field of the exception defined & used there is named "what", and that made the compiler complain.

The modification in CppClient contains only a comment - it can be uncommented and used as a test, to see the result of my change.

Please view the discussion in Jira:
https://issues.apache.org/jira/browse/THRIFT-727