### PR TITLE
THRIFT-3121 Librt does not exist on OSX

### DIFF
--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -89,7 +89,7 @@ target_link_libraries(TSocketInterruptTest
     ${Boost_LIBRARIES}
 )
 LINK_AGAINST_THRIFT_LIBRARY(TSocketInterruptTest thrift)
-if (NOT MSVC)
+if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 target_link_libraries(TSocketInterruptTest -lrt)
 endif ()
 add_test(NAME TSocketInterruptTest COMMAND TSocketInterruptTest)
@@ -100,7 +100,7 @@ target_link_libraries(TServerIntegrationTest
     ${Boost_LIBRARIES}
 )
 LINK_AGAINST_THRIFT_LIBRARY(TServerIntegrationTest thrift)
-if (NOT MSVC)
+if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 target_link_libraries(TServerIntegrationTest -lrt)
 endif ()
 add_test(NAME TServerIntegrationTest COMMAND TServerIntegrationTest)


### PR DESCRIPTION
librt does not exist on Mac OS X. Compilation with CMake failed.

THRIFT-3121
