### PR TITLE
THRIFT-3084 add optional concurrent client limit enforcement to lib/cpp

### DIFF
--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -317,6 +317,8 @@ class TestHandler : public ThriftTestIf {
 // C CLIENT
 extern "C" {
 
+#undef THRIFT_SOCKET /* from lib/cpp */
+
 #include "t_test_thrift_test.h"
 #include "t_test_thrift_test_types.h"
 #include <thrift/c_glib/transport/thrift_socket.h>

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -35,9 +35,11 @@ set( thriftcpp_SOURCES
    src/thrift/Thrift.cpp
    src/thrift/TApplicationException.cpp
    src/thrift/VirtualProfiling.cpp
+   src/thrift/async/TAsyncChannel.cpp
    src/thrift/concurrency/ThreadManager.cpp
    src/thrift/concurrency/TimerManager.cpp
    src/thrift/concurrency/Util.cpp
+   src/thrift/processor/PeekProcessor.cpp
    src/thrift/protocol/TDebugProtocol.cpp
    src/thrift/protocol/TDenseProtocol.cpp
    src/thrift/protocol/TJSONProtocol.cpp
@@ -60,8 +62,6 @@ set( thriftcpp_SOURCES
    src/thrift/server/TSimpleServer.cpp
    src/thrift/server/TThreadPoolServer.cpp
    src/thrift/server/TThreadedServer.cpp
-   src/thrift/async/TAsyncChannel.cpp
-   src/thrift/processor/PeekProcessor.cpp
 )
 
 # This files don't work on Windows CE as there is no pipe support
@@ -184,6 +184,8 @@ endif()
 if(MSVC)
     add_definitions("-DUNICODE -D_UNICODE")
 endif()
+
+add_definitions("-D__STDC_LIMIT_MACROS")
 
 # Install the headers
 install(DIRECTORY "src/thrift" DESTINATION "${INCLUDE_INSTALL_DIR}"

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -57,7 +57,7 @@ pkgconfig_DATA += thrift-qt5.pc
 endif
 
 AM_CXXFLAGS = -Wall -Wextra -pedantic
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(OPENSSL_INCLUDES) -I$(srcdir)/src
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(OPENSSL_INCLUDES) -I$(srcdir)/src -D__STDC_LIMIT_MACROS
 AM_LDFLAGS = $(BOOST_LDFLAGS) $(OPENSSL_LDFLAGS)
 
 # Define the source files for the module
@@ -65,9 +65,11 @@ AM_LDFLAGS = $(BOOST_LDFLAGS) $(OPENSSL_LDFLAGS)
 libthrift_la_SOURCES = src/thrift/Thrift.cpp \
                        src/thrift/TApplicationException.cpp \
                        src/thrift/VirtualProfiling.cpp \
+                       src/thrift/async/TAsyncChannel.cpp \
                        src/thrift/concurrency/ThreadManager.cpp \
                        src/thrift/concurrency/TimerManager.cpp \
                        src/thrift/concurrency/Util.cpp \
+                       src/thrift/processor/PeekProcessor.cpp \
                        src/thrift/protocol/TDebugProtocol.cpp \
                        src/thrift/protocol/TDenseProtocol.cpp \
                        src/thrift/protocol/TJSONProtocol.cpp \
@@ -94,9 +96,7 @@ libthrift_la_SOURCES = src/thrift/Thrift.cpp \
                        src/thrift/server/TServerFramework.cpp \
                        src/thrift/server/TSimpleServer.cpp \
                        src/thrift/server/TThreadPoolServer.cpp \
-                       src/thrift/server/TThreadedServer.cpp \
-                       src/thrift/async/TAsyncChannel.cpp \
-                       src/thrift/processor/PeekProcessor.cpp
+                       src/thrift/server/TThreadedServer.cpp
 
 if WITH_BOOSTTHREADS
 libthrift_la_SOURCES += src/thrift/concurrency/BoostThreadFactory.cpp \

--- a/lib/cpp/src/thrift/protocol/TDenseProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TDenseProtocol.cpp
@@ -87,7 +87,6 @@ Optional fields are a little tricky also.  We write a zero byte if they are
 absent and prefix them with an 0x01 byte if they are present
 */
 
-#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <thrift/protocol/TDenseProtocol.h>
 #include <thrift/TReflectionLocal.h>

--- a/lib/cpp/src/thrift/server/TSimpleServer.cpp
+++ b/lib/cpp/src/thrift/server/TSimpleServer.cpp
@@ -38,7 +38,9 @@ TSimpleServer::TSimpleServer(
         const shared_ptr<TTransportFactory>& transportFactory,
         const shared_ptr<TProtocolFactory>& protocolFactory)
   : TServerFramework(processorFactory, serverTransport,
-                     transportFactory, protocolFactory) {}
+                     transportFactory, protocolFactory) {
+  TServerFramework::setConcurrentClientLimit(1);
+}
 
 TSimpleServer::TSimpleServer(
         const shared_ptr<TProcessor>& processor,
@@ -46,7 +48,9 @@ TSimpleServer::TSimpleServer(
         const shared_ptr<TTransportFactory>& transportFactory,
         const shared_ptr<TProtocolFactory>& protocolFactory)
   : TServerFramework(processor, serverTransport,
-                     transportFactory, protocolFactory) {}
+                     transportFactory, protocolFactory) {
+  TServerFramework::setConcurrentClientLimit(1);
+}
 
 TSimpleServer::TSimpleServer(
         const shared_ptr<TProcessorFactory>& processorFactory,
@@ -57,7 +61,9 @@ TSimpleServer::TSimpleServer(
         const shared_ptr<TProtocolFactory>& outputProtocolFactory)
   : TServerFramework(processorFactory, serverTransport,
           inputTransportFactory, outputTransportFactory,
-          inputProtocolFactory, outputProtocolFactory) {}
+          inputProtocolFactory, outputProtocolFactory) {
+  TServerFramework::setConcurrentClientLimit(1);
+}
 
 TSimpleServer::TSimpleServer(
         const shared_ptr<TProcessor>& processor,
@@ -68,7 +74,9 @@ TSimpleServer::TSimpleServer(
         const shared_ptr<TProtocolFactory>& outputProtocolFactory)
   : TServerFramework(processor, serverTransport,
           inputTransportFactory, outputTransportFactory,
-          inputProtocolFactory, outputProtocolFactory) {}
+          inputProtocolFactory, outputProtocolFactory) {
+  TServerFramework::setConcurrentClientLimit(1);
+}
 
 TSimpleServer::~TSimpleServer() {}
 
@@ -85,6 +93,13 @@ void TSimpleServer::onClientConnected(const shared_ptr<TConnectedClient>& pClien
  * TSimpleServer does not track clients so there is nothing to do here.
  */
 void TSimpleServer::onClientDisconnected(TConnectedClient *pClient) {}
+
+/**
+ * This makes little sense to the simple server because it is not capable
+ * of having more than one client at a time, so we hide it.
+ */
+void TSimpleServer::setConcurrentClientLimit(int64_t newLimit) {}
+
 
 }
 }

--- a/lib/cpp/src/thrift/server/TSimpleServer.h
+++ b/lib/cpp/src/thrift/server/TSimpleServer.h
@@ -62,6 +62,9 @@ public:
 protected:
   virtual void onClientConnected(const boost::shared_ptr<TConnectedClient>& pClient) /* override */;
   virtual void onClientDisconnected(TConnectedClient *pClient) /* override */;
+
+private:
+  void setConcurrentClientLimit(int64_t newLimit);  // hide
 };
 
 }

