### PR TITLE
Implements ssl sockets on c_glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,6 @@ if test "$enable_libs" = "no"; then
   with_lua="no"
 fi
 
-
 AX_THRIFT_LIB(cpp, [C++], yes)
 have_cpp=no
 if test "$with_cpp" = "yes";  then
@@ -144,8 +143,6 @@ if test "$with_cpp" = "yes";  then
     AC_SUBST([BOOST_THREAD_LDADD], [$(echo "$BOOST_LIB_DIR/libboost_thread.a")])
     have_cpp="yes"
   fi
-
-  AX_CHECK_OPENSSL()
 
   AX_LIB_EVENT([1.0])
   have_libevent=$success
@@ -196,6 +193,12 @@ if test "$with_c_glib" = "yes"; then
   fi
 fi
 AM_CONDITIONAL(WITH_C_GLIB, [test "$have_glib2" = "yes" -a "$have_gobject2" = "yes"])
+
+echo "OpenSSL check"
+if test "$have_cpp" = "yes" -o "$have_c_glib" = "yes";  then
+	echo "Have cpp or c so we check for OpenSSL"
+	AX_CHECK_OPENSSL()
+fi
 
 AX_THRIFT_LIB(csharp, [C#], yes)
 if test "$with_csharp" = "yes";  then

--- a/configure.ac
+++ b/configure.ac
@@ -194,9 +194,8 @@ if test "$with_c_glib" = "yes"; then
 fi
 AM_CONDITIONAL(WITH_C_GLIB, [test "$have_glib2" = "yes" -a "$have_gobject2" = "yes"])
 
-echo "OpenSSL check"
+# check we have openssl
 if test "$have_cpp" = "yes" -o "$have_c_glib" = "yes";  then
-	echo "Have cpp or c so we check for OpenSSL"
 	AX_CHECK_OPENSSL()
 fi
 

--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -43,6 +43,7 @@ libthrift_c_glib_la_SOURCES = src/thrift/c_glib/thrift.c \
                               src/thrift/c_glib/transport/thrift_buffered_transport_factory.c \
                               src/thrift/c_glib/transport/thrift_framed_transport_factory.c \
                               src/thrift/c_glib/transport/thrift_socket.c \
+                              src/thrift/c_glib/transport/thrift_ssl_socket.c \
                               src/thrift/c_glib/transport/thrift_server_transport.c \
                               src/thrift/c_glib/transport/thrift_server_socket.c \
                               src/thrift/c_glib/transport/thrift_buffered_transport.c \
@@ -51,7 +52,8 @@ libthrift_c_glib_la_SOURCES = src/thrift/c_glib/thrift.c \
                               src/thrift/c_glib/server/thrift_server.c \
                               src/thrift/c_glib/server/thrift_simple_server.c
 
-libthrift_c_glib_la_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS)
+libthrift_c_glib_la_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS) $(OPENSSL_INCLUDES)
+libthrift_c_glib_la_LDFLAGS = $(AM_LDFLAGS) $(GLIB_LIBS) $(OPENSSL_LIBS) -lgobject-2.0 -avoid-version
 
 include_thriftdir = $(includedir)/thrift/c_glib
 include_thrift_HEADERS = \
@@ -73,6 +75,8 @@ include_transport_HEADERS = src/thrift/c_glib/transport/thrift_buffered_transpor
                             src/thrift/c_glib/transport/thrift_server_socket.h \
                             src/thrift/c_glib/transport/thrift_server_transport.h \
                             src/thrift/c_glib/transport/thrift_socket.h \
+                            src/thrift/c_glib/transport/thrift_platform_socket.h \
+                            src/thrift/c_glib/transport/thrift_ssl_socket.h \
                             src/thrift/c_glib/transport/thrift_transport.h \
                             src/thrift/c_glib/transport/thrift_transport_factory.h \
                             src/thrift/c_glib/transport/thrift_buffered_transport_factory.h \

--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -52,8 +52,8 @@ libthrift_c_glib_la_SOURCES = src/thrift/c_glib/thrift.c \
                               src/thrift/c_glib/server/thrift_server.c \
                               src/thrift/c_glib/server/thrift_simple_server.c
 
