### PR TITLE
Fix generated Node JS code

### DIFF
--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -639,11 +639,12 @@ void t_js_generator::generate_js_struct_definition(ofstream& out,
   vector<t_field*>::const_iterator m_iter;
 
   if (gen_node_) {
+    string prefix = has_js_namespace(tstruct->get_program()) ? js_namespace(tstruct->get_program()) : "var ";
     if (is_exported) {
-      out << "var " << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = "
+      out << prefix << tstruct->get_name() << " = "
           << "module.exports." << tstruct->get_name() << " = function(args) {" << endl;
     } else {
-      out << "var " << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = function(args) {"
+      out << prefix << tstruct->get_name() << " = function(args) {"
           << endl;
     }
   } else {
@@ -977,8 +978,8 @@ void t_js_generator::generate_service_processor(t_service* tservice) {
   vector<t_function*>::iterator f_iter;
 
   if (gen_node_) {
-    f_service_ << "var " << js_namespace(tservice->get_program()) << service_name_ << "Processor = "
-             << "exports.Processor = function(handler) ";
+    string prefix = has_js_namespace(tservice->get_program()) ? js_namespace(tservice->get_program()) : "var ";
+    f_service_ << prefix << service_name_ << "Processor = " << "exports.Processor = function(handler) ";
   } else {
     f_service_ << js_namespace(tservice->get_program()) << service_name_ << "Processor = "
              << "exports.Processor = function(handler) ";
@@ -1255,7 +1256,8 @@ void t_js_generator::generate_service_rest(t_service* tservice) {
  */
 void t_js_generator::generate_service_client(t_service* tservice) {
   if (gen_node_) {
-    f_service_ << "var " << js_namespace(tservice->get_program()) << service_name_ << "Client = "
+    string prefix = has_js_namespace(tservice->get_program()) ? js_namespace(tservice->get_program()) : "var ";
+    f_service_ << prefix << service_name_ << "Client = "
                << "exports.Client = function(output, pClass) {" << endl;
   } else {
     f_service_ << js_namespace(tservice->get_program()) << service_name_

--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -221,6 +221,11 @@ public:
     return js_namespace(p);
   }
 
+  bool has_js_namespace(t_program* p) {
+    std::string ns = p->get_namespace("js");
+    return (ns.size() > 0);
+  }
+
   std::string js_namespace(t_program* p) {
     std::string ns = p->get_namespace("js");
     if (ns.size() > 0) {

--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -383,7 +383,7 @@ string t_js_generator::render_includes() {
     const vector<t_program*>& includes = program_->get_includes();
     for (size_t i = 0; i < includes.size(); ++i) {
       result += "var " + includes[i]->get_name() + "_ttypes = require('./" + includes[i]->get_name()
-                + "_types')\n";
+                + "_types');\n";
     }
     if (includes.size() > 0) {
       result += "\n";
@@ -935,11 +935,11 @@ void t_js_generator::generate_service(t_service* tservice) {
   if (gen_node_) {
     if (tservice->get_extends() != NULL) {
       f_service_ << "var " << tservice->get_extends()->get_name() << " = require('./"
-                 << tservice->get_extends()->get_name() << "')" << endl << "var "
+                 << tservice->get_extends()->get_name() << "');" << endl << "var "
                  << tservice->get_extends()->get_name()
-                 << "Client = " << tservice->get_extends()->get_name() << ".Client" << endl
+                 << "Client = " << tservice->get_extends()->get_name() << ".Client;" << endl
                  << "var " << tservice->get_extends()->get_name()
-                 << "Processor = " << tservice->get_extends()->get_name() << ".Processor" << endl;
+                 << "Processor = " << tservice->get_extends()->get_name() << ".Processor;" << endl;
     }
 
     f_service_ << "var ttypes = require('./" + program_->get_name() + "_types');" << endl;

--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -635,10 +635,10 @@ void t_js_generator::generate_js_struct_definition(ofstream& out,
 
   if (gen_node_) {
     if (is_exported) {
-      out << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = "
+      out << "var " << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = "
           << "module.exports." << tstruct->get_name() << " = function(args) {" << endl;
     } else {
-      out << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = function(args) {"
+      out << "var " << js_namespace(tstruct->get_program()) << tstruct->get_name() << " = function(args) {"
           << endl;
     }
   } else {
@@ -971,8 +971,13 @@ void t_js_generator::generate_service_processor(t_service* tservice) {
   vector<t_function*> functions = tservice->get_functions();
   vector<t_function*>::iterator f_iter;
 
-  f_service_ << js_namespace(tservice->get_program()) << service_name_ << "Processor = "
+  if (gen_node_) {
+    f_service_ << "var " << js_namespace(tservice->get_program()) << service_name_ << "Processor = "
              << "exports.Processor = function(handler) ";
+  } else {
+    f_service_ << js_namespace(tservice->get_program()) << service_name_ << "Processor = "
+             << "exports.Processor = function(handler) ";
+  }
 
   scope_up(f_service_);
 
@@ -1245,7 +1250,7 @@ void t_js_generator::generate_service_rest(t_service* tservice) {
  */
 void t_js_generator::generate_service_client(t_service* tservice) {
   if (gen_node_) {
-    f_service_ << js_namespace(tservice->get_program()) << service_name_ << "Client = "
+    f_service_ << "var " << js_namespace(tservice->get_program()) << service_name_ << "Client = "
                << "exports.Client = function(output, pClass) {" << endl;
   } else {
     f_service_ << js_namespace(tservice->get_program()) << service_name_


### PR DESCRIPTION
As reported in https://issues.apache.org/jira/browse/THRIFT-1840 and https://issues.apache.org/jira/browse/THRIFT-2527 the generated JS code pollutes the global namespace because it lacks `var` keywords.

This PR adds the `var` keyword where appropriate.
It also appends missing `;`, thus making tools like [jshint](http://jshint.com/) et. al. happier.