### PR TITLE
THRIFT-3390 Tornado server should gracefully handle closed connections

### DIFF
--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -171,7 +171,13 @@ class TTornadoServer(tcpserver.TCPServer):
 
         try:
             while not trans.stream.closed():
-                frame = yield trans.readFrame()
+                try:
+                    frame = yield trans.readFrame()
+                except TTransportException as e:
+                    if e.type == TTransportException.END_OF_FILE:
+                        break
+                    else:
+                        raise
                 tr = TMemoryBuffer(frame)
                 iprot = self._iprot_factory.getProtocol(tr)
                 yield self._processor.process(iprot, oprot)


### PR DESCRIPTION
If END_OF_FILE exception is met the Tornado server should just break
the loop and close the connection instead of raising an exception