-libthrift_c_glib_la_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS) $(OPENSSL_INCLUDES)
-libthrift_c_glib_la_LDFLAGS = $(AM_LDFLAGS) $(GLIB_LIBS) $(OPENSSL_LIBS) -lgobject-2.0 -avoid-version
+libthrift_c_glib_la_CFLAGS = $(AM_CFLAGS) $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) $(OPENSSL_INCLUDES)
+libthrift_c_glib_la_LDFLAGS = $(AM_LDFLAGS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(OPENSSL_LIBS)
 
 include_thriftdir = $(includedir)/thrift/c_glib
 include_thrift_HEADERS = \

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_platform_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_platform_socket.h
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// clang-format off
+
+#ifndef _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
+#  define _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_
+
+#ifdef _WIN32
+#  define THRIFT_GET_SOCKET_ERROR ::WSAGetLastError()
+#  define THRIFT_ERRNO (*_errno())
+#  define THRIFT_EINPROGRESS WSAEINPROGRESS
+#  define THRIFT_EAGAIN WSAEWOULDBLOCK
+#  define THRIFT_EINTR WSAEINTR
+#  define THRIFT_ECONNRESET WSAECONNRESET
+#  define THRIFT_ENOTCONN WSAENOTCONN
+#  define THRIFT_ETIMEDOUT WSAETIMEDOUT
+#  define THRIFT_EWOULDBLOCK WSAEWOULDBLOCK
+#  define THRIFT_EPIPE WSAECONNRESET
+#  define THRIFT_NO_SOCKET_CACHING SO_EXCLUSIVEADDRUSE
+#  define THRIFT_INVALID_SOCKET INVALID_SOCKET
+#  define THRIFT_SOCKETPAIR thrift_socketpair
+#  define THRIFT_FCNTL thrift_fcntl
+#  define THRIFT_O_NONBLOCK 1
+#  define THRIFT_F_GETFL 0
+#  define THRIFT_F_SETFL 1
+#  define THRIFT_GETTIMEOFDAY thrift_gettimeofday
+#  define THRIFT_CLOSESOCKET closesocket
+#  define THRIFT_CLOSE _close
+#  define THRIFT_OPEN _open
+#  define THRIFT_FTRUNCATE _chsize_s
+#  define THRIFT_FSYNC _commit
+#  define THRIFT_LSEEK _lseek
+#  define THRIFT_WRITE _write
+#  define THRIFT_READ _read
+#  define THRIFT_FSTAT _fstat
+#  define THRIFT_STAT _stat
+#  ifdef _WIN32_WCE
+#    define THRIFT_GAI_STRERROR(...) thrift_wstr2str(gai_strerrorW(__VA_ARGS__))
+#  else
+#    define THRIFT_GAI_STRERROR gai_strerrorA
+#  endif
+#  define THRIFT_SSIZET ptrdiff_t
+#  define THRIFT_SNPRINTF _snprintf
+#  define THRIFT_SLEEP_SEC thrift_sleep
+#  define THRIFT_SLEEP_USEC thrift_usleep
+#  define THRIFT_TIMESPEC thrift_timespec
+#  define THRIFT_CTIME_R thrift_ctime_r
+#  define THRIFT_POLL thrift_poll
+#  if WINVER <= 0x0502 //XP, Server2003
+#    define THRIFT_POLLFD  thrift_pollfd
+#    define THRIFT_POLLIN  0x0300
+#    define THRIFT_POLLOUT 0x0010
+#  else //Vista, Win7...
+#    define THRIFT_POLLFD  pollfd
+#    define THRIFT_POLLIN  POLLIN
+#    define THRIFT_POLLOUT POLLOUT
+#  endif //WINVER
+#  define THRIFT_SHUT_RDWR SD_BOTH
+#else //not _WIN32
+#  include <errno.h>
+#  define THRIFT_GET_SOCKET_ERROR errno
+#  define THRIFT_ERRNO errno
+#  define THRIFT_EINTR       EINTR
+#  define THRIFT_EINPROGRESS EINPROGRESS
+#  define THRIFT_ECONNRESET  ECONNRESET
+#  define THRIFT_ENOTCONN    ENOTCONN
+#  define THRIFT_ETIMEDOUT   ETIMEDOUT
+#  define THRIFT_EWOULDBLOCK EWOULDBLOCK
+#  define THRIFT_EAGAIN      EAGAIN
+#  define THRIFT_EPIPE       EPIPE
+#  define THRIFT_NO_SOCKET_CACHING SO_REUSEADDR
+#  define THRIFT_INVALID_SOCKET (-1)
+#  define THRIFT_SOCKETPAIR socketpair
+#  define THRIFT_FCNTL fcntl
+#  define THRIFT_O_NONBLOCK O_NONBLOCK
+#  define THRIFT_F_GETFL F_GETFL
+#  define THRIFT_F_SETFL F_SETFL
+#  define THRIFT_GETTIMEOFDAY gettimeofday
+#  define THRIFT_CLOSESOCKET close
+#  define THRIFT_CLOSE close
+#  define THRIFT_OPEN open
+#  define THRIFT_FTRUNCATE ftruncate
+#  define THRIFT_FSYNC fsync
+#  define THRIFT_LSEEK lseek
+#  define THRIFT_WRITE write
+#  define THRIFT_READ read
+#  define THRIFT_STAT stat
+#  define THRIFT_FSTAT fstat
+#  define THRIFT_GAI_STRERROR gai_strerror
+#  define THRIFT_SSIZET ssize_t
+#  define THRIFT_SNPRINTF snprintf
+#  define THRIFT_SLEEP_SEC sleep
+#  define THRIFT_SLEEP_USEC usleep
+#  define THRIFT_TIMESPEC timespec
+#  define THRIFT_CTIME_R ctime_r
+#  define THRIFT_POLL poll
+#  define THRIFT_POLLFD  pollfd
+#  define THRIFT_POLLIN  POLLIN
+#  define THRIFT_POLLOUT POLLOUT
+#  define THRIFT_SHUT_RDWR SHUT_RDWR
+#endif
+
+#endif // _THRIFT_TRANSPORT_PLATFORM_SOCKET_H_

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
@@ -1,0 +1,634 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <openssl/ssl.h>
+
+#include <thrift/c_glib/thrift.h>
+#include <thrift/c_glib/transport/thrift_transport.h>
+#include <thrift/c_glib/transport/thrift_socket.h>
+#include <thrift/c_glib/transport/thrift_ssl_socket.h>
+
+#define OPENSSL_VERSION_NO_THREAD_ID 0x10000000L
+
+
+/* object properties */
+enum _ThriftSSLSocketProperties
+{
+	PROP_THRIFT_SSL_SOCKET_CONTEXT = 3
+};
+
+/* for errors coming from socket() and connect() */
+// extern int errno;
+
+// To hold a global state management of openssl for all instances
+static gboolean thrift_ssl_socket_openssl_initialized=FALSE;
+static SSL_CTX* thrift_ssl_socket_global_context=NULL; // Should this be keept at class level?
+
+#if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_NO_THREAD_ID)
+static unsigned long callbackThreadID() {
+	return (unsigned long)pthread_self();
+}
+#endif
+
+
+static void thrift_ssl_socket_static_locking_callback(int mode, int n, const char* unk, int id) {
+	if (mode & CRYPTO_LOCK) {
+//		g_printf("We should lock thread %d\n", n);
+		//mutexes[n].lock();
+	} else {
+//		g_printf("We should unlock thread %d\n", n);
+		//mutexes[n].unlock();
+	}
+}
+
+static void* thrift_ssl_socket_dyn_lock_create_callback(const char* unk, int id) {
+	g_print("We should create a lock\n");
+	return NULL;
+}
+
+static void thrift_ssl_socket_dyn_lock_callback(int mode, void* lock, const char* unk, int id) {
+	if (lock != NULL) {
+		if (mode & CRYPTO_LOCK) {
+			g_printf("We should lock thread %d\n");
+		} else {
+			g_printf("We should unlock thread %d\n");
+		}
+	}
+}
+
+static void thrift_ssl_socket_dyn_lock_destroy_callback(void* lock, const char* unk, int id) {
+	g_printf("We must destroy the lock\n");
+}
+
+
+
+G_DEFINE_TYPE(ThriftSSLSocket, thrift_ssl_socket, THRIFT_TYPE_SOCKET)
+
+
+/* implements thrift_transport_is_open */
+gboolean
+thrift_ssl_socket_is_open (ThriftTransport *transport)
+{
+	return thrift_socket_is_open(transport);
+}
+
+/* overrides thrift_transport_peek */
+gboolean
+thrift_ssl_socket_peek (ThriftTransport *transport, GError **error)
+{
+	gboolean retval = FALSE;
+	ThriftSSLSocket *ssl_socket = THRIFT_SSL_SOCKET (transport);
+	if(ssl_socket!=NULL && THRIFT_SSL_SOCKET_GET_CLASS(ssl_socket)->handle_handshake(transport, error)){
+		if (thrift_ssl_socket_is_open (transport))
+		{
+			int rc;
+			gchar byte;
+			rc = SSL_peek(ssl_socket->ssl, &byte, 1);
+			if (rc < 0) {
+				g_set_error (error,
+						THRIFT_TRANSPORT_ERROR,
+						THRIFT_SSL_SOCKET_ERROR_SSL,
+						"failed to peek at socket - id?");
+				//			    int errno_copy = THRIFT_GET_SOCKET_ERROR;
+				//			    string errors;
+				//			    buildErrors(errors, errno_copy);
+				//			    throw TSSLException("SSL_peek: " + errors);
+			}
+			if (rc == 0) {
+				ERR_clear_error();
+			}
+			retval = (rc > 0);
+		}
+	}
+	return retval;
+}
+
+/* implements thrift_transport_open */
+gboolean
+thrift_ssl_socket_open (ThriftTransport *transport, GError **error)
+{
+	return thrift_socket_open(transport, error);
+}
+
+/* implements thrift_transport_close */
+gboolean
+thrift_ssl_socket_close (ThriftTransport *transport, GError **error)
+{
+	gboolean retval = FALSE;
+	if(THRIFT_SSL_SOCKET(transport)->ssl) {
+		int rc = SSL_shutdown(THRIFT_SSL_SOCKET(transport)->ssl);
+		if (rc < 0) {
+			int errno_copy = THRIFT_SSL_SOCKET_ERROR_SSL;
+			// FIXME build error
+			//	      string errors;
+			//	      buildErrors(errors, errno_copy);
+			//	      GlobalOutput(("SSL_shutdown: " + errors).c_str());
+		}
+		SSL_free(THRIFT_SSL_SOCKET(transport)->ssl);
+		THRIFT_SSL_SOCKET(transport)->ssl = NULL;
+		ERR_remove_state(0);
+	}
+	return thrift_socket_close(transport, error);
+}
+
+/* implements thrift_transport_read */
+gint32
+thrift_ssl_socket_read (ThriftTransport *transport, gpointer buf,
+		guint32 len, GError **error)
+{
+	guint maxRecvRetries_ = 10;
+	ThriftSSLSocket *ssl_socket = THRIFT_SSL_SOCKET (transport);
+	guint bytes = 0;
+	guint retries = 0;
+	if(ssl_socket!=NULL && THRIFT_SSL_SOCKET_GET_CLASS(ssl_socket)->handle_handshake(transport, error)){
+		for (retries=0; retries < maxRecvRetries_; retries++) {
+			bytes = SSL_read(ssl_socket->ssl, buf, len);
+			if (bytes >= 0)
+				break;
+			int errno_copy = THRIFT_GET_SOCKET_ERROR;
+			if (SSL_get_error(ssl_socket->ssl, bytes) == SSL_ERROR_SYSCALL) {
+				if (ERR_get_error() == 0 && errno_copy == THRIFT_EINTR) {
+					continue;
+				}
+			}
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					THRIFT_TRANSPORT_ERROR_RECEIVE,
+					"failed to read %d bytes - %s", len, strerror(errno));
+			return -1;
+			//			string errors;
+			//			buildErrors(errors, errno_copy);
+			//			throw TSSLException("SSL_read: " + errors);
+		}
+	}
+	return bytes;
+}
+
+/* implements thrift_transport_read_end
+ * called when write is complete.  nothing to do on our end. */
+gboolean
+thrift_ssl_socket_read_end (ThriftTransport *transport, GError **error)
+{
+	/* satisfy -Wall */
+	THRIFT_UNUSED_VAR (transport);
+	THRIFT_UNUSED_VAR (error);
+	return TRUE;
+}
+
+/* implements thrift_transport_write */
+gboolean
+thrift_ssl_socket_write (ThriftTransport *transport, const gpointer buf,
+		const guint32 len, GError **error)
+{
+	ThriftSSLSocket *ssl_socket = THRIFT_SSL_SOCKET (transport);
+	gint ret = 0;
+	guint sent = 0;
+	if(THRIFT_SSL_SOCKET_GET_CLASS(ssl_socket)->handle_handshake(transport, error)){
+
+		ThriftSocket *socket = THRIFT_SSL_SOCKET (transport);
+		g_return_val_if_fail (socket->sd != THRIFT_INVALID_SOCKET, FALSE);
+
+		while (sent < len)
+		{
+			ret = SSL_write (ssl_socket->ssl, (guint8 *)buf + sent, len - sent);
+			if (ret < 0)
+			{
+				g_set_error (error, THRIFT_TRANSPORT_ERROR,
+						THRIFT_TRANSPORT_ERROR_SEND,
+						"failed to send %d bytes - %s", len, strerror(errno));
+				return FALSE;
+			}
+			sent += ret;
+		}
+
+	}
+	return sent==len;
+}
+
+/* implements thrift_transport_write_end
+ * called when write is complete.  nothing to do on our end. */
+gboolean
+thrift_ssl_socket_write_end (ThriftTransport *transport, GError **error)
+{
+	  /* satisfy -Wall */
+	  THRIFT_UNUSED_VAR (transport);
+	  THRIFT_UNUSED_VAR (error);
+	  return TRUE;
+}
+
+/* implements thrift_transport_flush
+ * flush pending data.  since we are not buffered, this is a no-op */
+gboolean
+thrift_ssl_socket_flush (ThriftTransport *transport, GError **error)
+{
+	ThriftSSLSocket *ssl_socket = THRIFT_SSL_SOCKET (transport);
+	gint ret = 0;
+	guint sent = 0;
+	if(THRIFT_SSL_SOCKET_GET_CLASS(ssl_socket)->handle_handshake(transport, error)){
+
+		BIO* bio = SSL_get_wbio(ssl_socket->ssl);
+		if (bio == NULL) {
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					THRIFT_TRANSPORT_ERROR_SEND,
+					"failed to flush, wbio returned null");
+			//			    throw TSSLException("SSL_get_wbio returns NULL");
+		}
+		if (BIO_flush(bio) != 1) {
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					THRIFT_TRANSPORT_ERROR_SEND,
+					"failed to flush it returned error");
+			//			    int errno_copy = THRIFT_GET_SOCKET_ERROR;
+			//			    string errors;
+			//			    buildErrors(errors, errno_copy);
+			//			    throw TSSLException("BIO_flush: " + errors);
+			return FALSE;
+		}
+
+	}
+	return TRUE;
+}
+
+
+gboolean
+thrift_ssl_socket_handle_handshake(ThriftTransport * transport, GError **error)
+{
+	ThriftSSLSocket *ssl_socket = THRIFT_SSL_SOCKET (transport);
+	ThriftSocket *socket = THRIFT_SOCKET (transport);
+	g_return_val_if_fail (thrift_transport_is_open (transport), FALSE);
+
+	if(ssl_socket==NULL || ssl_socket->ssl!=NULL){
+		return TRUE;
+	}
+
+	if(THRIFT_SSL_SOCKET_GET_CLASS(ssl_socket)->create_ssl_context(transport, error)){
+		// Context created
+		SSL_set_fd(ssl_socket->ssl, socket->sd);
+		int rc;
+		if(ssl_socket->server){
+			rc = SSL_accept(ssl_socket->ssl);
+		}else{
+			rc = SSL_connect(ssl_socket->ssl);
+		}
+		if (rc <= 0) {
+			fprintf(stderr,"The error returned was %d\n", SSL_get_error(ssl_socket->ssl, rc));
+			thrift_ssl_socket_get_error(error, "Not possible to connect", THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE);
+			return FALSE;
+			//		    int errno_copy = THRIFT_GET_SOCKET_ERROR;
+			//		    string fname(server() ? "SSL_accept" : "SSL_connect");
+			//		    string errors;
+			//		    buildErrors(errors, errno_copy);
+			//		    throw TSSLException(fname + ": " + errors);
+		}
+	}else
+		return FALSE;
+
+	return thrift_ssl_socket_authorize(transport, error);
+}
+
+gboolean
+thrift_ssl_socket_create_ssl_context(ThriftTransport * transport, GError **error)
+{
+	ThriftSSLSocket *socket = THRIFT_SSL_SOCKET (transport);
+
+	if(socket->ctx!=NULL){
+		if(socket->ssl!=NULL) {
+			return TRUE;
+		}
+
+		socket->ssl = SSL_new(socket->ctx);
+		if (socket->ssl == NULL) {
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					THRIFT_SSL_SOCKET_ERROR_TRANSPORT,
+					"Unable to create SSL context");
+			return FALSE;
+			//		    string errors;
+			//		    buildErrors(errors);
+			//		    throw TSSLException("SSL_new: " + errors);
+		}
+	}
+
+	return TRUE;
+}
+
+gboolean
+thrift_ssl_socket_authorize(ThriftTransport * transport, GError **error)
+{
+	ThriftSSLSocket *socket = THRIFT_SSL_SOCKET (transport);
+	void *access_manager = NULL; // We still don't support it
+	if(socket->ssl!=NULL){
+		int rc = SSL_get_verify_result(socket->ssl);
+		if (rc != X509_V_OK) { // verify authentication result
+			//		    throw TSSLException(string("SSL_get_verify_result(), ") + X509_verify_cert_error_string(rc));
+			g_warning("The certificate verification failed!");
+//			return FALSE;
+		}
+		X509* cert = SSL_get_peer_certificate(socket->ssl);
+		if (cert == NULL) {
+			// certificate is not present
+			if (SSL_get_verify_mode(socket->ssl) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) {
+				return FALSE;
+				//throw TSSLException("authorize: required certificate not present");
+			}
+			// certificate was optional: didn't intend to authorize remote
+			if (socket->server && access_manager != NULL) {
+				return FALSE;
+				//				throw TSSLException("authorize: certificate required for authorization");
+			}
+			return FALSE;
+		}
+		// certificate is present, since we don't support access manager we are done
+		if (access_manager == NULL) {
+			X509_free(cert);
+			return TRUE;
+		}
+
+		// Fill with line 365 and after on TSSLSocket
+	}
+
+
+
+	return TRUE;
+}
+
+
+/* initializes the instance */
+static void
+thrift_ssl_socket_init (ThriftSSLSocket *socket)
+{
+	socket->ssl = NULL;
+	socket->ctx = NULL;
+	socket->server = FALSE;
+}
+
+/* destructor */
+static void
+thrift_ssl_socket_finalize (GObject *object)
+{
+	ThriftSSLSocket *socket = THRIFT_SSL_SOCKET (object);
+	GError *error=NULL;
+	if(socket->ssl != NULL)
+	{
+		thrift_ssl_socket_close(THRIFT_TRANSPORT(object), &error);
+		socket->ssl=NULL;
+		socket->ctx=NULL;
+	}
+}
+
+/* property accessor */
+void
+thrift_ssl_socket_get_property (GObject *object, guint property_id,
+		GValue *value, GParamSpec *pspec)
+{
+	ThriftSSLSocket *socket = THRIFT_SSL_SOCKET (object);
+
+	THRIFT_UNUSED_VAR (pspec);
+	g_test_message("Getting property id %d", value);
+
+	switch (property_id)
+	{
+	case PROP_THRIFT_SSL_SOCKET_CONTEXT:
+		g_value_set_pointer (value, socket->ctx);
+		break;
+	}
+}
+
+/* property mutator */
+void
+thrift_ssl_socket_set_property (GObject *object, guint property_id,
+		const GValue *value, GParamSpec *pspec)
+{
+	//ThriftSocketClass *tsc= THRIFT_SOCKET_CLASS(object);
+	ThriftSSLSocket *socket = THRIFT_SSL_SOCKET (object);
+
+	THRIFT_UNUSED_VAR (pspec);
+	g_test_message("Setting property id %d", property_id);
+	switch (property_id)
+	{
+	case PROP_THRIFT_SSL_SOCKET_CONTEXT:
+		socket->ctx = g_value_get_pointer(value); // We copy the context
+		break;
+		//	default:
+		//		thrift_socket_set_property(object, property_id, value, pspec);
+		//		break;
+	}
+}
+
+void
+thrift_ssl_socket_initialize_openssl(void)
+{
+	if(thrift_ssl_socket_openssl_initialized){
+		return;
+	}
+	thrift_ssl_socket_openssl_initialized=TRUE;
+	SSL_library_init();
+	ERR_load_crypto_strings();
+	SSL_load_error_strings();
+	ERR_load_BIO_strings();
+
+#if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_NO_THREAD_ID)
+	CRYPTO_set_id_callback(callbackThreadID);
+#endif
+	CRYPTO_set_locking_callback(thrift_ssl_socket_static_locking_callback);
+	// dynamic locking
+	CRYPTO_set_dynlock_create_callback(thrift_ssl_socket_dyn_lock_create_callback);
+	CRYPTO_set_dynlock_lock_callback(thrift_ssl_socket_dyn_lock_callback);
+	CRYPTO_set_dynlock_destroy_callback(thrift_ssl_socket_dyn_lock_destroy_callback);
+}
+
+
+void thrift_ssl_socket_finalize_openssl(void) {
+
+	// FIXME This should not be here
+	if (thrift_ssl_socket_global_context != NULL) {
+		SSL_CTX_free(thrift_ssl_socket_global_context);
+		thrift_ssl_socket_global_context = NULL;
+	}
+
+	if (!thrift_ssl_socket_openssl_initialized) {
+		return;
+	}
+	thrift_ssl_socket_openssl_initialized = FALSE;
+#if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_NO_THREAD_ID)
+	CRYPTO_set_id_callback(NULL);
+#endif
+	CRYPTO_set_locking_callback(NULL);
+	CRYPTO_set_dynlock_create_callback(NULL);
+	CRYPTO_set_dynlock_lock_callback(NULL);
+	CRYPTO_set_dynlock_destroy_callback(NULL);
+	ERR_free_strings();
+	EVP_cleanup();
+	CRYPTO_cleanup_all_ex_data();
+	ERR_remove_state(0);
+
+
+}
+
+
+/* initializes the class */
+static void
+thrift_ssl_socket_class_init (ThriftSSLSocketClass *cls)
+{
+	ThriftTransportClass *ttc = THRIFT_TRANSPORT_CLASS (cls);
+	GObjectClass *gobject_class = G_OBJECT_CLASS (cls);
+	GParamSpec *param_spec = NULL;
+	g_test_message("Init of class\n");
+	/* setup accessors and mutators */
+	gobject_class->get_property = thrift_ssl_socket_get_property;
+	gobject_class->set_property = thrift_ssl_socket_set_property;
+	param_spec = g_param_spec_pointer ("ssl_context",
+			"ssl_context (construct)",
+			"Set the ssl context for handshake with the remote host",
+			G_PARAM_CONSTRUCT_ONLY |
+			G_PARAM_READWRITE);
+	g_object_class_install_property (gobject_class, PROP_THRIFT_SSL_SOCKET_CONTEXT,
+			param_spec);
+	//
+	//  param_spec = g_param_spec_uint ("port",
+	//                                  "port (construct)",
+	//                                  "Set the port of the remote host",
+	//                                  0, /* min */
+	//                                  65534, /* max */
+	//                                  9090, /* default by convention */
+	//                                  G_PARAM_CONSTRUCT_ONLY |
+	//                                  G_PARAM_READWRITE);
+	//  g_object_class_install_property (gobject_class, PROP_THRIFT_SSL_SOCKET_PORT,
+	//                                   param_spec);
+
+
+
+	// Class methods
+	cls->handle_handshake = thrift_ssl_socket_handle_handshake;
+	cls->create_ssl_context = thrift_ssl_socket_create_ssl_context;
+
+	// Override
+	gobject_class->finalize = thrift_ssl_socket_finalize;
+	ttc->is_open = thrift_ssl_socket_is_open;
+	ttc->peek = thrift_ssl_socket_peek;
+	ttc->open = thrift_ssl_socket_open;
+	ttc->close = thrift_ssl_socket_close;
+	ttc->read = thrift_ssl_socket_read;
+	ttc->read_end = thrift_ssl_socket_read_end;
+	ttc->write = thrift_ssl_socket_write;
+	ttc->write_end = thrift_ssl_socket_write_end;
+	ttc->flush = thrift_ssl_socket_flush;
+}
+
+
+/*
+ * Public API
+ */
+ThriftSSLSocket*
+thrift_ssl_socket_new(ThriftSSLSocketProtocol ssl_protocol, GError **error)
+{
+	ThriftSSLSocket *thriftSSLSocket = NULL;
+	// Create the context
+	if(thrift_ssl_socket_global_context==NULL){
+		if(!thrift_ssl_socket_context_initialize(ssl_protocol, error)){
+			// FIXME Do error control
+			return thriftSSLSocket;
+		}
+	}
+	// FIXME if the protocol is different?
+	thriftSSLSocket = g_object_new (THRIFT_TYPE_SSL_SOCKET, "ssl_context", thrift_ssl_socket_global_context, NULL);
+	return thriftSSLSocket;
+}
+
+ThriftSSLSocket*
+thrift_ssl_socket_new_with_host(ThriftSSLSocketProtocol ssl_protocol, gchar *hostname, guint port, GError **error)
+{
+	ThriftSSLSocket *thriftSSLSocket = NULL;
+	// Create the context
+	if(thrift_ssl_socket_global_context==NULL){
+		if(!thrift_ssl_socket_context_initialize(ssl_protocol, error)){
+			// FIXME Do error control
+			return thriftSSLSocket;
+		}
+	}
+	// FIXME if the protocol is different?
+	thriftSSLSocket = g_object_new (THRIFT_TYPE_SSL_SOCKET, "ssl_context", thrift_ssl_socket_global_context, "hostname", hostname, "port", port, NULL);
+	return thriftSSLSocket;
+}
+
+gboolean
+thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GError **error)
+{
+	switch(ssl_protocol){
+	case SSLTLS:
+		thrift_ssl_socket_global_context = SSL_CTX_new(SSLv23_method());
+		break;
+	case SSLv3:
+		thrift_ssl_socket_global_context = SSL_CTX_new(SSLv3_method());
+		break;
+	case TLSv1_0:
+		thrift_ssl_socket_global_context = SSL_CTX_new(TLSv1_method());
+		break;
+	case TLSv1_1:
+		thrift_ssl_socket_global_context = SSL_CTX_new(TLSv1_1_method());
+		break;
+	case TLSv1_2:
+		thrift_ssl_socket_global_context = SSL_CTX_new(TLSv1_2_method());
+		break;
+	default:
+		g_set_error (error, THRIFT_TRANSPORT_ERROR,
+				THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE,
+				"The SSL protocol is unknown for %d", ssl_protocol);
+		return FALSE;
+		break;
+	}
+
+	if (thrift_ssl_socket_global_context == NULL) {
+		thrift_ssl_socket_get_error(error, "No cipher overlay", THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE);
+		return FALSE;
+	}
+	SSL_CTX_set_mode(thrift_ssl_socket_global_context, SSL_MODE_AUTO_RETRY);
+
+	// Disable horribly insecure SSLv2 and SSLv3 protocols but allow a handshake
+	// with older clients so they get a graceful denial.
+	if (ssl_protocol == SSLTLS) {
+		SSL_CTX_set_options(thrift_ssl_socket_global_context, SSL_OP_NO_SSLv2);
+		SSL_CTX_set_options(thrift_ssl_socket_global_context, SSL_OP_NO_SSLv3);   // THRIFT-3164
+	}
+
+	return TRUE;
+}
+
+
+void thrift_ssl_socket_get_error(GError **error, const guchar *error_msg, guint thrift_error_no)
+{
+	unsigned long error_code;
+	while ((error_code = ERR_get_error()) != 0) {
+		const char* reason = ERR_reason_error_string(error_code);
+		if (reason == NULL) {
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					thrift_error_no,
+					"SSL error %lX: %s", error_code, error_msg);
+		}else{
+			g_set_error (error, THRIFT_TRANSPORT_ERROR,
+					thrift_error_no,
+					"SSL error %lX %s: %s", error_code,reason, error_msg);
+		}
+	}
+}
+

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
@@ -332,42 +332,6 @@ thrift_ssl_socket_create_ssl_context(ThriftTransport * transport, GError **error
 	return TRUE;
 }
 
