### PR TITLE
THRIFT-2413: JSON escaped unicode support for python3

### DIFF
--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -256,9 +256,8 @@ class TJSONProtocolBase(TProtocolBase):
       else:
         return chr(high)
     else:
-      codepoint = ((high & 0x3c0) + 1) << 16  # 0b000000000001111000000
-      codepoint += (high & 0x3f) << 10        # 0b000000000000000111111
-      codepoint += low & 0x3ff                # 0b000000000001111111111
+      codepoint = (1 << 16) + ((high & 0x3ff) << 10)
+      codepoint += low & 0x3ff
       if sys.version_info[0] == 2:
         s = "\\U%08x" % codepoint
         return s.decode('unicode-escape').encode('utf-8')

--- a/lib/py/test/thrift_json.py
+++ b/lib/py/test/thrift_json.py
@@ -15,7 +15,7 @@ import unittest
 class TestJSONString(unittest.TestCase):
 
   def test_escaped_unicode_string(self):
-    unicode_json = '"hello \\u0e01\\u0e02\\u0e03\\ud835\\udcab unicode"'
+    unicode_json = b'"hello \\u0e01\\u0e02\\u0e03\\ud835\\udcab unicode"'
     unicode_text = u'hello \u0e01\u0e02\u0e03\U0001D4AB unicode'
 
     buf = TTransport.TMemoryBuffer(unicode_json)

--- a/lib/py/test/thrift_json.py
+++ b/lib/py/test/thrift_json.py
@@ -15,8 +15,8 @@ import unittest
 class TestJSONString(unittest.TestCase):
 
   def test_escaped_unicode_string(self):
-    unicode_json = b'"hello \\u0e01\\u0e02\\u0e03\\ud835\\udcab unicode"'
-    unicode_text = u'hello \u0e01\u0e02\u0e03\U0001D4AB unicode'
+    unicode_json = b'"hello \\u0e01\\u0e02\\u0e03\\ud835\\udcab\\udb40\\udc70 unicode"'
+    unicode_text = u'hello \u0e01\u0e02\u0e03\U0001D4AB\U000E0070 unicode'
 
     buf = TTransport.TMemoryBuffer(unicode_json)
     transport = TTransport.TBufferedTransportFactory().getTransport(buf)


### PR DESCRIPTION
This should fixed THRIFT-2413 and should works on both python2 and python3.