### PR TITLE
THRIFT-2850: Fix some Windows CMake issues

### DIFF
--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SYSLIBS "")
 set( thriftcpp_SOURCES
    src/thrift/TApplicationException.cpp
    src/thrift/TOutput.cpp
-   src/thrift/VirtualProfiling.cpp
    src/thrift/async/TAsyncChannel.cpp
    src/thrift/concurrency/ThreadManager.cpp
    src/thrift/concurrency/TimerManager.cpp
@@ -57,7 +56,6 @@ set( thriftcpp_SOURCES
    src/thrift/transport/TTransportUtils.cpp
    src/thrift/transport/TBufferTransports.cpp
    src/thrift/server/TConnectedClient.cpp
-   src/thrift/server/TServer.cpp
    src/thrift/server/TServerFramework.cpp
    src/thrift/server/TSimpleServer.cpp
    src/thrift/server/TThreadPoolServer.cpp
@@ -88,6 +86,13 @@ if (WIN32)
             src/thrift/windows/OverlappedSubmissionThread.cpp
         )
     endif()
+else()
+    # These files evaluate to nothing on Windows, so omit them from the
+    # Windows build
+    list(APPEND thriftcpp_SOURCES
+        src/thrift/VirtualProfiling.cpp
+        src/thrift/server/TServer.cpp
+    )
 endif()
 
 # If OpenSSL is not found just ignore the OpenSSL stuff

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
@@ -19,6 +19,8 @@
 
 #include <thrift/async/TEvhttpClientChannel.h>
 #include <evhttp.h>
+#include <event2/buffer.h>
+#include <event2/buffer_compat.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/protocol/TProtocolException.h>
 

--- a/lib/cpp/src/thrift/async/TEvhttpServer.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpServer.cpp
@@ -21,6 +21,8 @@
 #include <thrift/async/TAsyncBufferProcessor.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <evhttp.h>
+#include <event2/buffer.h>
+#include <event2/buffer_compat.h>
 
 #include <iostream>
 

--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -38,6 +38,8 @@
 #include <unistd.h>
 #endif
 #include <event.h>
+#include <event2/event_compat.h>
+#include <event2/event_struct.h>
 
 namespace apache {
 namespace thrift {

--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -46,7 +46,7 @@ struct Handler : public test::ParentServiceIf {
 
 class Fixture {
 private:
-  struct Runner : public concurrency::Runnable {
+  struct Runner : public apache::thrift::concurrency::Runnable {
     boost::shared_ptr<server::TNonblockingServer> server;
     bool error;
     virtual void run() {
@@ -80,8 +80,8 @@ protected:
   }
 
   int startServer(int port) {
-    boost::scoped_ptr<concurrency::ThreadFactory> threadFactory(
-        new concurrency::PlatformThreadFactory(
+    boost::scoped_ptr<apache::thrift::concurrency::ThreadFactory> threadFactory(
+      new apache::thrift::concurrency::PlatformThreadFactory(
 #if !USE_BOOST_THREAD && !USE_STD_THREAD
             concurrency::PlatformThreadFactory::OTHER,
             concurrency::PlatformThreadFactory::NORMAL,
@@ -128,7 +128,7 @@ protected:
 private:
   boost::shared_ptr<event_base> userEventBase_;
   boost::shared_ptr<test::ParentServiceProcessor> processor;
-  boost::shared_ptr<concurrency::Thread> thread;
+  boost::shared_ptr<apache::thrift::concurrency::Thread> thread;
 
 protected:
   boost::shared_ptr<server::TNonblockingServer> server;

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -26,9 +26,8 @@ include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 
 find_package(OpenSSL REQUIRED)
 include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
-#list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
 
-find_package(Libevent REQUIRED)  # Libevent comes with CMake support form upstream
+find_package(Libevent REQUIRED)  # Libevent comes with CMake support from upstream
 include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 
 #Make sure gen-cpp files can be included

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -17,9 +17,19 @@
 # under the License.
 #
 
+# Contains the thrift specific LINK_AGAINST_THRIFT_LIBRARY
+include(ThriftMacros)
+
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options system filesystem)
 include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
+
+find_package(OpenSSL REQUIRED)
+include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+#list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+
+find_package(Libevent REQUIRED)  # Libevent comes with CMake support form upstream
+include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 
 #Make sure gen-cpp files can be included
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
@@ -34,28 +44,37 @@ set(crosstestgencpp_SOURCES
     src/ThriftTest_extras.cpp
 )
 add_library(crosstestgencpp STATIC ${crosstestgencpp_SOURCES})
-target_link_libraries(crosstestgencpp thrift)
+LINK_AGAINST_THRIFT_LIBRARY(crosstestgencpp thrift)
 
 set(crossstressgencpp_SOURCES
     gen-cpp/Service.cpp
-    gen-cpp/StressTest_types.cpp
+    #gen-cpp/StressTest_types.cpp #basically empty, so omitting
     gen-cpp/StressTest_constants.cpp
 )
 add_library(crossstressgencpp STATIC ${crossstressgencpp_SOURCES})
-target_link_libraries(crossstressgencpp thrift)
+LINK_AGAINST_THRIFT_LIBRARY(crossstressgencpp thrift)
 
 add_executable(TestServer src/TestServer.cpp)
-target_link_libraries(TestServer thrift thriftnb crosstestgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+target_link_libraries(TestServer crosstestgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+LINK_AGAINST_THRIFT_LIBRARY(TestServer thrift)
+LINK_AGAINST_THRIFT_LIBRARY(TestServer thriftnb)
 
 add_executable(TestClient src/TestClient.cpp)
-target_link_libraries(TestClient thrift thriftnb crosstestgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+target_link_libraries(TestClient crosstestgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+LINK_AGAINST_THRIFT_LIBRARY(TestClient thrift)
+LINK_AGAINST_THRIFT_LIBRARY(TestClient thriftnb)
 
 add_executable(StressTest src/StressTest.cpp)
-target_link_libraries(StressTest thrift thriftnb crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+target_link_libraries(StressTest crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+LINK_AGAINST_THRIFT_LIBRARY(StressTest thrift)
+LINK_AGAINST_THRIFT_LIBRARY(StressTest thriftnb)
 add_test(NAME StressTest COMMAND StressTest)
 
 add_executable(StressTestNonBlocking src/StressTestNonBlocking.cpp)
-target_link_libraries(StressTestNonBlocking thrift thriftz thriftnb crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+target_link_libraries(StressTestNonBlocking crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thrift)
+LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftnb)
+LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftz)
 add_test(NAME StressTestNonBlocking COMMAND StressTestNonBlocking)
 
 #


### PR DESCRIPTION
Some issues that are fixed here:
* Removed some files from the build that do nothing except for cause warnings on Windows (VirtualProfiling.cpp and Server.cpp)
* Fix includes for latest version of libevent.  Allegedly the entry points that libthriftnb use are deprecated, and require extra header includes.
* Fully qualifying apache::thrift::concurrency, because MSVC does funky things with an unadorned concurrency namespace.
* Added missing dependency include paths to test binaries
* Ensured that tests are built against the proper static / shared versions of Thrift.