### PR TITLE
THRIFT-2850 get windows cmake working again and building the unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-
 cmake_minimum_required(VERSION 2.8.12)
 
 project(thrift)

--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -31,6 +31,7 @@ endif(NOT HAVE_AI_ADDRCONFIG)
 
 check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_file(fcntl.h HAVE_FCNTL_H)
+check_include_file(getopt.h HAVE_GETOPT_H)
 check_include_file(inttypes.h HAVE_INTTYPES_H)
 check_include_file(netdb.h HAVE_NETDB_H)
 check_include_file(netinet/in.h HAVE_NETINET_IN_H)

--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -86,12 +86,15 @@ CMAKE_DEPENDENT_OPTION(BUILD_PYTHON "Build Python library" ON
 # Common library options
 option(WITH_SHARED_LIB "Build shared libraries" ON)
 option(WITH_STATIC_LIB "Build static libraries" ON)
+if (NOT WITH_SHARED_LIB AND NOT WITH_STATIC_LIB)
+    message(FATAL_ERROR "Cannot build with both shared and static outputs disabled!")
+endif()
 
 #NOTE: C++ compiler options are defined in the lib/cpp/CMakeLists.txt
 
 # Visual Studio only options
 if(MSVC)
-option(WITH_MT "Build unsing MT instead of MT (MSVC only)" OFF)
+option(WITH_MT "Build using MT instead of MD (MSVC only)" OFF)
 endif(MSVC)
 
 macro(MESSAGE_DEP flag summary)

--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -22,7 +22,7 @@
 if(MSVC)
     #For visual studio the library naming is as following:
     # Dynamic libraries:
-    #  - thfirt.dll  for release library
+    #  - thrift.dll  for release library
     #  - thriftd.dll for debug library
     #
     # Static libraries:
@@ -37,7 +37,6 @@ if(MSVC)
     # For Debug build types, append a "d" to the library names.
     set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
     set(CMAKE_RELEASE_POSTFIX "" CACHE STRING "Set release library postfix" FORCE)
-
 
     # Build using /MT option instead of /MD if the WITH_MT options is set
     if(WITH_MT)
@@ -56,6 +55,18 @@ if(MSVC)
     else(WITH_MT)
         set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
     endif(WITH_MT)
+
+    # Disable Windows.h definition of macros for min and max
+    add_definitions("-DNOMINMAX")
+
+    # Disable boost auto linking pragmas - cmake includes the right files
+    add_definitions("-DBOOST_ALL_NO_LIB")
+
+    # Windows build does not know how to make a shared library yet
+    # as there are no __declspec(dllexport) or exports files in the project.
+    if (WITH_SHARED_LIB)
+        message (FATAL_ERROR "Windows build does not support shared library output yet!")
+    endif()
 
 elseif(UNIX)
   # For UNIX

--- a/build/cmake/ThriftMacros.cmake
+++ b/build/cmake/ThriftMacros.cmake
@@ -52,7 +52,8 @@ if(WITH_STATIC_LIB)
         PUBLIC_HEADER DESTINATION "${INCLUDE_INSTALL_DIR}")
 endif()
 
-endmacro()
+endmacro(ADD_LIBRARY_THRIFT)
+
 
 macro(TARGET_LINK_LIBRARIES_THRIFT name)
 
@@ -64,4 +65,30 @@ if(WITH_STATIC_LIB)
     target_link_libraries(${name}_static ${ARGN})
 endif()
 
-endmacro()
+endmacro(TARGET_LINK_LIBRARIES_THRIFT)
+
+
+macro(LINK_AGAINST_THRIFT_LIBRARY target libname)
+
+if (WITH_SHARED_LIB)
+    target_link_libraries(${target} ${libname})
+elseif (WITH_STATIC_LIB)
+    target_link_libraries(${target} ${libname}_static)
+else()
+    message(FATAL "Not linking with shared or static libraries?")
+endif()
+
+endmacro(LINK_AGAINST_THRIFT_LIBRARY)
+
+
+macro(TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY target libname)
+
+if(WITH_SHARED_LIB)
+    target_link_libraries(${target} ${libname})
+endif()
+
+if(WITH_STATIC_LIB)
+    target_link_libraries(${target}_static ${libname}_static)
+endif()
+
+endmacro(TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY)

