### PR TITLE
THRIFT-3285 c glib build library with all warnings enabled

### DIFF
--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -24,7 +24,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 lib_LTLIBRARIES = libthrift_c_glib.la
 pkgconfig_DATA = thrift_c_glib.pc
 
-AM_CFLAGS = -Isrc -I src/thrift/c_glib
+AM_CPPFLAGS = -Isrc -I src/thrift/c_glib
 
 # Define the source files for the module
 

--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -25,6 +25,7 @@ lib_LTLIBRARIES = libthrift_c_glib.la
 pkgconfig_DATA = thrift_c_glib.pc
 
 AM_CPPFLAGS = -Isrc -I src/thrift/c_glib
+AM_CFLAGS = -Wall -Wextra -pedantic
 
 # Define the source files for the module
 

--- a/lib/c_glib/src/thrift/c_glib/processor/thrift_dispatch_processor.c
+++ b/lib/c_glib/src/thrift/c_glib/processor/thrift_dispatch_processor.c
@@ -23,7 +23,7 @@
 
 G_DEFINE_ABSTRACT_TYPE (ThriftDispatchProcessor,
                         thrift_dispatch_processor,
-                        THRIFT_TYPE_PROCESSOR);
+                        THRIFT_TYPE_PROCESSOR)
 
 gboolean
 thrift_dispatch_processor_process (ThriftProcessor *processor,

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.c
@@ -53,12 +53,12 @@ thrift_binary_protocol_write_message_begin (ThriftProtocol *protocol,
     const gchar *name, const ThriftMessageType message_type,
     const gint32 seqid, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 version = (THRIFT_BINARY_PROTOCOL_VERSION_1)
                    | ((gint32) message_type);
   gint32 ret;
   gint32 xfer = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_write_i32 (protocol, version, error)) < 0)
   {
@@ -117,11 +117,12 @@ thrift_binary_protocol_write_field_begin (ThriftProtocol *protocol,
                                           const gint16 field_id,
                                           GError **error)
 {
-  THRIFT_UNUSED_VAR (name);
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
+
+  THRIFT_UNUSED_VAR (name);
 
   if ((ret = thrift_protocol_write_byte (protocol, (gint8) field_type,
                                          error)) < 0)
@@ -162,10 +163,10 @@ thrift_binary_protocol_write_map_begin (ThriftProtocol *protocol,
                                         const guint32 size,
                                         GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_write_byte (protocol, (gint8) key_type,
                                          error)) < 0)
@@ -202,10 +203,10 @@ thrift_binary_protocol_write_list_begin (ThriftProtocol *protocol,
                                          const guint32 size, 
                                          GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1); 
-
   gint32 ret;
   gint32 xfer = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_write_byte (protocol, (gint8) element_type,
                                          error)) < 0)
@@ -256,8 +257,11 @@ gint32
 thrift_binary_protocol_write_bool (ThriftProtocol *protocol,
                                    const gboolean value, GError **error)
 {
+  guint8 tmp;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-  guint8 tmp = value ? 1 : 0;
+
+  tmp = value ? 1 : 0;
   return thrift_protocol_write_byte (protocol, tmp, error);
 }
 
