### PR TITLE
THRIFT-2850 CMake: improve Windows support

### DIFF
--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -69,17 +69,16 @@ if(MSVC)
     endif()
 
 elseif(UNIX)
-  # For UNIX
-  # WITH_*THREADS selects which threading library to use
-  if(WITH_BOOSTTHREADS)
-    add_definitions("-DUSE_BOOST_THREAD=1")
-  elseif(WITH_STDTHREADS)
-    add_definitions("-DUSE_STD_THREAD=1")
-  endif()
-
   find_program( MEMORYCHECK_COMMAND valgrind )
   set( MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --leak-check=full" )
   set( MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/test/valgrind.suppress" )
+endif()
+
+# WITH_*THREADS selects which threading library to use
+if(WITH_BOOSTTHREADS)
+  add_definitions("-DUSE_BOOST_THREAD=1")
+elseif(WITH_STDTHREADS)
+  add_definitions("-DUSE_STD_THREAD=1")
 endif()
 
 # GCC and Clang.

--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -65,7 +65,7 @@ if(MSVC)
     # Windows build does not know how to make a shared library yet
     # as there are no __declspec(dllexport) or exports files in the project.
     if (WITH_SHARED_LIB)
-        message (FATAL_ERROR "Windows build does not support shared library output yet!")
+      message (FATAL_ERROR "Windows build does not support shared library output yet, please set -DWITH_SHARED_LIB=off")
     endif()
 
 elseif(UNIX)

--- a/build/cmake/README.md
+++ b/build/cmake/README.md
@@ -15,15 +15,22 @@ specific soultion files. => No solution files within source tree.
 ## Usage
 just do this:
 
-    mkdir build
-    cmake ${THRIFT_SRC}
+    mkdir cmake-build && cd cmake-build
+    cmake ..
 
 if you use a specific toolchain pass it to cmake, the same for options:
 
-    cmake -DCMAKE_TOOLCHAIN_FILE=${THRIFT_SRC}/contrib/mingw32-toolchain.cmake ${THRIFT_SRC}
-    cmake -DCMAKE_C_COMPILER=clang-3.5 -DCMAKE_CXX_COMPILER=clang++-3.5 ${THRIFT_SRC}
-    cmake -DTHRIFT_COMPILER_HS=OFF ${THRIFT_SRC}
-    cmake -DWITH_ZLIB=ON ${THRIFT_SRC}
+    cmake -DCMAKE_TOOLCHAIN_FILE=${THRIFT_SRC}/contrib/mingw32-toolchain.cmake ..
+    cmake -DCMAKE_C_COMPILER=clang-3.5 -DCMAKE_CXX_COMPILER=clang++-3.5 ..
+    cmake -DTHRIFT_COMPILER_HS=OFF ..
+    cmake -DWITH_ZLIB=ON ..
+
+or on Windows
+
+    cmake -G "Visual Studio 12 2013 Win64" \
+    -DBOOST_ROOT=C:/3rdparty/boost_1_58_0 \
+    -DZLIB_ROOT=C:/3rdparty/zlib128-dll \
+    -DWITH_SHARED_LIB=off -DWITH_BOOSTTHREADS=ON ..
 
 and open the development environment you like with the solution or do this:
 
@@ -51,4 +58,3 @@ to generate an installer and distribution package do this:
   * tutorial
   * test
 * merge into /README.md
-

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -19,10 +19,8 @@
 
 # Windows has a different header
 if(MSVC)
-    set(FLEX_FLAGS "--wincompat") # Don't use unistd.h on windows
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/windows/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 else()
-    set(FLEX_FLAGS " ")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 endif()
 
@@ -31,7 +29,7 @@ find_package(BISON REQUIRED)
 
 # Create flex and bison files and build the lib parse static library
 BISON_TARGET(thrifty ${CMAKE_CURRENT_SOURCE_DIR}/src/thrifty.yy ${CMAKE_CURRENT_BINARY_DIR}/thrifty.cc)
-FLEX_TARGET(thriftl ${CMAKE_CURRENT_SOURCE_DIR}/src/thriftl.ll ${CMAKE_CURRENT_BINARY_DIR}/thriftl.cc COMPILE_FLAGS ${FLEX_FLAGS})
+FLEX_TARGET(thriftl ${CMAKE_CURRENT_SOURCE_DIR}/src/thriftl.ll ${CMAKE_CURRENT_BINARY_DIR}/thriftl.cc)
 ADD_FLEX_BISON_DEPENDENCY(thriftl thrifty)
 
 # HACK: Work around the fact that bison crates a .hh file but we need a .h file

--- a/compiler/cpp/README.md
+++ b/compiler/cpp/README.md
@@ -25,24 +25,27 @@ Now open the folder build_ec using eclipse.
 
 ## Build on windows
 
-In order to build on windows a few additional steps are necessary:
+### using Git Bash
+Git Bash provides flex and bison, so you just need to do this:
+
+    mkdir build_vs && cd build_vs
+    cmake -DWITH_SHARED_LIB=off ..
+
+### using Win flex-bison
+
+In order to build on windows with winflexbison a few additional steps are necessary:
 
 1. Download winflexbison from http://sourceforge.net/projects/winflexbison/
 2. Extract the winflex bison files to for e.g. C:\winflexbison
 3. Make the CMake variables point to the correct binaries.
   * FLEX_EXECUTABLE = C:/winbuild/win_flex.exe
   * BISON_EXECUTABLE = C:/winbuild/win_bison.exe
-
-
-### Create a Visual Studio project
-
-    mkdir build_vs && cd build_vs
-    cmake -G "Visual Studio 12" ..
-
-Now open the folder build_vs using Visual Studio 2013.
-
-
-
+4. Generate a Visual Studio project:
+```
+mkdir build_vs && cd build_vs
+cmake -G "Visual Studio 12" -DWITH_SHARED_LIB=off ..
+```
+5. Now open the folder build_vs using Visual Studio 2013.
 
 # Building the Thrift IDL compiler in Windows
 

--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -43,6 +43,8 @@
 #pragma warning(disable:4102)
 //avoid isatty redefinition
 #define YY_NEVER_INTERACTIVE 1
+
+#define YY_NO_UNISTD_H 1
 #endif
 
 #include <cassert>

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -74,7 +74,7 @@ set(UnitTest_SOURCES
     TServerTransportTest.cpp
 )
 
-if(NOT WITH_BOOSTTHREADS AND NOT WITH_STDTHREADS)
+if(NOT WITH_BOOSTTHREADS AND NOT WITH_STDTHREADS AND NOT MSVC)
     list(APPEND UnitTest_SOURCES RWMutexStarveTest.cpp)
 endif()
 

--- a/lib/cpp/test/TMemoryBufferTest.cpp
+++ b/lib/cpp/test/TMemoryBufferTest.cpp
@@ -38,27 +38,28 @@ using std::string;
 
 BOOST_AUTO_TEST_CASE(test_read_write_grow)
 {
-    // Added to test the fix for THRIFT-1248
-    TMemoryBuffer uut;
-    const int maxSiz = 65536;
-    std::vector<uint8_t> buf;
-    buf.resize(maxSiz);
-    for (uint32_t i = 0; i < maxSiz; ++i)
-    {
-        buf[i] = static_cast<uint8_t>(i);
-    }
+  // Added to test the fix for THRIFT-1248
+  TMemoryBuffer uut;
+  const int maxSize = 65536;
+  uint8_t verify[maxSize];
+  std::vector<uint8_t> buf;
+  buf.resize(maxSize);
 
-    for (uint32_t i = 1; i < maxSiz; i *= 2)
-    {
-        uut.write(&buf[0], i);
-    }
+  for (uint32_t i = 0; i < maxSize; ++i)
+  {
+    buf[i] = static_cast<uint8_t>(i);
+  }
 
-    for (uint32_t i = 1; i < maxSiz; i *= 2)
-    {
-        uint8_t verify[i];
-        uut.read(verify, i);
-        BOOST_CHECK_EQUAL(0, ::memcmp(verify, &buf[0], i));
-    }
+  for (uint32_t i = 1; i < maxSize; i *= 2)
+  {
+    uut.write(&buf[0], i);
+  }
+
+  for (uint32_t i = 1; i < maxSize; i *= 2)
+  {
+    uut.read(verify, i);
+    BOOST_CHECK_EQUAL(0, ::memcmp(verify, &buf[0], i));
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_roundtrip)


### PR DESCRIPTION
use YY_NO_UNISTD_H and remove --wincompat

Signed-off-by: Roger Meier <roger@apache.org>