### PR TITLE
THRIFT-3196 Fix a typo in the lua TBinaryProtocol

### DIFF
--- a/lib/lua/TBinaryProtocol.lua
+++ b/lib/lua/TBinaryProtocol.lua
@@ -31,7 +31,7 @@ TBinaryProtocol = __TObject.new(TProtocolBase, {
 })
 
 function TBinaryProtocol:writeMessageBegin(name, ttype, seqid)
-  if self.stirctWrite then
+  if self.strictWrite then
     self:writeI32(libluabitwise.bor(TBinaryProtocol.VERSION_1, ttype))
     self:writeString(name)
     self:writeI32(seqid)


### PR DESCRIPTION
The strictWrite instance variable in TBinaryProtocol's writeMessageBegin is misspelled as stirctWrite