--- a/compiler/cpp/src/generate/t_delphi_generator.cc
+++ b/compiler/cpp/src/generate/t_delphi_generator.cc
@@ -510,13 +510,13 @@ void t_delphi_generator::generate_delphi_doc(ostream& out, t_function* tfunction
 }
 
 bool t_delphi_generator::find_keyword(std::map<std::string, int>& keyword_map, std::string name) {
-  int len = name.length();
+  std::string::size_type len = name.length();
 
   if (len <= 0) {
     return false;
   }
 
-  int nlast = name.find_last_of('_');
+  std::string::size_type nlast = name.find_last_of('_');
 
   if (nlast >= 1) {
     if (nlast == (len - 1)) {

--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -2057,7 +2057,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
     vector<t_field*>::const_iterator a_iter;
-    int num_args = args.size();
+    std::vector<t_field*>::size_type num_args = args.size();
     bool first = true;
 
     for (int i = 0; i < num_args; ++i) {
@@ -2183,7 +2183,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
     vector<t_field*>::const_iterator a_iter;
-    int num_args = args.size();
+    std::vector<t_field*>::size_type num_args = args.size();
     string funcName((*f_iter)->get_name());
     string pubName(publicize(funcName));
     string argumentsName(publicize(funcName + "_args", true));

--- a/compiler/cpp/src/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/generate/t_hs_generator.cc
@@ -1201,7 +1201,7 @@ bool hasNoArguments(t_function* func) {
 
 string t_hs_generator::render_hs_type_for_function_name(t_type* type) {
   string type_str = render_hs_type(type, false);
-  int found = -1;
+  std::string::size_type found = -1;
 
   while (true) {
     found = type_str.find_first_of("[]. ", found + 1);

--- a/compiler/cpp/src/generate/t_html_generator.cc
+++ b/compiler/cpp/src/generate/t_html_generator.cc
@@ -665,7 +665,7 @@ std::string t_html_generator::escape_html(std::string const& str) {
  * Prints out the provided type in HTML
  */
 int t_html_generator::print_type(t_type* ttype) {
-  int len = 0;
+  std::string::size_type len = 0;
   f_out_ << "<code>";
   if (ttype->is_container()) {
     if (ttype->is_list()) {
@@ -708,7 +708,7 @@ int t_html_generator::print_type(t_type* ttype) {
     f_out_ << type_name << "</a>";
   }
   f_out_ << "</code>";
-  return len;
+  return (int)len;
 }
 
 /**
@@ -1030,7 +1030,7 @@ void t_html_generator::generate_service(t_service* tservice) {
     f_out_ << "<h4 id=\"Fn_" << service_name_ << "_" << fn_name << "\">Function: " << service_name_
            << "." << fn_name << "</h4>" << endl;
     f_out_ << "<pre>";
-    int offset = print_type((*fn_iter)->get_returntype());
+    std::string::size_type offset = print_type((*fn_iter)->get_returntype());
     bool first = true;
     f_out_ << " " << fn_name << "(";
     offset += fn_name.size() + 2;

--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -1413,7 +1413,7 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
     vector<t_field*>::const_iterator a_iter;
-    int num_args = args.size();
+    std::vector<t_field*>::size_type num_args = args.size();
     bool first = true;
     for (int i = 0; i < num_args; ++i) {
       if (first) {
@@ -1466,7 +1466,7 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
     vector<t_field*>::const_iterator a_iter;
-    int num_args = args.size();
+    std::vector<t_field*>::size_type num_args = args.size();
 
     f_remote << "if cmd == '" << (*f_iter)->get_name() << "':" << endl
              << "  if len(args) != " << num_args << ":" << endl << "    print('"

--- a/compiler/cpp/src/main.cc
+++ b/compiler/cpp/src/main.cc
@@ -1111,7 +1111,7 @@ int main(int argc, char** argv) {
 
 #ifdef _WIN32
         // strip out trailing \ on Windows
-        int last = out_path.length() - 1;
+        std::string::size_type last = out_path.length() - 1;
         if (out_path[last] == '\\') {
           out_path.erase(last);
         }

--- a/compiler/cpp/src/parse/t_program.h
+++ b/compiler/cpp/src/parse/t_program.h
@@ -271,7 +271,7 @@ public:
     include_prefix_ = include_prefix;
 
     // this is intended to be a directory; add a trailing slash if necessary
-    int len = include_prefix_.size();
+    std::string::size_type len = include_prefix_.size();
     if (len > 0 && include_prefix_[len - 1] != '/') {
       include_prefix_ += '/';
     }

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -23,8 +23,8 @@ if(WITH_BOOSTTHREADS)
 else()
   find_package(Boost 1.53.0 REQUIRED)
 endif()
-include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 
+include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 include_directories(src)
 
 # SYSLIBS contains libraries that need to be linked to all lib targets
@@ -65,7 +65,7 @@ set( thriftcpp_SOURCES
 )
 
 # This files don't work on Windows CE as there is no pipe support
-# TODO: This files won't work with UNICODE support on windows. If fixed this can be re-added.
+# TODO: These files won't work with UNICODE support on windows. If fixed this can be re-added.
 if (NOT WINCE)
     list(APPEND thriftcpp_SOURCES
        src/thrift/transport/TPipe.cpp
@@ -158,7 +158,8 @@ if(WITH_LIBEVENT)
     include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftnb ${thriftcppnb_SOURCES})
-    TARGET_LINK_LIBRARIES_THRIFT(thriftnb thrift ${SYSLIBS} ${LIBEVENT_LIBRARIES})
+    TARGET_LINK_LIBRARIES_THRIFT(thriftnb ${SYSLIBS} ${LIBEVENT_LIBRARIES})
+    TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY(thriftnb thrift)
 endif()
 
 if(WITH_ZLIB)
@@ -166,14 +167,16 @@ if(WITH_ZLIB)
     include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftz ${thriftcppz_SOURCES})
-    TARGET_LINK_LIBRARIES_THRIFT(thriftz thrift ${SYSLIBS} ${ZLIB_LIBRARIES})
+    TARGET_LINK_LIBRARIES_THRIFT(thriftz ${SYSLIBS} ${ZLIB_LIBRARIES})
+    TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY(thriftz thrift)
 endif()
 
 if(WITH_QT4)
     set(CMAKE_AUTOMOC ON)
     find_package(Qt4 REQUIRED COMPONENTS QtCore QtNetwork)
     ADD_LIBRARY_THRIFT(thriftqt ${thriftcppqt_SOURCES})
-    TARGET_LINK_LIBRARIES_THRIFT(thriftqt thrift ${SYSLIBS} Qt4::QtCore Qt4::QtNetwork)
+    TARGET_LINK_LIBRARIES_THRIFT(thriftqt ${SYSLIBS} Qt4::QtCore Qt4::QtNetwork)
+    TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY(thriftqt thrift)
 endif()
 
 if(WITH_QT5)

--- a/lib/cpp/src/thrift/concurrency/Mutex.h
+++ b/lib/cpp/src/thrift/concurrency/Mutex.h
@@ -22,6 +22,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
+#include <stdint.h>
 
 namespace apache {
 namespace thrift {

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -319,7 +319,7 @@ void TSSLSocket::checkHandshake() {
     return;
   }
   ssl_ = ctx_->createSSL();
-  SSL_set_fd(ssl_, socket_);
+  SSL_set_fd(ssl_, static_cast<int>(socket_));
   int rc;
   if (server()) {
     rc = SSL_accept(ssl_);
@@ -576,7 +576,7 @@ int TSSLSocketFactory::passwordCallback(char* password, int size, int, void* dat
   TSSLSocketFactory* factory = (TSSLSocketFactory*)data;
   string userPassword;
   factory->getPassword(userPassword, size);
-  int length = userPassword.size();
+  int length = static_cast<int>(userPassword.size());
   if (length > size) {
     length = size;
   }

--- a/lib/cpp/test/Benchmark.cpp
+++ b/lib/cpp/test/Benchmark.cpp
@@ -21,7 +21,8 @@
 #include <config.h>
 #endif
 #include <iostream>
-#include <cmath>
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include "thrift/transport/TBufferTransports.h"
 #include "thrift/protocol/TBinaryProtocol.h"
 #include "gen-cpp/DebugProtoTest_types.h"

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-
 # Find required packages
 set(Boost_USE_STATIC_LIBS ON) # Force the use of static boost test framework
 find_package(Boost 1.53.0 REQUIRED COMPONENTS chrono system thread unit_test_framework)
@@ -45,7 +44,6 @@ set(testgencpp_SOURCES
 )
 
 add_library(testgencpp STATIC ${testgencpp_SOURCES})
-target_link_libraries(testgencpp thrift)
 
 set(testgencpp_cob_SOURCES
     gen-cpp/ChildService.cpp
@@ -58,11 +56,11 @@ set(testgencpp_cob_SOURCES
     gen-cpp/proc_types.h
 )
 add_library(testgencpp_cob STATIC ${testgencpp_cob_SOURCES})
-target_link_libraries(testgencpp_cob thrift)
 
 
 add_executable(Benchmark Benchmark.cpp)
 target_link_libraries(Benchmark testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(Benchmark thrift)
 add_test(NAME Benchmark COMMAND Benchmark)
 
 set(UnitTest_SOURCES
@@ -81,15 +79,16 @@ if(NOT WITH_BOOSTTHREADS AND NOT WITH_STDTHREADS)
 endif()
 
 add_executable(UnitTests ${UnitTest_SOURCES})
-target_link_libraries(UnitTests testgencpp thrift ${Boost_LIBRARIES})
+target_link_libraries(UnitTests testgencpp ${Boost_LIBRARIES})
+LINK_AGAINST_THRIFT_LIBRARY(UnitTests thrift)
 add_test(NAME UnitTests COMMAND UnitTests)
 
 add_executable(TSocketInterruptTest TSocketInterruptTest.cpp)
 target_link_libraries(TSocketInterruptTest
     testgencpp
     ${Boost_LIBRARIES}
-    #-lrt
 )
+LINK_AGAINST_THRIFT_LIBRARY(TSocketInterruptTest thrift)
 if (NOT MSVC)
 target_link_libraries(TSocketInterruptTest -lrt)
 endif ()
@@ -100,6 +99,7 @@ target_link_libraries(TServerIntegrationTest
     testgencpp_cob
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(TServerIntegrationTest thrift)
 if (NOT MSVC)
 target_link_libraries(TServerIntegrationTest -lrt)
 endif ()
@@ -109,19 +109,21 @@ if(WITH_ZLIB)
 add_executable(TransportTest TransportTest.cpp)
 target_link_libraries(TransportTest
     testgencpp
-    thriftz
     ${Boost_LIBRARIES}
     ${ZLIB_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(TransportTest thrift)
+LINK_AGAINST_THRIFT_LIBRARY(TransportTest thriftz)
 add_test(NAME TransportTest COMMAND TransportTest)
 
 add_executable(ZlibTest ZlibTest.cpp)
 target_link_libraries(ZlibTest
     testgencpp
-    thriftz
     ${Boost_LIBRARIES}
     ${ZLIB_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(ZlibTest thrift)
+LINK_AGAINST_THRIFT_LIBRARY(ZlibTest thriftz)
 add_test(NAME ZlibTest COMMAND ZlibTest)
 endif(WITH_ZLIB)
 
@@ -131,25 +133,25 @@ target_link_libraries(EnumTest
     testgencpp
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(EnumTest thrift)
 add_test(NAME EnumTest COMMAND EnumTest)
 
+if(HAVE_GETOPT_H)
 add_executable(TFileTransportTest TFileTransportTest.cpp)
 target_link_libraries(TFileTransportTest
     testgencpp
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(TFileTransportTest thrift)
 add_test(NAME TFileTransportTest COMMAND TFileTransportTest)
+endif()
 
 add_executable(TFDTransportTest TFDTransportTest.cpp)
-target_link_libraries(TFDTransportTest
-    thrift
-)
+LINK_AGAINST_THRIFT_LIBRARY(TFDTransportTest thrift)
 add_test(NAME TFDTransportTest COMMAND TFDTransportTest)
 
 add_executable(TPipedTransportTest TPipedTransportTest.cpp)
-target_link_libraries(TPipedTransportTest
-    thrift
-)
+LINK_AGAINST_THRIFT_LIBRARY(TPipedTransportTest thrift)
 add_test(NAME TPipedTransportTest COMMAND TPipedTransportTest)
 
 set(AllProtocolsTest_SOURCES
@@ -159,39 +161,36 @@ set(AllProtocolsTest_SOURCES
     )
 
 add_executable(AllProtocolsTest ${AllProtocolsTest_SOURCES})
-target_link_libraries(AllProtocolsTest
-    testgencpp
-)
+target_link_libraries(AllProtocolsTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(AllProtocolsTest thrift)
 add_test(NAME AllProtocolsTest COMMAND AllProtocolsTest)
 
+# The debug run-time in Windows asserts on isprint() with negative inputs
+if (NOT MSVC OR (MSVC AND CMAKE_BUILD_TYPE EQUAL "DEBUG"))
 add_executable(DebugProtoTest DebugProtoTest.cpp)
-target_link_libraries(DebugProtoTest
-    testgencpp
-)
+target_link_libraries(DebugProtoTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(DebugProtoTest thrift)
 add_test(NAME DebugProtoTest COMMAND DebugProtoTest)
+endif()
 
 add_executable(JSONProtoTest JSONProtoTest.cpp)
-target_link_libraries(JSONProtoTest
-    testgencpp
-)
+target_link_libraries(JSONProtoTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(JSONProtoTest thrift)
 add_test(NAME JSONProtoTest COMMAND JSONProtoTest)
 
 add_executable(OptionalRequiredTest OptionalRequiredTest.cpp)
-target_link_libraries(OptionalRequiredTest
-    testgencpp
-)
+target_link_libraries(OptionalRequiredTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(OptionalRequiredTest thrift)
 add_test(NAME OptionalRequiredTest COMMAND OptionalRequiredTest)
 
 add_executable(RecursiveTest RecursiveTest.cpp)
-target_link_libraries(RecursiveTest
-    testgencpp
-)
+target_link_libraries(RecursiveTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(RecursiveTest thrift)
 add_test(NAME RecursiveTest COMMAND RecursiveTest)
 
 add_executable(SpecializationTest SpecializationTest.cpp)
-target_link_libraries(SpecializationTest
-    testgencpp
-)
+target_link_libraries(SpecializationTest testgencpp)
+LINK_AGAINST_THRIFT_LIBRARY(SpecializationTest thrift)
 add_test(NAME SpecializationTest COMMAND SpecializationTest)
 
 set(concurrency_test_SOURCES
@@ -201,9 +200,7 @@ set(concurrency_test_SOURCES
     concurrency/TimerManagerTests.h
 )
 add_executable(concurrency_test ${concurrency_test_SOURCES})
-target_link_libraries(concurrency_test
-    thrift
-)
+LINK_AGAINST_THRIFT_LIBRARY(concurrency_test thrift)
 add_test(NAME concurrency_test COMMAND concurrency_test)
 
 set(link_test_SOURCES
@@ -214,7 +211,8 @@ set(link_test_SOURCES
 )
 
 add_executable(link_test ${link_test_SOURCES})
-target_link_libraries(concurrency_test testgencpp_cob thrift)
+target_link_libraries(link_test testgencpp_cob)
+LINK_AGAINST_THRIFT_LIBRARY(link_test thrift)
 add_test(NAME link_test COMMAND link_test)
 
 if(WITH_LIBEVENT)
@@ -229,10 +227,10 @@ set(processor_test_SOURCES
 add_executable(processor_test ${processor_test_SOURCES})
 target_link_libraries(processor_test
     testgencpp_cob
-    thrift
-    thriftnb
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(processor_test thrift)
+LINK_AGAINST_THRIFT_LIBRARY(processor_test thriftnb)
 add_test(NAME processor_test COMMAND processor_test)
 
 set(TNonblockingServerTest_SOURCES TNonblockingServerTest.cpp)
@@ -240,21 +238,21 @@ add_executable(TNonblockingServerTest ${TNonblockingServerTest_SOURCES})
 include_directories(${LIBEVENT_INCLUDE_DIRS})
 target_link_libraries(TNonblockingServerTest
     testgencpp_cob
-    thrift
-    thriftnb
     ${LIBEVENT_LIBRARIES}
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(TNonblockingServerTest thrift)
+LINK_AGAINST_THRIFT_LIBRARY(TNonblockingServerTest thriftnb)
 add_test(NAME TNonblockingServerTest COMMAND TNonblockingServerTest)
 endif()
 
 if(OPENSSL_FOUND AND WITH_OPENSSL)
 add_executable(OpenSSLManualInitTest OpenSSLManualInitTest.cpp)
 target_link_libraries(OpenSSLManualInitTest
-    thrift
     ${OPENSSL_LIBRARIES}
     ${Boost_LIBRARIES}
 )
+LINK_AGAINST_THRIFT_LIBRARY(OpenSSLManualInitTest thrift)
 add_test(NAME OpenSSLManualInitTest COMMAND OpenSSLManualInitTest)
 endif()
 
@@ -265,7 +263,8 @@ set(TQTcpServerTest_SOURCES
     qt/TQTcpServerTest.cpp
 )
 add_executable(TQTcpServerTest ${TQTcpServerTest_SOURCES})
-target_link_libraries(TQTcpServerTest testgencpp_cob thriftqt thrift Qt4::QtTest)
+target_link_libraries(TQTcpServerTest testgencpp_cob thriftqt Qt4::QtTest)
+LINK_AGAINST_THRIFT_LIBRARY(TQTcpServerTest thrift)
 add_test(NAME TQTcpServerTest COMMAND TQTcpServerTest)
 endif()
 

--- a/lib/cpp/test/OpenSSLManualInitTest.cpp
+++ b/lib/cpp/test/OpenSSLManualInitTest.cpp
@@ -20,11 +20,12 @@
 // MANUAL_OPENSSL_INIT to 0 to cause automatic OpenSSL init/cleanup,
 // which will cause the test to fail
 #define MANUAL_OPENSSL_INIT 1
+#ifdef _WIN32
+#include <WinSock2.h>
+#endif
 
 #include <boost/test/unit_test.hpp>
-
 #include <openssl/evp.h>
-
 #include <thrift/transport/TSSLSocket.h>
 
 using namespace std;

--- a/lib/cpp/test/TFDTransportTest.cpp
+++ b/lib/cpp/test/TFDTransportTest.cpp
@@ -30,6 +30,9 @@ class DummyException : std::exception {};
 int main() {
   { TFDTransport t(256, TFDTransport::NO_CLOSE_ON_DESTROY); }
 
+  // Disabled on MSVC because the RTL asserts on an invalid file descriptor
+  // in both debug and release mode; at least in MSVCR100 (Visual Studio 2010)
+#if !defined(WIN32)
   try {
     {
       TFDTransport t(256, TFDTransport::CLOSE_ON_DESTROY);
@@ -51,6 +54,7 @@ int main() {
     std::abort();
   } catch (DummyException&) {
   }
+#endif
 
   return 0;
 }

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -24,7 +24,9 @@
 #endif
 
 #include <stdint.h>
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
 #include <cstddef>
 #include <fstream>
 #include <iostream>
@@ -400,7 +402,9 @@ boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
   THRIFT_UNUSED_VARIABLE(argc);
   THRIFT_UNUSED_VARIABLE(argv);
   uint32_t seed = static_cast<uint32_t>(time(NULL));
+#ifdef HAVE_INTTYPES_H
   printf("seed: %" PRIu32 "\n", seed);
+#endif
   rng.seed(seed);
 
   boost::unit_test::test_suite* suite = &boost::unit_test::framework::master_test_suite();


### PR DESCRIPTION
I made changes to the cmake environment so that cmake can build the compiler, static libraries and unit tests on Windows. In my testing I found that the shared thrift library build is not exporting any symbols so no IMPLIB is being generated (that would be thrift.lib or thriftd.lib), so none of the unit tests would link, nor would thriftz.

Here's the command I used to generate the environment:

mkdir thrift-build
cd thrift-build
"C:\Program Files (x86)\CMake\bin\cmake.exe" ..\thrift -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_SHARED_LIB=OFF -DWITH_STATIC_LIB=ON -DWITH_BOOSTTHREADS=ON -DBOOST_ROOT=C:\Boost -DZLIB_ROOT=C:\win3p\tools\x64\zlib-1.2.5 -DOPENSSL_ROOT_DIR=C:\win3p\tools\x64\openssl-1.0.1b -DFLEX_EXECUTABLE=C:\Users\Jim\workspace\winflexbison\win_flex.exe -DBISON_EXECUTABLE=C:\Users\Jim\workspace\winflexbison\win_bison.exe

You can also use -G"Visual Studio 10 Win64" to get a thrift.sln file that you can use to load visual studio, this example is for Visual Studio 2010. Visual Studio 2013 would be -G"Visual Studio 12 Win64".

I was not able to get the nonblocking server to build because libevent requires autoconf to generate a "event-config.h", and the libevent nmake project does not produce one of these, so I could not compile the non-blocking server; further the libevent header "event.h" conflicts with the Windows Platform SDK header Event.h, so FindLibevent.cmake always finds the Platform SDK as an include directory, so I did not attempt to get it working right now.

Tested this on Windows and on Ubuntu 12.04 using CMake-3.2.2.

When running the tests on Windows you need to put the library paths into your PATH environment for boost, openssl so that they can be found. The CMake environment does not copy required libraries into the "bin" directory at this time.