### PR TITLE
THRIFT-2794 Suppress warnings in autogenerated Java files

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -441,7 +441,7 @@ string t_java_generator::java_type_imports() {
 }
 
 string t_java_generator::java_suppressions() {
-  return "@SuppressWarnings({\"cast\", \"rawtypes\", \"serial\", \"unchecked\"})\n";
+  return "@SuppressWarnings({\"cast\", \"rawtypes\", \"serial\", \"unchecked\", \"unused\"})\n";
 }
 
 /**


### PR DESCRIPTION
Client: Java

Most importantly, this will ignore "unused" warnings.