@@ -280,9 +284,11 @@ gint32
 thrift_binary_protocol_write_i16 (ThriftProtocol *protocol, const gint16 value,
                                   GError **error)
 {
+  gint16 net;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
-  gint16 net = g_htons (value);
+  net = g_htons (value);
   if (thrift_transport_write (protocol->transport,
                               (const gpointer) &net, 2, error))
   {
@@ -296,9 +302,11 @@ gint32
 thrift_binary_protocol_write_i32 (ThriftProtocol *protocol, const gint32 value,
                                   GError **error)
 {
+  gint32 net;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
-  gint32 net = g_htonl (value);
+  net = g_htonl (value);
   if (thrift_transport_write (protocol->transport,
                               (const gpointer) &net, 4, error))
   {
@@ -312,9 +320,11 @@ gint32
 thrift_binary_protocol_write_i64 (ThriftProtocol *protocol, const gint64 value,
                                   GError **error)
 {
+  gint64 net;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
-  gint64 net = GUINT64_TO_BE (value);
+  net = GUINT64_TO_BE (value);
   if (thrift_transport_write (protocol->transport,
                               (const gpointer) &net, 8, error))
   {
@@ -328,9 +338,11 @@ gint32
 thrift_binary_protocol_write_double (ThriftProtocol *protocol,
                                      const gdouble value, GError **error)
 {
+  guint64 bits;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
-  guint64 bits = GUINT64_FROM_BE (thrift_bitwise_cast_guint64 (value));
+  bits = GUINT64_FROM_BE (thrift_bitwise_cast_guint64 (value));
   if (thrift_transport_write (protocol->transport,
                               (const gpointer) &bits, 8, error))
   {
@@ -344,9 +356,11 @@ gint32
 thrift_binary_protocol_write_string (ThriftProtocol *protocol,
                                      const gchar *str, GError **error)
 {
+  guint32 len;
+
   g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
-  guint32 len = str != NULL ? strlen (str) : 0;
+  len = str != NULL ? strlen (str) : 0;
   /* write the string length + 1 which includes the null terminator */
   return thrift_protocol_write_binary (protocol, (const gpointer) str, 
                                        len, error);
@@ -357,9 +371,10 @@ thrift_binary_protocol_write_binary (ThriftProtocol *protocol,
                                      const gpointer buf,
                                      const guint32 len, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
   gint32 xfer = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_write_i32 (protocol, len, error)) < 0)
   {
@@ -386,11 +401,11 @@ thrift_binary_protocol_read_message_begin (ThriftProtocol *protocol,
                                            ThriftMessageType *message_type,
                                            gint32 *seqid, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
   gint32 sz;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_read_i32 (protocol, &sz, error)) < 0)
   {
@@ -464,12 +479,13 @@ thrift_binary_protocol_read_field_begin (ThriftProtocol *protocol,
                                          gint16 *field_id,
                                          GError **error)
 {
-  THRIFT_UNUSED_VAR (name);
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
   gint8 type;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
+
+  THRIFT_UNUSED_VAR (name);
 
   if ((ret = thrift_protocol_read_byte (protocol, &type, error)) < 0)
   {
@@ -506,12 +522,12 @@ thrift_binary_protocol_read_map_begin (ThriftProtocol *protocol,
                                        guint32 *size,
                                        GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
   gint8 k, v;
   gint32 sizei;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_read_byte (protocol, &k, error)) < 0)
   {
@@ -559,12 +575,12 @@ thrift_binary_protocol_read_list_begin (ThriftProtocol *protocol,
                                         ThriftType *element_type,
                                         guint32 *size, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
-
   gint32 ret;
   gint32 xfer = 0;
   gint8 e;
   gint32 sizei;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = thrift_protocol_read_byte (protocol, &e, error)) < 0)
   {
@@ -623,9 +639,10 @@ gint32
 thrift_binary_protocol_read_bool (ThriftProtocol *protocol, gboolean *value,
                                   GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
   gpointer b[1];
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret = 
        thrift_transport_read (protocol->transport,
@@ -641,9 +658,10 @@ gint32
 thrift_binary_protocol_read_byte (ThriftProtocol *protocol, gint8 *value,
                                   GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
   gpointer b[1];
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret =
        thrift_transport_read (protocol->transport,
@@ -659,18 +677,22 @@ gint32
 thrift_binary_protocol_read_i16 (ThriftProtocol *protocol, gint16 *value,
                                  GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
-  gpointer b[2];
+  union
+  {
+    gint8 byte_array[2];
+    gint16 int16;
+  } b;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret =
        thrift_transport_read (protocol->transport,
-                              b, 2, error)) < 0)
+                              b.byte_array, 2, error)) < 0)
   {
     return -1;
   }
-  *value = *(gint16 *) b;
-  *value = g_ntohs (*value);
+  *value = g_ntohs (b.int16);
   return ret;
 }
 
@@ -678,18 +700,22 @@ gint32
 thrift_binary_protocol_read_i32 (ThriftProtocol *protocol, gint32 *value,
                                  GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
-  gpointer b[4];
+  union
+  {
+    gint8 byte_array[4];
+    gint32 int32;
+  } b;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret =
        thrift_transport_read (protocol->transport,
-                              b, 4, error)) < 0)
+                              b.byte_array, 4, error)) < 0)
   {
     return -1;
   }
-  *value = *(gint32 *) b;
-  *value = g_ntohl (*value);
+  *value = g_ntohl (b.int32);
   return ret;
 }
 
@@ -697,18 +723,22 @@ gint32
 thrift_binary_protocol_read_i64 (ThriftProtocol *protocol, gint64 *value,
                                  GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
-  gpointer b[8];
+  union
+  {
+    gint8 byte_array[8];
+    gint64 int64;
+  } b;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret =
        thrift_transport_read (protocol->transport,
-                              b, 8, error)) < 0)
+                              b.byte_array, 8, error)) < 0)
   {
     return -1;
   }
-  *value = *(gint64 *) b;
-  *value = GUINT64_FROM_BE (*value);
+  *value = GUINT64_FROM_BE (b.int64);
   return ret;
 }
 
