### PR TITLE
THRIFT-3309: Missing TConstant.php in /lib/php/Makefile.am

### DIFF
--- a/lib/php/Makefile.am
+++ b/lib/php/Makefile.am
@@ -112,7 +112,8 @@ phptransport_DATA = \
 phptypedir = $(phpdir)/Type
 phptype_DATA = \
   lib/Thrift/Type/TMessageType.php \
-  lib/Thrift/Type/TType.php
+  lib/Thrift/Type/TType.php \
+  lib/Thrift/Type/TConstant.php
 
 EXTRA_DIST = \
   lib \


### PR DESCRIPTION
The file lib/php/lib/Thrift/Type/TConstant.php is missing from the php
Makefile. Therefore "make install" don't copy the TConstant.php file.