### PR TITLE
Thrift 3512 c glib build fails due to missing features.h

### DIFF
--- a/lib/c_glib/test/testbinaryprotocol.c
+++ b/lib/c_glib/test/testbinaryprotocol.c
@@ -20,12 +20,8 @@
 /* Disable string-function optimizations when glibc is used, as these produce
    compiler warnings about string length when a string function is used inside
    a call to assert () */
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && \
-    !defined(__OpenBSD__) && !defined(__NetBSD__)
-#include <features.h>
-#endif
-
 #ifdef __GLIBC__
+#include <features.h>
 #define __NO_STRING_INLINES 1
 #endif
 

--- a/lib/cpp/src/thrift/concurrency/PosixThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/PosixThreadFactory.cpp
@@ -124,9 +124,11 @@ public:
     policy_ = PosixThreadFactory::OTHER;
 #endif
 
+#if _POSIX_THREAD_PRIORITY_SCHEDULING > 0
     if (pthread_attr_setschedpolicy(&thread_attr, policy_) != 0) {
       throw SystemResourceException("pthread_attr_setschedpolicy failed");
     }
+#endif
 
     struct sched_param sched_param;
     sched_param.sched_priority = priority_;


### PR DESCRIPTION
Include `features.h` (in `testbinaryprotocol.c`) only on platforms that use GNU libc.

This fixes THRIFT-3512 and assumes the fix for THRIFT-3498 has been committed.