### PR TITLE
THRIFT-3499: Add package_prefix to python generator

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -59,6 +59,12 @@ public:
     iter = parsed_options.find("slots");
     gen_slots_ = (iter != parsed_options.end());
 
+    iter = parsed_options.find("package_prefix");
+    if (iter != parsed_options.end()) {
+      package_prefix_ = iter->second;
+    }
+
+
     iter = parsed_options.find("dynamic");
     gen_dynamic_ = (iter != parsed_options.end());
 
@@ -233,7 +239,7 @@ public:
     return sub_namespace == "twisted";
   }
 
-  static std::string get_real_py_module(const t_program* program, bool gen_twisted) {
+  static std::string get_real_py_module(const t_program* program, bool gen_twisted, std::string package_dir="") {
     if (gen_twisted) {
       std::string twisted_module = program->get_namespace("py.twisted");
       if (!twisted_module.empty()) {
@@ -245,7 +251,7 @@ public:
     if (real_module.empty()) {
       return program->get_name();
     }
-    return real_module;
+    return package_dir + real_module;
   }
 
   static bool is_immutable(t_type* ttype) {
@@ -295,6 +301,8 @@ private:
    * eg. # -*- coding: utf-8 -*-
    */
   string coding_;
+
+  string package_prefix_;
 
   /**
    * File streams
@@ -378,7 +386,7 @@ string t_py_generator::render_includes() {
   const vector<t_program*>& includes = program_->get_includes();
   string result = "";
   for (size_t i = 0; i < includes.size(); ++i) {
-    result += "import " + get_real_py_module(includes[i], gen_twisted_) + ".ttypes\n";
+    result += "import " + get_real_py_module(includes[i], gen_twisted_, package_prefix_) + ".ttypes\n";
   }
   return result;
 }
@@ -1036,7 +1044,7 @@ void t_py_generator::generate_service(t_service* tservice) {
 
   if (tservice->get_extends() != NULL) {
     f_service_ << "import "
-               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_) << "."
+               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_, package_prefix_) << "."
                << tservice->get_extends()->get_name() << endl;
   }
 
@@ -2489,10 +2497,10 @@ string t_py_generator::type_name(t_type* ttype) {
 
   t_program* program = ttype->get_program();
   if (ttype->is_service()) {
-    return get_real_py_module(program, gen_twisted_) + "." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + "." + ttype->get_name();
   }
   if (program != NULL && program != program_) {
-    return get_real_py_module(program, gen_twisted_) + ".ttypes." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes." + ttype->get_name();
   }
   return ttype->get_name();
 }
@@ -2585,4 +2593,6 @@ THRIFT_REGISTER_GENERATOR(
     "    dynfrozen=CLS    Derive generated immutable classes from class CLS instead of TFrozenBase.\n"
     "    dynexc=CLS       Derive generated exceptions from CLS instead of TExceptionBase.\n"
     "    dynimport='from foo.bar import CLS'\n"
-    "                     Add an import line to generated code to find the dynbase class.\n")
+    "                     Add an import line to generated code to find the dynbase class.\n"
+    "    package_prefix='top.package.'\n"
+    "                     Package prefix for generated files.\n")


### PR DESCRIPTION
Permit prefixing import paths with a certain string to support devs who will place the generated code below the top level of their python hierarchy.

This is similar to the go generator's package_prefix generator option.