### PR TITLE
THRIFT-3158 Make deepcopy return T

### DIFF
--- a/lib/java/src/org/apache/thrift/TBase.java
+++ b/lib/java/src/org/apache/thrift/TBase.java
@@ -71,7 +71,7 @@ public interface TBase<T extends TBase<?,?>, F extends TFieldIdEnum> extends Com
    */
   public void setFieldValue(F field, Object value);
 
-  public TBase<T, F> deepCopy();
+  public T deepCopy();
 
   /**
    * Return to the state of having just been initialized, as though you had just


### PR DESCRIPTION
All TBase types return themselves, so this should be fine. I suppose that without https://github.com/apache/thrift/pull/498 this is not strictly backwards-compatible since `T` currently only extends `TBase<?,?>`.