### PR TITLE
THRIFT-3086 add valgrind suppression support to the ExperimentalMemCheck test run

### DIFF
--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -77,6 +77,9 @@ elseif(UNIX)
     add_definitions("-DUSE_STD_THREAD=1")
   endif()
 
+  find_program( MEMORYCHECK_COMMAND valgrind )
+  set( MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --leak-check=full" )
+  set( MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/test/valgrind.suppress" )
 endif()
 
 # GCC and Clang.

--- a/test/valgrind.suppress
+++ b/test/valgrind.suppress
@@ -1,0 +1,9 @@
+{
+   boost/get_once_per_thread_epoch/ignore
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN5boost6detail25get_once_per_thread_epochEv
+}
+
+


### PR DESCRIPTION
Consider this part of THRIFT-3086.