### PR TITLE
THRIFT-2073: Fixed Thrift C++ THttpClient error: cannot refill buffer

### DIFF
--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -95,8 +95,9 @@ uint32_t THttpTransport::readMoreData() {
     size = readChunked();
   } else {
     size = readContent(contentLength_);
+    readHeaders_ = true;
   }
-  readHeaders_ = true;
+
   return size;
 }
 


### PR DESCRIPTION
Fixed-by: Qiang Li <liqiang2yt@hotmail.com>
Sponsored-by: Roger Meier <r.meier@siemens.com>
Signed-off-by: Claudius Heine <ch@denx.de>