### PR TITLE
THRIFT-2974 fix optional writeToParcel

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -1634,7 +1634,7 @@ void t_java_generator::generate_java_struct_parcelable(ofstream& out, t_struct* 
     } else if (type_name(t) == "float") {
       indent(out) << "out.writeFloat(" << name << ");" << endl;
     } else if (t->is_enum()) {
-      indent(out) << "out.writeInt(" << name << ".getValue());" << endl;
+      indent(out) << "out.writeInt(" << name << " != null ? " << name << ".getValue() : -1);" << endl;
     } else if (t->is_list()) {
       if (((t_list*)t)->get_elem_type()->get_true_type()->is_struct()) {
         indent(out) << "out.writeTypedList(" << name << ");" << endl;


### PR DESCRIPTION
Fix for [THRIFT-2974](https://issues.apache.org/jira/browse/THRIFT-2974?jql=text%20~%20%22optional%20writeToParcel%22) which causes NPEs whenever struct with an unset optional enum is written to an Android [`Parcel`](http://developer.android.com/reference/android/os/Parcel.html#writeInt%28int%29).

[Thrift IDL docs](https://thrift.apache.org/docs/idl#enum) specify that enum values must be greater than or equal to zero. We can write -1 to the parcel to represent an unset enum. The corresponding code for reconstructing the struct (see line 1728) uses the `TEnum.findByValue` method which will return `null` for any unused enum values, which will always include -1.