### PR TITLE
THRIFT-3376 C# and Python JSON protocol double values lose precision

### DIFF
--- a/lib/csharp/src/Protocol/TJSONProtocol.cs
+++ b/lib/csharp/src/Protocol/TJSONProtocol.cs
@@ -505,7 +505,7 @@ namespace Thrift.Protocol
         private void WriteJSONDouble(double num)
         {
             context.Write();
-            String str = num.ToString("R", CultureInfo.InvariantCulture);
+            String str = num.ToString("G17", CultureInfo.InvariantCulture);
             bool special = false;
 
             switch (str[0])


### PR DESCRIPTION
Client: C#
Patch: Nobuaki Sukegawa

Use "G17" instead of "R" due to .NET Framework issue.