### PR TITLE
THRIFT-3408: correct emitted JSON types

### DIFF
--- a/compiler/cpp/src/generate/t_json_generator.cc
+++ b/compiler/cpp/src/generate/t_json_generator.cc
@@ -701,8 +701,12 @@ string t_json_generator::get_type_name(t_type* ttype) {
   if (ttype->is_xception()) {
     return "exception";
   }
-  //if (ttype->is_base_type() && ((t_base_type*)ttype)->is_binary()) {
-  return "binary";
+  if (ttype->is_base_type()) {
+    t_base_type* tbasetype = (t_base_type*)ttype;
+    return tbasetype->is_binary() ? "binary" : t_base_type::t_base_name(tbasetype->get_base());
+  }
+
+  return "(unknown)";
 }
 
 string t_json_generator::get_qualified_name(t_type* ttype) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-3408

Currently this has no tests associated with it because the JSON generator itself appears untested. No wonder there was this regression.