### PR TITLE
THRIFT-3162 Rename the 'format' parameter to disambiguate from std.format

### DIFF
--- a/lib/d/src/thrift/base.d
+++ b/lib/d/src/thrift/base.d
@@ -93,7 +93,7 @@ shared static this() {
 // This should be private, if it could still be used through the aliases then.
 template logFormatted(alias target) {
   void logFormatted(string file = __FILE__, int line = __LINE__,
-    T...)(string format, T args) if (
+    T...)(string fmt, T args) if (
     __traits(compiles, { target(""); })
   ) {
     import std.format, std.stdio;
@@ -107,9 +107,9 @@ template logFormatted(alias target) {
       formattedWrite(g_formatBuffer, "%s:%s: ", file, line);
 
       static if (T.length == 0) {
-        g_formatBuffer.put(format);
+        g_formatBuffer.put(fmt);
       } else {
-        formattedWrite(g_formatBuffer, format, args);
+        formattedWrite(g_formatBuffer, fmt, args);
       }
       target(g_formatBuffer.data);
     }


### PR DESCRIPTION
This is a workaround for 2.067 and 2.067.1.