### PR TITLE
THRIFT-3230: transform typedef when getting type name

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -2339,6 +2339,10 @@ string t_py_generator::argument_list(t_struct* tstruct, vector<string>* pre, vec
 }
 
 string t_py_generator::type_name(t_type* ttype) {
+  while (ttype->is_typedef()) {
+    ttype = ((t_typedef*)ttype)->get_type();
+  }
+
   t_program* program = ttype->get_program();
   if (ttype->is_service()) {
     return get_real_py_module(program, gen_twisted_) + "." + ttype->get_name();


### PR DESCRIPTION
Python compiler generates wrong code if there is function throwing a typedef of exception with another namespace. Use the real type name instead of  the name of typedef.