### PR TITLE
THRIFT-3220: dont' create @Generated annotation when using with java:android option

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -396,6 +396,8 @@ string t_java_generator::java_package() {
 string t_java_generator::java_type_imports() {
   string hash_builder;
   string tree_set_and_map;
+  string annotation_generated;
+
   string option;
   if (sorted_containers_) {
     tree_set_and_map = string() + "import java.util.TreeSet;\n" + "import java.util.TreeMap;\n";
@@ -403,6 +405,11 @@ string t_java_generator::java_type_imports() {
 
   if (use_option_type_) {
     option = string() + "import org.apache.thrift.Option;\n";
+  }
+
+  // android does not support @Generated Annotation
+  if (!android_style_) {
+    annotation_generated = string() + "import javax.annotation.Generated;\n";
   }
 
   return string() + hash_builder + "import org.apache.thrift.scheme.IScheme;\n"
@@ -421,7 +428,7 @@ string t_java_generator::java_type_imports() {
          + "import java.util.HashSet;\n" + "import java.util.EnumSet;\n" + tree_set_and_map
          + "import java.util.Collections;\n" + "import java.util.BitSet;\n"
          + "import java.nio.ByteBuffer;\n"
-           "import java.util.Arrays;\n" + "import javax.annotation.Generated;\n"
+         + "import java.util.Arrays;\n" + annotation_generated
          + "import org.slf4j.Logger;\n" + "import org.slf4j.LoggerFactory;\n\n";
 }
 
@@ -1333,7 +1340,7 @@ void t_java_generator::generate_java_struct_definition(ofstream& out,
 
   bool is_final = (tstruct->annotations_.find("final") != tstruct->annotations_.end());
 
-  if (!in_class) {
+  if (!in_class && !android_style_) {
     generate_javax_generated_annotation(out);
   }
 
@@ -2635,7 +2642,9 @@ void t_java_generator::generate_service(t_service* tservice) {
 
   f_service_ << autogen_comment() << java_package() << java_type_imports() << java_suppressions();
 
-  generate_javax_generated_annotation(f_service_);
+  if (!android_style_) {
+    generate_javax_generated_annotation(f_service_);
+  }
   f_service_ << "public class " << service_name_ << " {" << endl << endl;
   indent_up();
 


### PR DESCRIPTION
Generated Java RPC Client Code is using @Generated Annotation. 
But Android does not support @Generated Annotation.
so i think, thrift dont' have to create @Generated Annotation when using thrift command with java:android option

here is the issue.
https://issues.apache.org/jira/browse/THRIFT-3220