### PR TITLE
THRIFT-3558 fix typos in c_glib test assertions

### DIFF
--- a/lib/c_glib/test/testbinaryprotocol.c
+++ b/lib/c_glib/test/testbinaryprotocol.c
@@ -436,11 +436,11 @@ thrift_server_primitives (const int port)
                                               &len, NULL) > 0);
 
   assert (value_boolean == TEST_BOOL);
-  assert (value_byte = TEST_BYTE);
-  assert (value_16 = TEST_I16);
-  assert (value_32 = TEST_I32);
-  assert (value_64 = TEST_I64);
-  assert (value_double = TEST_DOUBLE);
+  assert (value_byte == TEST_BYTE);
+  assert (value_16 == TEST_I16);
+  assert (value_32 == TEST_I32);
+  assert (value_64 == TEST_I64);
+  assert (value_double == TEST_DOUBLE);
   assert (strcmp (TEST_STRING, string) == 0);
   assert (memcmp (comparator, binary, len) == 0);
 

--- a/lib/c_glib/test/testoptionalrequired.c
+++ b/lib/c_glib/test/testoptionalrequired.c
@@ -79,7 +79,7 @@ test_simple (void)
   assert (s1->__isset_im_default == FALSE);
   assert (s1->__isset_im_optional == FALSE);  
   write_to_read (THRIFT_STRUCT (s1), THRIFT_STRUCT (s2), NULL, NULL);
-  assert (s2->__isset_im_default = TRUE);
+  assert (s2->__isset_im_default == TRUE);
   assert (s2->__isset_im_optional == FALSE);
   assert (s2->im_optional == 0);
 


### PR DESCRIPTION
Fix a few apparently accidental assignments inside asserts in c_glib library tests.