--- a/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
@@ -112,6 +112,10 @@ void TThreadPoolServer::setTaskExpiration(int64_t value) {
   taskExpiration_ = value;
 }
 
+boost::shared_ptr<apache::thrift::concurrency::ThreadManager> TThreadPoolServer::getThreadManager() const {
+  return threadManager_;
+}
+
 void TThreadPoolServer::onClientConnected(const shared_ptr<TConnectedClient>& pClient) {
   threadManager_->add(pClient, timeout_, taskExpiration_);
 }

--- a/lib/cpp/src/thrift/server/TThreadPoolServer.h
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.h
@@ -37,14 +37,16 @@ public:
           const boost::shared_ptr<apache::thrift::transport::TServerTransport>& serverTransport,
           const boost::shared_ptr<apache::thrift::transport::TTransportFactory>& transportFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& protocolFactory,
-          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager);
+          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager =
+                  apache::thrift::concurrency::ThreadManager::newSimpleThreadManager());
 
   TThreadPoolServer(
           const boost::shared_ptr<apache::thrift::TProcessor>& processor,
           const boost::shared_ptr<apache::thrift::transport::TServerTransport>& serverTransport,
           const boost::shared_ptr<apache::thrift::transport::TTransportFactory>& transportFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& protocolFactory,
-          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager);
+          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager =
+                  apache::thrift::concurrency::ThreadManager::newSimpleThreadManager());
 
   TThreadPoolServer(
           const boost::shared_ptr<apache::thrift::TProcessorFactory>& processorFactory,
@@ -53,7 +55,8 @@ public:
           const boost::shared_ptr<apache::thrift::transport::TTransportFactory>& outputTransportFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& inputProtocolFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& outputProtocolFactory,
-          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager);
+          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager =
+                  apache::thrift::concurrency::ThreadManager::newSimpleThreadManager());
 
   TThreadPoolServer(
           const boost::shared_ptr<apache::thrift::TProcessor>& processor,
@@ -62,7 +65,8 @@ public:
           const boost::shared_ptr<apache::thrift::transport::TTransportFactory>& outputTransportFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& inputProtocolFactory,
           const boost::shared_ptr<apache::thrift::protocol::TProtocolFactory>& outputProtocolFactory,
-          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager);
+          const boost::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager =
+                  apache::thrift::concurrency::ThreadManager::newSimpleThreadManager());
 
   virtual ~TThreadPoolServer();
 
