### PR TITLE
THRIFT-3123: Include stdio.h to get a definition for FILE

### DIFF
--- a/compiler/cpp/src/main.h
+++ b/compiler/cpp/src/main.h
@@ -21,6 +21,7 @@
 #define T_MAIN_H
 
 #include <string>
+#include <stdio.h>
 #include "logging.h"
 #include "parse/t_const.h"
 #include "parse/t_field.h"


### PR DESCRIPTION
`FILE` is referenced on line 102 `extern FILE* yyin;`. I was cross compiling, and the definition for `FILE` not being included caused the build to fail, so I included it. I built again on Debian and FreeBSD, and it builds fine with the change