### PR TITLE
THRIFT-3521 : TSimpleJSONProtocolTest is not deterministic (fails when run on JDK 8)

### DIFF
--- a/lib/java/test/org/apache/thrift/protocol/TestTSimpleJSONProtocol.java
+++ b/lib/java/test/org/apache/thrift/protocol/TestTSimpleJSONProtocol.java
@@ -27,6 +27,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TMemoryBuffer;
 
 import thrift.test.CompactProtoTestStruct;
+import thrift.test.HolyMoley;
 
 public class TestTSimpleJSONProtocol extends TestCase {
   private TMemoryBuffer buf;
@@ -47,8 +48,12 @@ public class TestTSimpleJSONProtocol extends TestCase {
   }
 
   public void testHolyMoley() throws TException {
-    Fixtures.holyMoley.write(proto);
-    assertEquals("{\"big\":[{\"im_true\":1,\"im_false\":0,\"a_bite\":35,\"integer16\":27000,\"integer32\":16777216,\"integer64\":6000000000,\"double_precision\":3.141592653589793,\"some_characters\":\"JSON THIS! \\\"\\u0001\",\"zomg_unicode\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκ�‼\",\"what_who\":0,\"base64\":\"base64\",\"byte_list\":[1,2,3],\"i16_list\":[1,2,3],\"i64_list\":[1,2,3]},{\"im_true\":1,\"im_false\":0,\"a_bite\":-42,\"integer16\":27000,\"integer32\":16777216,\"integer64\":6000000000,\"double_precision\":3.141592653589793,\"some_characters\":\"JSON THIS! \\\"\\u0001\",\"zomg_unicode\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκ�‼\",\"what_who\":0,\"base64\":\"base64\",\"byte_list\":[1,2,3],\"i16_list\":[1,2,3],\"i64_list\":[1,2,3]}],\"contain\":[[],[\"then a one, two\",\"three!\",\"FOUR!!\"],[\"and a one\",\"and a two\"]],\"bonks\":{\"two\":[{\"type\":1,\"message\":\"Wait.\"},{\"type\":2,\"message\":\"What?\"}],\"three\":[],\"zero\":[]}}", bufToString());
+    final HolyMoley holyMoley = Fixtures.holyMoley.deepCopy();
+    // unset sets that produce inconsistent ordering between JDK7/8
+    holyMoley.unsetBonks();
+    holyMoley.unsetContain();
+    holyMoley.write(proto);
+    assertEquals("{\"big\":[{\"im_true\":1,\"im_false\":0,\"a_bite\":35,\"integer16\":27000,\"integer32\":16777216,\"integer64\":6000000000,\"double_precision\":3.141592653589793,\"some_characters\":\"JSON THIS! \\\"\\u0001\",\"zomg_unicode\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκ�‼\",\"what_who\":0,\"base64\":\"base64\",\"byte_list\":[1,2,3],\"i16_list\":[1,2,3],\"i64_list\":[1,2,3]},{\"im_true\":1,\"im_false\":0,\"a_bite\":-42,\"integer16\":27000,\"integer32\":16777216,\"integer64\":6000000000,\"double_precision\":3.141592653589793,\"some_characters\":\"JSON THIS! \\\"\\u0001\",\"zomg_unicode\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκ�‼\",\"what_who\":0,\"base64\":\"base64\",\"byte_list\":[1,2,3],\"i16_list\":[1,2,3],\"i64_list\":[1,2,3]}]}", bufToString());
   }
 
   public void testNesting() throws TException {
@@ -67,8 +72,19 @@ public class TestTSimpleJSONProtocol extends TestCase {
     struct.unsetList_byte_map();
     struct.unsetSet_byte_map();
     struct.unsetMap_byte_map();
+    // unset sets and maps that produce inconsistent ordering between JDK7/8
+    struct.unsetByte_set();
+    struct.unsetI16_set();
+    struct.unsetI64_set();
+    struct.unsetDouble_set();
+    struct.unsetString_set();
+    struct.unsetI16_byte_map();
+    struct.unsetI32_byte_map();
+    struct.unsetI64_byte_map();
+    struct.unsetDouble_byte_map();
+    struct.unsetString_byte_map();
     struct.write(proto);
-    assertEquals("{\"a_byte\":127,\"a_i16\":32000,\"a_i32\":1000000000,\"a_i64\":1099511627775,\"a_double\":5.6789,\"a_string\":\"my string\",\"a_binary\":\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\",\"true_field\":1,\"false_field\":0,\"empty_struct_field\":{},\"byte_list\":[-127,-1,0,1,127],\"i16_list\":[-1,0,1,32767],\"i32_list\":[-1,0,255,65535,16777215,2147483647],\"i64_list\":[-1,0,255,65535,16777215,4294967295,1099511627775,281474976710655,72057594037927935,9223372036854775807],\"double_list\":[0.1,0.2,0.3],\"string_list\":[\"first\",\"second\",\"third\"],\"boolean_list\":[1,1,1,0,0,0],\"struct_list\":[{},{}],\"byte_set\":[0,1,-127,127,-1],\"i16_set\":[0,1,32767,-1],\"i32_set\":[1,2,3],\"i64_set\":[9223372036854775807,72057594037927935,65535,0,-1,255,1099511627775,281474976710655,4294967295,16777215],\"double_set\":[0.1,0.2,0.3],\"string_set\":[\"second\",\"third\",\"first\"],\"boolean_set\":[0,1],\"struct_set\":[{}],\"byte_byte_map\":{\"1\":2},\"i16_byte_map\":{\"1\":1,\"32767\":1,\"-1\":1},\"i32_byte_map\":{\"1\":1,\"2147483647\":1,\"-1\":1},\"i64_byte_map\":{\"9223372036854775807\":1,\"-1\":1,\"0\":1,\"1\":1},\"double_byte_map\":{\"1.1\":1,\"-1.1\":1},\"string_byte_map\":{\"\":0,\"second\":2,\"third\":3,\"first\":1},\"boolean_byte_map\":{\"0\":0,\"1\":1},\"byte_i16_map\":{\"1\":1,\"2\":-1,\"3\":32767},\"byte_i32_map\":{\"1\":1,\"2\":-1,\"3\":2147483647},\"byte_i64_map\":{\"1\":1,\"2\":-1,\"3\":9223372036854775807},\"byte_double_map\":{\"1\":0.1,\"2\":-0.1,\"3\":1000000.0},\"byte_string_map\":{\"1\":\"\",\"2\":\"blah\",\"3\":\"loooooooooooooong string\"},\"byte_boolean_map\":{\"1\":1,\"2\":0},\"byte_map_map\":{\"0\":{},\"1\":{\"1\":1},\"2\":{\"1\":1,\"2\":2}},\"byte_set_map\":{\"0\":[],\"1\":[1],\"2\":[1,2]},\"byte_list_map\":{\"0\":[],\"1\":[1],\"2\":[1,2]}}", bufToString());
+    assertEquals("{\"a_byte\":127,\"a_i16\":32000,\"a_i32\":1000000000,\"a_i64\":1099511627775,\"a_double\":5.6789,\"a_string\":\"my string\",\"a_binary\":\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\",\"true_field\":1,\"false_field\":0,\"empty_struct_field\":{},\"byte_list\":[-127,-1,0,1,127],\"i16_list\":[-1,0,1,32767],\"i32_list\":[-1,0,255,65535,16777215,2147483647],\"i64_list\":[-1,0,255,65535,16777215,4294967295,1099511627775,281474976710655,72057594037927935,9223372036854775807],\"double_list\":[0.1,0.2,0.3],\"string_list\":[\"first\",\"second\",\"third\"],\"boolean_list\":[1,1,1,0,0,0],\"struct_list\":[{},{}],\"i32_set\":[1,2,3],\"boolean_set\":[0,1],\"struct_set\":[{}],\"byte_byte_map\":{\"1\":2},\"boolean_byte_map\":{\"0\":0,\"1\":1},\"byte_i16_map\":{\"1\":1,\"2\":-1,\"3\":32767},\"byte_i32_map\":{\"1\":1,\"2\":-1,\"3\":2147483647},\"byte_i64_map\":{\"1\":1,\"2\":-1,\"3\":9223372036854775807},\"byte_double_map\":{\"1\":0.1,\"2\":-0.1,\"3\":1000000.0},\"byte_string_map\":{\"1\":\"\",\"2\":\"blah\",\"3\":\"loooooooooooooong string\"},\"byte_boolean_map\":{\"1\":1,\"2\":0},\"byte_map_map\":{\"0\":{},\"1\":{\"1\":1},\"2\":{\"1\":1,\"2\":2}},\"byte_set_map\":{\"0\":[],\"1\":[1],\"2\":[1,2]},\"byte_list_map\":{\"0\":[],\"1\":[1],\"2\":[1,2]}}", bufToString());
   }
 
   public void testThrowsOnCollectionKeys() throws TException {


### PR DESCRIPTION
This PR removes fields that cause TSimpleJSONProtocolTest to fail when run using different version of the Java standard library.