### PR TITLE
Fix bad links to coding_standards.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
   * Remember to provide *tests* for all submited changes
   * When bugfixing: add test that will isolate bug *before* applying change that fixes it
-  * Verify that you follow [Thrift Coding Standards](/coding_standards) (you can run 'make style', which ensures proper format for some languages)
+  * Verify that you follow [Thrift Coding Standards](/doc/coding_standards.md) (you can run 'make style', which ensures proper format for some languages)
 
 1. Create a patch from project root directory (e.g. you@dev:~/thrift $ ):
 
@@ -32,7 +32,7 @@
 
   * Remember to provide *tests* for all submited changes
   * When bugfixing: add test that will isolate bug *before* applying change that fixes it
-  * Verify that you follow [Thrift Coding Standards](/coding_standards) (you can run 'make style', which ensures proper format for some languages)
+  * Verify that you follow [Thrift Coding Standards](/doc/coding_standards.md) (you can run 'make style', which ensures proper format for some languages)
   * Verify that your change works on other platforms by adding a GitHub service hook to [Travis CI](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in) and [AppVeyor](http://www.appveyor.com/docs)
 
 1. Commit and push changes to your branch (please use issue name and description as commit title, e.g. THRIFT-9999 make it perfect)


### PR DESCRIPTION
I noticed the other bad links to coding_standards.md had been fixed, and somehow CONTRIBUTING.md was missed. This is bad news bears since CONTRIBUTING.md is directly referenced by https://thrift.apache.org/docs/HowToContribute - which means these are currently broken on the live site.