### PR TITLE
Allow construction of TTransportFactory with a specified maxLength.

### DIFF
--- a/lib/go/thrift/framed_transport.go
+++ b/lib/go/thrift/framed_transport.go
@@ -47,6 +47,10 @@ func NewTFramedTransportFactory(factory TTransportFactory) TTransportFactory {
 	return &tFramedTransportFactory{factory: factory, maxLength: DEFAULT_MAX_LENGTH}
 }
 
+func NewTFramedTransportFactoryMaxLength(factory TTransportFactory, maxLength int) TTransportFactory {
+        return &tFramedTransportFactory{factory: factory, maxLength: maxLength}
+}
+
 func (p *tFramedTransportFactory) GetTransport(base TTransport) TTransport {
 	return NewTFramedTransportMaxLength(p.factory.GetTransport(base), p.maxLength)
 }


### PR DESCRIPTION
Hello,

Maybe I'm going crazy but I don't see any way to construct a TTransportFactory with maxLength set to something other than DEFAULT_MAX_LENGTH. I'd like to do this so I can pass this tFramedTransportFactory into NewTSimpleServer4.

Thanks,
Sean