### PR TITLE
THRIFT-3563: C++/Qt: removed usage of macro QT_PREPEND_NAMESPACE()

### DIFF
--- a/lib/cpp/src/thrift/qt/TQTcpServer.h
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.h
@@ -50,7 +50,7 @@ public:
   TQTcpServer(boost::shared_ptr<QTcpServer> server,
               boost::shared_ptr<TAsyncProcessor> processor,
               boost::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocolFactory,
-              QT_PREPEND_NAMESPACE(QObject)* parent = NULL);
+              QObject* parent = NULL);
   virtual ~TQTcpServer();
 
 private Q_SLOTS:
@@ -70,7 +70,7 @@ private:
   boost::shared_ptr<TAsyncProcessor> processor_;
   boost::shared_ptr<apache::thrift::protocol::TProtocolFactory> pfact_;
 
-  std::map<QT_PREPEND_NAMESPACE(QTcpSocket)*, boost::shared_ptr<ConnectionContext> > ctxMap_;
+  std::map<QTcpSocket*, boost::shared_ptr<ConnectionContext> > ctxMap_;
 };
 }
 }


### PR DESCRIPTION
as it wasn't use consequently for all Qt types, e.g. it cannot be combined with shared_ptr<>