### PR TITLE
THRIFT-2536: Java: TBinaryProtocol: Use a single temp byte[] buffer

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -52,6 +52,8 @@ public class TBinaryProtocol extends TProtocol {
   protected boolean strictRead_;
   protected boolean strictWrite_;
 
+  private final byte[] inoutTemp = new byte[8];
+
   /**
    * Factory
    */
@@ -156,39 +158,35 @@ public class TBinaryProtocol extends TProtocol {
     writeByte(b ? (byte)1 : (byte)0);
   }
 
-  private byte [] bout = new byte[1];
   public void writeByte(byte b) throws TException {
-    bout[0] = b;
-    trans_.write(bout, 0, 1);
+    inoutTemp[0] = b;
+    trans_.write(inoutTemp, 0, 1);
   }
 
-  private byte[] i16out = new byte[2];
   public void writeI16(short i16) throws TException {
-    i16out[0] = (byte)(0xff & (i16 >> 8));
-    i16out[1] = (byte)(0xff & (i16));
-    trans_.write(i16out, 0, 2);
+    inoutTemp[0] = (byte)(0xff & (i16 >> 8));
+    inoutTemp[1] = (byte)(0xff & (i16));
+    trans_.write(inoutTemp, 0, 2);
   }
 
-  private byte[] i32out = new byte[4];
   public void writeI32(int i32) throws TException {
-    i32out[0] = (byte)(0xff & (i32 >> 24));
-    i32out[1] = (byte)(0xff & (i32 >> 16));
-    i32out[2] = (byte)(0xff & (i32 >> 8));
-    i32out[3] = (byte)(0xff & (i32));
-    trans_.write(i32out, 0, 4);
+    inoutTemp[0] = (byte)(0xff & (i32 >> 24));
+    inoutTemp[1] = (byte)(0xff & (i32 >> 16));
+    inoutTemp[2] = (byte)(0xff & (i32 >> 8));
+    inoutTemp[3] = (byte)(0xff & (i32));
+    trans_.write(inoutTemp, 0, 4);
   }
 
-  private byte[] i64out = new byte[8];
   public void writeI64(long i64) throws TException {
-    i64out[0] = (byte)(0xff & (i64 >> 56));
-    i64out[1] = (byte)(0xff & (i64 >> 48));
-    i64out[2] = (byte)(0xff & (i64 >> 40));
-    i64out[3] = (byte)(0xff & (i64 >> 32));
-    i64out[4] = (byte)(0xff & (i64 >> 24));
-    i64out[5] = (byte)(0xff & (i64 >> 16));
-    i64out[6] = (byte)(0xff & (i64 >> 8));
-    i64out[7] = (byte)(0xff & (i64));
-    trans_.write(i64out, 0, 8);
+    inoutTemp[0] = (byte)(0xff & (i64 >> 56));
+    inoutTemp[1] = (byte)(0xff & (i64 >> 48));
+    inoutTemp[2] = (byte)(0xff & (i64 >> 40));
+    inoutTemp[3] = (byte)(0xff & (i64 >> 32));
+    inoutTemp[4] = (byte)(0xff & (i64 >> 24));
+    inoutTemp[5] = (byte)(0xff & (i64 >> 16));
+    inoutTemp[6] = (byte)(0xff & (i64 >> 8));
+    inoutTemp[7] = (byte)(0xff & (i64));
+    trans_.write(inoutTemp, 0, 8);
   }
 
   public void writeDouble(double dub) throws TException {
@@ -275,20 +273,18 @@ public class TBinaryProtocol extends TProtocol {
     return (readByte() == 1);
   }
 
-  private byte[] bin = new byte[1];
   public byte readByte() throws TException {
     if (trans_.getBytesRemainingInBuffer() >= 1) {
       byte b = trans_.getBuffer()[trans_.getBufferPosition()];
       trans_.consumeBuffer(1);
       return b;
     }
-    readAll(bin, 0, 1);
-    return bin[0];
+    readAll(inoutTemp, 0, 1);
+    return inoutTemp[0];
   }
 
-  private byte[] i16rd = new byte[2];
   public short readI16() throws TException {
-    byte[] buf = i16rd;
+    byte[] buf = inoutTemp;
     int off = 0;
 
     if (trans_.getBytesRemainingInBuffer() >= 2) {
@@ -296,7 +292,7 @@ public class TBinaryProtocol extends TProtocol {
       off = trans_.getBufferPosition();
       trans_.consumeBuffer(2);
     } else {
-      readAll(i16rd, 0, 2);
+      readAll(inoutTemp, 0, 2);
     }
 
     return
@@ -305,9 +301,8 @@ public class TBinaryProtocol extends TProtocol {
        ((buf[off+1] & 0xff)));
   }
 
-  private byte[] i32rd = new byte[4];
   public int readI32() throws TException {
-    byte[] buf = i32rd;
+    byte[] buf = inoutTemp;
     int off = 0;
 
     if (trans_.getBytesRemainingInBuffer() >= 4) {
@@ -315,7 +310,7 @@ public class TBinaryProtocol extends TProtocol {
       off = trans_.getBufferPosition();
       trans_.consumeBuffer(4);
     } else {
-      readAll(i32rd, 0, 4);
+      readAll(inoutTemp, 0, 4);
     }
     return
       ((buf[off] & 0xff) << 24) |
@@ -324,9 +319,8 @@ public class TBinaryProtocol extends TProtocol {
       ((buf[off+3] & 0xff));
   }
 
-  private byte[] i64rd = new byte[8];
   public long readI64() throws TException {
-    byte[] buf = i64rd;
+    byte[] buf = inoutTemp;
     int off = 0;
 
     if (trans_.getBytesRemainingInBuffer() >= 8) {
@@ -334,7 +328,7 @@ public class TBinaryProtocol extends TProtocol {
       off = trans_.getBufferPosition();
       trans_.consumeBuffer(8);
     } else {
-      readAll(i64rd, 0, 8);
+      readAll(inoutTemp, 0, 8);
     }
 
     return


### PR DESCRIPTION
Reduces allocations and GC when TBinaryProtocol is allocated repeatedly.

Originally separate byte[] arrays were allocated for each integer type, and
a separate array for input and output. However, one buffer of the largest
size (8 bytes for i64) can be used for all purposes.