@@ -77,6 +81,8 @@ public:
 
   virtual int64_t getTaskExpiration() const;
   virtual void setTaskExpiration(int64_t value);
+
+  virtual boost::shared_ptr<apache::thrift::concurrency::ThreadManager> getThreadManager() const;
 
 protected:
   virtual void onClientConnected(const boost::shared_ptr<TConnectedClient>& pClient) /* override */;

--- a/lib/cpp/src/thrift/server/TThreadedServer.h
+++ b/lib/cpp/src/thrift/server/TThreadedServer.h
@@ -29,8 +29,6 @@ namespace apache {
 namespace thrift {
 namespace server {
 
-#define THRIFT_DEFAULT_THREAD_FACTORY
-
 /**
  * Manage clients using a thread pool.
  */
@@ -86,7 +84,6 @@ protected:
 
   boost::shared_ptr<apache::thrift::concurrency::ThreadFactory> threadFactory_;
   apache::thrift::concurrency::Monitor clientsMonitor_;
-  std::set<TConnectedClient*> clients_;
 };
 
 }

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -323,7 +323,7 @@ gen-cpp/SecondService.cpp gen-cpp/ThriftTest_constants.cpp gen-cpp/ThriftTest.cp
 gen-cpp/ChildService.cpp gen-cpp/ChildService.h gen-cpp/ParentService.cpp gen-cpp/ParentService.h gen-cpp/proc_types.cpp gen-cpp/proc_types.h: processor/proc.thrift
 	$(THRIFT) --gen cpp:templates,cob_style $<
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) -I$(top_srcdir)/lib/cpp/src
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) -I$(top_srcdir)/lib/cpp/src -D__STDC_LIMIT_MACROS
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 AM_CXXFLAGS = -Wall -Wextra -pedantic
 

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -20,9 +20,12 @@
 #define BOOST_TEST_MODULE TServerIntegrationTest
 #include <boost/test/auto_unit_test.hpp>
 #include <boost/bind.hpp>
