### PR TITLE
Fix package.json to include only the needed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "mail": "dev@thrift.apache.org",
     "url": "https://issues.apache.org/jira/browse/THRIFT"
   },
+  "files": [
+    "lib/nodejs/lib/thrift",
+    "lib/nodejs/README.md"
+  ],
   "directories": {
     "lib": "./lib/nodejs/lib/thrift"
   },


### PR DESCRIPTION
Before:

```
> du -sh node_modules/thrift
 28M	node_modules/thrift
```

After:

```
> mkdir -p /tmp/thrift-module
> cp -r node_modules/thrift/lib/nodejs/{lib,README.md} /tmp/thrift-module
> du -sh /tmp/thrift-module
208K	/tmp/thrift-module
```

Reference: https://docs.npmjs.com/files/package.json#files