### PR TITLE
THRIFT-3255 Thrift generator doesn't exclude 'package' keyword for Java

### DIFF
--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -258,6 +258,7 @@ literal_begin (['\"])
 "nil"                { thrift_reserved_keyword(yytext); }
 "not"                { thrift_reserved_keyword(yytext); }
 "or"                 { thrift_reserved_keyword(yytext); }
+"package"            { thrift_reserved_keyword(yytext); }
 "pass"               { thrift_reserved_keyword(yytext); }
 "public"             { thrift_reserved_keyword(yytext); }
 "print"              { thrift_reserved_keyword(yytext); }


### PR DESCRIPTION
The patch adds "package" to the global list of reserved keywords, because it is used as keyword in Java, ActionScript, Go, Haxe, Perl.