-//
-///**
-// * Print the common name of certificate
-// */
-//void print_cn_name(const char* label, X509_NAME* const name)
-//{
-//	int idx = -1, success = 0;
-//	unsigned char *utf8 = NULL;
-//
-//	do
-//	{
-//		if(!name) break; /* failed */
-//
-//		idx = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
-//		if(!(idx > -1))  break; /* failed */
-//
-//		X509_NAME_ENTRY* entry = X509_NAME_get_entry(name, idx);
-//		if(!entry) break; /* failed */
-//
-//		ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
-//		if(!data) break; /* failed */
-//
-//		int length = ASN1_STRING_to_UTF8(&utf8, data);
-//		if(!utf8 || !(length > 0))  break; /* failed */
-//
-//		g_info("  %s: %s", label, utf8);
-//		success = 1;
-//
-//	} while (0);
-//
-//	if(utf8)
-//		OPENSSL_free(utf8);
-//
-//	if(!success)
-//		g_info("  %s: <not available>", label);
-//}
 
 gboolean thrift_ssl_load_cert_from_buffer(ThriftSSLSocket *ssl_socket, const char chain_certs[])
 {
@@ -382,12 +346,12 @@ gboolean thrift_ssl_load_cert_from_buffer(ThriftSSLSocket *ssl_socket, const cha
 	if(cert_store!=NULL){
 		int index = 0;
 		while ((cacert = PEM_read_bio_X509(mem, NULL, 0, NULL))!=NULL) {
-//			X509_NAME* iname = cacert ? X509_get_issuer_name(cacert) : NULL;
-//			X509_NAME* sname = cacert ? X509_get_subject_name(cacert) : NULL;
-//			/* Issuer is the authority we trust that warrants nothing useful */
-//			print_cn_name("Issuer (cn)", iname);
-//			/* Subject is who the certificate is issued to by the authority  */
-//			print_cn_name("Subject (cn)", sname);
+			//			X509_NAME* iname = cacert ? X509_get_issuer_name(cacert) : NULL;
+			//			X509_NAME* sname = cacert ? X509_get_subject_name(cacert) : NULL;
+			//			/* Issuer is the authority we trust that warrants nothing useful */
+			//			print_cn_name("Issuer (cn)", iname);
+			//			/* Subject is who the certificate is issued to by the authority  */
+			//			print_cn_name("Subject (cn)", sname);
 			X509_STORE_add_cert(cert_store, cacert);
 			if(cacert) {
 				X509_free(cacert);
@@ -411,9 +375,9 @@ thrift_ssl_socket_authorize(ThriftTransport * transport, GError **error)
 	gboolean authorization_result = FALSE;
 	// We still don't support it
 	if(cls!=NULL && ssl_socket->ssl!=NULL){
-//		if(!thrift_ssl_load_cert_from_buffer(ssl_socket, chain_certs)){
-//			g_warning("Cannot load the certificate chain");
-//		}
+		//		if(!thrift_ssl_load_cert_from_buffer(ssl_socket, chain_certs)){
+		//			g_warning("Cannot load the certificate chain");
+		//		}
 		int rc = SSL_get_verify_result(ssl_socket->ssl);
 		if (rc != X509_V_OK) { // verify authentication result
 			g_warning("The certificate verification failed!: %s", X509_verify_cert_error_string(rc));
@@ -640,10 +604,10 @@ thrift_ssl_socket_new(ThriftSSLSocketProtocol ssl_protocol, GError **error)
 
 void thrift_ssl_socket_set_manager(ThriftSSLSocket *ssl_socket, AUTHORIZATION_MANAGER_CALLBACK callback)
 {
-ThriftSSLSocketClass *sslSocketClass = THRIFT_SSL_SOCKET_GET_CLASS (ssl_socket);
- if(sslSocketClass){
- 	sslSocketClass->authorize_peer = callback;
- }
+	ThriftSSLSocketClass *sslSocketClass = THRIFT_SSL_SOCKET_GET_CLASS (ssl_socket);
+	if(sslSocketClass){
+		sslSocketClass->authorize_peer = callback;
+	}
 }
 
 

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _THRIFT_SSL_SOCKET_H
+#define _THRIFT_SSL_SOCKET_H
+
+#include <glib-object.h>
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+
+#include <thrift/c_glib/transport/thrift_transport.h>
+#include <thrift/c_glib/transport/thrift_socket.h>
+#include <thrift/c_glib/transport/thrift_platform_socket.h>
+
+G_BEGIN_DECLS
+
+/*! \file thrift_ssl_socket.h
+ *  \brief SSL Socket implementation of a Thrift transport.  Subclasses the
+ *         ThriftSocket class. Based on plain openssl.
+ *         In the future we should take a look to https://issues.apache.org/jira/browse/THRIFT-1016
+ */
+
+/* type macros */
+#define THRIFT_TYPE_SSL_SOCKET (thrift_ssl_socket_get_type ())
+#define THRIFT_SSL_SOCKET(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), THRIFT_TYPE_SSL_SOCKET, ThriftSSLSocket))
+#define THRIFT_IS_SSL_SOCKET(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), THRIFT_TYPE_SSL_SOCKET))
+#define THRIFT_SSL_SOCKET_CLASS(c) (G_TYPE_CHECK_CLASS_CAST ((c), THRIFT_TYPE_SSL_SOCKET, ThriftSSLSocketClass))
+#define THRIFT_IS_SSL_SOCKET_CLASS(c) (G_TYPE_CHECK_CLASS_TYPE ((c), THRIFT_TYPE_SSL_SOCKET))
+#define THRIFT_SSL_SOCKET_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), THRIFT_TYPE_SSL_SOCKET, ThriftSSLSocketClass))
+
+
+/* define error/exception types */
+typedef enum
+{
+  THRIFT_SSL_SOCKET_ERROR_TRANSPORT=7,
+  THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE,
+  THRIFT_SSL_SOCKET_ERROR_SSL
+} ThriftSSLSocketError;
+
+
+typedef struct _ThriftSSLSocket ThriftSSLSocket;
+
+/*!
+ * Thrift SSL Socket instance.
+ */
+struct _ThriftSSLSocket
+{
+  ThriftSocket parent;
+
+  /* private */
+  SSL *ssl;
+  SSL_CTX* ctx;
+  gboolean server;
+  /*
+  gchar *hostname;
+  gshort port;
+  int sd;
+  guint8 *buf;
+  guint32 buf_size;
+  guint32 buf_len;
+  */
+};
+
+typedef struct _ThriftSSLSocketClass ThriftSSLSocketClass;
+
+/*!
+ * Thrift Socket class.
+ */
+struct _ThriftSSLSocketClass
+{
+	ThriftSocketClass parent;
+
+	gboolean (* handle_handshake) (ThriftTransport * transport, GError **error);
+	gboolean (* create_ssl_context) (ThriftTransport * transport, GError **error);
+
+	/* Padding to allow adding up to 12 new virtual functions without
+	 * breaking ABI. */
+	gpointer padding[12];
+};
+
+typedef enum _ThriftSSLSocketProtocol ThriftSSLSocketProtocol;
+
+enum _ThriftSSLSocketProtocol {
+  SSLTLS  = 0,  // Supports SSLv2 and SSLv3 handshake but only negotiates at TLSv1_0 or later.
+//SSLv2   = 1,  // HORRIBLY INSECURE!
+  SSLv3   = 2,  // Supports SSLv3 only - also horribly insecure!
+  TLSv1_0 = 3,  // Supports TLSv1_0 or later.
+  TLSv1_1 = 4,  // Supports TLSv1_1 or later.
+  TLSv1_2 = 5,  // Supports TLSv1_2 or later.
+  LATEST  = TLSv1_2
+};
+
+/* used by THRIFT_TYPE_SSL_SOCKET */
+GType thrift_ssl_socket_get_type (void);
+
+ThriftSSLSocket*
+thrift_ssl_socket_new_with_host(ThriftSSLSocketProtocol ssl_protocol, gchar *hostname, guint port, GError **error);
+ThriftSSLSocket*
+thrift_ssl_socket_new(ThriftSSLSocketProtocol ssl_protocol, GError **error);
+
+G_END_DECLS
+
+
+
+#endif

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
@@ -21,10 +21,12 @@
 #define _THRIFT_SSL_SOCKET_H
 
 #include <glib-object.h>
+#include <glib.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
+#include <sys/socket.h>
 
 #include <thrift/c_glib/transport/thrift_transport.h>
 #include <thrift/c_glib/transport/thrift_socket.h>
@@ -80,7 +82,7 @@ struct _ThriftSSLSocket
 };
 
 typedef struct _ThriftSSLSocketClass ThriftSSLSocketClass;
-
+typedef gboolean (* AUTHORIZATION_MANAGER_CALLBACK) (ThriftTransport * transport, X509 *cert, struct sockaddr_storage *addr, GError **error);
 /*!
  * Thrift Socket class.
  */
@@ -90,13 +92,12 @@ struct _ThriftSSLSocketClass
 
 	gboolean (* handle_handshake) (ThriftTransport * transport, GError **error);
 	gboolean (* create_ssl_context) (ThriftTransport * transport, GError **error);
+	gboolean (* authorize_peer) (ThriftTransport * transport, X509 *cert, struct sockaddr_storage *addr, GError **error);
 
 	/* Padding to allow adding up to 12 new virtual functions without
 	 * breaking ABI. */
 	gpointer padding[12];
 };
-
-typedef enum _ThriftSSLSocketProtocol ThriftSSLSocketProtocol;
 
 enum _ThriftSSLSocketProtocol {
   SSLTLS  = 0,  // Supports SSLv2 and SSLv3 handshake but only negotiates at TLSv1_0 or later.
@@ -107,9 +108,20 @@ enum _ThriftSSLSocketProtocol {
   TLSv1_2 = 5,  // Supports TLSv1_2 or later.
   LATEST  = TLSv1_2
 };
+typedef enum _ThriftSSLSocketProtocol ThriftSSLSocketProtocol;
+
+
+/* Internal functions */
+gboolean
+thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GError **error);
+
 
 /* used by THRIFT_TYPE_SSL_SOCKET */
 GType thrift_ssl_socket_get_type (void);
+void thrift_ssl_socket_get_error(GError **error, const guchar *error_msg, guint thrift_error_no);
+
+
+void thrift_ssl_socket_set_manager(ThriftSSLSocket *ssl_socket, AUTHORIZATION_MANAGER_CALLBACK callback);
 
 ThriftSSLSocket*
 thrift_ssl_socket_new_with_host(ThriftSSLSocketProtocol ssl_protocol, gchar *hostname, guint port, GError **error);
@@ -117,7 +129,4 @@ ThriftSSLSocket*
 thrift_ssl_socket_new(ThriftSSLSocketProtocol ssl_protocol, GError **error);
 
 G_END_DECLS
-
-
-
 #endif

--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -37,15 +37,16 @@ BUILT_SOURCES = \
         gen-c_glib/t_test_thrift_test_types.h
 
 AM_CPPFLAGS = -I../src
-AM_CFLAGS = -g -Wall -Wextra -pedantic $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) \
+AM_CFLAGS = -g -Wall -Wextra -pedantic $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) $(OPENSSL_INCLUDES) \
 	@GCOV_CFLAGS@
 AM_CXXFLAGS = $(AM_CFLAGS)
-AM_LDFLAGS = $(GLIB_LIBS) $(GOBJECT_LIBS) @GCOV_LDFLAGS@
+AM_LDFLAGS = $(GLIB_LIBS) $(GOBJECT_LIBS) $(OPENSSL_LIBS) @GCOV_LDFLAGS@
 
 check_PROGRAMS = \
   testapplicationexception \
   testcontainertest \
   testtransportsocket \
+  testtransportsslsocket \
   testbinaryprotocol \
   testbufferedtransport \
   testframedtransport \
@@ -90,6 +91,16 @@ testtransportsocket_LDADD = \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_buffered_transport.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_transport.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_socket.o
+
+
+testtransportsslsocket_SOURCES = testtransportsslsocket.c
+testtransportsslsocket_LDADD = \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_transport.o \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_socket.o \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_buffered_transport.o \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_transport.o \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_socket.o
+
 
 testbinaryprotocol_SOURCES = testbinaryprotocol.c
 testbinaryprotocol_LDADD = \

--- a/lib/c_glib/test/testtransportsslsocket.c
+++ b/lib/c_glib/test/testtransportsslsocket.c
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <netdb.h>
+#include <sys/wait.h>
+
+#include <thrift/c_glib/transport/thrift_transport.h>
+#include <thrift/c_glib/transport/thrift_buffered_transport.h>
+#include <thrift/c_glib/transport/thrift_server_transport.h>
+#include <thrift/c_glib/transport/thrift_server_socket.h>
+#include <thrift/c_glib/transport/thrift_ssl_socket.h>
+
+//#define TEST_DATA { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' }
+#define TEST_DATA { "GET / HTTP/1.1\n\n" }
+
+
+/* substituted functions to test failures of system and library calls */
+static int socket_error = 0;
+int
+my_socket(int domain, int type, int protocol)
+{
+  if (socket_error == 0)
+  {
+    return socket (domain, type, protocol);
+  }
+  return -1;
+}
+
+static int recv_error = 0;
+ssize_t
+my_recv(int socket, void *buffer, size_t length, int flags)
+{
+  if (recv_error == 0)
+  {
+    return recv (socket, buffer, length, flags);
+  }
+  return -1;
+}
+
+static int send_error = 0;
+ssize_t
+my_send(int socket, const void *buffer, size_t length, int flags)
+{
+  if (send_error == 0)
+  {
+    return send (socket, buffer, length, flags);
+  }
+  return -1;
+}
+
+#define socket my_socket
+#define recv my_recv
+#define send my_send
+#include "../src/thrift/c_glib/transport/thrift_ssl_socket.c"
+#undef socket
+#undef recv
+#undef send
+
+static void thrift_ssl_socket_server (const int port);
+
+/* test object creation and destruction */
+static void
+test_ssl_create_and_destroy(void)
+{
+  gchar *hostname = NULL;
+  guint port = 0;
+
+  GObject *object = NULL;
+  object = g_object_new (THRIFT_TYPE_SSL_SOCKET, NULL);
+  assert (object != NULL);
+  g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, NULL);
+  g_free (hostname);
+  g_object_unref (object);
+}
+
+static void
+test_ssl_create_and_set_properties(void)
+{
+  gchar *hostname = NULL;
+  guint port = 0;
+  SSL_CTX* ssl_ctx= NULL;
+  GError *error=NULL;
+
+  GObject *object = NULL;
+  object = thrift_ssl_socket_new(SSLTLS, &error);
+  g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, "ssl_context", &ssl_ctx, NULL);
+  assert (ssl_ctx!=NULL);
+
+  g_free (hostname);
+  g_object_unref (object);
+}
+
+static void
+test_ssl_open_and_close(void)
+{
+  ThriftSSLSocket *tSSLSocket = NULL;
+  ThriftTransport *transport = NULL;
+  GError *error=NULL;
+
+  /* open a connection and close it */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
+
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  thrift_ssl_socket_open (transport, NULL);
+  assert (thrift_ssl_socket_is_open (transport) == TRUE);
+  thrift_ssl_socket_close (transport, NULL);
+  assert (thrift_ssl_socket_is_open (transport) == FALSE);
+
+  /* test close failure */
+  THRIFT_SOCKET(tSSLSocket)->sd = -1;
+  thrift_ssl_socket_close (transport, NULL);
+  g_object_unref (tSSLSocket);
+
+  /* try a hostname lookup failure */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost.broken", 51188, &error);
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  assert (thrift_ssl_socket_open (transport, &error) == FALSE);
+  g_object_unref (tSSLSocket);
+  g_error_free (error);
+  error = NULL;
+
+  /* try an error call to socket() */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  socket_error = 1;
+  assert (thrift_ssl_socket_open (transport, &error) == FALSE);
+  socket_error = 0;
+  g_object_unref (tSSLSocket);
+  g_error_free (error);
+}
+
+static void
+test_ssl_read_and_write(void)
+{
+  int status=0;
+  pid_t pid;
+  ThriftSSLSocket *tSSLsocket = NULL;
+  ThriftTransport *transport = NULL;
+//  int port = 51199;
+  int port = 443;
+  GError *error=NULL;
+
+  guchar buf[17] = TEST_DATA; /* a buffer */
+
+//  pid = fork ();
+//  assert ( pid >= 0 );
+//
+//  if ( pid == 0 )
+//  {
+//    /* child listens */
+//    thrift_ssl_socket_server (port);
+//    exit (0);
+//  } else {
+    /* parent connects, wait a bit for the socket to be created */
+    sleep (1);
+
+    tSSLsocket = thrift_ssl_socket_new_with_host(SSLTLS, "owncloud.level2crm.com", port, &error);
+
+    transport = THRIFT_TRANSPORT (tSSLsocket);
+    assert (thrift_ssl_socket_open (transport, NULL) == TRUE);
+    assert (thrift_ssl_socket_is_open (transport));
+    thrift_ssl_socket_write (transport, buf, 17, NULL);
+
+    /* write fail */
+    send_error = 1;
+    thrift_ssl_socket_write (transport, buf, 1, NULL);
+    send_error = 0;
+
+    thrift_ssl_socket_write_end (transport, NULL);
+    thrift_ssl_socket_flush (transport, NULL);
+    thrift_ssl_socket_close (transport, NULL);
+    g_object_unref (tSSLsocket);
+
+//    assert ( wait (&status) == pid );
+    assert ( status == 0 );
+//  }
+}
+
+/* test ThriftSocket's peek() implementation */
+//static void
+//test_ssl_peek(void)
+//{
+//  gint status;
+//  pid_t pid;
+//  guint port = 51199;
+//  gchar data = 'A';
+//  ThriftTransport *client_transport;
+//  GError *error = NULL;
+//
+//  client_transport = g_object_new (THRIFT_TYPE_SSL_SOCKET,
+//                                   "hostname", "localhost",
+//                                   "port",     port,
+//                                   NULL);
+//
+//  /* thrift_transport_peek returns FALSE when the socket is closed */
+//  g_assert (thrift_transport_is_open (client_transport) == FALSE);
+//  g_assert (thrift_transport_peek (client_transport, &error) == FALSE);
+//  g_assert (error == NULL);
+//
+//  pid = fork ();
+//  g_assert (pid >= 0);
+//
+//  if (pid == 0)
+//  {
+//    ThriftServerTransport *server_transport = NULL;
+//
+//    g_object_unref (client_transport);
+//
+//    /* child listens */
+//    server_transport = g_object_new (THRIFT_TYPE_SERVER_SOCKET,
+//                                     "port", port,
+//                                     NULL);
+//    g_assert (server_transport != NULL);
+//
+//    thrift_server_transport_listen (server_transport, &error);
+//    g_assert (error == NULL);
+//
+//    client_transport = g_object_new
+//      (THRIFT_TYPE_BUFFERED_TRANSPORT,
+//       "transport",  thrift_server_transport_accept (server_transport, &error),
+//       "r_buf_size", 0,
+//       "w_buf_size", sizeof data,
+//       NULL);
+//    g_assert (error == NULL);
+//    g_assert (client_transport != NULL);
+//
+//    /* write exactly one character to the client */
+//    g_assert (thrift_transport_write (client_transport,
+//                                      &data,
+//                                      sizeof data,
+//                                      &error) == TRUE);
+//
+//    thrift_transport_flush (client_transport, &error);
+//    thrift_transport_write_end (client_transport, &error);
+//    thrift_transport_close (client_transport, &error);
+//
+//    g_object_unref (client_transport);
+//    g_object_unref (server_transport);
+//
+//    exit (0);
+//  }
+//  else {
+//    /* parent connects, wait a bit for the socket to be created */
+//    sleep (1);
+//
+//    /* connect to the child */
+//    thrift_transport_open (client_transport, &error);
+//    g_assert (error == NULL);
+//    g_assert (thrift_transport_is_open (client_transport) == TRUE);
+//
+//    /* thrift_transport_peek returns TRUE when the socket is open and there is
+//       data available to be read */
+//    g_assert (thrift_transport_peek (client_transport, &error) == TRUE);
+//    g_assert (error == NULL);
+//
+//    /* read exactly one character from the server */
+//    g_assert_cmpint (thrift_transport_read (client_transport,
+//                                            &data,
+//                                            sizeof data,
+//                                            &error), ==, sizeof data);
+//
+//    /* thrift_transport_peek returns FALSE when the socket is open but there is
+//       no (more) data available to be read */
+//    g_assert (thrift_transport_is_open (client_transport) == TRUE);
+//    g_assert (thrift_transport_peek (client_transport, &error) == FALSE);
+//    g_assert (error == NULL);
+//
+//    thrift_transport_read_end (client_transport, &error);
+//    thrift_transport_close (client_transport, &error);
+//
+//    g_object_unref (client_transport);
+//
+//    g_assert (wait (&status) == pid);
+//    g_assert (status == 0);
+//  }
+//}
+
+static void
+thrift_ssl_socket_server (const int port)
+{
+  int bytes = 0;
+  ThriftServerTransport *transport = NULL;
+  ThriftTransport *client = NULL;
+  guchar buf[10]; /* a buffer */
+  guchar match[10] = TEST_DATA;
+
+  ThriftServerSocket *tsocket = g_object_new (THRIFT_TYPE_SERVER_SOCKET,
+                                              "port", port, NULL);
+
+  transport = THRIFT_SERVER_TRANSPORT (tsocket);
+  thrift_server_transport_listen (transport, NULL);
+  client = thrift_server_transport_accept (transport, NULL);
+  assert (client != NULL);
+
+  /* read 10 bytes */
+  bytes = thrift_ssl_socket_read (client, buf, 10, NULL);
+  assert (bytes == 10); /* make sure we've read 10 bytes */
+  assert ( memcmp(buf, match, 10) == 0 ); /* make sure what we got matches */
+
+  /* failed read */
+  recv_error = 1;
+  thrift_ssl_socket_read (client, buf, 1, NULL);
+  recv_error = 0;
+
+  thrift_ssl_socket_read_end (client, NULL);
+  thrift_ssl_socket_close (client, NULL);
+  g_object_unref (tsocket);
+  g_object_unref (client);
+}
+
+int
+main(int argc, char *argv[])
+{
+  int retval;
+#if (!GLIB_CHECK_VERSION (2, 36, 0))
+  g_type_init();
+#endif
+
+  g_test_init (&argc, &argv, NULL);
+
+  thrift_ssl_socket_initialize_openssl();
+
+  g_test_add_func ("/testtransportsslsocket/CreateAndDestroy", test_ssl_create_and_destroy);
+  g_test_add_func ("/testtransportsslsocket/CreateAndSetProperties", test_ssl_create_and_set_properties);
+  g_test_add_func ("/testtransportsslsocket/OpenAndClose", test_ssl_open_and_close);
+  g_test_add_func ("/testtransportsslsocket/ReadAndWrite", test_ssl_read_and_write);
+//  g_test_add_func ("/testtransportsslsocket/Peek", test_ssl_peek);
+
+  retval = g_test_run ();
+
+  thrift_ssl_socket_finalize_openssl();
+
+  return retval;
+}
+


### PR DESCRIPTION
Adds dependencies to gobject at compile time because it needs it.
Server side is not complete so some tests are failing. Looking to fix them all.

I moved openssl check outside of the cpp compilation because now it's needed for at least two subprojects at lib.

-avoid-version has to be reviewed as this is only for android, and must be enabled only when compiling with android-arm or android-*
