### PR TITLE
cmake // fixes for std/boost::thread detection; security test; qt test

### DIFF
--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -62,8 +62,10 @@ endif()
 find_package(OpenSSL QUIET)
 CMAKE_DEPENDENT_OPTION(WITH_OPENSSL "Build with OpenSSL support" ON
                        "OPENSSL_FOUND" OFF)
-option(WITH_BOOSTTHREADS "Build with Boost thread support" OFF)
 option(WITH_STDTHREADS "Build with C++ std::thread support" OFF)
+CMAKE_DEPENDENT_OPTION(WITH_BOOSTTHREADS "Build with Boost threads support" OFF
+    "NOT WITH_STDTHREADS;Boost_FOUND" OFF)
+
 
 # C GLib
 option(WITH_C_GLIB "Build C (GLib) Thrift library" ON)

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -117,17 +117,6 @@ target_link_libraries(TServerIntegrationTest -lrt)
 endif ()
 add_test(NAME TServerIntegrationTest COMMAND TServerIntegrationTest)
 
-add_executable(SecurityTest SecurityTest.cpp)
-target_link_libraries(SecurityTest
-    testgencpp
-    ${Boost_LIBRARIES}
-)
-LINK_AGAINST_THRIFT_LIBRARY(SecurityTest thrift)
-if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-target_link_libraries(SecurityTest -lrt)
-endif ()
-add_test(NAME SecurityTest COMMAND SecurityTest "${CMAKE_CURRENT_SOURCE_DIR}/../../../test/keys")
-
 if(WITH_ZLIB)
 add_executable(TransportTest TransportTest.cpp)
 target_link_libraries(TransportTest
@@ -301,6 +290,18 @@ target_link_libraries(OpenSSLManualInitTest
 )
 LINK_AGAINST_THRIFT_LIBRARY(OpenSSLManualInitTest thrift)
 add_test(NAME OpenSSLManualInitTest COMMAND OpenSSLManualInitTest)
+
+add_executable(SecurityTest SecurityTest.cpp)
+target_link_libraries(SecurityTest
+    testgencpp
+    ${Boost_LIBRARIES}
+)
+LINK_AGAINST_THRIFT_LIBRARY(SecurityTest thrift)
+if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+target_link_libraries(SecurityTest -lrt)
+endif ()
+add_test(NAME SecurityTest COMMAND SecurityTest "${CMAKE_CURRENT_SOURCE_DIR}/../../../test/keys")
+
 endif()
 
 if(WITH_QT4)

--- a/lib/cpp/test/qt/CMakeLists.txt
+++ b/lib/cpp/test/qt/CMakeLists.txt
@@ -18,11 +18,15 @@
 #
 
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt5 REQUIRED COMPONENTS Test Network)
 set(TQTcpServerTest_Qt5_SOURCES
     TQTcpServerTest.cpp
 )
 add_executable(TQTcpServerTest_Qt5 ${TQTcpServerTest_Qt5_SOURCES})
-target_link_libraries(TQTcpServerTest_Qt5 testgencpp_cob thriftqt5 thrift Qt5::Test)
+target_link_libraries(TQTcpServerTest_Qt5 testgencpp_cob)
+LINK_AGAINST_THRIFT_LIBRARY(TQTcpServerTest_Qt5 thriftqt5)
+LINK_AGAINST_THRIFT_LIBRARY(TQTcpServerTest_Qt5 thrift)
+target_link_libraries(TQTcpServerTest_Qt5 Qt5::Test Qt5::Network)
+
 add_test(NAME TQTcpServerTest_Qt5 COMMAND TQTcpServerTest_Qt5)
 


### PR DESCRIPTION
Hello All!

Relates to https://issues.apache.org/jira/browse/THRIFT-2850

1. Will use BOOST if not explicitly provided -DWITH_STDTHREADS=ON and Boost_FOUND.
2. Will not build SecurityTest if NOT OPENSSL_FOUND (SecurityTest uses SSL headers which is not available)
3. Fix for TQTcpServerTest_Qt5.

Build successful on Windows (MSVC 2013) and CentOS 7