### PR TITLE
THRIFT-3283: c_glib: Tutorial: Fix uninitialized-variable warning

### DIFF
--- a/tutorial/c_glib/c_glib_server.c
+++ b/tutorial/c_glib/c_glib_server.c
@@ -440,7 +440,7 @@ int main (void)
 
   struct sigaction sigint_action;
 
-  GError *error;
+  GError *error = NULL;
   int exit_status = 0;
 
 #if (!GLIB_CHECK_VERSION (2, 36, 0))


### PR DESCRIPTION
This patch makes the tutorial server initialize an error variable to NULL before using it, which resolves a GLib warning printed to the console when the server terminates.