### PR TITLE
THRIFT-3194 - fix remaining gomock path - see THRIFT-3192

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,7 +238,7 @@ test-driver
 /test/go/ThriftTest.thrift
 /test/go/gopath
 /test/go/pkg/
-/test/go/src/code.google.com/
+/test/go/src/github.com/golang/
 /test/go/src/gen/
 /test/go/src/thrift
 /test/haxe/bin

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -47,7 +47,7 @@ bin/stress: gopath
 	GOPATH=`pwd` $(GO) install bin/stress
 
 clean-local:
-	$(RM) -r src/gen src/code.google.com src/thrift bin pkg gopath ThriftTest.thrift
+	$(RM) -r src/gen src/github.com/golang src/thrift bin pkg gopath ThriftTest.thrift
 
 check_PROGRAMS: bin/testclient bin/testserver bin/stress
 

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -55,7 +55,7 @@ check: gopath
 	GOPATH=`pwd` $(GO) test -v common/...
 
 genmock: gopath
-	GOPATH=`pwd` $(GO) install code.google.com/p/gomock/mockgen
+	GOPATH=`pwd` $(GO) install github.com/golang/mock/mockgen
 	GOPATH=`pwd` bin/mockgen -destination=src/common/mock_handler.go -package=common gen/thrifttest ThriftTest
 
 EXTRA_DIST = \


### PR DESCRIPTION
pull request 523 covers most of this.  One path left over (perhaps unused?)