### PR TITLE
PHP Generator: fix JSON encoding of empty maps and maps with int keys

### DIFF
--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -1092,7 +1092,11 @@ void t_php_generator::generate_php_struct_json_serialize(ofstream& out,
       }
       indent(out) << "if ($this->" << name << " !== null) {" << endl;
       indent_up();
-      indent(out) << "$json->" << name << " = $this->" << name << ";" << endl;
+      indent(out) << "$json->" << name << " = ";
+      if (type->is_map()) {
+        out << "(object)";
+      }
+      out << "$this->" << name << ";" << endl;
       indent_down();
       indent(out) << "}" << endl;
     }

--- a/lib/php/test/Test/Thrift/JsonSerialize/JsonSerializeTest.php
+++ b/lib/php/test/Test/Thrift/JsonSerialize/JsonSerializeTest.php
@@ -92,4 +92,12 @@ class JsonSerializeTest extends \PHPUnit_Framework_TestCase
     $this->assertEquals($expected, json_decode(json_encode($nested)));
   }
 
+  public function testMaps()
+  {
+    $intmap = new \ThriftTest\ThriftTest_testMap_args(['thing' => [0 => 'zero']]);
+    $emptymap = new \ThriftTest\ThriftTest_testMap_args([]);
+    $this->assertEquals('{"thing":{"0":"zero"}}', json_encode($intmap));
+    $this->assertEquals('{}', json_encode($emptymap));
+  }
+
 }


### PR DESCRIPTION
Tracked by THRIFT-3126