+#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
+#include <thrift/server/TSimpleServer.h>
+#include <thrift/server/TThreadPoolServer.h>
 #include <thrift/server/TThreadedServer.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TServerSocket.h>
@@ -44,12 +47,17 @@ using apache::thrift::transport::TServerSocket;
 using apache::thrift::transport::TServerTransport;
 using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
+using apache::thrift::transport::TTransportException;
 using apache::thrift::transport::TTransportFactory;
+using apache::thrift::server::TServer;
 using apache::thrift::server::TServerEventHandler;
+using apache::thrift::server::TSimpleServer;
+using apache::thrift::server::TThreadPoolServer;
 using apache::thrift::server::TThreadedServer;
 using apache::thrift::test::ParentServiceClient;
 using apache::thrift::test::ParentServiceIf;
 using apache::thrift::test::ParentServiceProcessor;
+using boost::posix_time::milliseconds;
 
 /**
  * preServe runs after listen() is successful, when we can connect
@@ -81,7 +89,10 @@ private:
   uint64_t accepted_;
 };
 
-class ParentHandler : virtual public ParentServiceIf {
+/**
+ * Reusing another generated test, just something to serve up
+ */
+class ParentHandler : public ParentServiceIf {
 public:
   ParentHandler() : generation_(0) {}
 
@@ -123,11 +134,17 @@ protected:
   std::vector<std::string> strings_;
 };
 
