### PR TITLE
THRIFT-3170: Add a flag to allow the ignoring of common initialisms in Go

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -97,6 +97,8 @@ public:
 
     iter = parsed_options.find("read_write_private");
     read_write_private_ = (iter != parsed_options.end());
+    iter = parsed_options.find("ignore_initialisms");
+    ignore_initialisms_ = (iter != parsed_options.end());    
   }
 
   /**
@@ -282,6 +284,7 @@ private:
   std::string gen_package_prefix_;
   std::string gen_thrift_import_;
   bool read_write_private_;
+  bool ignore_initialisms_;
 
   /**
    * File streams
@@ -429,7 +432,7 @@ std::string t_go_generator::camelcase(const std::string& value) const {
       }
       std::string word = value2.substr(i, value2.find('_', i));
       std::transform(word.begin(), word.end(), word.begin(), ::toupper);
-      if (commonInitialisms.find(word) != commonInitialisms.end()) {
+      if (!ignore_initialisms_ && commonInitialisms.find(word) != commonInitialisms.end()) {
         value2.replace(i, word.length(), word);
       }
     }

--- a/lib/go/test/IgnoreInitialismsTest.thrift
+++ b/lib/go/test/IgnoreInitialismsTest.thrift
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+struct IgnoreInitialismsTest {
+    1: i64 id,
+    2: i64 my_id,
+    3: i64 num_cpu,
+    4: i64 num_gpu,
+    5: i64 my_ID,
+}

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -36,7 +36,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				NamesTest.thrift \
 				InitialismsTest.thrift \
 				DontExportRWTest.thrift \
-				dontexportrwtest/compile_test.go
+				dontexportrwtest/compile_test.go \
+				IgnoreInitialismsTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -52,6 +53,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) NamesTest.thrift
 	$(THRIFT) $(THRIFTARGS) InitialismsTest.thrift
 	$(THRIFT) $(THRIFTARGS),read_write_private DontExportRWTest.thrift
+	$(THRIFT) $(THRIFTARGS),ignore_initialisms IgnoreInitialismsTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get code.google.com/p/gomock/gomock
 	ln -nfs ../../../thrift gopath/src/thrift
 	ln -nfs ../../tests gopath/src/tests
@@ -92,4 +94,5 @@ EXTRA_DIST = \
 	ErrorTest.thrift \
 	NamesTest.thrift \
 	InitialismsTest.thrift \
-	DontExportRWTest.thrift
+	DontExportRWTest.thrift \
+	IgnoreInitialismsTest.thrift

--- a/lib/go/test/tests/ignoreinitialisms_test.go
+++ b/lib/go/test/tests/ignoreinitialisms_test.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"ignoreinitialismstest"
+	"reflect"
+	"testing"
+)
+
+func TestIgnoreInitialismsFlagIsHonoured(t *testing.T) {
+	s := ignoreinitialismstest.IgnoreInitialismsTest{}
+	st := reflect.TypeOf(s)
+	_, ok := st.FieldByName("Id")
+	if !ok {
+		t.Error("Id attribute is missing!")
+	}
+	_, ok = st.FieldByName("MyId")
+	if !ok {
+		t.Error("MyId attribute is missing!")
+	}
+	_, ok = st.FieldByName("NumCpu")
+	if !ok {
+		t.Error("NumCpu attribute is missing!")
+	}
+	_, ok = st.FieldByName("NumGpu")
+	if !ok {
+		t.Error("NumGpu attribute is missing!")
+	}
+	_, ok = st.FieldByName("My_ID")
+	if !ok {
+		t.Error("My_ID attribute is missing!")
+	}
+}


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/THRIFT-3170