### PR TITLE
THRIFT-3561: C++/Qt: make use of Q_DISABLE_COPY() to get rid of copy ctor and assignment operator

### DIFF
--- a/lib/cpp/src/thrift/qt/TQTcpServer.h
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.h
@@ -59,8 +59,7 @@ private Q_SLOTS:
   void socketClosed();
 
 private:
-  TQTcpServer(const TQTcpServer&);
-  TQTcpServer& operator=(const TQTcpServer&);
+  Q_DISABLE_COPY(TQTcpServer)
 
   struct ConnectionContext;
 


### PR DESCRIPTION
…