### PR TITLE
[THRIFT-3392] Java TZlibTransport: ensure inflater/deflater are closed upon close()

### DIFF
--- a/lib/java/test/org/apache/thrift/transport/TestTZlibTransport.java
+++ b/lib/java/test/org/apache/thrift/transport/TestTZlibTransport.java
@@ -18,13 +18,18 @@
  */
 package org.apache.thrift.transport;
 
-import junit.framework.TestCase;
-
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.zip.DataFormatException;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
+
+import junit.framework.TestCase;
 
 public class TestTZlibTransport extends TestCase {
 
@@ -48,6 +53,21 @@ public class TestTZlibTransport extends TestCase {
     trans.write(byteSequence(0, 245));
     countingTrans.close();
     trans.close();
+  }
+
+  public void testCloseOpen() throws TTransportException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    TTransport trans = getTransport(new TIOStreamTransport(baos));
+    byte[] uncompressed = byteSequence(0, 245);
+    trans.write(uncompressed);
+    trans.close();
+    final byte[] compressed = baos.toByteArray();
+
+    final byte[] buf = new byte[255];
+    TTransport transRead = getTransport(new TIOStreamTransport(new ByteArrayInputStream(compressed)));
+    int readBytes = transRead.read(buf, 0, buf.length);
+    assertEquals(uncompressed.length, readBytes);
+    transRead.close();
   }
 
   public void testRead() throws IOException, TTransportException {


### PR DESCRIPTION
More information available on the JIRA issue:

https://issues.apache.org/jira/browse/THRIFT-3392