### PR TITLE
THRIFT-3574 Cocoa: use the right namespace for included generated .h files

### DIFF
--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -345,7 +345,10 @@ string t_cocoa_generator::cocoa_thrift_imports() {
   // Include other Thrift includes
   const vector<t_program*>& other_includes = program_->get_includes();
   for (size_t i = 0; i < other_includes.size(); ++i) {
-    includes << "#import \"" << cocoa_prefix_ << capitalize(other_includes[i]->get_name()) << ".h\"" << endl;
+    includes << "#import \""
+             << other_includes[i]->get_namespace("cocoa")
+             << capitalize(other_includes[i]->get_name())
+             << ".h\"" << endl;
   }
   
   includes << endl;


### PR DESCRIPTION
The Cocoa generator currently uses the namespace of the including file in imports statements, instead of the included file.
