### PR TITLE
Fix word-extraction substr bug in initialism code

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -446,7 +446,11 @@ std::string t_go_generator::camelcase(const std::string& value) const {
 // and if so replaces it with the upper case version of the word.
 void t_go_generator::fix_common_initialism(std::string& value, int i) const {
   if (!ignore_initialisms_) {
-    std::string word = value.substr(i, value.find('_', i));
+    size_t wordLen = value.find('_', i);
+    if (wordLen != std::string::npos) {
+      wordLen -= i;
+    }
+    std::string word = value.substr(i, wordLen);
     std::transform(word.begin(), word.end(), word.begin(), ::toupper);
     if (commonInitialisms.find(word) != commonInitialisms.end()) {
       value.replace(i, word.length(), word);


### PR DESCRIPTION
Initialisms were not handled in the second word or later. E.g. for the given Thrift file,
```thrift
service S {
  void get_id()
}
```

The generated code was using `GetIdArgs` instead of `GetIDArgs`. This was happening because fix_common_initialism was passing the position of the underscore to substr when extracting the word, when substr expects a length.