### PR TITLE
THRIFT-3559 - Fix awkward sem-colons & newlines from THRIFT-3545

### DIFF
--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -2758,7 +2758,7 @@ void t_cocoa_generator::print_const_value(ostream& out,
         mapout << ", ";
       }
     }
-    mapout << "};" << endl;
+    mapout << "}";
     out << mapout.str();
   } else if (type->is_list()) {
     ostringstream listout;
@@ -2775,7 +2775,7 @@ void t_cocoa_generator::print_const_value(ostream& out,
         listout << ", ";
       }
     }
-    listout << "];" << endl;
+    listout << "]";
     out << listout.str();
   } else if (type->is_set()) {
     ostringstream setout;
@@ -2785,14 +2785,14 @@ void t_cocoa_generator::print_const_value(ostream& out,
     vector<t_const_value*>::const_iterator v_iter;
     if (defval)
       setout << type_name(type) << " ";
-    setout << name << " = [[NSSet alloc] initWithArray:@[";
+    setout << name << " = [NSSet setWithArray:@[";
     for (v_iter = val.begin(); v_iter != val.end();) {
       setout << render_const_value(out, etype, *v_iter, true);
       if (++v_iter != val.end()) {
         setout << ", ";
       }
     }
-    setout << "]];" << endl;
+    setout << "]]";
     out << setout.str();
   } else {
     throw "compiler error: no const of type " + type->get_name();
@@ -2840,6 +2840,7 @@ string t_cocoa_generator::render_const_value(ostream& out,
   } else {
     string t = tmp("tmp");
     print_const_value(out, t, type, value, true);
+    out << ";" << endl;
     render << t;
   }
 


### PR DESCRIPTION
This essentially reverts THRIFT 3545 and uses simpler changes to fix the problem. These changes do not introduce the extra newlines and semi-colons.