### PR TITLE
THRIFT-3199: Uses StructMetaData for exception fieldvalue

### DIFF
--- a/compiler/cpp/src/generate/t_as3_generator.cc
+++ b/compiler/cpp/src/generate/t_as3_generator.cc
@@ -1370,7 +1370,7 @@ void t_as3_generator::generate_field_value_meta_data(std::ofstream& out, t_type*
   out << endl;
   indent_up();
   indent_up();
-  if (type->is_struct()) {
+  if (type->is_struct() || type->is_xception()) {
     indent(out) << "new StructMetaData(TType.STRUCT, " << type_name(type);
   } else if (type->is_container()) {
     if (type->is_list()) {

--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2574,7 +2574,7 @@ void t_java_generator::generate_field_value_meta_data(std::ofstream& out, t_type
   out << endl;
   indent_up();
   indent_up();
-  if (type->is_struct()) {
+  if (type->is_struct() || type->is_xception()) {
     indent(out) << "new "
                    "org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType."
                    "STRUCT, " << type_name(type) << ".class";

--- a/compiler/cpp/src/generate/t_javame_generator.cc
+++ b/compiler/cpp/src/generate/t_javame_generator.cc
@@ -1816,7 +1816,7 @@ void t_javame_generator::generate_field_value_meta_data(std::ofstream& out, t_ty
   out << endl;
   indent_up();
   indent_up();
-  if (type->is_struct()) {
+  if (type->is_struct() || type->is_xception()) {
     indent(out) << "new StructMetaData(TType.STRUCT, " << type_name(type) << ".class";
   } else if (type->is_container()) {
     if (type->is_list()) {


### PR DESCRIPTION
As stated in issue [THRIFT-3199](https://issues.apache.org/jira/browse/THRIFT-3199), fields based on exception have limited metadata information, and this doesn't include the thrift class used to represent the field.