### PR TITLE
THRIFT-3520 Dart TSocket onError type as Object

### DIFF
--- a/lib/dart/lib/src/transport/t_socket.dart
+++ b/lib/dart/lib/src/transport/t_socket.dart
@@ -22,7 +22,7 @@ enum TSocketState { CLOSED, OPEN }
 abstract class TSocket {
   Stream<TSocketState> get onState;
 
-  Stream<String> get onError;
+  Stream<Object> get onError;
 
   Stream<Uint8List> get onMessage;
 


### PR DESCRIPTION
Dart TSocket exposes `onError` as a `Stream<String>`. However, the payload may be either a String or an Error, and should be typed as `Stream<Object>`.  

This is a follow up to https://issues.apache.org/jira/browse/THRIFT-3468, and really should have been done with that change.

https://issues.apache.org/jira/browse/THRIFT-3520

@evanweible-wf
@tylertreat-wf
@stevenosborne-wf