### PR TITLE
THRIFT-3131 fix path for "go get"

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -27,7 +27,7 @@ Using Thrift with Go
 In following Go conventions, we recommend you use the 'go' tool to install
 Thrift for go.
 
-    $ go get git-wip-us.apache.org/repos/asf/thrift.git/lib/go/thrift
+    $ go get git.apache.org/thrift.git/lib/go/thrift
 
 Will retrieve and install the most recent version of the package.
 


### PR DESCRIPTION
git.apache.org/thrift.git/lib/go/thrift is the correct import path as it is used
by default in the generated go code.

Unfortunately "go get" can download this library only using git:// scheme so if
a user running "go get" is behind a firewall or Git is down at
git.apache.org (which seems to be the case from time to time) then running go
get with this path will fail.

I will try to get this fixed in Go 1.5. Issues to watch:
- https://issues.apache.org/jira/browse/INFRA-9658
- https://github.com/golang/go/issues/10797