### PR TITLE
Thrift 3496: C++: Cob style client fails when sending a consecutive request

### DIFF
--- a/compiler/cpp/src/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/generate/t_cpp_generator.cc
@@ -2437,6 +2437,10 @@ void t_cpp_generator::generate_service_client(t_service* tservice, string style)
         out <<
           indent() << "::apache::thrift::async::TConcurrentSendSentry sentry(&this->sync_);" << endl;
       }
+      if (style == "Cob") {
+        out <<
+          indent() << _this << "otrans_->resetBuffer();" << endl;
+      }
       out <<
         indent() << _this << "oprot_->writeMessageBegin(\"" << 
         (*f_iter)->get_name() << 

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
@@ -74,8 +74,8 @@ private:
 
   std::string host_;
   std::string path_;
-  using Completion = std::pair<VoidCallback, apache::thrift::transport::TMemoryBuffer*>;
-  using CompletionQueue = std::queue<Completion>;
+  typedef std::pair<VoidCallback, apache::thrift::transport::TMemoryBuffer*> Completion;
+  typedef std::queue<Completion> CompletionQueue;
   CompletionQueue completionQueue_;
   struct evhttp_connection* conn_;
 };

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
@@ -20,7 +20,9 @@
 #ifndef _THRIFT_TEVHTTP_CLIENT_CHANNEL_H_
 #define _THRIFT_TEVHTTP_CLIENT_CHANNEL_H_ 1
 
+#include <queue>
 #include <string>
+#include <utility>
 #include <boost/shared_ptr.hpp>
 #include <thrift/async/TAsyncChannel.h>
 
@@ -72,8 +74,9 @@ private:
 
   std::string host_;
   std::string path_;
-  VoidCallback cob_;
-  apache::thrift::transport::TMemoryBuffer* recvBuf_;
+  using Completion = std::pair<VoidCallback, apache::thrift::transport::TMemoryBuffer*>;
+  using CompletionQueue = std::queue<Completion>;
+  CompletionQueue completionQueue_;
   struct evhttp_connection* conn_;
 };
 }


### PR DESCRIPTION
see THRIFT-3496