### PR TITLE
THRIFT-3263: PHP Compiler always casts scalar types in jsonSerialize()

### DIFF
--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -1095,6 +1095,8 @@ void t_php_generator::generate_php_struct_json_serialize(ofstream& out,
       indent(out) << "$json->" << name << " = ";
       if (type->is_map()) {
         out << "(object)";
+      } else {
+        out << type_to_cast(type);
       }
       out << "$this->" << name << ";" << endl;
       indent_down();

--- a/lib/php/test/Test/Thrift/JsonSerialize/JsonSerializeTest.php
+++ b/lib/php/test/Test/Thrift/JsonSerialize/JsonSerializeTest.php
@@ -33,6 +33,11 @@ $loader->register();
 
 class JsonSerializeTest extends \PHPUnit_Framework_TestCase
 {
+  protected function setUp() {
+    if (version_compare(phpversion(), '5.4', '<')) {
+      $this->markTestSkipped('Requires PHP 5.4 or newer!');
+    }
+  }
 
   public function testEmptyStruct()
   {
@@ -98,6 +103,14 @@ class JsonSerializeTest extends \PHPUnit_Framework_TestCase
     $emptymap = new \ThriftTest\ThriftTest_testMap_args([]);
     $this->assertEquals('{"thing":{"0":"zero"}}', json_encode($intmap));
     $this->assertEquals('{}', json_encode($emptymap));
+  }
+
+  public function testScalarTypes()
+  {
+    $b = new \ThriftTest\Bools(['im_true' => '1', 'im_false' => '0']);
+    $this->assertEquals('{"im_true":true,"im_false":false}', json_encode($b));
+    $s = new \ThriftTest\StructA(['s' => 42]);
+    $this->assertEquals('{"s":"42"}', json_encode($s));
   }
 
 }


### PR DESCRIPTION
In PHP, values from databases and such are usually always strings, so it is useful to cast values during JSON serialization to maintain the Thrift schema's types.

THRIFT-3263
