### PR TITLE
THRIFT-2921 Make Erlang impl ready for OTP 18 release (dict/0 and set…

### DIFF
--- a/compiler/cpp/src/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/generate/t_erl_generator.cc
@@ -513,9 +513,9 @@ string t_erl_generator::render_member_type(t_field* field) {
   } else if (type->is_struct() || type->is_xception()) {
     return atomify(type->get_name()) + "()";
   } else if (type->is_map()) {
-    return "dict()";
+    return "dict:dict()";
   } else if (type->is_set()) {
-    return "set()";
+    return "sets:set()";
   } else if (type->is_list()) {
     return "list()";
   } else {


### PR DESCRIPTION
THRIFT-2921 Make Erlang impl ready for OTP 18 release (dict/0 and set/0 are deprecated)

Very minor change, essentially this is just a namespace change to support Erlang OTP 18. It is backwards compatible all the way back to R12B-5, when the `set` data type was added to the `sets` module in the stdlib.