### PR TITLE
THRIFT-3260 multiple warnings in c glib tutorial

### DIFF
--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -1384,7 +1384,7 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
              << "                         G_IMPLEMENT_INTERFACE (" << this->nspace_uc << "TYPE_"
              << service_name_uc << "_IF," << endl
              << "                                                " << this->nspace_lc
-             << service_name_lc << "_if_interface_init));" << endl << endl;
+             << service_name_lc << "_if_interface_init))" << endl << endl;
 
   // Generate property-related code only for base services---child
   // service-client classes have only properties inherited from their
@@ -1780,7 +1780,7 @@ void t_c_glib_generator::generate_service_handler(t_service* tservice) {
              << args_indent << "G_IMPLEMENT_INTERFACE (" << this->nspace_uc << "TYPE_"
              << service_name_uc << "_IF," << endl;
   args_indent += string(23, ' ');
-  f_service_ << args_indent << class_name_lc << "_" << service_name_lc << "_if_interface_init));"
+  f_service_ << args_indent << class_name_lc << "_" << service_name_lc << "_if_interface_init))"
              << endl << endl;
 
   // Generate the handler method implementations
@@ -1966,7 +1966,7 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
   // Generate the implementation boilerplate
   args_indent = string(15, ' ');
   f_service_ << "G_DEFINE_TYPE (" << class_name << "," << endl << args_indent << class_name_lc
-             << "," << endl << args_indent << parent_type_name << ");" << endl << endl;
+             << "," << endl << args_indent << parent_type_name << ")" << endl << endl;
 
   // Generate the processor's processing-function type
   args_indent = string(process_function_type_name.length() + 23, ' ');

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -1620,6 +1620,9 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
     f_service_ << "  client->input_protocol = NULL;" << endl << "  client->output_protocol = NULL;"
                << endl;
   }
+  else {
+    f_service_ << "  THRIFT_UNUSED_VAR (client);" << endl;
+  }
   f_service_ << "}" << endl << endl;
 
   // create the client class initializer
@@ -1649,6 +1652,9 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
                << "  g_object_class_install_property (gobject_class," << endl
                << "                                   PROP_" << this->nspace_uc << service_name_uc
                << "_CLIENT_OUTPUT_PROTOCOL, param_spec);" << endl;
+  }
+  else {
+    f_service_ << "  THRIFT_UNUSED_VAR (cls);" << endl;
   }
   f_service_ << "}" << endl << endl;
 }

--- a/tutorial/c_glib/Makefile.am
+++ b/tutorial/c_glib/Makefile.am
@@ -46,6 +46,8 @@ nodist_libtutorialgencglib_la_SOURCES = \
 libtutorialgencglib_la_LIBADD = \
 	$(top_builddir)/lib/c_glib/libthrift_c_glib.la
 
+libtutorialgencglib_la_CFLAGS = \
+	$(AM_CFLAGS) -Wno-unused-function
 
 noinst_PROGRAMS = \
 	tutorial_server \

--- a/tutorial/c_glib/c_glib_server.c
+++ b/tutorial/c_glib/c_glib_server.c
@@ -100,7 +100,7 @@ G_END_DECLS
 
 G_DEFINE_TYPE (TutorialCalculatorHandler,
                tutorial_calculator_handler,
-               TYPE_CALCULATOR_HANDLER);
+               TYPE_CALCULATOR_HANDLER)
 
 /* Each of a handler's methods accepts at least two parameters: A
    pointer to the service-interface implementation (the handler object


### PR DESCRIPTION
This patch resolves the remaining warning messages output by the compiler when building the C (GLib) tutorial. It

- Modifies the compiler to not emit spurious semicolons after GObject type macros (e.g G_DEFINE_TYPE),
- Removes a spurious semicolon at an equivalent spot in the server tutorial,
- Modifies the compiler to explicitly state initializer and class-initializer parameters are unused if they are and
- Disables the warning about unused functions when building (only) the generated code.