### PR TITLE
THRIFT-3498 C++ library assumes optional function pthread_attr_setschedpolicy is available

### DIFF
--- a/lib/cpp/src/thrift/concurrency/PosixThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/PosixThreadFactory.cpp
@@ -124,9 +124,11 @@ public:
     policy_ = PosixThreadFactory::OTHER;
 #endif
 
+#if _POSIX_THREAD_PRIORITY_SCHEDULING > 0
     if (pthread_attr_setschedpolicy(&thread_attr, policy_) != 0) {
       throw SystemResourceException("pthread_attr_setschedpolicy failed");
     }
+#endif
 
     struct sched_param sched_param;
     sched_param.sched_priority = priority_;


### PR DESCRIPTION
This patch allows Thrift to build on Haiku and other systems that do not implement POSIX's thread-execution scheduling option. It adds a check around the call to `pthread_attr_setschedpolicy` in the C++ library.

[According to POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html#tag_13_77_03_02) `_POSIX_THREAD_PRIORITY_SCHEDULING` should be defined in `unistd.h` with a value greater than zero if the `pthread_attr_setschedpolicy` function is known to be available at runtime.

`PosixThreadFactory.cpp`: Test for availability of optional `pthread_attr_setschedpolicy` function before including in source code