### PR TITLE
THRIFT-3274 calling "make clean" twice in a row yields make error

### DIFF
--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -360,7 +360,7 @@ AM_LDFLAGS = $(BOOST_LDFLAGS)
 AM_CXXFLAGS = -Wall -Wextra -pedantic
 
 clean-local:
-	$(RM) -r gen-cpp
+	$(RM) gen-cpp/*
 
 EXTRA_DIST = \
 	concurrency \

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -111,7 +111,7 @@ AM_CXXFLAGS = -Wall -Wextra -pedantic
 AM_LDFLAGS = $(BOOST_LDFLAGS) $(LIBEVENT_LDFLAGS) $(ZLIB_LIBS)
 
 clean-local:
-	$(RM) -r gen-cpp
+	$(RM) gen-cpp/*
 
 style-local:
 	$(CPPSTYLE_CMD)


### PR DESCRIPTION
Removing `gen-cpp/.deps` hidden directory broke the source tree where any subsequent make command failed.