### PR TITLE
THRIFT-3497 Build fails with "invalid use of incomplete type"

### DIFF
--- a/lib/cpp/src/thrift/concurrency/Monitor.cpp
+++ b/lib/cpp/src/thrift/concurrency/Monitor.cpp
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <thrift/thrift-config.h>
+
 #include <thrift/concurrency/Monitor.h>
 #include <thrift/concurrency/Exception.h>
 #include <thrift/concurrency/Util.h>

--- a/lib/cpp/src/thrift/concurrency/Monitor.h
+++ b/lib/cpp/src/thrift/concurrency/Monitor.h
@@ -20,6 +20,10 @@
 #ifndef _THRIFT_CONCURRENCY_MONITOR_H_
 #define _THRIFT_CONCURRENCY_MONITOR_H_ 1
 
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+
 #include <thrift/concurrency/Exception.h>
 #include <thrift/concurrency/Mutex.h>
 


### PR DESCRIPTION
This change fixes an "invalid use of incomplete type" compiler error referring to `struct timeval` when building on Haiku.

- `Monitor.cpp`: Include `thrift-config.h` for definition of `HAVE_SYS_TIME_H`.
- `Monitor.h`: Explicitly include `sys/time.h` on platforms that require this.