### PR TITLE
THRIFT-3393 Introducing i8 to provide consistent set of Thrift integers

### DIFF
--- a/compiler/cpp/src/generate/t_as3_generator.cc
+++ b/compiler/cpp/src/generate/t_as3_generator.cc
@@ -578,7 +578,7 @@ string t_as3_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       render << "(byte)" << value->get_integer();
       break;
     case t_base_type::TYPE_I16:
@@ -1339,7 +1339,7 @@ std::string t_as3_generator::get_as3_type_string(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
       break;
     case t_base_type::TYPE_I16:
@@ -1978,7 +1978,7 @@ void t_as3_generator::generate_deserialize_field(ofstream& out, t_field* tfield,
       case t_base_type::TYPE_BOOL:
         out << "readBool();";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte();";
         break;
       case t_base_type::TYPE_I16:
@@ -2162,7 +2162,7 @@ void t_as3_generator::generate_serialize_field(ofstream& out, t_field* tfield, s
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -2351,7 +2351,7 @@ string t_as3_generator::base_type_name(t_base_type* type, bool in_container) {
     }
   case t_base_type::TYPE_BOOL:
     return "Boolean";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
   case t_base_type::TYPE_I16:
   case t_base_type::TYPE_I32:
     return "int";
@@ -2388,7 +2388,7 @@ string t_as3_generator::declare_field(t_field* tfield, bool init) {
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2465,7 +2465,7 @@ string t_as3_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/generate/t_c_glib_generator.cc
@@ -559,7 +559,7 @@ string t_c_glib_generator::type_name(t_type* ttype, bool in_typedef, bool is_con
         case t_base_type::TYPE_VOID:
           throw "compiler error: cannot determine array type";
         case t_base_type::TYPE_BOOL:
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
         case t_base_type::TYPE_I16:
         case t_base_type::TYPE_I32:
         case t_base_type::TYPE_I64:
@@ -615,7 +615,7 @@ string t_c_glib_generator::property_type_name(t_type* ttype, bool in_typedef, bo
 
   if (ttype->is_base_type()) {
     switch (((t_base_type*)ttype)->get_base()) {
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
       if (is_const) {
@@ -652,7 +652,7 @@ string t_c_glib_generator::base_type_name(t_base_type* type) {
     }
   case t_base_type::TYPE_BOOL:
     return "gboolean";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "gint8";
   case t_base_type::TYPE_I16:
     return "gint16";
@@ -684,7 +684,7 @@ string t_c_glib_generator::type_to_enum(t_type* type) {
       return "T_STRING";
     case t_base_type::TYPE_BOOL:
       return "T_BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "T_BYTE";
     case t_base_type::TYPE_I16:
       return "T_I16";
@@ -729,7 +729,7 @@ string t_c_glib_generator::constant_literal(t_type* type, t_const_value* value) 
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() != 0) ? "TRUE" : "FALSE");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -791,7 +791,7 @@ string t_c_glib_generator::constant_value(string name, t_type* type, t_const_val
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() != 0) ? 1 : 0);
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -915,7 +915,7 @@ string t_c_glib_generator::declare_field(t_field* tfield,
       case t_base_type::TYPE_VOID:
         break;
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -1026,7 +1026,7 @@ void t_c_glib_generator::generate_const_initializer(string name,
       case t_base_type::TYPE_VOID:
         throw "compiler error: cannot determine array type";
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2857,7 +2857,7 @@ void t_c_glib_generator::generate_object(t_struct* tstruct) {
             assign_function_name = "g_value_get_boolean";
             break;
 
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
           case t_base_type::TYPE_I16:
           case t_base_type::TYPE_I32:
             assign_function_name = "g_value_get_int";
@@ -2967,7 +2967,7 @@ void t_c_glib_generator::generate_object(t_struct* tstruct) {
           setter_function_name = "g_value_set_boolean";
           break;
 
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
         case t_base_type::TYPE_I16:
         case t_base_type::TYPE_I32:
           setter_function_name = "g_value_set_int";
@@ -3190,7 +3190,7 @@ void t_c_glib_generator::generate_object(t_struct* tstruct) {
           case t_base_type::TYPE_VOID:
             throw "compiler error: cannot determine array type";
           case t_base_type::TYPE_BOOL:
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
           case t_base_type::TYPE_I16:
           case t_base_type::TYPE_I32:
           case t_base_type::TYPE_I64:
@@ -3302,7 +3302,7 @@ void t_c_glib_generator::generate_object(t_struct* tstruct) {
                                 ? "TRUE"
                                 : "FALSE") << "," << endl << args_indent << "G_PARAM_READWRITE));"
                         << endl;
-        } else if ((base_type == t_base_type::TYPE_BYTE) || (base_type == t_base_type::TYPE_I16)
+        } else if ((base_type == t_base_type::TYPE_I8) || (base_type == t_base_type::TYPE_I16)
                    || (base_type == t_base_type::TYPE_I32) || (base_type == t_base_type::TYPE_I64)
                    || (base_type == t_base_type::TYPE_DOUBLE)) {
           string param_spec_function_name = "g_param_spec_int";
@@ -3311,7 +3311,7 @@ void t_c_glib_generator::generate_object(t_struct* tstruct) {
           ostringstream default_value;
 
           switch (base_type) {
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
             min_value = "G_MININT8";
             max_value = "G_MAXINT8";
             break;
@@ -3670,7 +3670,7 @@ void t_c_glib_generator::generate_serialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "bool (protocol, " << name;
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "byte (protocol, " << name;
         break;
       case t_base_type::TYPE_I16:
@@ -3912,7 +3912,7 @@ void t_c_glib_generator::generate_serialize_list_element(ofstream& out,
     case t_base_type::TYPE_BOOL:
       name = "g_array_index (" + list + ", gboolean, " + index + ")";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       name = "g_array_index (" + list + ", gint8, " + index + ")";
       break;
     case t_base_type::TYPE_I16:
@@ -3943,7 +3943,7 @@ void t_c_glib_generator::generate_serialize_list_element(ofstream& out,
         throw "compiler error: cannot determine array type";
         break;
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -4009,7 +4009,7 @@ void t_c_glib_generator::generate_deserialize_field(ofstream& out,
     case t_base_type::TYPE_BOOL:
       out << "bool (protocol, &" << name;
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       out << "byte (protocol, &" << name;
       break;
     case t_base_type::TYPE_I16:
@@ -4292,7 +4292,7 @@ void t_c_glib_generator::generate_deserialize_list_element(ofstream& out,
       out << "g_ptr_array_add (" << prefix << ", " << elem << ");" << endl;
       return;
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -4317,7 +4317,7 @@ string t_c_glib_generator::generate_free_func_from_type(t_type* ttype) {
       throw "compiler error: cannot determine hash type";
       break;
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -4346,7 +4346,7 @@ string t_c_glib_generator::generate_free_func_from_type(t_type* ttype) {
         throw "compiler error: cannot determine array type";
         break;
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -4383,7 +4383,7 @@ string t_c_glib_generator::generate_hash_func_from_type(t_type* ttype) {
       throw "compiler error: cannot determine hash type";
       break;
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
       return "g_int_hash";
@@ -4418,7 +4418,7 @@ string t_c_glib_generator::generate_cmp_func_from_type(t_type* ttype) {
       throw "compiler error: cannot determine hash type";
       break;
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
       return "g_int_equal";
@@ -4461,7 +4461,7 @@ string t_c_glib_generator::generate_new_array_from_type(t_type* ttype) {
       break;
     case t_base_type::TYPE_BOOL:
       return "g_array_new (0, 1, sizeof (gboolean));";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "g_array_new (0, 1, sizeof (gint8));";
     case t_base_type::TYPE_I16:
       return "g_array_new (0, 1, sizeof (gint16));";

--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -669,7 +669,7 @@ void t_cocoa_generator::generate_cocoa_struct_init_with_coder_method(ofstream& o
       case t_base_type::TYPE_BOOL:
         out << "[decoder decodeBoolForKey: @\"" << (*m_iter)->get_name() << "\"];" << endl;
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "[decoder decodeIntForKey: @\"" << (*m_iter)->get_name() << "\"];" << endl;
         break;
       case t_base_type::TYPE_I16:
@@ -736,7 +736,7 @@ void t_cocoa_generator::generate_cocoa_struct_encode_with_coder_method(ofstream&
         out << indent() << "[encoder encodeBool: _" << (*m_iter)->get_name() << " forKey: @\""
             << (*m_iter)->get_name() << "\"];" << endl;
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << indent() << "[encoder encodeInt: _" << (*m_iter)->get_name() << " forKey: @\""
             << (*m_iter)->get_name() << "\"];" << endl;
         break;
@@ -2171,7 +2171,7 @@ void t_cocoa_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "readBool:&" << fieldName << " error: __thriftError]";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte:(UInt8 *)&" << fieldName << " error: __thriftError]";
         break;
       case t_base_type::TYPE_I16:
@@ -2285,7 +2285,7 @@ string t_cocoa_generator::box(t_type* ttype, string field_name) {
       case t_base_type::TYPE_VOID:
         throw "can't box void";
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2314,7 +2314,7 @@ string t_cocoa_generator::unbox(t_type* ttype, string field_name) {
         throw "can't unbox void";
       case t_base_type::TYPE_BOOL:
         return "[" + field_name + " boolValue]";
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         return "((SInt8)[" + field_name + " charValue])";
       case t_base_type::TYPE_I16:
         return "((SInt16)[" + field_name + " shortValue])";
@@ -2420,7 +2420,7 @@ void t_cocoa_generator::generate_serialize_field(ofstream& out, t_field* tfield,
       case t_base_type::TYPE_BOOL:
         out << "writeBool: " << fieldName << " error: __thriftError]";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte: (UInt8)" << fieldName << " error: __thriftError]";
         break;
       case t_base_type::TYPE_I16:
@@ -2677,7 +2677,7 @@ string t_cocoa_generator::base_type_name(t_base_type* type) {
     }
   case t_base_type::TYPE_BOOL:
     return "BOOL";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "SInt8";
   case t_base_type::TYPE_I16:
     return "SInt16";
@@ -2817,7 +2817,7 @@ string t_cocoa_generator::render_const_value(ostream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "YES" : "NO");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -2868,7 +2868,7 @@ string t_cocoa_generator::render_const_value(string name,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "YES" : "NO");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -3154,7 +3154,7 @@ string t_cocoa_generator::type_to_enum(t_type* type) {
       return "TTypeSTRING";
     case t_base_type::TYPE_BOOL:
       return "TTypeBOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TTypeBYTE";
     case t_base_type::TYPE_I16:
       return "TTypeI16";
@@ -3195,7 +3195,7 @@ string t_cocoa_generator::format_string_for_type(t_type* type) {
       return "\\\"%@\\\"";
     case t_base_type::TYPE_BOOL:
       return "%i";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "%i";
     case t_base_type::TYPE_I16:
       return "%hi";
@@ -3236,7 +3236,7 @@ string t_cocoa_generator::format_cast_for_type(t_type* type) {
       return ""; // "\\\"%@\\\"";
     case t_base_type::TYPE_BOOL:
       return ""; // "%i";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return ""; // "%i";
     case t_base_type::TYPE_I16:
       return ""; // "%hi";

--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -685,7 +685,7 @@ string t_cpp_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
       render << value->get_integer();
@@ -3641,7 +3641,7 @@ void t_cpp_generator::generate_deserialize_field(ofstream& out,
     case t_base_type::TYPE_BOOL:
       out << "readBool(" << name << ");";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       out << "readByte(" << name << ");";
       break;
     case t_base_type::TYPE_I16:
@@ -3848,7 +3848,7 @@ void t_cpp_generator::generate_serialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -4142,7 +4142,7 @@ string t_cpp_generator::base_type_name(t_base_type::t_base tbase) {
     return "std::string";
   case t_base_type::TYPE_BOOL:
     return "bool";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "int8_t";
   case t_base_type::TYPE_I16:
     return "int16_t";
@@ -4196,7 +4196,7 @@ string t_cpp_generator::declare_field(t_field* tfield,
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -4309,7 +4309,7 @@ string t_cpp_generator::type_to_enum(t_type* type) {
       return "::apache::thrift::protocol::T_STRING";
     case t_base_type::TYPE_BOOL:
       return "::apache::thrift::protocol::T_BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "::apache::thrift::protocol::T_BYTE";
     case t_base_type::TYPE_I16:
       return "::apache::thrift::protocol::T_I16";

--- a/compiler/cpp/src/generate/t_csharp_generator.cc
+++ b/compiler/cpp/src/generate/t_csharp_generator.cc
@@ -620,7 +620,7 @@ std::string t_csharp_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -2163,7 +2163,7 @@ void t_csharp_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "ReadBool();";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "ReadByte();";
         break;
       case t_base_type::TYPE_I16:
@@ -2341,7 +2341,7 @@ void t_csharp_generator::generate_serialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "WriteBool(" << nullable_name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "WriteByte(" << nullable_name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -2683,7 +2683,7 @@ string t_csharp_generator::base_type_name(t_base_type* tbase,
     }
   case t_base_type::TYPE_BOOL:
     return "bool" + postfix;
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "sbyte" + postfix;
   case t_base_type::TYPE_I16:
     return "short" + postfix;
@@ -2719,7 +2719,7 @@ string t_csharp_generator::declare_field(t_field* tfield, bool init, std::string
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2798,7 +2798,7 @@ string t_csharp_generator::type_to_enum(t_type* type) {
       return "TType.String";
     case t_base_type::TYPE_BOOL:
       return "TType.Bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.Byte";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_d_generator.cc
+++ b/compiler/cpp/src/generate/t_d_generator.cc
@@ -504,7 +504,7 @@ private:
       case t_base_type::TYPE_BOOL:
         out << ((value->get_integer() > 0) ? "true" : "false");
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
         out << "cast(" << render_type_name(type) << ")" << value->get_integer();
         break;
@@ -622,7 +622,7 @@ private:
         return "string";
       case t_base_type::TYPE_BOOL:
         return "bool";
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         return "byte";
       case t_base_type::TYPE_I16:
         return "short";

--- a/compiler/cpp/src/generate/t_dart_generator.cc
+++ b/compiler/cpp/src/generate/t_dart_generator.cc
@@ -612,7 +612,7 @@ string t_dart_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1279,7 +1279,7 @@ std::string t_dart_generator::get_dart_type_string(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
       break;
     case t_base_type::TYPE_I16:
@@ -1740,7 +1740,7 @@ void t_dart_generator::generate_deserialize_field(ofstream& out, t_field* tfield
       case t_base_type::TYPE_BOOL:
         out << "readBool();";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte();";
         break;
       case t_base_type::TYPE_I16:
@@ -1922,7 +1922,7 @@ void t_dart_generator::generate_serialize_field(ofstream& out, t_field* tfield, 
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -2093,7 +2093,7 @@ string t_dart_generator::base_type_name(t_base_type* type) {
     }
   case t_base_type::TYPE_BOOL:
     return "bool";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
   case t_base_type::TYPE_I16:
   case t_base_type::TYPE_I32:
   case t_base_type::TYPE_I64:
@@ -2129,7 +2129,7 @@ string t_dart_generator::declare_field(t_field* tfield, bool init) {
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2208,7 +2208,7 @@ string t_dart_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_delphi_generator.cc
+++ b/compiler/cpp/src/generate/t_delphi_generator.cc
@@ -975,7 +975,7 @@ void t_delphi_generator::init_known_types_list() {
   types_known[type_name(g_type_string)] = 1;
   types_known[type_name(g_type_binary)] = 1;
   types_known[type_name(g_type_bool)] = 1;
-  types_known[type_name(g_type_byte)] = 1;
+  types_known[type_name(g_type_i8)] = 1;
   types_known[type_name(g_type_i16)] = 1;
   types_known[type_name(g_type_i32)] = 1;
   types_known[type_name(g_type_i64)] = 1;
@@ -1329,7 +1329,7 @@ string t_delphi_generator::render_const_value(ostream& vars,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "True" : "False");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       render << "ShortInt( " << value->get_integer() << ")";
       break;
     case t_base_type::TYPE_I16:
@@ -2537,7 +2537,7 @@ void t_delphi_generator::generate_deserialize_field(ostream& out,
       case t_base_type::TYPE_BOOL:
         out << "ReadBool();";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "ReadByte();";
         break;
       case t_base_type::TYPE_I16:
@@ -2739,7 +2739,7 @@ void t_delphi_generator::generate_serialize_field(ostream& out,
       case t_base_type::TYPE_BOOL:
         out << "WriteBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "WriteByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -3029,7 +3029,7 @@ string t_delphi_generator::input_arg_prefix(t_type* ttype) {
       return "const ";
 
     // all others don't need to be
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_BOOL:
@@ -3078,7 +3078,7 @@ string t_delphi_generator::base_type_name(t_base_type* tbase) {
     }
   case t_base_type::TYPE_BOOL:
     return "Boolean";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "ShortInt";
   case t_base_type::TYPE_I16:
     return "SmallInt";
@@ -3214,7 +3214,7 @@ string t_delphi_generator::type_to_enum(t_type* type) {
       return "TType.String_";
     case t_base_type::TYPE_BOOL:
       return "TType.Bool_";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.Byte_";
     case t_base_type::TYPE_I16:
       return "TType.I16";
@@ -3262,7 +3262,7 @@ string t_delphi_generator::empty_value(t_type* type) {
       }
     case t_base_type::TYPE_BOOL:
       return "False";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:

--- a/compiler/cpp/src/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/generate/t_erl_generator.cc
@@ -387,7 +387,7 @@ string t_erl_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -517,7 +517,7 @@ string t_erl_generator::render_member_type(t_field* field) {
       return "string() | binary()";
     case t_base_type::TYPE_BOOL:
       return "boolean()";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -918,8 +918,8 @@ string t_erl_generator::type_to_enum(t_type* type) {
       return "?tType_STRING";
     case t_base_type::TYPE_BOOL:
       return "?tType_BOOL";
-    case t_base_type::TYPE_BYTE:
-      return "?tType_BYTE";
+    case t_base_type::TYPE_I8:
+      return "?tType_I8";
     case t_base_type::TYPE_I16:
       return "?tType_I16";
     case t_base_type::TYPE_I32:
@@ -961,7 +961,7 @@ std::string t_erl_generator::render_type_term(t_type* type,
       return "string";
     case t_base_type::TYPE_BOOL:
       return "bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "byte";
     case t_base_type::TYPE_I16:
       return "i16";

--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -339,7 +339,7 @@ bool t_go_generator::omit_initialization(t_field* tfield) {
       return value->get_string().empty();
 
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -397,7 +397,7 @@ bool t_go_generator::is_pointer_field(t_field* tfield, bool in_container_value) 
       return !has_default;
 
     case t_base_type::TYPE_BOOL:
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1027,7 +1027,7 @@ string t_go_generator::render_const_value(t_type* type, t_const_value* value, co
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
 
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -2294,7 +2294,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
                    << endl;
           break;
 
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
           f_remote << indent() << "tmp" << i << ", " << err << " := (strconv.Atoi(flag.Arg("
                    << flagArg << ")))" << endl;
           f_remote << indent() << "if " << err << " != nil {" << endl;
@@ -2440,7 +2440,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
 
         case t_base_type::TYPE_STRING:
         case t_base_type::TYPE_BOOL:
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
         case t_base_type::TYPE_I16:
         case t_base_type::TYPE_I32:
         case t_base_type::TYPE_I64:
@@ -2819,7 +2819,7 @@ void t_go_generator::generate_deserialize_field(ofstream& out,
         out << "ReadBool()";
         break;
 
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "ReadByte()";
         break;
 
@@ -2855,7 +2855,7 @@ void t_go_generator::generate_deserialize_field(ofstream& out,
 
     if (type->is_enum() || (orig_type->is_typedef() && !use_true_type)) {
       wrap = publicize(type_name(orig_type));
-    } else if (((t_base_type*)type)->get_base() == t_base_type::TYPE_BYTE) {
+    } else if (((t_base_type*)type)->get_base() == t_base_type::TYPE_I8) {
       wrap = "int8";
     }
 
@@ -3070,7 +3070,7 @@ void t_go_generator::generate_serialize_field(ofstream& out,
         out << "WriteBool(bool(" << name << "))";
         break;
 
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "WriteByte(int8(" << name << "))";
         break;
 
@@ -3438,7 +3438,7 @@ string t_go_generator::type_to_enum(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "thrift.BOOL";
 
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "thrift.BYTE";
 
     case t_base_type::TYPE_I16:
@@ -3522,7 +3522,7 @@ string t_go_generator::type_to_go_type_with_opt(t_type* type,
     case t_base_type::TYPE_BOOL:
       return maybe_pointer + "bool";
 
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return maybe_pointer + "int8";
 
     case t_base_type::TYPE_I16:

--- a/compiler/cpp/src/generate/t_haxe_generator.cc
+++ b/compiler/cpp/src/generate/t_haxe_generator.cc
@@ -610,7 +610,7 @@ string t_haxe_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       render << "(byte)" << value->get_integer();
       break;
     case t_base_type::TYPE_I16:
@@ -1392,7 +1392,7 @@ std::string t_haxe_generator::get_haxe_type_string(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
       break;
     case t_base_type::TYPE_I16:
@@ -2194,7 +2194,7 @@ void t_haxe_generator::generate_deserialize_field(ofstream& out, t_field* tfield
       case t_base_type::TYPE_BOOL:
         out << "readBool();";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte();";
         break;
       case t_base_type::TYPE_I16:
@@ -2378,7 +2378,7 @@ void t_haxe_generator::generate_serialize_field(ofstream& out, t_field* tfield, 
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -2541,7 +2541,7 @@ string t_haxe_generator::type_name(t_type* ttype, bool in_container, bool in_ini
         if (!(((t_base_type*)tkey)->is_binary())) {
           return "StringMap< " + type_name(tval) + ">";
         }
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
         return "IntMap< " + type_name(tval) + ">";
@@ -2566,7 +2566,7 @@ string t_haxe_generator::type_name(t_type* ttype, bool in_container, bool in_ini
         if (!(((t_base_type*)tkey)->is_binary())) {
           return "StringSet";
         }
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
         return "IntSet";
@@ -2620,7 +2620,7 @@ string t_haxe_generator::base_type_name(t_base_type* type, bool in_container) {
     }
   case t_base_type::TYPE_BOOL:
     return "Bool";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
   case t_base_type::TYPE_I16:
   case t_base_type::TYPE_I32:
     return "haxe.Int32";
@@ -2657,7 +2657,7 @@ string t_haxe_generator::declare_field(t_field* tfield, bool init) {
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2756,7 +2756,7 @@ string t_haxe_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/generate/t_hs_generator.cc
@@ -379,7 +379,7 @@ string t_hs_generator::render_const_value(t_type* type, t_const_value* value) {
       out << (value->get_integer() > 0 ? "P.True" : "P.False");
       break;
 
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1542,7 +1542,7 @@ string t_hs_generator::type_to_enum(t_type* type) {
       return "T.T_STRING";
     case t_base_type::TYPE_BOOL:
       return "T.T_BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "T.T_BYTE";
     case t_base_type::TYPE_I16:
       return "T.T_I16";
@@ -1590,7 +1590,7 @@ string t_hs_generator::type_to_default(t_type* type) {
       return "\"\"";
     case t_base_type::TYPE_BOOL:
       return "P.False";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "0";
     case t_base_type::TYPE_I16:
       return "0";
@@ -1637,7 +1637,7 @@ string t_hs_generator::render_hs_type(t_type* type, bool needs_parens) {
       return (((t_base_type*)type)->is_binary() ? "LBS.ByteString" : "LT.Text");
     case t_base_type::TYPE_BOOL:
       return "P.Bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "I.Int8";
     case t_base_type::TYPE_I16:
       return "I.Int16";
@@ -1690,7 +1690,7 @@ string t_hs_generator::type_to_constructor(t_type* type) {
       return "T.TString";
     case t_base_type::TYPE_BOOL:
       return "T.TBool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "T.TByte";
     case t_base_type::TYPE_I16:
       return "T.TI16";

--- a/compiler/cpp/src/generate/t_html_generator.cc
+++ b/compiler/cpp/src/generate/t_html_generator.cc
@@ -740,7 +740,7 @@ void t_html_generator::print_const_value(t_type* type, t_const_value* tvalue) {
     case t_base_type::TYPE_BOOL:
       f_out_ << ((tvalue->get_integer() != 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       f_out_ << tvalue->get_integer();
       break;
     case t_base_type::TYPE_I16:

--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -695,7 +695,7 @@ string t_java_generator::render_const_value(ofstream& out, t_type* type, t_const
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       render << "(byte)" << value->get_integer();
       break;
     case t_base_type::TYPE_I16:
@@ -1666,7 +1666,7 @@ void t_java_generator::generate_java_struct_parcelable(ofstream& out, t_struct* 
         case t_base_type::TYPE_BOOL:
           indent(out) << "out.writeInt(" << name << " ? 1 : 0);" << endl;
           break;
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
           indent(out) << "out.writeByte(" << name << ");" << endl;
           break;
         case t_base_type::TYPE_DOUBLE:
@@ -1763,7 +1763,7 @@ void t_java_generator::generate_java_struct_parcelable(ofstream& out, t_struct* 
         case t_base_type::TYPE_BOOL:
           indent(out) << prefix << " = (in.readInt()==1);" << endl;
           break;
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
           indent(out) << prefix << " = in.readByte();" << endl;
           break;
         case t_base_type::TYPE_DOUBLE:
@@ -2558,7 +2558,7 @@ std::string t_java_generator::get_java_type_string(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "org.apache.thrift.protocol.TType.BOOL";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "org.apache.thrift.protocol.TType.BYTE";
       break;
     case t_base_type::TYPE_I16:
@@ -3527,7 +3527,7 @@ void t_java_generator::generate_deserialize_field(ofstream& out,
     case t_base_type::TYPE_BOOL:
       out << "readBool();";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       out << "readByte();";
       break;
     case t_base_type::TYPE_I16:
@@ -3812,7 +3812,7 @@ void t_java_generator::generate_serialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -4043,7 +4043,7 @@ string t_java_generator::base_type_name(t_base_type* type, bool in_container) {
     }
   case t_base_type::TYPE_BOOL:
     return (in_container ? "Boolean" : "boolean");
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return (in_container ? "Byte" : "byte");
   case t_base_type::TYPE_I16:
     return (in_container ? "Short" : "short");
@@ -4083,7 +4083,7 @@ string t_java_generator::declare_field(t_field* tfield, bool init, bool comment)
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -4244,7 +4244,7 @@ string t_java_generator::type_to_enum(t_type* type) {
       return "org.apache.thrift.protocol.TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "org.apache.thrift.protocol.TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "org.apache.thrift.protocol.TType.BYTE";
     case t_base_type::TYPE_I16:
       return "org.apache.thrift.protocol.TType.I16";
@@ -4759,7 +4759,7 @@ void t_java_generator::generate_java_struct_clear(std::ofstream& out, t_struct* 
     t_base_type* base_type = (t_base_type*)t;
 
     switch (base_type->get_base()) {
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:

--- a/compiler/cpp/src/generate/t_javame_generator.cc
+++ b/compiler/cpp/src/generate/t_javame_generator.cc
@@ -546,7 +546,7 @@ string t_javame_generator::render_const_value(ofstream& out,
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       render << "(byte)" << value->get_integer();
       break;
     case t_base_type::TYPE_I16:
@@ -584,7 +584,7 @@ string t_javame_generator::box_type(t_type* type, string value) {
     switch (((t_base_type*)type)->get_base()) {
     case t_base_type::TYPE_BOOL:
       return "new Boolean(" + value + ")";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "new Byte(" + value + ")";
     case t_base_type::TYPE_I16:
       return "new Short(" + value + ")";
@@ -1785,7 +1785,7 @@ std::string t_javame_generator::get_java_type_string(t_type* type) {
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
       break;
     case t_base_type::TYPE_I16:
@@ -2415,7 +2415,7 @@ void t_javame_generator::generate_deserialize_field(ofstream& out, t_field* tfie
     case t_base_type::TYPE_BOOL:
       out << "readBool();";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       out << "readByte();";
       break;
     case t_base_type::TYPE_I16:
@@ -2611,7 +2611,7 @@ void t_javame_generator::generate_serialize_field(ofstream& out, t_field* tfield
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -2814,7 +2814,7 @@ string t_javame_generator::base_type_name(t_base_type* type, bool in_container) 
     }
   case t_base_type::TYPE_BOOL:
     return (in_container ? "Boolean" : "boolean");
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return (in_container ? "Byte" : "byte");
   case t_base_type::TYPE_I16:
     return (in_container ? "Short" : "short");
@@ -2853,7 +2853,7 @@ string t_javame_generator::declare_field(t_field* tfield, bool init) {
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2934,7 +2934,7 @@ string t_javame_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";
@@ -3263,7 +3263,7 @@ void t_javame_generator::generate_java_struct_clear(std::ofstream& out, t_struct
         indent(out) << "set" << get_cap_name((*m_iter)->get_name()) << get_cap_name("isSet")
                     << "(false);" << endl;
         switch (((t_base_type*)t)->get_base()) {
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
         case t_base_type::TYPE_I16:
         case t_base_type::TYPE_I32:
         case t_base_type::TYPE_I64:

--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -495,7 +495,7 @@ string t_js_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1596,7 +1596,7 @@ void t_js_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "readBool()";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte()";
         break;
       case t_base_type::TYPE_I16:
@@ -1649,9 +1649,9 @@ void t_js_generator::generate_deserialize_container(ofstream& out, t_type* ttype
   string rtmp3 = tmp("_rtmp3");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   out << indent() << "var " << size << " = 0;" << endl;
   out << indent() << "var " << rtmp3 << ";" << endl;
@@ -1794,7 +1794,7 @@ void t_js_generator::generate_serialize_field(ofstream& out, t_field* tfield, st
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ")";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ")";
         break;
       case t_base_type::TYPE_I16:
@@ -1950,7 +1950,7 @@ string t_js_generator::declare_field(t_field* tfield, bool init, bool obj) {
         break;
       case t_base_type::TYPE_STRING:
       case t_base_type::TYPE_BOOL:
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2042,7 +2042,7 @@ string t_js_generator::type_to_enum(t_type* type) {
       return "Thrift.Type.STRING";
     case t_base_type::TYPE_BOOL:
       return "Thrift.Type.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "Thrift.Type.BYTE";
     case t_base_type::TYPE_I16:
       return "Thrift.Type.I16";
@@ -2087,7 +2087,7 @@ string t_js_generator::ts_get_type(t_type* type) {
     case t_base_type::TYPE_BOOL:
       ts_type = "boolean";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       ts_type = "any";
       break;
     case t_base_type::TYPE_I16:

--- a/compiler/cpp/src/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/generate/t_lua_generator.cc
@@ -244,7 +244,7 @@ string t_lua_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
       out << value->get_integer();
@@ -787,7 +787,7 @@ void t_lua_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "readBool()";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte()";
         break;
       case t_base_type::TYPE_I16:
@@ -835,9 +835,9 @@ void t_lua_generator::generate_deserialize_container(ofstream& out,
   string etype = tmp("_etype");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   // Declare variables, read header
   indent(out) << (local ? "local " : "") << prefix << " = {}" << endl;
@@ -942,7 +942,7 @@ void t_lua_generator::generate_serialize_field(ofstream& out, t_field* tfield, s
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ")";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ")";
         break;
       case t_base_type::TYPE_I16:
@@ -1098,7 +1098,7 @@ string t_lua_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_ocaml_generator.cc
+++ b/compiler/cpp/src/generate/t_ocaml_generator.cc
@@ -355,7 +355,7 @@ string t_ocaml_generator::render_const_value(t_type* type, t_const_value* value)
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
       out << value->get_integer();
       break;
@@ -1339,7 +1339,7 @@ void t_ocaml_generator::generate_deserialize_type(ofstream& out, t_type* type) {
     case t_base_type::TYPE_BOOL:
       out << "readBool";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       out << "readByte";
       break;
     case t_base_type::TYPE_I16:
@@ -1390,9 +1390,9 @@ void t_ocaml_generator::generate_deserialize_container(ofstream& out, t_type* tt
   string con = tmp("_con");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   out << endl;
   indent_up();
@@ -1480,7 +1480,7 @@ void t_ocaml_generator::generate_serialize_field(ofstream& out, t_field* tfield,
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ")";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ")";
         break;
       case t_base_type::TYPE_I16:
@@ -1682,7 +1682,7 @@ string t_ocaml_generator::type_to_enum(t_type* type) {
       return "Protocol.T_STRING";
     case t_base_type::TYPE_BOOL:
       return "Protocol.T_BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "Protocol.T_BYTE";
     case t_base_type::TYPE_I16:
       return "Protocol.T_I16";
@@ -1723,7 +1723,7 @@ string t_ocaml_generator::render_ocaml_type(t_type* type) {
       return "string";
     case t_base_type::TYPE_BOOL:
       return "bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "int";
     case t_base_type::TYPE_I16:
       return "int";

--- a/compiler/cpp/src/generate/t_perl_generator.cc
+++ b/compiler/cpp/src/generate/t_perl_generator.cc
@@ -324,7 +324,7 @@ string t_perl_generator::render_const_value(t_type* type, t_const_value* value) 
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "1" : "0");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1179,7 +1179,7 @@ void t_perl_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "readBool(\\$" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte(\\$" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -1232,9 +1232,9 @@ void t_perl_generator::generate_deserialize_container(ofstream& out, t_type* tty
   string etype = tmp("_etype");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   out << indent() << "my $" << size << " = 0;" << endl;
 
@@ -1370,7 +1370,7 @@ void t_perl_generator::generate_serialize_field(ofstream& out, t_field* tfield, 
       case t_base_type::TYPE_BOOL:
         out << "writeBool($" << name << ");";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte($" << name << ");";
         break;
       case t_base_type::TYPE_I16:
@@ -1526,7 +1526,7 @@ string t_perl_generator::declare_field(t_field* tfield, bool init, bool obj) {
       case t_base_type::TYPE_BOOL:
         result += " = 0";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -1613,7 +1613,7 @@ string t_perl_generator::type_to_enum(t_type* type) {
       return "TType::STRING";
     case t_base_type::TYPE_BOOL:
       return "TType::BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType::BYTE";
     case t_base_type::TYPE_I16:
       return "TType::I16";

--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -548,7 +548,7 @@ string t_php_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -861,7 +861,7 @@ void t_php_generator::generate_php_struct_reader(ofstream& out, t_struct* tstruc
 
   // Read beginning field marker
   if (binary_inline_) {
-    t_field fftype(g_type_byte, "ftype");
+    t_field fftype(g_type_i8, "ftype");
     t_field ffid(g_type_i16, "fid");
     generate_deserialize_field(out, &fftype);
     out << indent() << "if ($ftype == "
@@ -1211,7 +1211,7 @@ void t_php_generator::generate_service_processor(t_service* tservice) {
 
   if (binary_inline_) {
     t_field ffname(g_type_string, "fname");
-    t_field fmtype(g_type_byte, "mtype");
+    t_field fmtype(g_type_i8, "mtype");
     t_field fseqid(g_type_i32, "rseqid");
     generate_deserialize_field(f_service_, &ffname, "", true);
     generate_deserialize_field(f_service_, &fmtype, "", true);
@@ -1770,7 +1770,7 @@ void t_php_generator::generate_deserialize_field(ofstream& out,
             out << indent() << "$" << name << " = unpack('c', " << itrans << "->readAll(1));"
                 << endl << indent() << "$" << name << " = (bool)$" << name << "[1];" << endl;
             break;
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
             out << indent() << "$" << name << " = unpack('c', " << itrans << "->readAll(1));"
                 << endl << indent() << "$" << name << " = $" << name << "[1];" << endl;
             break;
@@ -1825,7 +1825,7 @@ void t_php_generator::generate_deserialize_field(ofstream& out,
           case t_base_type::TYPE_BOOL:
             out << "readBool($" << name << ");";
             break;
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
             out << "readByte($" << name << ");";
             break;
           case t_base_type::TYPE_I16:
@@ -1875,9 +1875,9 @@ void t_php_generator::generate_deserialize_container(ofstream& out, t_type* ttyp
   string etype = tmp("_etype");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   out << indent() << "$" << prefix << " = array();" << endl << indent() << "$" << size << " = 0;"
       << endl;
@@ -2024,7 +2024,7 @@ void t_php_generator::generate_serialize_field(ofstream& out, t_field* tfield, s
         case t_base_type::TYPE_BOOL:
           out << indent() << "$output .= pack('c', $" << name << " ? 1 : 0);" << endl;
           break;
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
           out << indent() << "$output .= pack('c', $" << name << ");" << endl;
           break;
         case t_base_type::TYPE_I16:
@@ -2062,7 +2062,7 @@ void t_php_generator::generate_serialize_field(ofstream& out, t_field* tfield, s
         case t_base_type::TYPE_BOOL:
           out << "writeBool($" << name << ");";
           break;
-        case t_base_type::TYPE_BYTE:
+        case t_base_type::TYPE_I8:
           out << "writeByte($" << name << ");";
           break;
         case t_base_type::TYPE_I16:
@@ -2320,7 +2320,7 @@ string t_php_generator::declare_field(t_field* tfield, bool init, bool obj) {
       case t_base_type::TYPE_BOOL:
         result += " = false";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
       case t_base_type::TYPE_I16:
       case t_base_type::TYPE_I32:
       case t_base_type::TYPE_I64:
@@ -2402,7 +2402,7 @@ string t_php_generator::type_to_cast(t_type* type) {
     switch (btype->get_base()) {
     case t_base_type::TYPE_BOOL:
       return "(bool)";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -2435,7 +2435,7 @@ string t_php_generator::type_to_enum(t_type* type) {
       return "TType::STRING";
     case t_base_type::TYPE_BOOL:
       return "TType::BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType::BYTE";
     case t_base_type::TYPE_I16:
       return "TType::I16";
@@ -2476,7 +2476,7 @@ string t_php_generator::type_to_phpdoc(t_type* type) {
       return "string";
     case t_base_type::TYPE_BOOL:
       return "bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "int";
     case t_base_type::TYPE_I16:
       return "int";

--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -494,7 +494,7 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "True" : "False");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1922,7 +1922,7 @@ void t_py_generator::generate_deserialize_field(ofstream& out,
       case t_base_type::TYPE_BOOL:
         out << "readBool()";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "readByte()";
         break;
       case t_base_type::TYPE_I16:
@@ -1971,9 +1971,9 @@ void t_py_generator::generate_deserialize_container(ofstream& out, t_type* ttype
   string etype = tmp("_etype");
 
   t_field fsize(g_type_i32, size);
-  t_field fktype(g_type_byte, ktype);
-  t_field fvtype(g_type_byte, vtype);
-  t_field fetype(g_type_byte, etype);
+  t_field fktype(g_type_i8, ktype);
+  t_field fvtype(g_type_i8, vtype);
+  t_field fetype(g_type_i8, etype);
 
   // Declare variables, read header
   if (ttype->is_map()) {
@@ -2094,7 +2094,7 @@ void t_py_generator::generate_serialize_field(ofstream& out, t_field* tfield, st
       case t_base_type::TYPE_BOOL:
         out << "writeBool(" << name << ")";
         break;
-      case t_base_type::TYPE_BYTE:
+      case t_base_type::TYPE_I8:
         out << "writeByte(" << name << ")";
         break;
       case t_base_type::TYPE_I16:
@@ -2391,7 +2391,7 @@ string t_py_generator::type_to_enum(t_type* type) {
       return "TType.STRING";
     case t_base_type::TYPE_BOOL:
       return "TType.BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType.BYTE";
     case t_base_type::TYPE_I16:
       return "TType.I16";

--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -421,7 +421,7 @@ t_rb_ofstream& t_rb_generator::render_const_value(t_rb_ofstream& out,
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1125,7 +1125,7 @@ string t_rb_generator::type_to_enum(t_type* type) {
       return "::Thrift::Types::STRING";
     case t_base_type::TYPE_BOOL:
       return "::Thrift::Types::BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "::Thrift::Types::BYTE";
     case t_base_type::TYPE_I16:
       return "::Thrift::Types::I16";

--- a/compiler/cpp/src/generate/t_st_generator.cc
+++ b/compiler/cpp/src/generate/t_st_generator.cc
@@ -371,7 +371,7 @@ string t_st_generator::render_const_value(t_type* type, t_const_value* value) {
     case t_base_type::TYPE_BOOL:
       out << (value->get_integer() > 0 ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -788,7 +788,7 @@ string t_st_generator::write_val(t_type* t, string fname) {
     case t_base_type::TYPE_DOUBLE:
       return "iprot writeDouble: " + fname + " asFloat";
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -1020,7 +1020,7 @@ string t_st_generator::type_to_enum(t_type* type) {
       return "TType string";
     case t_base_type::TYPE_BOOL:
       return "TType bool";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return "TType byte";
     case t_base_type::TYPE_I16:
       return "TType i16";

--- a/compiler/cpp/src/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/generate/t_swift_generator.cc
@@ -1818,7 +1818,7 @@ string t_swift_generator::base_type_name(t_base_type* type) {
     }
   case t_base_type::TYPE_BOOL:
     return "Bool";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "Int8";
   case t_base_type::TYPE_I16:
     return "Int16";
@@ -1851,7 +1851,7 @@ void t_swift_generator::render_const_value(ostream& out,
     case t_base_type::TYPE_BOOL:
       out << ((value->get_integer() > 0) ? "true" : "false");
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
     case t_base_type::TYPE_I16:
     case t_base_type::TYPE_I32:
     case t_base_type::TYPE_I64:
@@ -2110,7 +2110,7 @@ string t_swift_generator::type_to_enum(t_type* type, bool qualified) {
       return result + "STRING";
     case t_base_type::TYPE_BOOL:
       return result + "BOOL";
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       return result + "BYTE";
     case t_base_type::TYPE_I16:
       return result + "I16";

--- a/compiler/cpp/src/generate/t_xsd_generator.cc
+++ b/compiler/cpp/src/generate/t_xsd_generator.cc
@@ -337,7 +337,7 @@ string t_xsd_generator::base_type_name(t_base_type::t_base tbase) {
     return "string";
   case t_base_type::TYPE_BOOL:
     return "boolean";
-  case t_base_type::TYPE_BYTE:
+  case t_base_type::TYPE_I8:
     return "byte";
   case t_base_type::TYPE_I16:
     return "short";

--- a/compiler/cpp/src/globals.h
+++ b/compiler/cpp/src/globals.h
@@ -70,7 +70,7 @@ extern t_type* g_type_string;
 extern t_type* g_type_binary;
 extern t_type* g_type_slist;
 extern t_type* g_type_bool;
-extern t_type* g_type_byte;
+extern t_type* g_type_i8;
 extern t_type* g_type_i16;
 extern t_type* g_type_i32;
 extern t_type* g_type_i64;

--- a/compiler/cpp/src/main.cc
+++ b/compiler/cpp/src/main.cc
@@ -71,7 +71,7 @@ t_type* g_type_string;
 t_type* g_type_binary;
 t_type* g_type_slist;
 t_type* g_type_bool;
-t_type* g_type_byte;
+t_type* g_type_i8;
 t_type* g_type_i16;
 t_type* g_type_i32;
 t_type* g_type_i64;
@@ -636,7 +636,7 @@ void dump_docstrings(t_program* program) {
 void check_for_list_of_bytes(t_type* list_elem_type) {
   if ((g_parse_mode == PROGRAM) && (list_elem_type != NULL) && list_elem_type->is_base_type()) {
     t_base_type* tbase = (t_base_type*)list_elem_type;
-    if (tbase->get_base() == t_base_type::TYPE_BYTE) {
+    if (tbase->get_base() == t_base_type::TYPE_I8) {
       pwarning(1, "Consider using the more efficient \"binary\" type instead of \"list<byte>\".");
     }
   }
@@ -733,7 +733,7 @@ void validate_const_rec(std::string name, t_type* type, t_const_value* value) {
         throw "type error: const \"" + name + "\" was declared as bool";
       }
       break;
-    case t_base_type::TYPE_BYTE:
+    case t_base_type::TYPE_I8:
       if (value->get_type() != t_const_value::CV_INTEGER) {
         throw "type error: const \"" + name + "\" was declared as byte";
       }
@@ -1185,7 +1185,7 @@ int main(int argc, char** argv) {
   g_type_slist = new t_base_type("string", t_base_type::TYPE_STRING);
   ((t_base_type*)g_type_slist)->set_string_list(true);
   g_type_bool = new t_base_type("bool", t_base_type::TYPE_BOOL);
-  g_type_byte = new t_base_type("byte", t_base_type::TYPE_BYTE);
+  g_type_i8 = new t_base_type("byte", t_base_type::TYPE_I8);
   g_type_i16 = new t_base_type("i16", t_base_type::TYPE_I16);
   g_type_i32 = new t_base_type("i32", t_base_type::TYPE_I32);
   g_type_i64 = new t_base_type("i64", t_base_type::TYPE_I64);
@@ -1275,7 +1275,7 @@ int main(int argc, char** argv) {
   delete g_type_void;
   delete g_type_string;
   delete g_type_bool;
-  delete g_type_byte;
+  delete g_type_i8;
   delete g_type_i16;
   delete g_type_i32;
   delete g_type_i64;

--- a/compiler/cpp/src/main.cc
+++ b/compiler/cpp/src/main.cc
@@ -642,6 +642,20 @@ void check_for_list_of_bytes(t_type* list_elem_type) {
   }
 }
 
+
+static bool g_byte_warning_emitted = false;
+
+/**
+ * Emits a one-time warning on byte type, promoting the new i8 type instead
+ */
+void emit_byte_type_warning() {
+  if( ! g_byte_warning_emitted) {
+    pwarning(1, "The \"byte\" type is a compatibility alias for \"i8\". Use \"i8\" to emphasize the signedness of this type.\n");
+	g_byte_warning_emitted = true;  
+  } 
+}
+
+
 /**
  * Prints the version number
  */

--- a/compiler/cpp/src/main.h
+++ b/compiler/cpp/src/main.h
@@ -97,6 +97,11 @@ void declare_valid_program_doctext();
 void check_for_list_of_bytes(t_type* list_elem_type);
 
 /**
+ * Emits a one-time warning on byte type, promoting the new i8 type instead
+ */
+void emit_byte_type_warning();
+	
+/**
  * Flex utilities
  */
 

--- a/compiler/cpp/src/parse/t_base_type.h
+++ b/compiler/cpp/src/parse/t_base_type.h
@@ -37,7 +37,7 @@ public:
     TYPE_VOID,
     TYPE_STRING,
     TYPE_BOOL,
-    TYPE_BYTE,
+    TYPE_I8,
     TYPE_I16,
     TYPE_I32,
     TYPE_I64,
@@ -84,7 +84,7 @@ public:
     case TYPE_BOOL:
       return "bool";
       break;
-    case TYPE_BYTE:
+    case TYPE_I8:
       return "byte";
       break;
     case TYPE_I16:

--- a/compiler/cpp/src/parse/t_scope.h
+++ b/compiler/cpp/src/parse/t_scope.h
@@ -112,7 +112,7 @@ public:
           case t_base_type::TYPE_I32:
           case t_base_type::TYPE_I64:
           case t_base_type::TYPE_BOOL:
-          case t_base_type::TYPE_BYTE:
+          case t_base_type::TYPE_I8:
             const_val->set_integer(constant->get_value()->get_integer());
             break;
           case t_base_type::TYPE_STRING:

--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -155,7 +155,8 @@ literal_begin (['\"])
 "include"            { return tok_include;              }
 "void"               { return tok_void;                 }
 "bool"               { return tok_bool;                 }
-"byte"               { return tok_byte;                 }
+"byte"               { return tok_i8;                   }
+"i8"                 { return tok_i8;                   }
 "i16"                { return tok_i16;                  }
 "i32"                { return tok_i32;                  }
 "i64"                { return tok_i64;                  }

--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -155,7 +155,10 @@ literal_begin (['\"])
 "include"            { return tok_include;              }
 "void"               { return tok_void;                 }
 "bool"               { return tok_bool;                 }
-"byte"               { return tok_i8;                   }
+"byte"               { 
+  emit_byte_type_warning();
+  return tok_i8;
+}
 "i8"                 { return tok_i8;                   }
 "i16"                { return tok_i16;                  }
 "i32"                { return tok_i32;                  }

--- a/compiler/cpp/src/thrifty.yy
+++ b/compiler/cpp/src/thrifty.yy
@@ -136,11 +136,11 @@ const int struct_is_union = 1;
  */
 %token tok_void
 %token tok_bool
-%token tok_byte
 %token tok_string
 %token tok_binary
 %token tok_slist
 %token tok_senum
+%token tok_i8
 %token tok_i16
 %token tok_i32
 %token tok_i64
@@ -1169,10 +1169,10 @@ SimpleBaseType:
       pdebug("BaseType -> tok_bool");
       $$ = g_type_bool;
     }
-| tok_byte
+| tok_i8
     {
-      pdebug("BaseType -> tok_byte");
-      $$ = g_type_byte;
+      pdebug("BaseType -> tok_i8");
+      $$ = g_type_i8;
     }
 | tok_i16
     {

--- a/lib/erl/include/thrift_constants.hrl
+++ b/lib/erl/include/thrift_constants.hrl
@@ -22,6 +22,7 @@
 -define(tType_VOID, 1).
 -define(tType_BOOL, 2).
 -define(tType_BYTE, 3).
+-define(tType_I8, 3).
 -define(tType_DOUBLE, 4).
 -define(tType_I16, 6).
 -define(tType_I32, 8).

--- a/lib/erl/src/thrift_json_protocol.erl
+++ b/lib/erl/src/thrift_json_protocol.erl
@@ -56,6 +56,7 @@
 typeid_to_json(?tType_BOOL) -> "tf";
 typeid_to_json(?tType_BYTE) -> "i8";
 typeid_to_json(?tType_DOUBLE) -> "dbl";
+typeid_to_json(?tType_I8) -> "i8";
 typeid_to_json(?tType_I16) -> "i16";
 typeid_to_json(?tType_I32) -> "i32";
 typeid_to_json(?tType_I64) -> "i64";
@@ -66,8 +67,8 @@ typeid_to_json(?tType_SET) -> "set";
 typeid_to_json(?tType_LIST) -> "lst".
 
 json_to_typeid("tf") -> ?tType_BOOL;
-json_to_typeid("i8") -> ?tType_BYTE;
 json_to_typeid("dbl") -> ?tType_DOUBLE;
+json_to_typeid("i8") -> ?tType_I8;
 json_to_typeid("i16") -> ?tType_I16;
 json_to_typeid("i32") -> ?tType_I32;
 json_to_typeid("i64") -> ?tType_I64;

--- a/lib/erl/src/thrift_protocol.erl
+++ b/lib/erl/src/thrift_protocol.erl
@@ -63,8 +63,8 @@ close_transport(#protocol{module = Module,
 typeid_to_atom(?tType_STOP) -> field_stop;
 typeid_to_atom(?tType_VOID) -> void;
 typeid_to_atom(?tType_BOOL) -> bool;
-typeid_to_atom(?tType_BYTE) -> byte;
 typeid_to_atom(?tType_DOUBLE) -> double;
+typeid_to_atom(?tType_I8) -> byte;
 typeid_to_atom(?tType_I16) -> i16;
 typeid_to_atom(?tType_I32) -> i32;
 typeid_to_atom(?tType_I64) -> i64;
@@ -76,8 +76,9 @@ typeid_to_atom(?tType_LIST) -> list.
 
 term_to_typeid(void) -> ?tType_VOID;
 term_to_typeid(bool) -> ?tType_BOOL;
-term_to_typeid(byte) -> ?tType_BYTE;
+term_to_typeid(byte) -> ?tType_I8;
 term_to_typeid(double) -> ?tType_DOUBLE;
+term_to_typeid(i8) -> ?tType_I8;
 term_to_typeid(i16) -> ?tType_I16;
 term_to_typeid(i32) -> ?tType_I32;
 term_to_typeid(i64) -> ?tType_I64;

--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -86,7 +86,7 @@ struct Xtruct
 
 struct Xtruct2
 {
-  1: byte   byte_thing,
+  1: i8     byte_thing,  // used to be byte, hence the name
   2: Xtruct struct_thing,
   3: i32    i32_thing
 }
@@ -152,10 +152,11 @@ service ThriftTest
 
   /**
    * Prints 'testByte("%d")' with thing as '%d'
-   * @param byte thing - the byte to print
-   * @return byte - returns the byte 'thing'
+   * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+   * @param byte thing - the i8/byte to print
+   * @return i8 - returns the i8/byte 'thing'
    */
-  byte         testByte(1: byte thing),
+  i8         testByte(1: byte thing),
 
   /**
    * Prints 'testI32("%d")' with thing as '%d'


### PR DESCRIPTION
THRIFT-3393 Introducing i8 to provide consistent set of Thrift integers
Client: Compiler (general)
Patch: Jens Geyer

