### PR TITLE
fix travis dependencies

### DIFF
--- a/build/travis/installCXXDependencies.sh
+++ b/build/travis/installCXXDependencies.sh
@@ -22,8 +22,14 @@
 # see what we need: http://thrift.apache.org/docs/install/ubuntu
 
 # General dependencies
-sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
-sudo apt-get update -qq
+# sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
 
-sudo apt-get install -qq libpango-1.0-0 libqt4-dev qtbase5-dev qtbase5-dev-tools qt5-default libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make cmake git debhelper bc nsis ninja-build
+# for cmake-2.8.12 on precise
+sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
+
+# for qt5 development on precise
+sudo apt-add-repository ppa:ubuntu-sdk-team/ppa -y
+
+sudo apt-get update -qq
+sudo apt-get install -qq libpango1.0-0 libqt4-dev qtbase5-dev qtbase5-dev-tools qt5-default libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make cmake git debhelper bc nsis ninja-build
 dpkg -S /usr/include/boost/version.hpp

--- a/build/travis/installCXXDependencies.sh
+++ b/build/travis/installCXXDependencies.sh
@@ -31,5 +31,9 @@ sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
 sudo apt-add-repository ppa:ubuntu-sdk-team/ppa -y
 
 sudo apt-get update -qq
+
+# remove cmake from ubuntu
+sudo apt-get remove cmake cmake-data
+
 sudo apt-get install libpango1.0-0 libqt4-dev qtbase5-dev qtbase5-dev-tools qt5-default libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make cmake git debhelper bc nsis ninja-build
 dpkg -S /usr/include/boost/version.hpp

--- a/build/travis/installCXXDependencies.sh
+++ b/build/travis/installCXXDependencies.sh
@@ -24,6 +24,9 @@
 # General dependencies
 # sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
 
+# clean up held packages
+sudo apt-get autoremove
+
 # for cmake-2.8.12 on precise
 sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
 

--- a/build/travis/installCXXDependencies.sh
+++ b/build/travis/installCXXDependencies.sh
@@ -24,9 +24,6 @@
 # General dependencies
 # sudo apt-add-repository "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted" -y
 
-# clean up held packages
-sudo apt-get autoremove
-
 # for cmake-2.8.12 on precise
 sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
 
@@ -34,5 +31,5 @@ sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
 sudo apt-add-repository ppa:ubuntu-sdk-team/ppa -y
 
 sudo apt-get update -qq
-sudo apt-get install -qq libpango1.0-0 libqt4-dev qtbase5-dev qtbase5-dev-tools qt5-default libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make cmake git debhelper bc nsis ninja-build
+sudo apt-get install libpango1.0-0 libqt4-dev qtbase5-dev qtbase5-dev-tools qt5-default libboost-dev libboost-test-dev libboost-program-options-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev make cmake git debhelper bc nsis ninja-build
 dpkg -S /usr/include/boost/version.hpp


### PR DESCRIPTION
Stop using the trusty repository on top of precise and switch to publicly available repositories with versions of the libraries we need to build in precise, which travis uses.