### PR TITLE
THRIFT-406 Convert C++ Test to Boost::Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ test-driver
 /lib/cpp/test/Benchmark
 /lib/cpp/test/AllProtocolsTest
 /lib/cpp/test/DebugProtoTest
+/lib/cpp/test/DenseProtoTest
 /lib/cpp/test/EnumTest
 /lib/cpp/test/JSONProtoTest
 /lib/cpp/test/OptionalRequiredTest

--- a/lib/cpp/test/AllProtocolTests.cpp
+++ b/lib/cpp/test/AllProtocolTests.cpp
@@ -22,6 +22,10 @@
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/protocol/TCompactProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
+
+#define BOOST_TEST_MODULE AllProtocolTests
+#include <boost/test/unit_test.hpp>
+
 #include "AllProtocolTests.tcc"
 
 using namespace apache::thrift;
@@ -30,15 +34,10 @@ using namespace apache::thrift::transport;
 
 char errorMessage[ERR_LEN];
 
-int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
-  try {
-    testProtocol<TBinaryProtocol>("TBinaryProtocol");
-    testProtocol<TCompactProtocol>("TCompactProtocol");
-  } catch (TException e) {
-    printf("%s\n", e.what());
-    return 1;
-  }
-  return 0;
+BOOST_AUTO_TEST_CASE(test_binary_protocol) {
+  testProtocol<TBinaryProtocol>("TBinaryProtocol");
+}
+
+BOOST_AUTO_TEST_CASE(test_compact_protocol) {
+  testProtocol<TCompactProtocol>("TCompactProtocol");
 }

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -147,10 +147,16 @@ add_test(NAME TFileTransportTest COMMAND TFileTransportTest)
 endif()
 
 add_executable(TFDTransportTest TFDTransportTest.cpp)
