### PR TITLE
THRIFT 3089 - stop adding period before enum name unless java namespace is provided

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -697,8 +697,11 @@ string t_java_generator::render_const_value(ofstream& out, t_type* type, t_const
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
   } else if (type->is_enum()) {
-    render << type->get_program()->get_namespace("java") << "."
-           << value->get_identifier_with_parent();
+    std::string namespace_prefix = type->get_program()->get_namespace("java");
+    if (namespace_prefix.length() > 0) {
+        namespace_prefix += ".";
+    }
+    render << namespace_prefix << value->get_identifier_with_parent();
   } else {
     string t = tmp("tmp");
     print_const_value(out, t, type, value, true);


### PR DESCRIPTION
Using the example from issue's description:

IDL file contains:
```
struct Params {
    1: optional Color bColor = Color.BLACK; 
}
```
Compiled to java (no namespace):
```
public Params() {
    this.bColor = .Color.BLACK;
}
```
How it looks like with namespace `enumtest`:
```
public Params() {
    this.bColor = enumtest.Color.BLACK;
}
```

This fix prevents adding the period sign when there's no java namespacec provided in the IDL file.

Compare:
https://issues.apache.org/jira/browse/THRIFT-3089