### PR TITLE
THRIFT-3112: Typed AsyncMethodCallback with return type

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -4144,7 +4144,8 @@ string t_java_generator::async_function_call_arglist(t_function* tfunc,
   }
 
   if (include_types) {
-    arglist += "org.apache.thrift.async.AsyncMethodCallback ";
+    arglist += "org.apache.thrift.async.AsyncMethodCallback<";
+    arglist += type_name(tfunc->get_returntype(), true) + "> ";
   }
   arglist += "resultHandler";
 
@@ -4199,7 +4200,8 @@ string t_java_generator::async_argument_list(t_function* tfunct,
     result += ", ";
   }
   if (include_types) {
-    result += "org.apache.thrift.async.AsyncMethodCallback ";
+    result += "org.apache.thrift.async.AsyncMethodCallback<";
+    result += type_name(tfunct->get_returntype(), true) + "> ";
   }
   result += "resultHandler";
   return result;


### PR DESCRIPTION
In Java generator, a few occurrences of AsyncMethodCallback were typed with function return type, and a few were not. Please correct me if it should be typed differently.

See:
https://issues.apache.org/jira/browse/THRIFT-3112