+void autoSocketCloser(TSocket *pSock) {
+  pSock->close();
+  delete pSock;
+}
+
+template<class TServerType>
 class TServerIntegrationTestFixture : public TestPortFixture
 {
 public:
   TServerIntegrationTestFixture() :
-      pServer(new TThreadedServer(
+      pServer(new TServerType(
                     boost::shared_ptr<ParentServiceProcessor>(new ParentServiceProcessor(
                             boost::shared_ptr<ParentServiceIf>(new ParentHandler))),
                     boost::shared_ptr<TServerTransport>(new TServerSocket("localhost", m_serverPort)),
@@ -139,7 +156,7 @@ public:
   }
 
   void startServer() {
-    pServerThread.reset(new boost::thread(boost::bind(&TThreadedServer::serve, pServer.get())));
+    pServerThread.reset(new boost::thread(boost::bind(&TServerType::serve, pServer.get())));
 
     // block until listen() completes so clients will be able to connect
     Synchronized sync(*(pEventHandler.get()));
@@ -160,41 +177,106 @@ public:
   }
 
   void stopServer() {
-    pServer->stop();
-    BOOST_MESSAGE("server stop completed");
-    pServerThread->join();
-    BOOST_MESSAGE("server thread joined");
+    if (pServerThread) {
+      pServer->stop();
+      BOOST_MESSAGE("server stop completed");
+
+      pServerThread->join();
+      BOOST_MESSAGE("server thread joined");
+      pServerThread.reset();
+    }
   }
 
   ~TServerIntegrationTestFixture() {
     stopServer();
   }
 
-  void delayClose(boost::shared_ptr<TTransport> toClose) {
-    boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
+  void delayClose(boost::shared_ptr<TTransport> toClose, boost::posix_time::time_duration after) {
+    boost::this_thread::sleep(after);
     toClose->close();
   }
 
-  boost::shared_ptr<TThreadedServer> pServer;
+  void baseline(int64_t numToMake, int64_t expectedHWM) {
+    startServer();
+    std::vector<boost::shared_ptr<TSocket> > holdSockets;
+    std::vector<boost::shared_ptr<boost::thread> > holdThreads;
+
+    for (int64_t i = 0; i < numToMake; ++i) {
+        boost::shared_ptr<TSocket> pClientSock(new TSocket("localhost", m_serverPort), autoSocketCloser);
+        holdSockets.push_back(pClientSock);
+        boost::shared_ptr<TProtocol> pClientProtocol(new TBinaryProtocol(pClientSock));
+        ParentServiceClient client(pClientProtocol);
+        pClientSock->open();
+        client.incrementGeneration();
+        holdThreads.push_back(
+                boost::shared_ptr<boost::thread>(
+                        new boost::thread(
+                                boost::bind(&TServerIntegrationTestFixture::delayClose, this,
+                                            pClientSock, milliseconds(100 * numToMake)))));
+    }
+
+    BOOST_CHECK_EQUAL(expectedHWM, pServer->getConcurrentClientCountHWM());
+    stopServer();
+    BOOST_FOREACH(boost::shared_ptr<boost::thread> pThread, holdThreads) {
+        pThread->join();
+    }
+    holdThreads.clear();
+    holdSockets.clear();
+  }
+
+  boost::shared_ptr<TServerType> pServer;
   boost::shared_ptr<TServerReadyEventHandler> pEventHandler;
   boost::shared_ptr<boost::thread> pServerThread;
 };
 
-BOOST_FIXTURE_TEST_SUITE ( TServerIntegrationTest, TServerIntegrationTestFixture )
+BOOST_FIXTURE_TEST_SUITE( Baseline, TestPortFixture )
 
-BOOST_AUTO_TEST_CASE(test_execute_one_request_and_close)
+BOOST_FIXTURE_TEST_CASE(test_simple, TServerIntegrationTestFixture<TSimpleServer>)
 {
-    // this test establishes some basic sanity
-
-    startServer();
-    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort));
-    boost::shared_ptr<TProtocol> pClientProtocol1(new TBinaryProtocol(pClientSock1));
-    ParentServiceClient client1(pClientProtocol1);
-    pClientSock1->open();
-    client1.incrementGeneration();
-    pClientSock1->close();
-    stopServer();
+    baseline(3, 1);
 }
+
+BOOST_FIXTURE_TEST_CASE(test_threaded, TServerIntegrationTestFixture<TThreadedServer>)
+{
+    baseline(10, 10);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_threaded_bound, TServerIntegrationTestFixture<TThreadedServer>)
+{
+    pServer->setConcurrentClientLimit(4);
+    baseline(10, 4);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_threadpool, TServerIntegrationTestFixture<TThreadPoolServer>)
+{
+    pServer->getThreadManager()->threadFactory(
+            boost::shared_ptr<apache::thrift::concurrency::ThreadFactory>(
+                    new apache::thrift::concurrency::PlatformThreadFactory));
+    pServer->getThreadManager()->start();
+
+    // thread factory has 4 threads as a default
+    // thread factory however is a bad way to limit concurrent clients
+    // as accept() will be called to grab a 5th client socket, in this case
+    // and then the thread factory will block adding the thread to manage
+    // that client.
+    baseline(10, 5);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_threadpool_bound, TServerIntegrationTestFixture<TThreadPoolServer>)
+{
+    pServer->getThreadManager()->threadFactory(
+            boost::shared_ptr<apache::thrift::concurrency::ThreadFactory>(
+                    new apache::thrift::concurrency::PlatformThreadFactory));
+    pServer->getThreadManager()->start();
+    pServer->setConcurrentClientLimit(4);
+
+    baseline(10, 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_FIXTURE_TEST_SUITE ( TServerIntegrationTest, TServerIntegrationTestFixture<TThreadedServer> )
 
 BOOST_AUTO_TEST_CASE(test_stop_with_interruptable_clients_connected)
 {
@@ -202,10 +284,10 @@ BOOST_AUTO_TEST_CASE(test_stop_with_interruptable_clients_connected)
 
     startServer();
 
-    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort));
+    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort), autoSocketCloser);
     pClientSock1->open();
 
-    boost::shared_ptr<TSocket> pClientSock2(new TSocket("localhost", m_serverPort));
+    boost::shared_ptr<TSocket> pClientSock2(new TSocket("localhost", m_serverPort), autoSocketCloser);
     pClientSock2->open();
 
     // Ensure they have been accepted
@@ -219,8 +301,6 @@ BOOST_AUTO_TEST_CASE(test_stop_with_interruptable_clients_connected)
     uint8_t buf[1];
     BOOST_CHECK_EQUAL(0, pClientSock1->read(&buf[0], 1));   // 0 = disconnected
     BOOST_CHECK_EQUAL(0, pClientSock2->read(&buf[0], 1));   // 0 = disconnected
-    pClientSock1->close();
-    pClientSock2->close();
 }
 
 BOOST_AUTO_TEST_CASE(test_stop_with_uninterruptable_clients_connected)
