### PR TITLE
THRIFT-3178: c_glib does not compile

### DIFF
--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -4194,6 +4194,10 @@ void t_c_glib_generator::declare_local_variable(ofstream& out, t_type* ttype, st
     t_map* tmap = (t_map*)ttype;
     out << indent() << tname << ptr << " " << name << " = "
         << generate_new_hash_from_type(tmap->get_key_type(), tmap->get_val_type()) << endl;
+  } else if (ttype->is_list()) {
+    t_list* tlist = (t_list*)ttype;
+    out << indent() << tname << ptr << " " << name << " = "
+        << generate_new_array_from_type(tlist->get_elem_type()) << endl;
   } else if (ttype->is_enum()) {
     out << indent() << tname << ptr << " " << name << ";" << endl;
   } else {

--- a/lib/c_glib/test/ContainerTest.thrift
+++ b/lib/c_glib/test/ContainerTest.thrift
@@ -26,4 +26,6 @@ struct ContainersWithDefaultValues {
 service ContainerService {
   void receiveStringList(1: list<string> stringList);
   list<string> returnStringList();
+
+  list<list<string>> returnListStringList();
 }

--- a/lib/c_glib/test/ContainerTest.thrift
+++ b/lib/c_glib/test/ContainerTest.thrift
@@ -19,6 +19,9 @@
 
 namespace c_glib TTest
 
+typedef list<string> StringList
+typedef list<StringList> ListStringList
+
 struct ContainersWithDefaultValues {
   1: list<string> StringList = [ "Apache", "Thrift" ];
 }
@@ -28,4 +31,5 @@ service ContainerService {
   list<string> returnStringList();
 
   list<list<string>> returnListStringList();
+  ListStringList returnTypedefdListStringList();
 }

--- a/lib/c_glib/test/testcontainertest.c
+++ b/lib/c_glib/test/testcontainertest.c
@@ -156,6 +156,26 @@ test_container_service_handler_return_list_string_list (TTestContainerServiceIf 
   return TRUE;
 }
 
+static gboolean
+test_container_service_handler_return_typedefd_list_string_list (TTestContainerServiceIf *iface,
+                                                                 TTestListStringList **_return,
+                                                                 GError **error)
+{
+  TestContainerServiceHandler *self = TEST_CONTAINER_SERVICE_HANDLER (iface);
+  TTestStringList *nested_list;
+
+  /* Return a list containing our list of strings */
+  nested_list
+    = g_ptr_array_new_with_free_func ((GDestroyNotify)g_ptr_array_unref);
+  g_ptr_array_add (nested_list, self->string_list);
+  g_ptr_array_ref (self->string_list);
+
+  g_ptr_array_add (*_return, nested_list);
+
+  g_clear_error (error);
+  return TRUE;
+}
+
 static void
 test_container_service_handler_finalize (GObject *object) {
   TestContainerServiceHandler *self = TEST_CONTAINER_SERVICE_HANDLER (object);
@@ -190,6 +210,8 @@ test_container_service_handler_class_init (TestContainerServiceHandlerClass *kla
     test_container_service_handler_return_string_list;
   parent_class->return_list_string_list =
     test_container_service_handler_return_list_string_list;
+  parent_class->return_typedefd_list_string_list =
+    test_container_service_handler_return_typedefd_list_string_list;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -370,6 +392,67 @@ test_container_service_list_string_list (void)
   g_object_unref (socket);
 }
 
+static void
+test_container_service_typedefd_list_string_list (void)
+{
+  ThriftSocket *socket;
+  ThriftTransport *transport;
+  ThriftProtocol *protocol;
+
+  TTestContainerServiceIf *client;
+
+  TTestListStringList *incoming_list;
+  TTestStringList *nested_list;
+
+  GError *error = NULL;
+
+  /* Create a client with which to access the server */
+  socket    = g_object_new (THRIFT_TYPE_SOCKET,
+                            "hostname", TEST_SERVER_HOSTNAME,
+                            "port",     TEST_SERVER_PORT,
+                            NULL);
+  transport = g_object_new (THRIFT_TYPE_BUFFERED_TRANSPORT,
+                            "transport", socket,
+                            NULL);
+  protocol  = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL,
+                            "transport", transport,
+                            NULL);
+
+  thrift_transport_open (transport, &error);
+  g_assert_no_error (error);
+
+  client = g_object_new (T_TEST_TYPE_CONTAINER_SERVICE_CLIENT,
+                         "input_protocol",  protocol,
+                         "output_protocol", protocol,
+                         NULL);
+
+  /* Receive a list of string lists from the server */
+  incoming_list =
+    g_ptr_array_new_with_free_func ((GDestroyNotify)g_ptr_array_unref);
+  g_assert
+    (t_test_container_service_client_return_list_string_list (client,
+                                                              &incoming_list,
+                                                              &error) &&
+     error == NULL);
+
+  /* Make sure the list and its contents are valid */
+  g_assert_cmpint (incoming_list->len, >, 0);
+
+  nested_list = (TTestStringList *)g_ptr_array_index (incoming_list, 0);
+  g_assert (nested_list != NULL);
+  g_assert_cmpint (nested_list->len, >=, 0);
+
+  /* Clean up and exit */
+  g_ptr_array_unref (incoming_list);
+
+  thrift_transport_close (transport, NULL);
+
+  g_object_unref (client);
+  g_object_unref (protocol);
+  g_object_unref (transport);
+  g_object_unref (socket);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -399,6 +482,9 @@ main(int argc, char *argv[])
     g_test_add_func
       ("/testcontainertest/ContainerTest/Services/ContainerService/ListStringList",
        test_container_service_list_string_list);
+    g_test_add_func
+      ("/testcontainertest/ContainerTest/Services/ContainerService/TypedefdListStringList",
+       test_container_service_typedefd_list_string_list);
 
     /* Run the tests and make the result available to our parent process */
     _exit (g_test_run ());


### PR DESCRIPTION
These changes allow Hypertable's Thrift interface to be compiled by the C (GLib) compiler by correcting the way the compiler handles "compound" and typedef'd list types. The changes include

- Adding test cases for list-of-string-list containers (variables of type `list<list<string>>`) returned by service methods, both aliased with a typedef and not;
- Modifying the compiler to
  - Initialize list variables (pointer arrays) in the generated code before they are used,
  - Correctly identify the type of typedef'd list elements and
  - Omit the dereference operator ("*") in typedef'd types to match the way they would naturally be used in client code.

The final commit refactors the test cases to put common code related to creating a service client in its own function.