### PR TITLE
THRIFT-3144 go: do not include enum name in string representation

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -878,16 +878,16 @@ void t_go_generator::generate_enum(t_enum* tenum) {
     f_types_ << indent() << "  " << tenum_name << "_" << iter_name << ' ' << tenum_name << " = "
              << value << endl;
     // Dictionaries to/from string names of enums
-    to_string_mapping << indent() << "  case " << tenum_name << "_" << iter_name << ": return \""
-                      << tenum_name << "_" << iter_std_name << "\"" << endl;
+    to_string_mapping << indent() << "  case " << tenum_name << "_" << iter_name
+                      << ": return \"" << iter_std_name << "\"" << endl;
 
     if (iter_std_name != escape_string(iter_name)) {
-      from_string_mapping << indent() << "  case \"" << tenum_name << "_" << iter_std_name
-                          << "\", \"" << escape_string(iter_name) << "\": return " << tenum_name
+      from_string_mapping << indent() << "  case \"" << iter_std_name << "\", \""
+                          << escape_string(iter_name) << "\": return " << tenum_name
                           << "_" << iter_name << ", nil " << endl;
     } else {
-      from_string_mapping << indent() << "  case \"" << tenum_name << "_" << iter_std_name
-                          << "\": return " << tenum_name << "_" << iter_name << ", nil " << endl;
+      from_string_mapping << indent() << "  case \"" << iter_std_name << "\": return "
+                          << tenum_name << "_" << iter_name << ", nil " << endl;
     }
   }
 

--- a/lib/go/thrift/serializer_types.go
+++ b/lib/go/thrift/serializer_types.go
@@ -69,26 +69,26 @@ const (
 func (p TestEnum) String() string {
 	switch p {
 	case TestEnum_FIRST:
-		return "TestEnum_FIRST"
+		return "FIRST"
 	case TestEnum_SECOND:
-		return "TestEnum_SECOND"
+		return "SECOND"
 	case TestEnum_THIRD:
-		return "TestEnum_THIRD"
+		return "THIRD"
 	case TestEnum_FOURTH:
-		return "TestEnum_FOURTH"
+		return "FOURTH"
 	}
 	return "<UNSET>"
 }
 
 func TestEnumFromString(s string) (TestEnum, error) {
 	switch s {
-	case "TestEnum_FIRST":
+	case "FIRST":
 		return TestEnum_FIRST, nil
-	case "TestEnum_SECOND":
+	case "SECOND":
 		return TestEnum_SECOND, nil
-	case "TestEnum_THIRD":
+	case "THIRD":
 		return TestEnum_THIRD, nil
-	case "TestEnum_FOURTH":
+	case "FOURTH":
 		return TestEnum_FOURTH, nil
 	}
 	return TestEnum(0), fmt.Errorf("not a valid TestEnum string")


### PR DESCRIPTION
Changed generated String/FromString methods for enums to use values from thrift
definition file for string representation of an enum.

E.g.:
- before: String(TestEnum_FIRST) = "TestEnum_FIRST"
- after : String(TestEnum_FIRST) = "FIRST"