+target_link_libraries(TFDTransportTest
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(TFDTransportTest thrift)
 add_test(NAME TFDTransportTest COMMAND TFDTransportTest)
 
 add_executable(TPipedTransportTest TPipedTransportTest.cpp)
+target_link_libraries(TPipedTransportTest
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(TPipedTransportTest thrift)
 add_test(NAME TPipedTransportTest COMMAND TPipedTransportTest)
 
@@ -161,35 +167,53 @@ set(AllProtocolsTest_SOURCES
     )
 
 add_executable(AllProtocolsTest ${AllProtocolsTest_SOURCES})
-target_link_libraries(AllProtocolsTest testgencpp)
+target_link_libraries(AllProtocolsTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(AllProtocolsTest thrift)
 add_test(NAME AllProtocolsTest COMMAND AllProtocolsTest)
 
 # The debug run-time in Windows asserts on isprint() with negative inputs
 if (NOT MSVC OR (MSVC AND CMAKE_BUILD_TYPE EQUAL "DEBUG"))
 add_executable(DebugProtoTest DebugProtoTest.cpp)
-target_link_libraries(DebugProtoTest testgencpp)
+target_link_libraries(DebugProtoTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(DebugProtoTest thrift)
 add_test(NAME DebugProtoTest COMMAND DebugProtoTest)
 endif()
 
 add_executable(JSONProtoTest JSONProtoTest.cpp)
-target_link_libraries(JSONProtoTest testgencpp)
+target_link_libraries(JSONProtoTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(JSONProtoTest thrift)
 add_test(NAME JSONProtoTest COMMAND JSONProtoTest)
 
 add_executable(OptionalRequiredTest OptionalRequiredTest.cpp)
-target_link_libraries(OptionalRequiredTest testgencpp)
+target_link_libraries(OptionalRequiredTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(OptionalRequiredTest thrift)
 add_test(NAME OptionalRequiredTest COMMAND OptionalRequiredTest)
 
 add_executable(RecursiveTest RecursiveTest.cpp)
-target_link_libraries(RecursiveTest testgencpp)
+target_link_libraries(RecursiveTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(RecursiveTest thrift)
 add_test(NAME RecursiveTest COMMAND RecursiveTest)
 
 add_executable(SpecializationTest SpecializationTest.cpp)
-target_link_libraries(SpecializationTest testgencpp)
+target_link_libraries(SpecializationTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
 LINK_AGAINST_THRIFT_LIBRARY(SpecializationTest thrift)
 add_test(NAME SpecializationTest COMMAND SpecializationTest)
 

--- a/lib/cpp/test/DebugProtoTest.cpp
+++ b/lib/cpp/test/DebugProtoTest.cpp
@@ -18,72 +18,169 @@
  */
 
 #define _USE_MATH_DEFINES
-#include <iostream>
 #include <cmath>
 #include "gen-cpp/DebugProtoTest_types.h"
 #include <thrift/protocol/TDebugProtocol.h>
 
-int main() {
-  using std::cout;
-  using std::endl;
-  using namespace thrift::test::debug;
+#define BOOST_TEST_MODULE DebugProtoTest
+#include <boost/test/unit_test.hpp>
 
-  OneOfEach ooe;
-  ooe.im_true = true;
-  ooe.im_false = false;
-  ooe.a_bite = 0x7f;
-  ooe.integer16 = 27000;
-  ooe.integer32 = 1 << 24;
-  ooe.integer64 = (uint64_t)6000 * 1000 * 1000;
-  ooe.double_precision = M_PI;
-  ooe.some_characters = "Debug THIS!";
-  ooe.zomg_unicode = "\xd7\n\a\t";
+using namespace thrift::test::debug;
 
-  cout << apache::thrift::ThriftDebugString(ooe) << endl << endl;
+static std::auto_ptr<OneOfEach> ooe;
 
-  Nesting n;
-  n.my_ooe = ooe;
-  n.my_ooe.integer16 = 16;
-  n.my_ooe.integer32 = 32;
-  n.my_ooe.integer64 = 64;
-  n.my_ooe.double_precision = (std::sqrt(5.0) + 1) / 2;
-  n.my_ooe.some_characters = ":R (me going \"rrrr\")";
-  n.my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20"
-                              "\xd0\x9d\xce\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0\xb0\xcf\x81\xe2\x84\x8e"
-                              "\x20\xce\x91\x74\x74\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80\xbc";
-  n.my_bonk.type = 31337;
-  n.my_bonk.message = "I am a bonk... xor!";
+void testCaseSetup_1() {
+  ooe.reset(new OneOfEach);
+  ooe->im_true = true;
+  ooe->im_false = false;
+  ooe->a_bite = 0x7f;
+  ooe->integer16 = 27000;
+  ooe->integer32 = 1 << 24;
+  ooe->integer64 = (uint64_t)6000 * 1000 * 1000;
+  ooe->double_precision = M_PI;
+  ooe->some_characters = "Debug THIS!";
+  ooe->zomg_unicode = "\xd7\n\a\t";
+}
 
-  cout << apache::thrift::ThriftDebugString(n) << endl << endl;
+BOOST_AUTO_TEST_CASE(test_debug_proto_1) {
+  testCaseSetup_1();
 
-  HolyMoley hm;
+  const std::string expected_result(
+    "OneOfEach {\n"
+    "  01: im_true (bool) = true,\n"
+    "  02: im_false (bool) = false,\n"
+    "  03: a_bite (byte) = 0x7f,\n"
+    "  04: integer16 (i16) = 27000,\n"
+    "  05: integer32 (i32) = 16777216,\n"
+    "  06: integer64 (i64) = 6000000000,\n"
+    "  07: double_precision (double) = 3.1415926535897931,\n"
+    "  08: some_characters (string) = \"Debug THIS!\",\n"
+    "  09: zomg_unicode (string) = \"\\xd7\\n\\a\\t\",\n"
+    "  10: what_who (bool) = false,\n"
+    "  11: base64 (string) = \"\",\n"
+    "  12: byte_list (list) = list<byte>[3] {\n"
+    "    [0] = 0x01,\n"
+    "    [1] = 0x02,\n"
+    "    [2] = 0x03,\n"
+    "  },\n"
+    "  13: i16_list (list) = list<i16>[3] {\n"
+    "    [0] = 1,\n"
+    "    [1] = 2,\n"
+    "    [2] = 3,\n"
+    "  },\n"
+    "  14: i64_list (list) = list<i64>[3] {\n"
+    "    [0] = 1,\n"
+    "    [1] = 2,\n"
+    "    [2] = 3,\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(*ooe));
 
-  hm.big.push_back(ooe);
-  hm.big.push_back(n.my_ooe);
-  hm.big[0].a_bite = 0x22;
-  hm.big[1].a_bite = 0x33;
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+static std::auto_ptr<Nesting> n;
+
+void testCaseSetup_2() {
+  testCaseSetup_1();
+
+  n.reset(new Nesting);
+  n->my_ooe = *ooe;
+  n->my_ooe.integer16 = 16;
+  n->my_ooe.integer32 = 32;
+  n->my_ooe.integer64 = 64;
+  n->my_ooe.double_precision = (std::sqrt(5.0) + 1) / 2;
+  n->my_ooe.some_characters = ":R (me going \"rrrr\")";
+  n->my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20\xd0\x9d\xce"
+                               "\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0"
+                               "\xb0\xcf\x81\xe2\x84\x8e\x20\xce\x91\x74\x74"
+                               "\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80"
+                               "\xbc";
+  n->my_bonk.type = 31337;
+  n->my_bonk.message = "I am a bonk... xor!";
+}
+
+BOOST_AUTO_TEST_CASE(test_debug_proto_2) {
+  testCaseSetup_2();
+
+  const std::string expected_result(
+    "Nesting {\n"
+    "  01: my_bonk (struct) = Bonk {\n"
+    "    01: type (i32) = 31337,\n"
+    "    02: message (string) = \"I am a bonk... xor!\",\n"
+    "  },\n"
+    "  02: my_ooe (struct) = OneOfEach {\n"
+    "    01: im_true (bool) = true,\n"
+    "    02: im_false (bool) = false,\n"
+    "    03: a_bite (byte) = 0x7f,\n"
+    "    04: integer16 (i16) = 16,\n"
+    "    05: integer32 (i32) = 32,\n"
+    "    06: integer64 (i64) = 64,\n"
+    "    07: double_precision (double) = 1.6180339887498949,\n"
+    "    08: some_characters (string) = \":R (me going \\\"rrrr\\\")\",\n"
+    "    09: zomg_unicode (string) = \"\\xd3\\x80\\xe2\\x85\\xae\\xce\\x9d \\xd"
+      "0\\x9d\\xce\\xbf\\xe2\\x85\\xbf\\xd0\\xbe\\xc9\\xa1\\xd0\\xb3\\xd0\\xb0"
+      "\\xcf\\x81\\xe2\\x84\\x8e \\xce\\x91tt\\xce\\xb1\\xe2\\x85\\xbd\\xce\\xb"
+      "a\\xc7\\x83\\xe2\\x80\\xbc\",\n"
+    "    10: what_who (bool) = false,\n"
+    "    11: base64 (string) = \"\",\n"
+    "    12: byte_list (list) = list<byte>[3] {\n"
+    "      [0] = 0x01,\n"
+    "      [1] = 0x02,\n"
+    "      [2] = 0x03,\n"
+    "    },\n"
+    "    13: i16_list (list) = list<i16>[3] {\n"
+    "      [0] = 1,\n"
+    "      [1] = 2,\n"
+    "      [2] = 3,\n"
+    "    },\n"
+    "    14: i64_list (list) = list<i64>[3] {\n"
+    "      [0] = 1,\n"
+    "      [1] = 2,\n"
+    "      [2] = 3,\n"
+    "    },\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(*n));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+static std::auto_ptr<HolyMoley> hm;
+
+void testCaseSetup_3() {
+  testCaseSetup_2();
+
+  hm.reset(new HolyMoley);
+
+  hm->big.push_back(*ooe);
+  hm->big.push_back(n->my_ooe);
+  hm->big[0].a_bite = 0x22;
+  hm->big[1].a_bite = 0x33;
 
   std::vector<std::string> stage1;
   stage1.push_back("and a one");
   stage1.push_back("and a two");
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
   stage1.clear();
   stage1.push_back("then a one, two");
   stage1.push_back("three!");
   stage1.push_back("FOUR!!");
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
   stage1.clear();
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
 
   std::vector<Bonk> stage2;
-  hm.bonks["nothing"] = stage2;
+  hm->bonks["nothing"] = stage2;
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 1;
   stage2.back().message = "Wait.";
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 2;
   stage2.back().message = "What?";
-  hm.bonks["something"] = stage2;
+  hm->bonks["something"] = stage2;
   stage2.clear();
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 3;
@@ -94,9 +191,119 @@ int main() {
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 5;
   stage2.back().message = "nevermore";
-  hm.bonks["poe"] = stage2;
+  hm->bonks["poe"] = stage2;
+}
 
-  cout << apache::thrift::ThriftDebugString(hm) << endl << endl;
+BOOST_AUTO_TEST_CASE(test_debug_proto_3) {
+  testCaseSetup_3();
 
-  return 0;
+  const std::string expected_result(
+    "HolyMoley {\n"
+    "  01: big (list) = list<struct>[2] {\n"
+    "    [0] = OneOfEach {\n"
+    "      01: im_true (bool) = true,\n"
+    "      02: im_false (bool) = false,\n"
+    "      03: a_bite (byte) = 0x22,\n"
+    "      04: integer16 (i16) = 27000,\n"
+    "      05: integer32 (i32) = 16777216,\n"
+    "      06: integer64 (i64) = 6000000000,\n"
+    "      07: double_precision (double) = 3.1415926535897931,\n"
+    "      08: some_characters (string) = \"Debug THIS!\",\n"
+    "      09: zomg_unicode (string) = \"\\xd7\\n\\a\\t\",\n"
+    "      10: what_who (bool) = false,\n"
+    "      11: base64 (string) = \"\",\n"
+    "      12: byte_list (list) = list<byte>[3] {\n"
+    "        [0] = 0x01,\n"
+    "        [1] = 0x02,\n"
+    "        [2] = 0x03,\n"
+    "      },\n"
+    "      13: i16_list (list) = list<i16>[3] {\n"
+    "        [0] = 1,\n"
+    "        [1] = 2,\n"
+    "        [2] = 3,\n"
+    "      },\n"
+    "      14: i64_list (list) = list<i64>[3] {\n"
+    "        [0] = 1,\n"
+    "        [1] = 2,\n"
+    "        [2] = 3,\n"
+    "      },\n"
+    "    },\n"
+    "    [1] = OneOfEach {\n"
+    "      01: im_true (bool) = true,\n"
+    "      02: im_false (bool) = false,\n"
+    "      03: a_bite (byte) = 0x33,\n"
+    "      04: integer16 (i16) = 16,\n"
+    "      05: integer32 (i32) = 32,\n"
+    "      06: integer64 (i64) = 64,\n"
+    "      07: double_precision (double) = 1.6180339887498949,\n"
+    "      08: some_characters (string) = \":R (me going \\\"rrrr\\\")\",\n"
+    "      09: zomg_unicode (string) = \"\\xd3\\x80\\xe2\\x85\\xae\\xce\\x9d \\"
+      "xd0\\x9d\\xce\\xbf\\xe2\\x85\\xbf\\xd0\\xbe\\xc9\\xa1\\xd0\\xb3\\xd0\\xb"
+      "0\\xcf\\x81\\xe2\\x84\\x8e \\xce\\x91tt\\xce\\xb1\\xe2\\x85\\xbd\\xce\\x"
+      "ba\\xc7\\x83\\xe2\\x80\\xbc\",\n"
+    "      10: what_who (bool) = false,\n"
+    "      11: base64 (string) = \"\",\n"
+    "      12: byte_list (list) = list<byte>[3] {\n"
+    "        [0] = 0x01,\n"
+    "        [1] = 0x02,\n"
+    "        [2] = 0x03,\n"
+    "      },\n"
+    "      13: i16_list (list) = list<i16>[3] {\n"
+    "        [0] = 1,\n"
+    "        [1] = 2,\n"
+    "        [2] = 3,\n"
+    "      },\n"
+    "      14: i64_list (list) = list<i64>[3] {\n"
+    "        [0] = 1,\n"
+    "        [1] = 2,\n"
+    "        [2] = 3,\n"
+    "      },\n"
+    "    },\n"
+    "  },\n"
+    "  02: contain (set) = set<list>[3] {\n"
+    "    list<string>[0] {\n"
+    "    },\n"
+    "    list<string>[2] {\n"
+    "      [0] = \"and a one\",\n"
+    "      [1] = \"and a two\",\n"
+    "    },\n"
+    "    list<string>[3] {\n"
+    "      [0] = \"then a one, two\",\n"
+    "      [1] = \"three!\",\n"
+    "      [2] = \"FOUR!!\",\n"
+    "    },\n"
+    "  },\n"
+    "  03: bonks (map) = map<string,list>[3] {\n"
+    "    \"nothing\" -> list<struct>[0] {\n"
+    "    },\n"
+    "    \"poe\" -> list<struct>[3] {\n"
+    "      [0] = Bonk {\n"
+    "        01: type (i32) = 3,\n"
+    "        02: message (string) = \"quoth\",\n"
+    "      },\n"
+    "      [1] = Bonk {\n"
+    "        01: type (i32) = 4,\n"
+    "        02: message (string) = \"the raven\",\n"
+    "      },\n"
+    "      [2] = Bonk {\n"
+    "        01: type (i32) = 5,\n"
+    "        02: message (string) = \"nevermore\",\n"
+    "      },\n"
+    "    },\n"
+    "    \"something\" -> list<struct>[2] {\n"
+    "      [0] = Bonk {\n"
+    "        01: type (i32) = 1,\n"
+    "        02: message (string) = \"Wait.\",\n"
+    "      },\n"
+    "      [1] = Bonk {\n"
+    "        01: type (i32) = 2,\n"
+    "        02: message (string) = \"What?\",\n"
+    "      },\n"
+    "    },\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(*hm));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
 }

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -18,75 +18,124 @@
  */
 
 #define _USE_MATH_DEFINES
-#include <iostream>
 #include <cmath>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/protocol/TJSONProtocol.h>
 #include "gen-cpp/DebugProtoTest_types.h"
 
-int main() {
-  using std::cout;
-  using std::endl;
-  using namespace thrift::test::debug;
-  using apache::thrift::transport::TMemoryBuffer;
-  using apache::thrift::protocol::TJSONProtocol;
+#define BOOST_TEST_MODULE JSONProtoTest
+#include <boost/test/unit_test.hpp>
 
-  OneOfEach ooe;
-  ooe.im_true = true;
-  ooe.im_false = false;
-  ooe.a_bite = 0x7f;
-  ooe.integer16 = 27000;
-  ooe.integer32 = 1 << 24;
-  ooe.integer64 = (uint64_t)6000 * 1000 * 1000;
-  ooe.double_precision = M_PI;
-  ooe.some_characters = "JSON THIS! \"\1";
-  ooe.zomg_unicode = "\xd7\n\a\t";
-  ooe.base64 = "\1\2\3\255";
-  cout << apache::thrift::ThriftJSONString(ooe) << endl << endl;
+using namespace thrift::test::debug;
+using apache::thrift::transport::TMemoryBuffer;
+using apache::thrift::protocol::TJSONProtocol;
 
-  Nesting n;
-  n.my_ooe = ooe;
-  n.my_ooe.integer16 = 16;
-  n.my_ooe.integer32 = 32;
-  n.my_ooe.integer64 = 64;
-  n.my_ooe.double_precision = (std::sqrt(5.0) + 1) / 2;
-  n.my_ooe.some_characters = ":R (me going \"rrrr\")";
-  n.my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20"
-                              "\xd0\x9d\xce\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0\xb0\xcf\x81\xe2\x84\x8e"
-                              "\x20\xce\x91\x74\x74\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80\xbc";
-  n.my_bonk.type = 31337;
-  n.my_bonk.message = "I am a bonk... xor!";
+static std::auto_ptr<OneOfEach> ooe;
 
-  cout << apache::thrift::ThriftJSONString(n) << endl << endl;
+void testCaseSetup_1() {
+  ooe.reset(new OneOfEach);
+  ooe->im_true = true;
+  ooe->im_false = false;
+  ooe->a_bite = 0x7f;
+  ooe->integer16 = 27000;
+  ooe->integer32 = 1 << 24;
+  ooe->integer64 = (uint64_t)6000 * 1000 * 1000;
+  ooe->double_precision = M_PI;
+  ooe->some_characters = "JSON THIS! \"\1";
+  ooe->zomg_unicode = "\xd7\n\a\t";
+  ooe->base64 = "\1\2\3\255";
+}
 
-  HolyMoley hm;
+BOOST_AUTO_TEST_CASE(test_json_proto_1) {
+  testCaseSetup_1();
 
-  hm.big.push_back(ooe);
-  hm.big.push_back(n.my_ooe);
-  hm.big[0].a_bite = 0x22;
-  hm.big[1].a_bite = 0x33;
+  const std::string expected_result(
+  "{\"1\":{\"tf\":1},\"2\":{\"tf\":0},\"3\":{\"i8\":127},\"4\":{\"i16\":27000},"
+  "\"5\":{\"i32\":16777216},\"6\":{\"i64\":6000000000},\"7\":{\"dbl\":3.1415926"
+  "53589793},\"8\":{\"str\":\"JSON THIS! \\\"\\u0001\"},\"9\":{\"str\":\"\xd7\\"
+  "n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":\"AQIDrQ\"},\"12\":{\"lst\""
+  ":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2,3]},\"14\":{\"lst\":[\"i64"
+  "\",3,1,2,3]}}");
+
+  const std::string result(apache::thrift::ThriftJSONString(*ooe));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+static std::auto_ptr<Nesting> n;
+
+void testCaseSetup_2() {
+  testCaseSetup_1();
+
+  n.reset(new Nesting);
+  n->my_ooe = *ooe;
+  n->my_ooe.integer16 = 16;
+  n->my_ooe.integer32 = 32;
+  n->my_ooe.integer64 = 64;
+  n->my_ooe.double_precision = (std::sqrt(5.0) + 1) / 2;
+  n->my_ooe.some_characters = ":R (me going \"rrrr\")";
+  n->my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20\xd0\x9d\xce"
+                               "\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0"
+                               "\xb0\xcf\x81\xe2\x84\x8e\x20\xce\x91\x74\x74"
+                               "\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80"
+                               "\xbc";
+  n->my_bonk.type = 31337;
+  n->my_bonk.message = "I am a bonk... xor!";
+}
+
+BOOST_AUTO_TEST_CASE(test_json_proto_2) {
+  testCaseSetup_2();
+
+  const std::string expected_result(
+    "{\"1\":{\"rec\":{\"1\":{\"i32\":31337},\"2\":{\"str\":\"I am a bonk... xor"
+    "!\"}}},\"2\":{\"rec\":{\"1\":{\"tf\":1},\"2\":{\"tf\":0},\"3\":{\"i8\":127"
+    "},\"4\":{\"i16\":16},\"5\":{\"i32\":32},\"6\":{\"i64\":64},\"7\":{\"dbl\":"
+    "1.618033988749895},\"8\":{\"str\":\":R (me going \\\"rrrr\\\")\"},\"9\":{"
+    "\"str\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκǃ‼\"},\"10\":{\"tf\":0},\"11\":{\"str\":\""
+    "AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2"
+    ",3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]}}}}"
+  );
+
+  const std::string result(apache::thrift::ThriftJSONString(*n));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+static std::auto_ptr<HolyMoley> hm;
+
+void testCaseSetup_3() {
+  testCaseSetup_2();
+
+  hm.reset(new HolyMoley);
+
+  hm->big.push_back(*ooe);
+  hm->big.push_back(n->my_ooe);
+  hm->big[0].a_bite = 0x22;
+  hm->big[1].a_bite = 0x33;
 
   std::vector<std::string> stage1;
   stage1.push_back("and a one");
   stage1.push_back("and a two");
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
   stage1.clear();
   stage1.push_back("then a one, two");
   stage1.push_back("three!");
   stage1.push_back("FOUR!!");
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
   stage1.clear();
-  hm.contain.insert(stage1);
+  hm->contain.insert(stage1);
 
   std::vector<Bonk> stage2;
-  hm.bonks["nothing"] = stage2;
+  hm->bonks["nothing"] = stage2;
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 1;
   stage2.back().message = "Wait.";
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 2;
   stage2.back().message = "What?";
-  hm.bonks["something"] = stage2;
+  hm->bonks["something"] = stage2;
   stage2.clear();
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 3;
@@ -97,33 +146,69 @@ int main() {
   stage2.resize(stage2.size() + 1);
   stage2.back().type = 5;
   stage2.back().message = "nevermore";
-  hm.bonks["poe"] = stage2;
+  hm->bonks["poe"] = stage2;
+}
 
-  cout << apache::thrift::ThriftJSONString(hm) << endl << endl;
+BOOST_AUTO_TEST_CASE(test_json_proto_3) {
+  testCaseSetup_3();
+
+  const std::string expected_result(
+  "{\"1\":{\"lst\":[\"rec\",2,{\"1\":{\"tf\":1},\"2\":{\"tf\":0},\"3\":{\"i8\":"
+  "34},\"4\":{\"i16\":27000},\"5\":{\"i32\":16777216},\"6\":{\"i64\":6000000000"
+  "},\"7\":{\"dbl\":3.141592653589793},\"8\":{\"str\":\"JSON THIS! \\\"\\u0001"
+  "\"},\"9\":{\"str\":\"\xd7\\n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":"
+  "\"AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2"
+  ",3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]}},{\"1\":{\"tf\":1},\"2\":{\"tf\":0},"
+  "\"3\":{\"i8\":51},\"4\":{\"i16\":16},\"5\":{\"i32\":32},\"6\":{\"i64\":64},"
+  "\"7\":{\"dbl\":1.618033988749895},\"8\":{\"str\":\":R (me going \\\"rrrr\\\""
+  ")\"},\"9\":{\"str\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκǃ‼\"},\"10\":{\"tf\":0},\"11\":{"
+  "\"str\":\"AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16"
+  "\",3,1,2,3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]}}]},\"2\":{\"set\":[\"lst\",3"
+  ",[\"str\",0],[\"str\",2,\"and a one\",\"and a two\"],[\"str\",3,\"then a one"
+  ", two\",\"three!\",\"FOUR!!\"]]},\"3\":{\"map\":[\"str\",\"lst\",3,{\"nothin"
+  "g\":[\"rec\",0],\"poe\":[\"rec\",3,{\"1\":{\"i32\":3},\"2\":{\"str\":\"quoth"
+  "\"}},{\"1\":{\"i32\":4},\"2\":{\"str\":\"the raven\"}},{\"1\":{\"i32\":5},\""
+  "2\":{\"str\":\"nevermore\"}}],\"something\":[\"rec\",2,{\"1\":{\"i32\":1},\""
+  "2\":{\"str\":\"Wait.\"}},{\"1\":{\"i32\":2},\"2\":{\"str\":\"What?\"}}]}]}}"
+  );
+
+  const std::string result(apache::thrift::ThriftJSONString(*hm));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_json_proto_4) {
+  testCaseSetup_1();
 
   boost::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer());
   boost::shared_ptr<TJSONProtocol> proto(new TJSONProtocol(buffer));
 
-  cout << "Testing ooe" << endl;
-
-  ooe.write(proto.get());
+  ooe->write(proto.get());
   OneOfEach ooe2;
   ooe2.read(proto.get());
 
-  assert(ooe == ooe2);
+  BOOST_CHECK(*ooe == ooe2);
+}
 
-  cout << "Testing hm" << endl;
+BOOST_AUTO_TEST_CASE(test_json_proto_5) {
+  testCaseSetup_3();
 
-  hm.write(proto.get());
+  boost::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer());
+  boost::shared_ptr<TJSONProtocol> proto(new TJSONProtocol(buffer));
+
+  hm->write(proto.get());
   HolyMoley hm2;
   hm2.read(proto.get());
 
-  assert(hm == hm2);
+  BOOST_CHECK(*hm == hm2);
 
   hm2.big[0].a_bite = 0x00;
 
-  assert(hm != hm2);
+  BOOST_CHECK(*hm != hm2);
+}
 
+BOOST_AUTO_TEST_CASE(test_json_proto_6) {
   Doubles dub;
   dub.nan = HUGE_VAL / HUGE_VAL;
   dub.inf = HUGE_VAL;
@@ -133,9 +218,22 @@ int main() {
   dub.tiny = 1E-305;
   dub.zero = 0.0;
   dub.negzero = -0.0;
-  cout << apache::thrift::ThriftJSONString(dub) << endl << endl;
 
-  cout << "Testing base" << endl;
+  const std::string expected_result(
+  "{\"1\":{\"dbl\":\"NaN\"},\"2\":{\"dbl\":\"Infinity\"},\"3\":{\"dbl\":\"-Infi"
+  "nity\"},\"4\":{\"dbl\":3.333333333333333},\"5\":{\"dbl\":9.999999999999999e+"
+  "304},\"6\":{\"dbl\":1e-305},\"7\":{\"dbl\":0},\"8\":{\"dbl\":-0}}"
+  );
+
+  const std::string result(apache::thrift::ThriftJSONString(dub));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_json_proto_7) {
+  boost::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer());
+  boost::shared_ptr<TJSONProtocol> proto(new TJSONProtocol(buffer));
 
   Base64 base;
   base.a = 123;
@@ -150,7 +248,5 @@ int main() {
   Base64 base2;
   base2.read(proto.get());
 
-  assert(base == base2);
-
-  return 0;
+  BOOST_CHECK(base == base2);
 }

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -195,6 +195,7 @@ TPipedTransportTest_SOURCES = \
 	TPipedTransportTest.cpp
 
 TPipedTransportTest_LDADD = \
+	$(BOOST_TEST_LDADD) \
 	$(top_builddir)/lib/cpp/libthrift.la
 
 #

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -203,7 +203,9 @@ AllProtocolsTest_SOURCES = \
 	AllProtocolTests.tcc \
 	GenericHelpers.h
 
-AllProtocolsTest_LDADD = libtestgencpp.la
+AllProtocolsTest_LDADD = \
+  libtestgencpp.la \
+  $(BOOST_TEST_LDADD)
 
 #
 # DebugProtoTest

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -184,8 +184,8 @@ TFDTransportTest_SOURCES = \
 	TFDTransportTest.cpp
 
 TFDTransportTest_LDADD =  \
-	$(BOOST_TEST_LDADD) \
-	$(top_builddir)/lib/cpp/libthrift.la
+	$(top_builddir)/lib/cpp/libthrift.la \
+	$(BOOST_TEST_LDADD)
 
 
 #
@@ -195,8 +195,8 @@ TPipedTransportTest_SOURCES = \
 	TPipedTransportTest.cpp
 
 TPipedTransportTest_LDADD = \
-	$(BOOST_TEST_LDADD) \
-	$(top_builddir)/lib/cpp/libthrift.la
+	$(top_builddir)/lib/cpp/libthrift.la \
+	$(BOOST_TEST_LDADD)
 
 #
 # AllProtocolsTest

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -269,8 +269,7 @@ DenseProtoTest_SOURCES = \
 
 DenseProtoTest_LDADD = \
 	libtestgencpp.la \
-	$(BOOST_TEST_LDADD) \
-	-lthrift
+	$(BOOST_TEST_LDADD)
 
 #
 # SpecializationTest
@@ -278,7 +277,9 @@ DenseProtoTest_LDADD = \
 SpecializationTest_SOURCES = \
 	SpecializationTest.cpp
 
-SpecializationTest_LDADD = libtestgencpp.la
+SpecializationTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD)
 
 concurrency_test_SOURCES = \
 	concurrency/Tests.cpp \

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -225,7 +225,9 @@ DebugProtoTest_LDADD = \
 JSONProtoTest_SOURCES = \
 	JSONProtoTest.cpp
 
-JSONProtoTest_LDADD = libtestgencpp.la
+JSONProtoTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD)
 
 #
 # TNonblockingServerTest

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -183,7 +183,8 @@ TFileTransportTest_LDADD = \
 TFDTransportTest_SOURCES = \
 	TFDTransportTest.cpp
 
-TFDTransportTest_LDADD = \
+TFDTransportTest_LDADD =  \
+	$(BOOST_TEST_LDADD) \
 	$(top_builddir)/lib/cpp/libthrift.la
 
 

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -212,9 +212,11 @@ AllProtocolsTest_LDADD = \
 # DebugProtoTest
 #
 DebugProtoTest_SOURCES = \
-	DebugProtoTest.cpp
+	DebugProtoTest.cpp 
 
-DebugProtoTest_LDADD = libtestgencpp.la
+DebugProtoTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD)
 
 
 #

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -247,7 +247,9 @@ TNonblockingServerTest_LDADD = libprocessortest.la \
 OptionalRequiredTest_SOURCES = \
 	OptionalRequiredTest.cpp
 
-OptionalRequiredTest_LDADD = libtestgencpp.la
+OptionalRequiredTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD)
 
 #
 # OptionalRequiredTest

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -88,7 +88,8 @@ check_PROGRAMS = \
 	TFileTransportTest \
 	link_test \
 	OpenSSLManualInitTest \
-	EnumTest
+	EnumTest \
+	DenseProtoTest
 
 if AMX_HAVE_LIBEVENT
 noinst_PROGRAMS += \
@@ -253,6 +254,17 @@ RecursiveTest_SOURCES = \
 RecursiveTest_LDADD = libtestgencpp.la
 
 #
+# DenseProtoTest
+#
+DenseProtoTest_SOURCES = \
+	DenseProtoTest.cpp
+
+DenseProtoTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD) \
+	-lthrift
+
+#
 # SpecializationTest
 #
 SpecializationTest_SOURCES = \
@@ -333,7 +345,6 @@ clean-local:
 	$(RM) -r gen-cpp
 
 EXTRA_DIST = \
-	DenseProtoTest.cpp \
 	ThriftTest_extras.cpp \
 	DebugProtoTest_extras.cpp \
 	concurrency \

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -257,7 +257,9 @@ OptionalRequiredTest_LDADD = \
 RecursiveTest_SOURCES = \
 	RecursiveTest.cpp
 
-RecursiveTest_LDADD = libtestgencpp.la
+RecursiveTest_LDADD = \
+	libtestgencpp.la \
+	$(BOOST_TEST_LDADD)
 
 #
 # DenseProtoTest

--- a/lib/cpp/test/OptionalRequiredTest.cpp
+++ b/lib/cpp/test/OptionalRequiredTest.cpp
@@ -21,18 +21,15 @@
  * details.
  */
 
-#include <cassert>
 #include <map>
-#include <iostream>
 #include <thrift/protocol/TDebugProtocol.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 #include "gen-cpp/OptionalRequiredTest_types.h"
 
-using std::cout;
-using std::endl;
-using std::map;
-using std::string;
+#define BOOST_TEST_MODULE OptionalRequiredTest
+#include <boost/test/unit_test.hpp>
+
 using namespace thrift::test;
 using namespace apache::thrift;
 using namespace apache::thrift::transport;
@@ -49,7 +46,7 @@ void trywrite(const Struct& s, bool should_work) {
   } catch (TProtocolException & ex) {
     worked = false;
   }
-  assert(worked == should_work);
+  BOOST_CHECK(worked == should_work);
 }
 */
 
@@ -60,219 +57,330 @@ void write_to_read(const Struct1& w, Struct2& r) {
   r.read(&protocol);
 }
 
-int main() {
+BOOST_AUTO_TEST_CASE(test_optional_required_1) {
+  OldSchool o;
 
-  cout << "This old school struct should have three fields." << endl;
-  {
-    OldSchool o;
-    cout << ThriftDebugString(o) << endl;
-  }
-  cout << endl;
+  const std::string expected_result(
+    "OldSchool {\n"
+    "  01: im_int (i16) = 0,\n"
+    "  02: im_str (string) = \"\",\n"
+    "  03: im_big (list) = list<map>[0] {\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(o));
 
-  cout << "Setting a value before setting isset." << endl;
-  {
-    Simple s;
-    cout << ThriftDebugString(s) << endl;
-    s.im_optional = 10;
-    cout << ThriftDebugString(s) << endl;
-    s.__isset.im_optional = true;
-    cout << ThriftDebugString(s) << endl;
-  }
-  cout << endl;
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
 
-  cout << "Setting isset before setting a value." << endl;
-  {
-    Simple s;
-    cout << ThriftDebugString(s) << endl;
-    s.__isset.im_optional = true;
-    cout << ThriftDebugString(s) << endl;
-    s.im_optional = 10;
-    cout << ThriftDebugString(s) << endl;
-  }
-  cout << endl;
+BOOST_AUTO_TEST_CASE(test_optional_required_2_1) {
+  Simple s;
 
+  const std::string expected_result(
+    "Simple {\n"
+    "  01: im_default (i16) = 0,\n"
+    "  02: im_required (i16) = 0,\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(s));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_2_2) {
+  Simple s;
+  s.im_optional = 10;
+
+  const std::string expected_result(
+    "Simple {\n"
+    "  01: im_default (i16) = 0,\n"
+    "  02: im_required (i16) = 0,\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(s));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_2_3) {
+  Simple s;
+  s.im_optional = 10;
+  s.__isset.im_optional = true;
+
+  const std::string expected_result(
+    "Simple {\n"
+    "  01: im_default (i16) = 0,\n"
+    "  02: im_required (i16) = 0,\n"
+    "  03: im_optional (i16) = 10,\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(s));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_2_4) {
+  Simple s;
+  s.__isset.im_optional = true;
+
+  const std::string expected_result(
+    "Simple {\n"
+    "  01: im_default (i16) = 0,\n"
+    "  02: im_required (i16) = 0,\n"
+    "  03: im_optional (i16) = 0,\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(s));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_2_5) {
+  Simple s;
+  s.__isset.im_optional = true;
+  s.im_optional = 10;
+
+  const std::string expected_result(
+    "Simple {\n"
+    "  01: im_default (i16) = 0,\n"
+    "  02: im_required (i16) = 0,\n"
+    "  03: im_optional (i16) = 10,\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(s));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_3) {
   // assign/copy-construct with non-required fields
-  {
-    Simple s1, s2;
-    s1.__isset.im_default = true;
-    s1.__set_im_optional(10);
-    assert(s1.__isset.im_default);
-    assert(s1.__isset.im_optional);
 
-    s2 = s1;
+  Simple s1, s2;
+  s1.__isset.im_default = true;
+  s1.__set_im_optional(10);
+  BOOST_CHECK(s1.__isset.im_default);
+  BOOST_CHECK(s1.__isset.im_optional);
 
-    assert(s2.__isset.im_default);
-    assert(s2.__isset.im_optional);
+  s2 = s1;
 
-    Simple s3(s1);
+  BOOST_CHECK(s2.__isset.im_default);
+  BOOST_CHECK(s2.__isset.im_optional);
 
-    assert(s3.__isset.im_default);
-    assert(s3.__isset.im_optional);
-  }
+  Simple s3(s1);
 
+  BOOST_CHECK(s3.__isset.im_default);
+  BOOST_CHECK(s3.__isset.im_optional);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_4) {
   // Write-to-read with optional fields.
-  {
-    Simple s1, s2, s3;
-    s1.im_optional = 10;
-    assert(!s1.__isset.im_default);
-    // assert(!s1.__isset.im_required);  // Compile error.
-    assert(!s1.__isset.im_optional);
 
-    write_to_read(s1, s2);
+  Simple s1, s2, s3;
+  s1.im_optional = 10;
+  BOOST_CHECK(!s1.__isset.im_default);
+  // BOOST_CHECK(!s1.__isset.im_required);  // Compile error.
+  BOOST_CHECK(!s1.__isset.im_optional);
 
-    assert(s2.__isset.im_default);
-    // assert( s2.__isset.im_required);  // Compile error.
-    assert(!s2.__isset.im_optional);
-    assert(s3.im_optional == 0);
+  write_to_read(s1, s2);
 
-    s1.__isset.im_optional = true;
-    write_to_read(s1, s3);
+  BOOST_CHECK(s2.__isset.im_default);
+  // BOOST_CHECK( s2.__isset.im_required);  // Compile error.
+  BOOST_CHECK(!s2.__isset.im_optional);
+  BOOST_CHECK(s3.im_optional == 0);
 
-    assert(s3.__isset.im_default);
-    // assert( s3.__isset.im_required);  // Compile error.
-    assert(s3.__isset.im_optional);
-    assert(s3.im_optional == 10);
-  }
+  s1.__isset.im_optional = true;
+  write_to_read(s1, s3);
 
+  BOOST_CHECK(s3.__isset.im_default);
+  // BOOST_CHECK( s3.__isset.im_required);  // Compile error.
+  BOOST_CHECK(s3.__isset.im_optional);
+  BOOST_CHECK(s3.im_optional == 10);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_5) {
   // Writing between optional and default.
-  {
-    Tricky1 t1;
-    Tricky2 t2;
 
-    t2.im_optional = 10;
-    write_to_read(t2, t1);
-    write_to_read(t1, t2);
-    assert(!t1.__isset.im_default);
-    assert(t2.__isset.im_optional);
-    assert(t1.im_default == t2.im_optional);
-    assert(t1.im_default == 0);
-  }
+  Tricky1 t1;
+  Tricky2 t2;
 
+  t2.im_optional = 10;
+  write_to_read(t2, t1);
+  write_to_read(t1, t2);
+  BOOST_CHECK(!t1.__isset.im_default);
+  BOOST_CHECK(t2.__isset.im_optional);
+  BOOST_CHECK(t1.im_default == t2.im_optional);
+  BOOST_CHECK(t1.im_default == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_6) {
   // Writing between default and required.
-  {
-    Tricky1 t1;
-    Tricky3 t3;
-    write_to_read(t1, t3);
-    write_to_read(t3, t1);
-    assert(t1.__isset.im_default);
-  }
 
+  Tricky1 t1;
+  Tricky3 t3;
+  write_to_read(t1, t3);
+  write_to_read(t3, t1);
+  BOOST_CHECK(t1.__isset.im_default);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_7) {
   // Writing between optional and required.
-  {
-    Tricky2 t2;
-    Tricky3 t3;
-    t2.__isset.im_optional = true;
-    write_to_read(t2, t3);
-    write_to_read(t3, t2);
-  }
 
+  Tricky2 t2;
+  Tricky3 t3;
+  t2.__isset.im_optional = true;
+  write_to_read(t2, t3);
+  write_to_read(t3, t2);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_8) {
   // Mu-hu-ha-ha-ha!
-  {
-    Tricky2 t2;
-    Tricky3 t3;
-    try {
-      write_to_read(t2, t3);
-      abort();
-    } catch (const TProtocolException&) {
-    }
 
-    write_to_read(t3, t2);
-    assert(t2.__isset.im_optional);
+  Tricky2 t2;
+  Tricky3 t3;
+  try {
+    write_to_read(t2, t3);
+    abort();
+  } catch (const TProtocolException&) {
   }
 
-  cout << "Complex struct, simple test." << endl;
-  {
-    Complex c;
-    cout << ThriftDebugString(c) << endl;
-  }
+  write_to_read(t3, t2);
+  BOOST_CHECK(t2.__isset.im_optional);
+}
 
-  {
-    Tricky1 t1;
-    Tricky2 t2;
-    // Compile error.
-    //(void)(t1 == t2);
-  }
+BOOST_AUTO_TEST_CASE(test_optional_required_9) {
+  Complex c;
 
-  {
-    OldSchool o1, o2, o3;
-    assert(o1 == o2);
-    o1.im_int = o2.im_int = 10;
-    assert(o1 == o2);
-    o1.__isset.im_int = true;
-    o2.__isset.im_int = false;
-    assert(o1 == o2);
-    o1.im_int = 20;
-    o1.__isset.im_int = false;
-    assert(o1 != o2);
-    o1.im_int = 10;
-    assert(o1 == o2);
-    o1.im_str = o2.im_str = "foo";
-    assert(o1 == o2);
-    o1.__isset.im_str = o2.__isset.im_str = true;
-    assert(o1 == o2);
-    map<int32_t, string> mymap;
-    mymap[1] = "bar";
-    mymap[2] = "baz";
-    o1.im_big.push_back(map<int32_t, string>());
-    assert(o1 != o2);
-    o2.im_big.push_back(map<int32_t, string>());
-    assert(o1 == o2);
-    o2.im_big.push_back(mymap);
-    assert(o1 != o2);
-    o1.im_big.push_back(mymap);
-    assert(o1 == o2);
+  const std::string expected_result(
+    "Complex {\n"
+    "  01: cp_default (i16) = 0,\n"
+    "  02: cp_required (i16) = 0,\n"
+    "  04: the_map (map) = map<i16,struct>[0] {\n"
+    "  },\n"
+    "  05: req_simp (struct) = Simple {\n"
+    "    01: im_default (i16) = 0,\n"
+    "    02: im_required (i16) = 0,\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(c));
 
-    TBinaryProtocol protocol(boost::shared_ptr<TTransport>(new TMemoryBuffer));
-    o1.write(&protocol);
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
 
-    o1.im_big.push_back(mymap);
-    mymap[3] = "qux";
-    o2.im_big.push_back(mymap);
-    assert(o1 != o2);
-    o1.im_big.back()[3] = "qux";
-    assert(o1 == o2);
+BOOST_AUTO_TEST_CASE(test_optional_required_10) {
+  Tricky1 t1;
+  Tricky2 t2;
+  // Compile error.
+  //(void)(t1 == t2);
+}
 
-    o3.read(&protocol);
-    o3.im_big.push_back(mymap);
-    assert(o1 == o3);
+BOOST_AUTO_TEST_CASE(test_optional_required_11) {
+  OldSchool o1, o2, o3;
+  BOOST_CHECK(o1 == o2);
+  o1.im_int = o2.im_int = 10;
+  BOOST_CHECK(o1 == o2);
+  o1.__isset.im_int = true;
+  o2.__isset.im_int = false;
+  BOOST_CHECK(o1 == o2);
+  o1.im_int = 20;
+  o1.__isset.im_int = false;
+  BOOST_CHECK(o1 != o2);
+  o1.im_int = 10;
+  BOOST_CHECK(o1 == o2);
+  o1.im_str = o2.im_str = "foo";
+  BOOST_CHECK(o1 == o2);
+  o1.__isset.im_str = o2.__isset.im_str = true;
+  BOOST_CHECK(o1 == o2);
+  std::map<int32_t, std::string> mymap;
+  mymap[1] = "bar";
+  mymap[2] = "baz";
+  o1.im_big.push_back(std::map<int32_t, std::string>());
+  BOOST_CHECK(o1 != o2);
+  o2.im_big.push_back(std::map<int32_t, std::string>());
+  BOOST_CHECK(o1 == o2);
+  o2.im_big.push_back(mymap);
+  BOOST_CHECK(o1 != o2);
+  o1.im_big.push_back(mymap);
+  BOOST_CHECK(o1 == o2);
 
-    // cout << ThriftDebugString(o3) << endl;
-  }
+  TBinaryProtocol protocol(boost::shared_ptr<TTransport>(new TMemoryBuffer));
+  o1.write(&protocol);
 
-  {
-    Tricky2 t1, t2;
-    assert(t1.__isset.im_optional == false);
-    assert(t2.__isset.im_optional == false);
-    assert(t1 == t2);
-    t1.im_optional = 5;
-    assert(t1 == t2);
-    t2.im_optional = 5;
-    assert(t1 == t2);
-    t1.__isset.im_optional = true;
-    assert(t1 != t2);
-    t2.__isset.im_optional = true;
-    assert(t1 == t2);
-    t1.im_optional = 10;
-    assert(t1 != t2);
-    t2.__isset.im_optional = false;
-    assert(t1 != t2);
-  }
+  o1.im_big.push_back(mymap);
+  mymap[3] = "qux";
+  o2.im_big.push_back(mymap);
+  BOOST_CHECK(o1 != o2);
+  o1.im_big.back()[3] = "qux";
+  BOOST_CHECK(o1 == o2);
+  
+  o3.read(&protocol);
+  o3.im_big.push_back(mymap);
+  BOOST_CHECK(o1 == o3);
 
-  {
-    OptionalDefault t1, t2;
-    cout << ThriftDebugString(t1) << endl;
-    assert(t1.__isset.opt_int == true);
-    assert(t1.__isset.opt_str == true);
-    assert(t1.opt_int == t2.opt_int);
-    assert(t1.opt_str == t2.opt_str);
+  const std::string expected_result(
+    "OldSchool {\n"
+    "  01: im_int (i16) = 10,\n"
+    "  02: im_str (string) = \"foo\",\n"
+    "  03: im_big (list) = list<map>[3] {\n"
+    "    [0] = map<i32,string>[0] {\n"
+    "    },\n"
+    "    [1] = map<i32,string>[2] {\n"
+    "      1 -> \"bar\",\n"
+    "      2 -> \"baz\",\n"
+    "    },\n"
+    "    [2] = map<i32,string>[3] {\n"
+    "      1 -> \"bar\",\n"
+    "      2 -> \"baz\",\n"
+    "      3 -> \"qux\",\n"
+    "    },\n"
+    "  },\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(o3));
 
-    write_to_read(t1, t2);
-    cout << ThriftDebugString(t2) << endl;
-    assert(t2.__isset.opt_int == true);
-    assert(t2.__isset.opt_str == true);
-    assert(t1.opt_int == t2.opt_int);
-    assert(t1.opt_str == t2.opt_str);
-  }
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
+}
 
-  return 0;
+BOOST_AUTO_TEST_CASE(test_optional_required_12) {
+  Tricky2 t1, t2;
+  BOOST_CHECK(t1.__isset.im_optional == false);
+  BOOST_CHECK(t2.__isset.im_optional == false);
+  BOOST_CHECK(t1 == t2);
+  t1.im_optional = 5;
+  BOOST_CHECK(t1 == t2);
+  t2.im_optional = 5;
+  BOOST_CHECK(t1 == t2);
+  t1.__isset.im_optional = true;
+  BOOST_CHECK(t1 != t2);
+  t2.__isset.im_optional = true;
+  BOOST_CHECK(t1 == t2);
+  t1.im_optional = 10;
+  BOOST_CHECK(t1 != t2);
+  t2.__isset.im_optional = false;
+  BOOST_CHECK(t1 != t2);
+}
+
+BOOST_AUTO_TEST_CASE(test_optional_required_13) {
+  OptionalDefault t1, t2;
+
+  BOOST_CHECK(t1.__isset.opt_int == true);
+  BOOST_CHECK(t1.__isset.opt_str == true);
+  BOOST_CHECK(t1.opt_int == t2.opt_int);
+  BOOST_CHECK(t1.opt_str == t2.opt_str);
+
+  write_to_read(t1, t2);
+  BOOST_CHECK(t2.__isset.opt_int == true);
+  BOOST_CHECK(t2.__isset.opt_str == true);
+  BOOST_CHECK(t1.opt_int == t2.opt_int);
+  BOOST_CHECK(t1.opt_str == t2.opt_str);
+
+  const std::string expected_result(
+    "OptionalDefault {\n"
+    "  01: opt_int (i16) = 1234,\n"
+    "  02: opt_str (string) = \"default\",\n"
+    "}");
+  const std::string result(apache::thrift::ThriftDebugString(t2));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
 }

--- a/lib/cpp/test/SpecializationTest.cpp
+++ b/lib/cpp/test/SpecializationTest.cpp
@@ -1,21 +1,20 @@
 #define _USE_MATH_DEFINES
-#include <iostream>
 #include <cmath>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <gen-cpp/DebugProtoTest_types.h>
 
-using std::cout;
-using std::endl;
 using namespace thrift::test::debug;
 using namespace apache::thrift::transport;
 using namespace apache::thrift::protocol;
 
+#define BOOST_TEST_MODULE SpecializationTest
+#include <boost/test/unit_test.hpp>
+
 typedef TBinaryProtocolT<TMemoryBuffer> MyProtocol;
 // typedef TBinaryProtocolT<TTransport> MyProtocol;
 
-int main() {
-
+BOOST_AUTO_TEST_CASE(test_specialization_1) {
   OneOfEach ooe;
   ooe.im_true = true;
   ooe.im_false = false;
@@ -35,9 +34,11 @@ int main() {
   n.my_ooe.integer64 = 64;
   n.my_ooe.double_precision = (std::sqrt(5.0) + 1) / 2;
   n.my_ooe.some_characters = ":R (me going \"rrrr\")";
-  n.my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20"
-                              "\xd0\x9d\xce\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0\xb0\xcf\x81\xe2\x84\x8e"
-                              "\x20\xce\x91\x74\x74\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80\xbc";
+  n.my_ooe.zomg_unicode     = "\xd3\x80\xe2\x85\xae\xce\x9d\x20\xd0\x9d\xce"
+                              "\xbf\xe2\x85\xbf\xd0\xbe\xc9\xa1\xd0\xb3\xd0"
+                              "\xb0\xcf\x81\xe2\x84\x8e\x20\xce\x91\x74\x74"
+                              "\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80"
+                              "\xbc";
   n.my_bonk.type = 31337;
   n.my_bonk.message = "I am a bonk... xor!";
 
@@ -84,25 +85,19 @@ int main() {
   boost::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer());
   boost::shared_ptr<TProtocol> proto(new MyProtocol(buffer));
 
-  cout << "Testing ooe" << endl;
-
   ooe.write(proto.get());
   OneOfEach ooe2;
   ooe2.read(proto.get());
 
-  assert(ooe == ooe2);
-
-  cout << "Testing hm" << endl;
+  BOOST_CHECK(ooe == ooe2);
 
   hm.write(proto.get());
   HolyMoley hm2;
   hm2.read(proto.get());
 
-  assert(hm == hm2);
+  BOOST_CHECK(hm == hm2);
 
   hm2.big[0].a_bite = 0x00;
 
-  assert(hm != hm2);
-
-  return 0;
+  BOOST_CHECK(hm != hm2);
 }

--- a/lib/cpp/test/TFDTransportTest.cpp
+++ b/lib/cpp/test/TFDTransportTest.cpp
@@ -19,42 +19,32 @@
 
 #include <cstdlib>
 #include <stdexcept>
-#include <iostream>
 #include <thrift/Thrift.h>
 #include <thrift/transport/TFDTransport.h>
-using apache::thrift::transport::TTransportException;
-using apache::thrift::transport::TFDTransport;
 
-class DummyException : std::exception {};
-
-int main() {
-  { TFDTransport t(256, TFDTransport::NO_CLOSE_ON_DESTROY); }
+#define BOOST_TEST_MODULE TFDTransportTest
+#include <boost/test/unit_test.hpp>
 
 // Disabled on MSVC because the RTL asserts on an invalid file descriptor
 // in both debug and release mode; at least in MSVCR100 (Visual Studio 2010)
 #if !defined(WIN32)
-  try {
-    {
-      TFDTransport t(256, TFDTransport::CLOSE_ON_DESTROY);
-      t.close();
-    }
-    std::cout << "NOT OK 0!" << std::endl;
-    std::abort();
-  } catch (TTransportException) {
-    std::cout << "OK!" << std::endl;
-  }
 
-  try {
-    {
-      TFDTransport t(256, TFDTransport::CLOSE_ON_DESTROY);
-      throw DummyException();
-    }
-    std::abort();
-  } catch (TTransportException&) {
-    std::abort();
-  } catch (DummyException&) {
-  }
-#endif
+using apache::thrift::transport::TTransportException;
+using apache::thrift::transport::TFDTransport;
 
-  return 0;
+BOOST_AUTO_TEST_CASE(test_tfdtransport_1) {
+  BOOST_CHECK_NO_THROW(TFDTransport t(256, TFDTransport::CLOSE_ON_DESTROY));
 }
+
+BOOST_AUTO_TEST_CASE(test_tfdtransport_2) {
+  TFDTransport t(256, TFDTransport::CLOSE_ON_DESTROY);
+  BOOST_CHECK_THROW(t.close(), TTransportException);
+}
+
+#else
+
+BOOST_AUTO_TEST_CASE(test_tfdtransport_dummy) {
+  BOOST_CHECK(true);
+}
+
+#endif

--- a/lib/cpp/test/TMemoryBufferTest.cpp
+++ b/lib/cpp/test/TMemoryBufferTest.cpp
@@ -20,7 +20,6 @@
 #include <boost/test/auto_unit_test.hpp>
 #include <iostream>
 #include <climits>
-#include <cassert>
 #include <vector>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/protocol/TBinaryProtocol.h>
@@ -77,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_roundtrip) {
   thrift::test::Xtruct a2;
   a2.read(binaryProtcol2.get());
 
-  assert(a == a2);
+  BOOST_CHECK(a == a2);
 }
 
 BOOST_AUTO_TEST_CASE(test_copy) {
@@ -90,16 +89,16 @@ BOOST_AUTO_TEST_CASE(test_copy) {
   string* str2 = new string("plsreuse");
   bool obj_reuse = (str1 == str2);
   bool dat_reuse = (data1 == str2->data());
-  cout << "Object reuse: " << obj_reuse << "   Data reuse: " << dat_reuse
-       << ((obj_reuse && dat_reuse) ? "   YAY!" : "") << endl;
+  BOOST_MESSAGE("Object reuse: " << obj_reuse << "   Data reuse: " << dat_reuse
+                << ((obj_reuse && dat_reuse) ? "   YAY!" : ""));
   delete str2;
 
   string str3 = "wxyz", str4 = "6789";
   buf.readAppendToString(str3, 4);
   buf.readAppendToString(str4, INT_MAX);
 
-  assert(str3 == "wxyzabcd");
-  assert(str4 == "67891234");
+  BOOST_CHECK(str3 == "wxyzabcd");
+  BOOST_CHECK(str4 == "67891234");
 }
 
 BOOST_AUTO_TEST_CASE(test_exceptions) {
@@ -107,20 +106,14 @@ BOOST_AUTO_TEST_CASE(test_exceptions) {
 
   TMemoryBuffer buf1((uint8_t*)data, 7, TMemoryBuffer::OBSERVE);
   string str = buf1.getBufferAsString();
-  assert(str.length() == 7);
+  BOOST_CHECK(str.length() == 7);
+
   buf1.resetBuffer();
-  try {
-    buf1.write((const uint8_t*)"foo", 3);
-    assert(false);
-  } catch (TTransportException&) {
-  }
+
+  BOOST_CHECK_THROW(buf1.write((const uint8_t*)"foo", 3), TTransportException);
 
   TMemoryBuffer buf2((uint8_t*)data, 7, TMemoryBuffer::COPY);
-  try {
-    buf2.write((const uint8_t*)"bar", 3);
-  } catch (TTransportException&) {
-    assert(false);
-  }
+  BOOST_CHECK_NO_THROW(buf2.write((const uint8_t*)"bar", 3));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/TPipedTransportTest.cpp
+++ b/lib/cpp/test/TPipedTransportTest.cpp
@@ -17,17 +17,18 @@
  * under the License.
  */
 
-#include <cstdlib>
-#include <stdexcept>
 #include <thrift/Thrift.h>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/transport/TBufferTransports.h>
-using namespace std;
+
+#define BOOST_TEST_MODULE TPipedTransportTest
+#include <boost/test/unit_test.hpp>
+
 using apache::thrift::transport::TTransportException;
 using apache::thrift::transport::TPipedTransport;
 using apache::thrift::transport::TMemoryBuffer;
 
-int main() {
+BOOST_AUTO_TEST_CASE(test_tpipedtransport_1) {
   boost::shared_ptr<TMemoryBuffer> underlying(new TMemoryBuffer);
   boost::shared_ptr<TMemoryBuffer> pipe(new TMemoryBuffer);
   boost::shared_ptr<TPipedTransport> trans(new TPipedTransport(underlying, pipe));
@@ -36,17 +37,15 @@ int main() {
 
   underlying->write((uint8_t*)"abcd", 4);
   trans->readAll(buffer, 2);
-  assert(string((char*)buffer, 2) == "ab");
+  BOOST_CHECK(std::string((char*)buffer, 2) == "ab");
   trans->readEnd();
-  assert(pipe->getBufferAsString() == "ab");
+  BOOST_CHECK(pipe->getBufferAsString() == "ab");
   pipe->resetBuffer();
   underlying->write((uint8_t*)"ef", 2);
   trans->readAll(buffer, 2);
-  assert(string((char*)buffer, 2) == "cd");
+  BOOST_CHECK(std::string((char*)buffer, 2) == "cd");
   trans->readAll(buffer, 2);
-  assert(string((char*)buffer, 2) == "ef");
+  BOOST_CHECK(std::string((char*)buffer, 2) == "ef");
   trans->readEnd();
-  assert(pipe->getBufferAsString() == "cdef");
-
-  return 0;
+  BOOST_CHECK(pipe->getBufferAsString() == "cdef");
 }


### PR DESCRIPTION
This converts all C++ test to Boost::Test, integrates the DenseProtocolTest as a test like the others and removes C asserts from the TMemoryBufferTest.

Two test cases from DenseProtocolTest have to be commented, because they use the private vlqRead and vlqWrite Methods of apache::thrift::protocol::TDenseProtocol.