### PR TITLE
THRIFT-3323 - Update TJSONProtocol.py

### DIFF
--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -41,8 +41,8 @@ BACKSLASH = '\\'
 ZERO = '0'
 
 ESCSEQ = '\\u00'
-ESCAPE_CHAR = '"\\bfnrt'
-ESCAPE_CHAR_VALS = ['"', '\\', '\b', '\f', '\n', '\r', '\t']
+ESCAPE_CHAR = '"\\bfnrt/'
+ESCAPE_CHAR_VALS = ['"', '\\', '\b', '\f', '\n', '\r', '\t', '/']
 NUMERIC_CHAR = '+-.0123456789Ee'
 
 CTYPES = {TType.BOOL:       'tf',


### PR DESCRIPTION
According to JSON spec a forward slash "/" may (but not always) be escaped too; and when that happened, it triggered an issue with deserializing the object.

This small fix addresses that.