### PR TITLE
THRIFT-3251 Add a Http Transport for go lib.

### DIFF
--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import "net/http"
+
+// NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function
+func NewThriftHandlerFunc(processor TProcessor,
+	inPfactory, outPfactory TProtocolFactory) func(w http.ResponseWriter, r *http.Request) {
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/x-thrift")
+
+		transport := NewStreamTransport(r.Body, w)
+		processor.Process(inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
+	}
+}

--- a/test/go/src/common/client.go
+++ b/test/go/src/common/client.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"fmt"
 	"gen/thrifttest"
+	"net/http"
 	"thrift"
 )
 
@@ -75,10 +76,21 @@ func StartClient(
 	}
 	switch transport {
 	case "http":
-		trans, err = thrift.NewTHttpClient(fmt.Sprintf("http://%s/service", hostPort))
+		if ssl {
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := &http.Client{Transport: tr}
+			trans, err = thrift.NewTHttpPostClientWithOptions(fmt.Sprintf("https://%s/", hostPort), thrift.THttpClientOptions{Client: client})
+			fmt.Println(hostPort)
+		} else {
+			trans, err = thrift.NewTHttpPostClient(fmt.Sprintf("http://%s/", hostPort))
+		}
+
 		if err != nil {
 			return nil, err
 		}
+
 	case "framed":
 		trans = thrift.NewTFramedTransport(trans)
 	case "buffered":

--- a/test/go/src/common/clientserver_test.go
+++ b/test/go/src/common/clientserver_test.go
@@ -20,12 +20,13 @@
 package common
 
 import (
-	"github.com/golang/mock/gomock"
 	"errors"
 	"gen/thrifttest"
 	"reflect"
 	"testing"
 	"thrift"
+
+	"github.com/golang/mock/gomock"
 )
 
 type test_unit struct {
@@ -56,7 +57,15 @@ func doUnit(t *testing.T, unit *test_unit) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	handler := NewMockThriftTest(ctrl)
-	server, err := StartServer(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl, "../../../keys", handler)
+
+	processor, serverTransport, transportFactory, protocolFactory, err := GetServerParams(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl, "../../../keys", handler)
+
+	server := thrift.NewTSimpleServer4(processor, serverTransport, transportFactory, protocolFactory)
+	if err = server.Listen(); err != nil {
+		return
+	}
+	go server.AcceptLoop()
+	server.Serve()
 	if err != nil {
 		t.Errorf("Unable to start server", err)
 		t.FailNow()
@@ -175,7 +184,7 @@ func callEverythingWithMock(t *testing.T, client *thrifttest.ThriftTestClient, h
 	}
 
 	// TODO: add TestBinary() call
-	
+
 	xs := thrifttest.NewXtruct()
 	xs.StringThing = "thing"
 	xs.ByteThing = 42

--- a/test/go/src/common/server.go
+++ b/test/go/src/common/server.go
@@ -37,7 +37,7 @@ func init() {
 	flag.BoolVar(&debugServerProtocol, "debug_server_protocol", false, "turn server protocol trace on")
 }
 
-func StartServer(
+func GetServerParams(
 	host string,
 	port int64,
 	domain_socket string,
@@ -45,8 +45,9 @@ func StartServer(
 	protocol string,
 	ssl bool,
 	certPath string,
-	handler thrifttest.ThriftTest) (srv *thrift.TSimpleServer, err error) {
+	handler thrifttest.ThriftTest) (thrift.TProcessor, thrift.TServerTransport, thrift.TTransportFactory, thrift.TProtocolFactory, error) {
 
+	var err error
 	hostPort := fmt.Sprintf("%s:%d", host, port)
 
 	var protocolFactory thrift.TProtocolFactory
@@ -60,7 +61,7 @@ func StartServer(
 	case "binary":
 		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
 	default:
-		return nil, fmt.Errorf("Invalid protocol specified %s", protocol)
+		return nil, nil, nil, nil, fmt.Errorf("Invalid protocol specified %s", protocol)
 	}
 	if debugServerProtocol {
 		protocolFactory = thrift.NewTDebugProtocolFactory(protocolFactory, "server:")
@@ -70,7 +71,7 @@ func StartServer(
 	if ssl {
 		cfg := new(tls.Config)
 		if cert, err := tls.LoadX509KeyPair(certPath+"/server.crt", certPath+"/server.key"); err != nil {
-			return nil, err
+			return nil, nil, nil, nil, err
 		} else {
 			cfg.Certificates = append(cfg.Certificates, cert)
 		}
@@ -83,18 +84,15 @@ func StartServer(
 		}
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	var transportFactory thrift.TTransportFactory
 
 	switch transport {
 	case "http":
-		return nil, fmt.Errorf("Http server transport is not supported")
-		// trans, err = thrift.NewTHttpClient(fmt.Sprintf("http://%s/service", hostPort))
-		// if err != nil {
-		// 	return nil, err
-		// }
+		// It does not exists some kind of THttpTransportFactory
+		transportFactory = nil
 	case "framed":
 		transportFactory = thrift.NewTTransportFactory()
 		transportFactory = thrift.NewTFramedTransportFactory(transportFactory)
@@ -105,13 +103,9 @@ func StartServer(
 	case "":
 		transportFactory = thrift.NewTTransportFactory()
 	default:
-		return nil, fmt.Errorf("Invalid transport specified %s", transport)
+		return nil, nil, nil, nil, fmt.Errorf("Invalid transport specified %s", transport)
 	}
 	processor := thrifttest.NewThriftTestProcessor(handler)
-	server := thrift.NewTSimpleServer4(processor, serverTransport, transportFactory, protocolFactory)
-	if err = server.Listen(); err != nil {
-		return
-	}
-	go server.AcceptLoop()
-	return server, nil
+
+	return processor, serverTransport, transportFactory, protocolFactory, nil
 }

--- a/test/tests.json
+++ b/test/tests.json
@@ -44,7 +44,8 @@
     },
     "transports": [
       "buffered",
-      "framed"
+      "framed",
+      "http"
     ],
     "sockets": [
       "ip",


### PR DESCRIPTION
The protocol was implemented as a HandlerFunc using the standard net/http package.

See: https://github.com/apache/thrift/pull/557
See: https://issues.apache.org/jira/browse/THRIFT-3251