### PR TITLE
THRIFT-3182: Close transport after reading an invalid frame size

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TFastFramedTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TFastFramedTransport.java
@@ -19,12 +19,12 @@
 package org.apache.thrift.transport;
 
 /**
- * This transport is wire compatible with {@link TFramedTransport}, but makes 
+ * This transport is wire compatible with {@link TFramedTransport}, but makes
  * use of reusable, expanding read and write buffers in order to avoid
  * allocating new byte[]s all the time. Since the buffers only expand, you
  * should probably only use this transport if your messages are not too variably
  * large, unless the persistent memory cost is not an issue.
- * 
+ *
  * This implementation is NOT threadsafe.
  */
 public class TFastFramedTransport extends TTransport {
@@ -91,7 +91,7 @@ public class TFastFramedTransport extends TTransport {
   }
 
   /**
-   * 
+   *
    * @param underlying Transport that real reads and writes will go through to.
    * @param initialBufferCapacity The initial size of the read and write buffers.
    * In practice, it's not critical to set this unless you know in advance that
@@ -141,11 +141,14 @@ public class TFastFramedTransport extends TTransport {
     int size = TFramedTransport.decodeFrameSize(i32buf);
 
     if (size < 0) {
-      throw new TTransportException("Read a negative frame size (" + size + ")!");
+      close();
+      throw new TTransportException(TTransportException.CORRUPTED_DATA, "Read a negative frame size (" + size + ")!");
     }
 
     if (size > maxLength) {
-      throw new TTransportException("Frame size (" + size + ") larger than max length (" + maxLength + ")!");
+      close();
+      throw new TTransportException(TTransportException.CORRUPTED_DATA,
+          "Frame size (" + size + ") larger than max length (" + maxLength + ")!");
     }
 
     readBuffer.fill(underlying, size);

--- a/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
@@ -130,11 +130,14 @@ public class TFramedTransport extends TTransport {
     int size = decodeFrameSize(i32buf);
 
     if (size < 0) {
-      throw new TTransportException("Read a negative frame size (" + size + ")!");
+      close();
+      throw new TTransportException(TTransportException.CORRUPTED_DATA, "Read a negative frame size (" + size + ")!");
     }
 
     if (size > maxLength_) {
-      throw new TTransportException("Frame size (" + size + ") larger than max length (" + maxLength_ + ")!");
+      close();
+      throw new TTransportException(TTransportException.CORRUPTED_DATA,
+          "Frame size (" + size + ") larger than max length (" + maxLength_ + ")!");
     }
 
     byte[] buff = new byte[size];
@@ -166,7 +169,7 @@ public class TFramedTransport extends TTransport {
   }
 
   public static final int decodeFrameSize(final byte[] buf) {
-    return 
+    return
       ((buf[0] & 0xff) << 24) |
       ((buf[1] & 0xff) << 16) |
       ((buf[2] & 0xff) <<  8) |

--- a/lib/java/src/org/apache/thrift/transport/TTransportException.java
+++ b/lib/java/src/org/apache/thrift/transport/TTransportException.java
@@ -34,6 +34,7 @@ public class TTransportException extends TException {
   public static final int ALREADY_OPEN = 2;
   public static final int TIMED_OUT = 3;
   public static final int END_OF_FILE = 4;
+  public static final int CORRUPTED_DATA = 5;
 
   protected int type_ = UNKNOWN;
 

--- a/lib/java/test/org/apache/thrift/transport/ReadCountingTransport.java
+++ b/lib/java/test/org/apache/thrift/transport/ReadCountingTransport.java
@@ -22,26 +22,40 @@ package org.apache.thrift.transport;
 public class ReadCountingTransport extends TTransport {
   public int readCount = 0;
   private TTransport trans;
+  private boolean open = true;
 
   public ReadCountingTransport(TTransport underlying) {
     trans = underlying;
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    open = false;
+  }
 
   @Override
-  public boolean isOpen() {return true;}
+  public boolean isOpen() {
+    return open;
+  }
 
   @Override
-  public void open() throws TTransportException {}
+  public void open() throws TTransportException {
+    open = true;
+  }
 
   @Override
   public int read(byte[] buf, int off, int len) throws TTransportException {
+    if (!isOpen()) {
+      throw new TTransportException(TTransportException.NOT_OPEN, "Transport is closed");
+    }
     readCount++;
     return trans.read(buf, off, len);
   }
 
   @Override
-  public void write(byte[] buf, int off, int len) throws TTransportException {}
+  public void write(byte[] buf, int off, int len) throws TTransportException {
+    if (!isOpen()) {
+      throw new TTransportException(TTransportException.NOT_OPEN, "Transport is closed");
+    }
+  }
 }

--- a/lib/java/test/org/apache/thrift/transport/TestTFastFramedTransport.java
+++ b/lib/java/test/org/apache/thrift/transport/TestTFastFramedTransport.java
@@ -23,4 +23,9 @@ public class TestTFastFramedTransport extends TestTFramedTransport {
   protected TTransport getTransport(TTransport underlying) {
     return new TFastFramedTransport(underlying, 50, 10 * 1024 * 1024);
   }
+
+  @Override
+  protected TTransport getTransport(TTransport underlying, int maxLength) {
+    return new TFastFramedTransport(underlying, 50, maxLength);
+  }
 }


### PR DESCRIPTION
This is necessary because after reading the invalid
frame size from the underlying transport the transport
is left in a bad state. Any following reads will
likely throw more invalid frame size exceptions and
if they don’t they will be reading corrupted messages.

Closing forces the caller to discard the connection and
get a new one.