### PR TITLE
THRIFT-3260 multiple warnings in c glib tutorial

### DIFF
--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -485,11 +485,20 @@ void t_c_glib_generator::generate_xception(t_struct* tstruct) {
 
   generate_object(tstruct);
 
-  f_types_ << "/* exception */" << endl << "typedef enum" << endl << "{" << endl << "  "
-           << this->nspace_uc << name_uc << "_ERROR_CODE" << endl << "} " << this->nspace << name
-           << "Error;" << endl << endl << "GQuark " << this->nspace_lc << name_lc
-           << "_error_quark (void);" << endl << "#define " << this->nspace_uc << name_uc
-           << "_ERROR (" << this->nspace_lc << name_lc << "_error_quark())" << endl << endl << endl;
+  f_types_ << "/* exception */" << endl
+           << "typedef enum" << endl
+           << "{" << endl;
+  indent_up();
+  f_types_ << indent() << this->nspace_uc << name_uc << "_ERROR_CODE" << endl;
+  indent_down();
+  f_types_ << "} " << this->nspace << name << "Error;" << endl
+           << endl
+           << "GQuark " << this->nspace_lc << name_lc
+           << "_error_quark (void);" << endl
+           << "#define " << this->nspace_uc << name_uc << "_ERROR ("
+           << this->nspace_lc << name_lc << "_error_quark())" << endl
+           << endl
+           << endl;
 
   f_types_impl_ << "/* define the GError domain for exceptions */" << endl << "#define "
                 << this->nspace_uc << name_uc << "_ERROR_DOMAIN \"" << this->nspace_lc << name_lc

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -2116,10 +2116,10 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
                << "ThriftProtocol *output_protocol," << endl << args_indent << "GError **error)"
                << endl;
     scope_up(f_service_);
-    f_service_ << indent() << "gboolean result = TRUE;" << endl << indent()
-               << "ThriftTransport * transport;" << endl << indent()
-               << "ThriftApplicationException *xception;" << endl << indent()
-               << args_class_name + " * args =" << endl;
+    f_service_ << indent() << "gboolean result = TRUE;" << endl
+               << indent() << "ThriftTransport * transport;" << endl
+               << indent() << "ThriftApplicationException *xception;" << endl
+               << indent() << args_class_name + " * args =" << endl;
     indent_up();
     f_service_ << indent() << "g_object_new (" << args_class_type << ", NULL);" << endl << endl;
     indent_down();

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -2118,6 +2118,7 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
     scope_up(f_service_);
     f_service_ << indent() << "gboolean result = TRUE;" << endl << indent()
                << "ThriftTransport * transport;" << endl << indent()
+               << "ThriftApplicationException *xception;" << endl << indent()
                << args_class_name + " * args =" << endl;
     indent_up();
     f_service_ << indent() << "g_object_new (" << args_class_type << ", NULL);" << endl << endl;
@@ -2310,7 +2311,7 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
                << (*function_iter)->get_name() << " implementation returned FALSE \"" << endl
                << indent() << string(11, ' ') << "\"but did not set an error\");" << endl << endl;
     indent_down();
-    f_service_ << indent() << "ThriftApplicationException *xception =" << endl;
+    f_service_ << indent() << "xception =" << endl;
     indent_up();
     f_service_ << indent() << "g_object_new (THRIFT_TYPE_APPLICATION_EXCEPTION," << endl;
     args_indent = indent() + string(14, ' ');

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -1384,7 +1384,7 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
              << "                         G_IMPLEMENT_INTERFACE (" << this->nspace_uc << "TYPE_"
              << service_name_uc << "_IF," << endl
              << "                                                " << this->nspace_lc
-             << service_name_lc << "_if_interface_init));" << endl << endl;
+             << service_name_lc << "_if_interface_init))" << endl << endl;
 
   // Generate property-related code only for base services---child
   // service-client classes have only properties inherited from their
@@ -1780,7 +1780,7 @@ void t_c_glib_generator::generate_service_handler(t_service* tservice) {
              << args_indent << "G_IMPLEMENT_INTERFACE (" << this->nspace_uc << "TYPE_"
              << service_name_uc << "_IF," << endl;
   args_indent += string(23, ' ');
-  f_service_ << args_indent << class_name_lc << "_" << service_name_lc << "_if_interface_init));"
+  f_service_ << args_indent << class_name_lc << "_" << service_name_lc << "_if_interface_init))"
              << endl << endl;
 
   // Generate the handler method implementations
@@ -1966,7 +1966,7 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
   // Generate the implementation boilerplate
   args_indent = string(15, ' ');
   f_service_ << "G_DEFINE_TYPE (" << class_name << "," << endl << args_indent << class_name_lc
-             << "," << endl << args_indent << parent_type_name << ");" << endl << endl;
+             << "," << endl << args_indent << parent_type_name << ")" << endl << endl;
 
   // Generate the processor's processing-function type
   args_indent = string(process_function_type_name.length() + 23, ' ');

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -1485,42 +1485,74 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << function_signature(&recv_function) << endl;
       scope_up(f_service_);
 
-      f_service_ << endl << indent() << "gint32 rseqid;" << endl << indent()
-                 << "gchar * fname = NULL;" << endl << indent() << "ThriftMessageType mtype;"
-                 << endl << indent() << "ThriftProtocol * protocol = " << this->nspace_uc
-                 << base_service_name_uc << "_CLIENT (iface)->input_protocol;" << endl << endl
+      f_service_ << indent() << "gint32 rseqid;" << endl
+                 << indent() << "gchar * fname = NULL;" << endl
+                 << indent() << "ThriftMessageType mtype;" << endl
+                 << indent() << "ThriftProtocol * protocol = "
+                 << this->nspace_uc << base_service_name_uc
+                 << "_CLIENT (iface)->input_protocol;" << endl
+                 << indent() << "ThriftApplicationException *xception;" << endl
+                 << endl
                  << indent() << "if (thrift_protocol_read_message_begin "
-                 << "(protocol, &fname, &mtype, &rseqid, error) < 0)" << endl << indent() << "{"
-                 << endl << indent() << "  if (fname) g_free (fname);" << endl << indent()
-                 << "  return FALSE;" << endl << indent() << "}" << endl << endl << indent()
-                 << "if (mtype == T_EXCEPTION) {" << endl << indent()
-                 << "  if (fname) g_free (fname);" << endl << indent()
-                 << "  ThriftApplicationException *xception = g_object_new "
-                    "(THRIFT_TYPE_APPLICATION_EXCEPTION, NULL);" << endl << indent()
-                 << "  thrift_struct_read (THRIFT_STRUCT (xception), protocol, NULL);" << endl
-                 << indent() << "  thrift_protocol_read_message_end (protocol, NULL);" << endl
-                 << indent() << "  thrift_transport_read_end (protocol->transport, NULL);" << endl
-                 << indent() << "  g_set_error (error, THRIFT_APPLICATION_EXCEPTION_ERROR, "
-                                "xception->type, \"application error: %s\", xception->message);"
-                 << endl << indent() << "  g_object_unref (xception);" << endl << indent()
-                 << "  return FALSE;" << endl << indent() << "} else if (mtype != T_REPLY) {"
-                 << endl << indent() << "  if (fname) g_free (fname);" << endl << indent()
-                 << "  thrift_protocol_skip (protocol, T_STRUCT, NULL);" << endl << indent()
-                 << "  thrift_protocol_read_message_end (protocol, NULL);" << endl << indent()
-                 << "  thrift_transport_read_end (protocol->transport, NULL);" << endl << indent()
-                 << "  g_set_error (error, THRIFT_APPLICATION_EXCEPTION_ERROR, "
-                    "THRIFT_APPLICATION_EXCEPTION_ERROR_INVALID_MESSAGE_TYPE, \"invalid message "
-                    "type %d, expected T_REPLY\", mtype);" << endl << indent() << "  return FALSE;"
-                 << endl << indent() << "} else if (strncmp (fname, \"" << name << "\", "
-                 << name.length() << ") != 0) {" << endl << indent()
-                 << "  thrift_protocol_skip (protocol, T_STRUCT, NULL);" << endl << indent()
-                 << "  thrift_protocol_read_message_end (protocol, error);" << endl << indent()
-                 << "  thrift_transport_read_end (protocol->transport, error);" << endl << indent()
-                 << "  g_set_error (error, THRIFT_APPLICATION_EXCEPTION_ERROR, "
-                    "THRIFT_APPLICATION_EXCEPTION_ERROR_WRONG_METHOD_NAME, \"wrong method name %s, "
-                    "expected " << name << "\", fname);" << endl << indent()
-                 << "  if (fname) g_free (fname);" << endl << indent() << "  return FALSE;" << endl
-                 << indent() << "}" << endl << indent() << "if (fname) g_free (fname);" << endl
+                    "(protocol, &fname, &mtype, &rseqid, error) < 0) {" << endl;
+      indent_up();
+      f_service_ << indent() << "if (fname) g_free (fname);" << endl
+                 << indent() << "return FALSE;" << endl;
+      indent_down();
+      f_service_ << indent() << "}" << endl
+                 << endl
+                 << indent() << "if (mtype == T_EXCEPTION) {" << endl;
+      indent_up();
+      f_service_ << indent() << "if (fname) g_free (fname);" << endl
+                 << indent() << "xception = g_object_new "
+                    "(THRIFT_TYPE_APPLICATION_EXCEPTION, NULL);" << endl
+                 << indent() << "thrift_struct_read (THRIFT_STRUCT (xception), "
+                    "protocol, NULL);" << endl
+                 << indent() << "thrift_protocol_read_message_end "
+                    "(protocol, NULL);" << endl
+                 << indent() << "thrift_transport_read_end "
+                    "(protocol->transport, NULL);" << endl
+                 << indent() << "g_set_error (error, "
+                    "THRIFT_APPLICATION_EXCEPTION_ERROR,xception->type, "
+                    "\"application error: %s\", xception->message);" << endl
+                 << indent() << "g_object_unref (xception);" << endl
+                 << indent() << "return FALSE;" << endl;
+      indent_down();
+      f_service_ << indent() << "} else if (mtype != T_REPLY) {" << endl;
+      indent_up();
+      f_service_ << indent() << "if (fname) g_free (fname);" << endl
+                 << indent() << "thrift_protocol_skip (protocol, T_STRUCT, "
+                    "NULL);" << endl
+                 << indent() << "thrift_protocol_read_message_end (protocol, "
+                    "NULL);" << endl
+                 << indent() << "thrift_transport_read_end ("
+                    "protocol->transport, NULL);" << endl
+                 << indent() << "g_set_error (error, "
+                    "THRIFT_APPLICATION_EXCEPTION_ERROR, "
+                    "THRIFT_APPLICATION_EXCEPTION_ERROR_INVALID_MESSAGE_TYPE, "
+                    "\"invalid message type %d, expected T_REPLY\", mtype);"
+                 << endl
+                 << indent() << "return FALSE;" << endl;
+      indent_down();
+      f_service_ << indent() << "} else if (strncmp (fname, \"" << name
+                 << "\", " << name.length() << ") != 0) {" << endl;
+      indent_up();
+      f_service_ << indent() << "thrift_protocol_skip (protocol, T_STRUCT, "
+                    "NULL);" << endl
+                 << indent() << "thrift_protocol_read_message_end (protocol,"
+                    "error);" << endl
+                 << indent() << "thrift_transport_read_end ("
+                    "protocol->transport, error);" << endl
+                 << indent() << "g_set_error (error, "
+                    "THRIFT_APPLICATION_EXCEPTION_ERROR, "
+                    "THRIFT_APPLICATION_EXCEPTION_ERROR_WRONG_METHOD_NAME, "
+                    "\"wrong method name %s, expected " << name
+                    << "\", fname);" << endl
+                 << indent() << "if (fname) g_free (fname);" << endl
+                 << indent() << "return FALSE;" << endl;
+      indent_down();
+      f_service_ << indent() << "}" << endl
+                 << indent() << "if (fname) g_free (fname);" << endl
                  << endl;
 
       t_struct* xs = (*f_iter)->get_xceptions();

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -486,7 +486,7 @@ void t_c_glib_generator::generate_xception(t_struct* tstruct) {
   generate_object(tstruct);
 
   f_types_ << "/* exception */" << endl << "typedef enum" << endl << "{" << endl << "  "
-           << this->nspace_uc << name_uc << "_ERROR_CODE," << endl << "} " << this->nspace << name
+           << this->nspace_uc << name_uc << "_ERROR_CODE" << endl << "} " << this->nspace << name
            << "Error;" << endl << endl << "GQuark " << this->nspace_lc << name_lc
            << "_error_quark (void);" << endl << "#define " << this->nspace_uc << name_uc
            << "_ERROR (" << this->nspace_lc << name_lc << "_error_quark())" << endl << endl << endl;

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -1620,6 +1620,9 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
     f_service_ << "  client->input_protocol = NULL;" << endl << "  client->output_protocol = NULL;"
                << endl;
   }
+  else {
+    f_service_ << "  THRIFT_UNUSED_VAR (client);" << endl;
+  }
   f_service_ << "}" << endl << endl;
 
   // create the client class initializer
@@ -1649,6 +1652,9 @@ void t_c_glib_generator::generate_service_client(t_service* tservice) {
                << "  g_object_class_install_property (gobject_class," << endl
                << "                                   PROP_" << this->nspace_uc << service_name_uc
                << "_CLIENT_OUTPUT_PROTOCOL, param_spec);" << endl;
+  }
+  else {
+    f_service_ << "  THRIFT_UNUSED_VAR (cls);" << endl;
   }
   f_service_ << "}" << endl << endl;
 }

--- a/lib/c_glib/src/thrift/c_glib/thrift.h
+++ b/lib/c_glib/src/thrift/c_glib/thrift.h
@@ -35,4 +35,4 @@ void thrift_hash_table_get_keys (gpointer key, gpointer value,
                                  gpointer user_data);
 void thrift_string_free (gpointer str);
 
-#endif // #ifndef _THRIFT_THRIFT_H
+#endif /* #ifndef _THRIFT_THRIFT_H */

--- a/tutorial/c_glib/Makefile.am
+++ b/tutorial/c_glib/Makefile.am
@@ -46,6 +46,8 @@ nodist_libtutorialgencglib_la_SOURCES = \
 libtutorialgencglib_la_LIBADD = \
 	$(top_builddir)/lib/c_glib/libthrift_c_glib.la
 
+libtutorialgencglib_la_CFLAGS = \
+	$(AM_CFLAGS) -Wno-unused-function
 
 noinst_PROGRAMS = \
 	tutorial_server \

--- a/tutorial/c_glib/c_glib_server.c
+++ b/tutorial/c_glib/c_glib_server.c
@@ -173,8 +173,6 @@ tutorial_calculator_handler_calculate (CalculatorIf      *iface,
                                        InvalidOperation **ouch,
                                        GError           **error)
 {
-  THRIFT_UNUSED_VAR (error);
-
   TutorialCalculatorHandler *self;
 
   gint *log_key;
@@ -185,6 +183,8 @@ tutorial_calculator_handler_calculate (CalculatorIf      *iface,
   gint num2;
   Operation op;
   gboolean result = TRUE;
+
+  THRIFT_UNUSED_VAR (error);
 
   g_return_val_if_fail (IS_TUTORIAL_CALCULATOR_HANDLER (iface),
                         FALSE);
@@ -300,13 +300,13 @@ tutorial_calculator_handler_get_struct (SharedServiceIf  *iface,
                                         const gint32      key32,
                                         GError          **error)
 {
-  THRIFT_UNUSED_VAR (error);
-
   gint key = (gint)key32;
   TutorialCalculatorHandler *self;
   SharedStruct *log_struct;
   gint log_key;
   gchar *log_value;
+
+  THRIFT_UNUSED_VAR (error);
 
   g_return_val_if_fail (IS_TUTORIAL_CALCULATOR_HANDLER (iface),
                         FALSE);

--- a/tutorial/c_glib/c_glib_server.c
+++ b/tutorial/c_glib/c_glib_server.c
@@ -100,7 +100,7 @@ G_END_DECLS
 
 G_DEFINE_TYPE (TutorialCalculatorHandler,
                tutorial_calculator_handler,
-               TYPE_CALCULATOR_HANDLER);
+               TYPE_CALCULATOR_HANDLER)
 
 /* Each of a handler's methods accepts at least two parameters: A
    pointer to the service-interface implementation (the handler object


### PR DESCRIPTION
Here are additional changes that should really and truly resolve all the warnings generated when building the c_glib tutorial:

Compiler
- Do not output a trailing comma in exception-enum definitions.
- Move variable declarations to avoid mixing declarations and code in generated code.
- Improve the readability of affected code blocks (and rely on indent_up and indent_down for indentation).

Library
- Use only C-style comments in headers included by clients.

Tutorial
- Move THRIFT_UNUSED_VAR calls to avoid mixing declarations and code.