@@ -230,24 +310,56 @@ BOOST_AUTO_TEST_CASE(test_stop_with_uninterruptable_clients_connected)
 
     boost::dynamic_pointer_cast<TServerSocket>(pServer->getServerTransport())->
             setInterruptableChildren(false);    // returns to pre-THRIFT-2441 behavior
+
     startServer();
 
-    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort));
+    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort), autoSocketCloser);
     pClientSock1->open();
 
-    boost::shared_ptr<TSocket> pClientSock2(new TSocket("localhost", m_serverPort));
+    boost::shared_ptr<TSocket> pClientSock2(new TSocket("localhost", m_serverPort), autoSocketCloser);
     pClientSock2->open();
 
     // Ensure they have been accepted
     blockUntilAccepted(2);
 
-    boost::thread t1(boost::bind(&TServerIntegrationTestFixture::delayClose, this, pClientSock1));
-    boost::thread t2(boost::bind(&TServerIntegrationTestFixture::delayClose, this, pClientSock2));
+    boost::thread t1(boost::bind(&TServerIntegrationTestFixture::delayClose, this, pClientSock1, milliseconds(250)));
+    boost::thread t2(boost::bind(&TServerIntegrationTestFixture::delayClose, this, pClientSock2, milliseconds(250)));
 
     // Once the clients disconnect the server will stop
     stopServer();
-
-    pClientSock1->close();
-    pClientSock2->close();
+    t1.join();
+    t2.join();
 }
+
+BOOST_AUTO_TEST_CASE(test_concurrent_client_limit)
+{
+    startServer();
+
+    BOOST_CHECK_EQUAL(INT64_MAX, pServer->getConcurrentClientLimit());
+    pServer->setConcurrentClientLimit(2);
+    BOOST_CHECK_EQUAL(0, pServer->getConcurrentClientCount());
+    BOOST_CHECK_EQUAL(2, pServer->getConcurrentClientLimit());
+
+    boost::shared_ptr<TSocket> pClientSock1(new TSocket("localhost", m_serverPort), autoSocketCloser);
+    pClientSock1->open();
+    blockUntilAccepted(1);
+    BOOST_CHECK_EQUAL(1, pServer->getConcurrentClientCount());
+
+    boost::shared_ptr<TSocket> pClientSock2(new TSocket("localhost", m_serverPort), autoSocketCloser);
+    pClientSock2->open();
+    blockUntilAccepted(2);
+    BOOST_CHECK_EQUAL(2, pServer->getConcurrentClientCount());
+
+    // a third client cannot connect until one of the other two closes
+    boost::thread t2(boost::bind(&TServerIntegrationTestFixture::delayClose, this, pClientSock2, milliseconds(250)));
+    boost::shared_ptr<TSocket> pClientSock3(new TSocket("localhost", m_serverPort), autoSocketCloser);
+    pClientSock2->open();
+    blockUntilAccepted(2);
+    BOOST_CHECK_EQUAL(2, pServer->getConcurrentClientCount());
+    BOOST_CHECK_EQUAL(2, pServer->getConcurrentClientCountHWM());
+
+    stopServer();
+    t2.join();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 
 #ifndef _GNU_SOURCE


### PR DESCRIPTION
This allows users of TThreadedServer and TThreadPoolServer to declare the maximum number of concurrent clients allowed in at any given time.  When the limit is reached, the serve() thread is blocked from accept()ing another connection until one of the other connections closes.