### PR TITLE
THRIFT-3385 warning: format ‘%lu’ expects ‘long unsigned int’

### DIFF
--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -488,7 +488,7 @@ int main(int argc, char** argv) {
       testClient.testBinary(bin_result, string(bin_data, 256));
       if (bin_result.size() != 256) {
         printf("}\n*** FAILED ***\n");
-        printf("invalid length: %lu\n", bin_result.size());
+        printf("invalid length: %zu\n", bin_result.size());
         return_code |= ERR_BASETYPES;
       } else {
         bool first = true;


### PR DESCRIPTION
THRIFT-3385  warning: format ‘%lu’ expects ‘long unsigned int’
