### PR TITLE
THRIFT-3486 - Java generated `getFieldValue` is incompatible with `setFieldValue` for binary values.

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2064,12 +2064,23 @@ void t_java_generator::generate_reflection_setters(ostringstream& out,
                                                    t_type* type,
                                                    string field_name,
                                                    string cap_name) {
+  const bool is_binary = type->is_base_type() && ((t_base_type*)type)->is_binary();
   indent(out) << "case " << constant_name(field_name) << ":" << endl;
   indent_up();
   indent(out) << "if (value == null) {" << endl;
   indent(out) << "  unset" << get_cap_name(field_name) << "();" << endl;
   indent(out) << "} else {" << endl;
+  if (is_binary) {
+    indent_up();
+    indent(out) << "if (value instanceof byte[]) {" << endl;
+    indent(out) << "  set" << cap_name << "((byte[])value);" << endl;
+    indent(out) << "} else {" << endl;
+  }
   indent(out) << "  set" << cap_name << "((" << type_name(type, true, false) << ")value);" << endl;
+  if (is_binary) {
+    indent(out) << "}" << endl;
+    indent_down();
+  }
   indent(out) << "}" << endl;
   indent(out) << "break;" << endl << endl;
 

--- a/lib/java/test/org/apache/thrift/TestStruct.java
+++ b/lib/java/test/org/apache/thrift/TestStruct.java
@@ -309,11 +309,33 @@ public class TestStruct extends TestCase {
   }
 
   public void testBytesBufferFeatures() throws Exception {
-    JavaTestHelper o = new JavaTestHelper();
+    
+    final String testString = "testBytesBufferFeatures";
+    final JavaTestHelper o = new JavaTestHelper();
+
     o.setReq_bin((ByteBuffer)null);
     assertNull(o.getReq_bin());
+
+    o.setReq_bin(ByteBuffer.wrap(testString.getBytes()));
+    assertNotNull(o.getReq_bin());
+
     o.setReq_bin((byte[])null);
     assertNull(o.getReq_bin());
+
+    o.setReq_bin(testString.getBytes());
+    assertNotNull(o.getReq_bin());
+
+    o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, null);
+    assertNull(o.getReq_bin());
+
+    o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, testString.getBytes());
+    assertNotNull(o.getReq_bin());
+
+    o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, null);
+    assertNull(o.getReq_bin());
+
+    o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, ByteBuffer.wrap(testString.getBytes()));
+    assertNotNull(o.getReq_bin());
   }
 
   public void testJavaSerializable() throws Exception {

--- a/lib/java/test/org/apache/thrift/TestStruct.java
+++ b/lib/java/test/org/apache/thrift/TestStruct.java
@@ -308,6 +308,12 @@ public class TestStruct extends TestCase {
         object.toString());
   }
 
+  private static void assertArrayEquals(byte[] expected, byte[] actual) {
+    if (!java.util.Arrays.equals(expected, actual)) {
+      fail("Expected byte array did not match actual.");
+    }
+  }
+
   public void testBytesBufferFeatures() throws Exception {
     
     final String testString = "testBytesBufferFeatures";
@@ -317,25 +323,25 @@ public class TestStruct extends TestCase {
     assertNull(o.getReq_bin());
 
     o.setReq_bin(ByteBuffer.wrap(testString.getBytes()));
-    assertNotNull(o.getReq_bin());
+    assertArrayEquals(testString.getBytes(), o.getReq_bin());
 
     o.setReq_bin((byte[])null);
     assertNull(o.getReq_bin());
 
     o.setReq_bin(testString.getBytes());
-    assertNotNull(o.getReq_bin());
+    assertArrayEquals(testString.getBytes(), o.getReq_bin());
 
     o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, null);
     assertNull(o.getReq_bin());
 
     o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, testString.getBytes());
-    assertNotNull(o.getReq_bin());
+    assertArrayEquals(testString.getBytes(), o.getReq_bin());
 
     o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, null);
     assertNull(o.getReq_bin());
 
     o.setFieldValue(JavaTestHelper._Fields.REQ_BIN, ByteBuffer.wrap(testString.getBytes()));
-    assertNotNull(o.getReq_bin());
+    assertArrayEquals(testString.getBytes(), o.getReq_bin());
   }
 
   public void testJavaSerializable() throws Exception {


### PR DESCRIPTION
For binary fields, the compiler generates Java getter/setter methods for primitive byte arrays (`byte[]`) as well as `java.nio.ByteBuffer` objects.  However, `setFieldValue` only accepts a `ByteBuffer`, and throws a `ClassCastException` if a `byte[]` is passed as an argument. To further confuse things, `getFieldValue` returns a `byte[]`. By allowing either a `ByteBuffer` or a `byte[]` as input, `setFieldValue` could exhibit less confusing behavior for end users.

These changes add an `instanceof` check for binary fields in the generated `setFieldValue()` method so that it accepts either a `byte[]` or a `ByteBuffer`.  There is also an update to the Java library's test suite to test for this functionality.