@@ -716,19 +746,22 @@ gint32
 thrift_binary_protocol_read_double (ThriftProtocol *protocol,
                                     gdouble *value, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
-  gpointer b[8];
+  union
+  {
+    gint8 byte_array[8];
+    guint64 uint64;
+  } b;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   if ((ret =
        thrift_transport_read (protocol->transport,
-                              b, 8, error)) < 0)
+                              b.byte_array, 8, error)) < 0)
   {
     return -1;
   }
-  guint64 bits = *(guint64 *) b;
-  bits = GUINT64_FROM_BE (bits);
-  *value = thrift_bitwise_cast_gdouble (bits);
+  *value = thrift_bitwise_cast_gdouble (GUINT64_FROM_BE (b.uint64));
   return ret;
 }
 
@@ -736,11 +769,12 @@ gint32
 thrift_binary_protocol_read_string (ThriftProtocol *protocol,
                                     gchar **str, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   guint32 len;
   gint32 ret;
   gint32 xfer = 0;
   gint32 read_len = 0;
+
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
 
   /* read the length into read_len */
   if ((ret =
@@ -753,7 +787,7 @@ thrift_binary_protocol_read_string (ThriftProtocol *protocol,
   if (read_len > 0)
   {
     /* allocate the memory for the string */
-    len = (guint32) read_len + 1; // space for null terminator
+    len = (guint32) read_len + 1; /* space for null terminator */
     *str = g_new0 (gchar, len);
     if ((ret =
          thrift_transport_read (protocol->transport,
@@ -777,11 +811,12 @@ thrift_binary_protocol_read_binary (ThriftProtocol *protocol,
                                     gpointer *buf, guint32 *len,
                                     GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
   gint32 ret;
   gint32 xfer = 0;
   gint32 read_len = 0;
  
+  g_return_val_if_fail (THRIFT_IS_BINARY_PROTOCOL (protocol), -1);
+
   /* read the length into read_len */
   if ((ret =
        thrift_protocol_read_i32 (protocol, &read_len, error)) < 0)

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol_factory.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol_factory.c
@@ -27,10 +27,10 @@ ThriftProtocol *
 thrift_binary_protocol_factory_get_protocol (ThriftProtocolFactory *factory,
                                              ThriftTransport *transport)
 {
-  THRIFT_UNUSED_VAR (factory);
-
   ThriftBinaryProtocol *tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL,
                                            "transport", transport, NULL);
+
+  THRIFT_UNUSED_VAR (factory);
 
   return THRIFT_PROTOCOL (tb);
 }

--- a/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
+++ b/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
@@ -27,13 +27,13 @@ G_DEFINE_TYPE(ThriftSimpleServer, thrift_simple_server, THRIFT_TYPE_SERVER)
 gboolean
 thrift_simple_server_serve (ThriftServer *server, GError **error)
 {
-  g_return_val_if_fail (THRIFT_IS_SIMPLE_SERVER (server), FALSE);
-
   ThriftTransport *t = NULL;
   ThriftTransport *input_transport = NULL, *output_transport = NULL;
   ThriftProtocol *input_protocol = NULL, *output_protocol = NULL;
   ThriftSimpleServer *tss = THRIFT_SIMPLE_SERVER(server);
   GError *process_error = NULL;
+
+  g_return_val_if_fail (THRIFT_IS_SIMPLE_SERVER (server), FALSE);
 
   if (thrift_server_transport_listen (server->server_transport, error)) {
     tss->running = TRUE;
@@ -69,11 +69,11 @@ thrift_simple_server_serve (ThriftServer *server, GError **error)
           g_message ("thrift_simple_server_serve: %s", process_error->message);
           g_clear_error (&process_error);
 
-          // Note we do not propagate processing errors to the caller as they
-          // normally are transient and not fatal to the server
+          /* Note we do not propagate processing errors to the caller as they
+           * normally are transient and not fatal to the server */
         }
 
-        // TODO: handle exceptions
+        /* TODO: handle exceptions */
         THRIFT_TRANSPORT_GET_CLASS (input_transport)->close (input_transport,
                                                              NULL);
         THRIFT_TRANSPORT_GET_CLASS (output_transport)->close (output_transport,
@@ -81,13 +81,13 @@ thrift_simple_server_serve (ThriftServer *server, GError **error)
       }
     }
 
-    // attempt to shutdown
+    /* attempt to shutdown */
     THRIFT_SERVER_TRANSPORT_GET_CLASS (server->server_transport)
       ->close (server->server_transport, NULL);
   }
 
-  // Since this method is designed to run forever, it can only ever return on
-  // error
+  /* Since this method is designed to run forever, it can only ever return on
+   * error */
   return FALSE;
 }
 
@@ -101,9 +101,9 @@ thrift_simple_server_stop (ThriftServer *server)
 static void
 thrift_simple_server_init (ThriftSimpleServer *tss)
 {
-  tss->running = FALSE;
-
   ThriftServer *server = THRIFT_SERVER(tss);
+
+  tss->running = FALSE;
 
   if (server->input_transport_factory == NULL)
   {

--- a/lib/c_glib/src/thrift/c_glib/thrift.c
+++ b/lib/c_glib/src/thrift/c_glib/thrift.c
@@ -25,8 +25,10 @@
 void
 thrift_hash_table_get_keys (gpointer key, gpointer value, gpointer user_data)
 {
-  THRIFT_UNUSED_VAR (value);
   GList **list = (GList **) user_data;
+
+  THRIFT_UNUSED_VAR (value);
+
   *list = g_list_append (*list, key);
 }
 

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
@@ -32,7 +32,7 @@
 enum _ThriftMemoryBufferProperties
 {
   PROP_0,
-  PROP_THRIFT_MEMORY_BUFFER_BUFFER_SIZE,
+  PROP_THRIFT_MEMORY_BUFFER_BUFFER_SIZE
 };
 
 G_DEFINE_TYPE(ThriftMemoryBuffer, thrift_memory_buffer, THRIFT_TYPE_TRANSPORT)
@@ -68,9 +68,10 @@ gint32
 thrift_memory_buffer_read (ThriftTransport *transport, gpointer buf,
                            guint32 len, GError **error)
 {
-  THRIFT_UNUSED_VAR (error);
   ThriftMemoryBuffer *t = THRIFT_MEMORY_BUFFER (transport);
   guint32 give = len; 
+
+  THRIFT_UNUSED_VAR (error);
 
   /* if the requested bytes are more than what we have available,
    * just give all that we have the buffer */
@@ -102,9 +103,9 @@ thrift_memory_buffer_write (ThriftTransport *transport,
                             const gpointer buf,     
                             const guint32 len, GError **error)
 {
-  THRIFT_UNUSED_VAR (error);
-
   ThriftMemoryBuffer *t = THRIFT_MEMORY_BUFFER (transport);
+
+  THRIFT_UNUSED_VAR (error);
 
   /* return an exception if the buffer doesn't have enough space. */
   if (len > t->buf_size - t->buf->len)
@@ -165,8 +166,9 @@ void
 thrift_memory_buffer_get_property (GObject *object, guint property_id,
                                    GValue *value, GParamSpec *pspec)
 {
-  THRIFT_UNUSED_VAR (pspec);
   ThriftMemoryBuffer *transport = THRIFT_MEMORY_BUFFER (object);
+
+  THRIFT_UNUSED_VAR (pspec);
 
   switch (property_id)
   {
@@ -181,8 +183,9 @@ void
 thrift_memory_buffer_set_property (GObject *object, guint property_id,
                                    const GValue *value, GParamSpec *pspec)
 {
-  THRIFT_UNUSED_VAR (pspec);
   ThriftMemoryBuffer *transport = THRIFT_MEMORY_BUFFER (object);
+
+  THRIFT_UNUSED_VAR (pspec);
 
   switch (property_id)
   {
@@ -196,6 +199,7 @@ thrift_memory_buffer_set_property (GObject *object, guint property_id,
 static void
 thrift_memory_buffer_class_init (ThriftMemoryBufferClass *cls)
 {
+  ThriftTransportClass *ttc = THRIFT_TRANSPORT_CLASS (cls);
   GObjectClass *gobject_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec = NULL;
 
@@ -214,8 +218,6 @@ thrift_memory_buffer_class_init (ThriftMemoryBufferClass *cls)
   g_object_class_install_property (gobject_class,
                                    PROP_THRIFT_MEMORY_BUFFER_BUFFER_SIZE,
                                    param_spec);
-
-  ThriftTransportClass *ttc = THRIFT_TRANSPORT_CLASS (cls);
 
   gobject_class->finalize = thrift_memory_buffer_finalize;
   ttc->is_open = thrift_memory_buffer_is_open;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
@@ -215,6 +215,7 @@ thrift_server_socket_set_property (GObject *object, guint property_id,
 static void
 thrift_server_socket_class_init (ThriftServerSocketClass *cls)
 {
+  ThriftServerTransportClass *tstc = THRIFT_SERVER_TRANSPORT_CLASS (cls);
   GObjectClass *gobject_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec = NULL;
 
@@ -248,7 +249,6 @@ thrift_server_socket_class_init (ThriftServerSocketClass *cls)
 
   gobject_class->finalize = thrift_server_socket_finalize;
 
-  ThriftServerTransportClass *tstc = THRIFT_SERVER_TRANSPORT_CLASS (cls);
   tstc->listen = thrift_server_socket_listen;
   tstc->accept = thrift_server_socket_accept;
   tstc->close = thrift_server_socket_close;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.c
@@ -186,7 +186,7 @@ thrift_socket_read (ThriftTransport *transport, gpointer buf,
 
   while (got < len)
   {
-    ret = recv (socket->sd, buf+got, len-got, 0);
+    ret = recv (socket->sd, (guint8 *)buf + got, len-got, 0);
     if (ret <= 0)
     {
       g_set_error (error, THRIFT_TRANSPORT_ERROR,
@@ -224,7 +224,7 @@ thrift_socket_write (ThriftTransport *transport, const gpointer buf,
 
   while (sent < len)
   {
-    ret = send (socket->sd, buf + sent, len - sent, 0);
+    ret = send (socket->sd, (guint8 *)buf + sent, len - sent, 0);
     if (ret < 0)
     {
       g_set_error (error, THRIFT_TRANSPORT_ERROR,
@@ -291,8 +291,9 @@ void
 thrift_socket_get_property (GObject *object, guint property_id,
                             GValue *value, GParamSpec *pspec)
 {
-  THRIFT_UNUSED_VAR (pspec);
   ThriftSocket *socket = THRIFT_SOCKET (object);
+
+  THRIFT_UNUSED_VAR (pspec);
 
   switch (property_id)
   {
@@ -310,8 +311,9 @@ void
 thrift_socket_set_property (GObject *object, guint property_id,
                             const GValue *value, GParamSpec *pspec)
 {
-  THRIFT_UNUSED_VAR (pspec);
   ThriftSocket *socket = THRIFT_SOCKET (object);
+
+  THRIFT_UNUSED_VAR (pspec);
 
   switch (property_id)
   {
@@ -328,6 +330,7 @@ thrift_socket_set_property (GObject *object, guint property_id,
 static void
 thrift_socket_class_init (ThriftSocketClass *cls)
 {
+  ThriftTransportClass *ttc = THRIFT_TRANSPORT_CLASS (cls);
   GObjectClass *gobject_class = G_OBJECT_CLASS (cls);
   GParamSpec *param_spec = NULL;
 
@@ -354,8 +357,6 @@ thrift_socket_class_init (ThriftSocketClass *cls)
                                   G_PARAM_READWRITE);
   g_object_class_install_property (gobject_class, PROP_THRIFT_SOCKET_PORT,
                                    param_spec);
-
-  ThriftTransportClass *ttc = THRIFT_TRANSPORT_CLASS (cls);
 
   gobject_class->finalize = thrift_socket_finalize;
   ttc->is_open = thrift_socket_is_open;


### PR DESCRIPTION
These changes

- Update the C (GLib) library's makefile so the AM_CPPFLAGS and AM_CFLAGS variables are used correctly according to automake's documentation,
- Enable the same compiler warnings enabled during the C++-library build, and
- Update portions of the library so it will build without generating any compiler warnings.

The changes to the library itself comprise

- Moving variable declarations to the top of every code block,
- Using unions instead of type-punning to obey strict-aliasing rules,
- Replacing variable-length array declarations with arrays allocated on the stack (using g_newa and g_alloca),
- Casting void pointers to a suitably sized data type before performing arithmetic on them,
- Replacing C++-style ("//") comments with C-style equivalents, and
- Removing an errant semicolon and comma.

Applying these changes should allow us to also close THRIFT-2795, "thrift_binary_protocol.c: 'dereferencing type-punned pointer will break strict-aliasing rules'".