### PR TITLE
THRIFT-3402: add unix socket support to perl

### DIFF
--- a/build/travis/installDependencies.sh
+++ b/build/travis/installDependencies.sh
@@ -22,9 +22,6 @@ SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 # Mainly aiming Travis CI's Ubuntu machines for now
 # see what we need: http://thrift.apache.org/docs/install/ubuntu
 
-# General dependencies
-sh ${SCRIPTPATH}/installCXXDependencies.sh
-
 # Java dependencies
 sudo apt-get install -qq ant openjdk-7-jdk
 sudo update-java-alternatives -s java-1.7.0-openjdk-amd64

--- a/lib/perl/lib/Thrift/ServerSocket.pm
+++ b/lib/perl/lib/Thrift/ServerSocket.pm
@@ -52,9 +52,6 @@ sub new
         $self = { port => $args };
     }
 
-    if (not defined $self->{port}) {
-        die("port number not specified");
-    }
     if (not defined $self->{queue}) {
         $self->{queue} = 128;
     }

--- a/lib/perl/lib/Thrift/UnixServerSocket.pm
+++ b/lib/perl/lib/Thrift/UnixServerSocket.pm
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+require 5.6.0;
+use strict;
+use warnings;
+
+use Thrift;
+use Thrift::UnixSocket;
+
+use IO::Socket::UNIX;
+use IO::Select;
+
+package Thrift::UnixServerSocket;
+
+use base qw( Thrift::ServerSocket );
+
+#
+# Constructor.
+# If a single argument is given that is not a hash, that is the unix domain socket path.
+# If a single argument is given that is a hash:
+# @param[in]  path   unix domain socket file name
+# @param[in]  queue  the listen queue size (default is not specified is supplied by ServerSocket)
+# @example    my $serversock = new Thrift::UnixServerSocket($path);
+# @example    my $serversock = new Thrift::UnixServerSocket(path => "somepath", queue => 64);
+#
+sub new
+{
+    my $classname = shift;
+    my $args      = shift;
+    my $self;
+
+    if (ref($args) eq 'HASH') {
+        $self = $classname->SUPER::new($args);
+    } else {
+        $self = $classname->SUPER::new();
+        $self->{path} = $args;
+    }
+
+    return bless($self, $classname);
+}
+
+sub __client
+{
+	return new Thrift::UnixSocket();
+}
+
+sub __listen
+{
+    my $self = shift;
+
+    my $sock = IO::Socket::UNIX->new(
+        Type      => IO::Socket::SOCK_STREAM,
+        Local     => $self->{path},
+        Listen    => $self->{queue})
+    || do {
+        my $error = 'UnixServerSocket: Could not bind to ' .
+                    $self->{path} . ' (' . $! . ')';
+        if ($self->{debug}) {
+            $self->{debugHandler}->($error);
+        }
+        die new Thrift::TException($error);
+    };
+
+    return $sock;
+}
+
+1;

--- a/lib/perl/lib/Thrift/UnixSocket.pm
+++ b/lib/perl/lib/Thrift/UnixSocket.pm
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+require 5.6.0;
+use strict;
+use warnings;
+
+use Thrift;
+use Thrift::Transport;
+
+use IO::Socket::UNIX;
+use IO::Select;
+
+package Thrift::UnixSocket;
+
+use base qw( Thrift::Socket );
+
+#
+# Constructor.
+# Takes a unix domain socket filename.
+# See Thirft::Socket for base class parameters.
+# @param[in]  path   path to unix socket file
+# @example    my $sock = new Thrift::UnixSocket($path);
+#
+sub new
+{
+    my $classname = shift;
+    my $self      = $classname->SUPER::new();
+    $self->{path} = shift;     
+    return bless($self, $classname);
+}
+
+sub __open
+{
+    my $self = shift;
+
+    my $sock = IO::Socket::UNIX->new(
+        Type      => IO::Socket::SOCK_STREAM,
+        Peer      => $self->{path})
+    || do {
+        my $error = 'UnixSocket: Could not connect to ' .
+            $self->{path} . ' (' . $! . ')';
+        if ($self->{debug}) {
+            $self->{debugHandler}->($error);
+        }
+        die new Thrift::TException($error);
+    };
+
+    return $sock;
+}
+
+1;

--- a/test/perl/TestClient.pl
+++ b/test/perl/TestClient.pl
@@ -35,6 +35,7 @@ use Thrift::BufferedTransport;
 use Thrift::FramedTransport;
 use Thrift::SSLSocket;
 use Thrift::Socket;
+use Thrift::UnixSocket;
 
 use ThriftTest::ThriftTest;
 use ThriftTest::Types;
@@ -48,6 +49,7 @@ Usage: $0 [OPTIONS]
 Options:                          (default)
   --cert                                       Certificate to use.
                                                Required if using --ssl.
+  --domain-socket <file>                       Use a unix domain socket.
   --help                                       Show usage.
   --port <portnum>                9090         Port to use.
   --protocol {binary}             binary       Protocol to use.
@@ -65,6 +67,7 @@ my %opts = (
 
 GetOptions(\%opts, qw (
     cert=s
+    domain-socket=s
     help
     host=s
     port=i
@@ -84,7 +87,9 @@ if ($opts{ssl} and not defined $opts{cert}) {
 }
 
 my $socket = undef;
-if ($opts{ssl}) {
+if ($opts{"domain-socket"}) {
+    $socket = new Thrift::UnixSocket($opts{"domain-socket"});
+} elsif ($opts{ssl}) {
 	$socket = new Thrift::SSLSocket($opts{host}, $opts{port});
 } else {
 	$socket = new Thrift::Socket($opts{host}, $opts{port});

--- a/test/tests.json
+++ b/test/tests.json
@@ -126,8 +126,8 @@
       "framed"
     ],
     "sockets": [
-      "ip-ssl",
-      "ip"
+      "ip",
+      "ip-ssl"
     ],
     "protocols": [
       "compact",
@@ -190,8 +190,8 @@
       "framed"
     ],
     "sockets": [
-      "ip-ssl",
-      "ip"
+      "ip",
+      "ip-ssl"
     ],
     "protocols": [
       "compact",
@@ -221,8 +221,8 @@
       "framed"
     ],
     "sockets": [
-      "ip-ssl",
       "ip",
+      "ip-ssl",
       "domain"
     ],
     "protocols": [
@@ -307,7 +307,8 @@
     ],
     "sockets": [
       "ip",
-      "ip-ssl"
+      "ip-ssl",
+      "domain"
     ],
     "protocols": [
       "binary"


### PR DESCRIPTION
Usage:

my $serversock = new Thrift::UnixServerSocket($path);
or
my $serversock = new Thrift::UnixServerSocket(path => $path, queue => $queue);

my $sock = new Thrift::UnixSocket($path);

Leverages the refactored socket code in perl that was added in 0.9.3 using virtual overrides.