### PR TITLE
THRIFT-3500: Strings unicode py2

### DIFF
--- a/lib/py/src/compat.py
+++ b/lib/py/src/compat.py
@@ -1,14 +1,21 @@
 import sys
+import logging
 
 if sys.version_info[0] == 2:
 
   from cStringIO import StringIO as BufferIO
 
   def binary_to_str(bin_val):
-    return bin_val
+    try:
+      return bin_val.decode('utf8')
+    except:
+      return bin_val
 
   def str_to_binary(str_val):
-    return str_val
+    try:
+      return str_val.encode('utf8')
+    except:
+      return str_val
 
 else:
 

--- a/lib/py/src/compat.py
+++ b/lib/py/src/compat.py
@@ -5,13 +5,19 @@ if sys.version_info[0] == 2:
 
   from cStringIO import StringIO as BufferIO
 
-  def binary_to_str(bin_val):
+  def binary_to_string(bin_val):
+    """
+    Change a binary value string b'' to a u''.
+    """
     try:
       return bin_val.decode('utf8')
     except:
       return bin_val
 
-  def str_to_binary(str_val):
+  def string_to_binary(str_val):
+    """
+    Change a string to binary, u'' to b''
+    """
     try:
       return str_val.encode('utf8')
     except:
@@ -21,13 +27,19 @@ else:
 
   from io import BytesIO as BufferIO
 
-  def binary_to_str(bin_val):
+  def binary_to_string(bin_val):
+    """
+    Change a binary value to a string, b'' to ''.
+    """
     try:
       return bin_val.decode('utf8')
     except:
       return bin_val
 
-  def str_to_binary(str_val):
+  def string_to_binary(str_val):
+    """
+    Change a string to binary, '' to b''
+    """
     try:
       return bytearray(str_val, 'utf8')
     except:

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -20,7 +20,8 @@
 from .TProtocol import TType, TProtocolBase, TProtocolException, checkIntegerLimits
 from struct import pack, unpack
 
-from ..compat import binary_to_str, str_to_binary
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 __all__ = ['TCompactProtocol', 'TCompactProtocolFactory']
 
@@ -143,7 +144,7 @@ class TCompactProtocol(TProtocolBase):
     self.__writeUByte(self.PROTOCOL_ID)
     self.__writeUByte(self.VERSION | (type << self.TYPE_SHIFT_AMOUNT))
     self.__writeVarint(seqid)
-    self.__writeBinary(str_to_binary(name))
+    self.__writeBinary(string_to_binary(name))
     self.state = VALUE_WRITE
 
   def writeMessageEnd(self):
@@ -320,7 +321,7 @@ class TCompactProtocol(TProtocolBase):
       raise TProtocolException(TProtocolException.BAD_VERSION,
                                'Bad version: %d (expect %d)' % (version, self.VERSION))
     seqid = self.__readVarint()
-    name = binary_to_str(self.__readBinary())
+    name = binary_to_string(self.__readBinary())
     return (name, type, seqid)
 
   def readMessageEnd(self):

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -22,8 +22,8 @@ import base64
 import math
 import sys
 
-from ..compat import str_to_binary
-from ..compat import binary_to_str
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 
 __all__ = ['TJSONProtocol',
@@ -212,7 +212,7 @@ class TJSONProtocolBase(TProtocolBase):
       escaped = ESCAPE_CHAR_VALS.get(s, s)
       json_str.append(escaped)
     json_str.append(QUOTE_CHAR)
-    self.trans.write(str_to_binary(EMPTY_STRING.join(json_str)))
+    self.trans.write(string_to_binary(EMPTY_STRING.join(json_str)))
 
   def writeJSONNumber(self, number, formatter='{}'):
     self.context.write()
@@ -331,7 +331,7 @@ class TJSONProtocolBase(TProtocolBase):
     # A JSON String must be decoded to the most String like type a language
     #  has, which is unicode in Python 2 and str in python 3.
     if PY2:
-      return binary_to_str(''.join(string))
+      return binary_to_string(''.join(string))
     return EMPTY_STRING.join(string)
 
   def isJSONNumeric(self, character):

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -20,7 +20,8 @@
 from thrift.Thrift import TException, TType, TFrozenDict
 import six
 
-from ..compat import binary_to_str, str_to_binary
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 
 class TProtocolException(TException):
@@ -103,7 +104,7 @@ class TProtocolBase:
     pass
 
   def writeString(self, str_val):
-    self.writeBinary(str_to_binary(str_val))
+    self.writeBinary(string_to_binary(str_val))
 
   def writeBinary(self, str_val):
     pass
@@ -163,7 +164,7 @@ class TProtocolBase:
     pass
 
   def readString(self):
-    return binary_to_str(self.readBinary())
+    return binary_to_string(self.readBinary())
 
   def readBinary(self):
     pass

--- a/lib/py/test/thrift_json.py
+++ b/lib/py/test/thrift_json.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from thrift import Thrift
 from thrift.protocol.TJSONProtocol import TJSONProtocol
 from thrift.transport import TTransport
@@ -22,8 +23,6 @@ class TestJSONString(unittest.TestCase):
     transport = TTransport.TBufferedTransportFactory().getTransport(buf)
     protocol = TJSONProtocol(transport)
 
-    if sys.version_info[0] == 2:
-      unicode_text = unicode_text.encode('utf8')
     self.assertEqual(protocol.readString(), unicode_text)
 
 if __name__ == '__main__':


### PR DESCRIPTION
As the test shows, this makes Thrift protocols treat Strings as unicode in Python 2 which is essentially equivalent as the str in Python 3. Indeed Python 3.5 now treats u"hello" as a str literal, just as Python 2 treats it as a unicode literal.

The python 2 standard lib contains the json package, that, when loading JSON, deserializes strings into unicode objects, where the TJSONProtocol deserializes them into utf-8 encoded bytes without this change.

https://issues.apache.org/jira/browse/THRIFT-3500
