### PR TITLE
THRIFT-3087 Pass on errors like "connection closed"

### DIFF
--- a/lib/erl/test/test_transport_errors.erl
+++ b/lib/erl/test/test_transport_errors.erl
@@ -1,0 +1,36 @@
+-module(test_transport_errors).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+error_on_write_test_() ->
+    {setup, local, fun start_client/0, fun teardown_client/1, fun error_on_write/1}.
+
+error_on_write(Client) ->
+    ?_assertEqual(
+        {Client, {error, ebadf}},
+        thrift_client:call(Client, testString, [<<"hello world">>])
+    ).
+
+start_client() ->
+    TransportFactory =
+        fun() ->
+            case file:open([], [ram, read]) of
+                {ok, IODevice} ->
+                    thrift_file_transport:new(IODevice, [{should_close, true}, {mode, write}]);
+                Error  ->
+                    Error
+            end
+        end,
+
+    {ok, ProtocolFactory} = thrift_binary_protocol:new_protocol_factory(
+        TransportFactory, []),
+
+    {ok, Protocol} = ProtocolFactory(),
+    {ok, Client} = thrift_client:new(Protocol, thrift_test_thrift),
+    Client.
+
+teardown_client(Client) ->
+    thrift_client:close(Client).
+
+-endif.


### PR DESCRIPTION
Currently client received 'badmatch' error when the thrift server teardown. I'd like information about errors in the thrift clinet before the process exits.
I've attached an implementation which fixes this good enough for my own and add test.