### PR TITLE
THRIFT-3502: C++ TServerSocket passes small buffer to getsockname

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -494,14 +494,14 @@ void TServerSocket::listen() {
 
     // retrieve bind info
     if (port_ == 0 && retries <= retryLimit_) {
-      struct sockaddr sa;
+      struct sockaddr_storage sa;
       socklen_t len = sizeof(sa);
       std::memset(&sa, 0, len);
-      if (::getsockname(serverSocket_, &sa, &len) < 0) {
+      if (::getsockname(serverSocket_, reinterpret_cast<struct sockaddr*>(&sa), &len) < 0) {
         int errno_copy = errno;
         GlobalOutput.perror("TServerSocket::getPort() getsockname() ", errno_copy);
       } else {
-        if (sa.sa_family == AF_INET6) {
+        if (sa.ss_family == AF_INET6) {
           const struct sockaddr_in6* sin = reinterpret_cast<const struct sockaddr_in6*>(&sa);
           port_ = ntohs(sin->sin6_port);
         } else {


### PR DESCRIPTION
When binding with a port number of 0, TServerSocket::listen calls
getsockname to retrieve the bound port number. The previous code was
passing too small a buffer as a parameter, failing on Windows with
errno 2 and WSAGetLastError WSAEFAULT. This change fixes the issue by
using struct sockaddr_storage instead of struct sockaddr as the
parameter buffer.