### PR TITLE
THRIFT-2980 Accept external buffer in thrift_memory_buffer constructor

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.h
@@ -51,6 +51,7 @@ struct _ThriftMemoryBuffer
   /* private */
   GByteArray *buf;
   guint32 buf_size;
+  gboolean owner;
 };
 
 typedef struct _ThriftMemoryBufferClass ThriftMemoryBufferClass;

--- a/lib/c_glib/test/testmemorybuffer.c
+++ b/lib/c_glib/test/testmemorybuffer.c
@@ -25,13 +25,35 @@
 #include <thrift/c_glib/transport/thrift_server_transport.h>
 #include <thrift/c_glib/transport/thrift_server_socket.h>
 
-#define TEST_DATA { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' }
+static const gchar TEST_DATA[11] = "abcdefghij";
 
 #include "../src/thrift/c_glib/transport/thrift_memory_buffer.c"
 
 /* test object creation and destruction */
 static void
-test_create_and_destroy(void)
+test_create_and_destroy (void)
+{
+  GObject *object = NULL;
+  object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                         "buf_size", 10,
+                         NULL);
+  assert (object != NULL);
+  g_object_unref (object);
+}
+
+static void
+test_create_and_destroy_large (void)
+{
+  GObject *object = NULL;
+  object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                         "buf_size", 10 * 1024 * 1024,
+                         NULL);
+  assert (object != NULL);
+  g_object_unref (object);
+}
+
+static void
+test_create_and_destroy_default (void)
 {
   GObject *object = NULL;
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
@@ -40,31 +62,68 @@ test_create_and_destroy(void)
 }
 
 static void
-test_open_and_close(void)
+test_create_and_destroy_external (void)
+{
+  GObject *object = NULL;
+  GByteArray *buf = g_byte_array_new ();
+  assert (buf != NULL);
+  object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                         "buf", buf,
+                         NULL);
+  assert (object != NULL);
+  g_object_unref (object);
+}
+
+static void
+test_create_and_destroy_unowned (void)
+{
+  GObject *object = NULL;
+  GValue val = G_VALUE_INIT;
+  GByteArray *buf;
+
+  object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                         "owner", FALSE,
+                         NULL);
+  assert (object != NULL);
+
+  g_value_init (&val, G_TYPE_POINTER);
+  g_object_get_property (object, "buf", &val);
+  buf = (GByteArray*) g_value_get_pointer (&val);
+  assert (buf != NULL);
+
+  g_byte_array_unref (buf);
+  g_value_unset (&val);
+  g_object_unref (object);
+}
+
+static void
+test_open_and_close (void)
 {
   ThriftMemoryBuffer *tbuffer = NULL;
 
   /* create a ThriftMemoryBuffer */
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
 
-  /* this shouldn't work */
+  /* no-ops */
   assert (thrift_memory_buffer_open (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
   assert (thrift_memory_buffer_is_open (THRIFT_TRANSPORT (tbuffer)) == TRUE);
   assert (thrift_memory_buffer_close (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
+
   g_object_unref (tbuffer);
 }
 
 static void
-test_read_and_write(void)
+test_read_and_write (void)
 {
   ThriftMemoryBuffer *tbuffer = NULL;
-  guchar buf[10] = TEST_DATA;
-  guchar read[10];
+  gint got, want;
+  gchar read[10];
+  gchar *b;
   GError *error = NULL;
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf_size", 5, NULL);
   assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
-                                      (gpointer) buf,
+                                      (gpointer) TEST_DATA,
                                       10, &error) == FALSE);
   assert (error != NULL);
   g_error_free (error);
@@ -73,26 +132,93 @@ test_read_and_write(void)
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf_size", 15, NULL);
   assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
-                                      (gpointer) buf, 10, &error) == TRUE);
+                                      (gpointer) TEST_DATA, 10, &error) == TRUE);
   assert (error == NULL);
 
-  assert (thrift_memory_buffer_read (THRIFT_TRANSPORT (tbuffer),
-                                     &read, 10, &error) > 0);
+  memset(read, 0, 10);
+  b = read;
+  want = 10;
+  while (want > 0) {
+    got = thrift_memory_buffer_read (THRIFT_TRANSPORT (tbuffer),
+                                     (gpointer) b, want, &error);
+    assert (got > 0 && got <= want);
+    assert (error == NULL);
+    b += got;
+    want -= got;
+  }
+  assert (memcmp (read, TEST_DATA, 10) == 0);
+  g_object_unref (tbuffer);
+}
+
+static void
+test_read_and_write_default (void)
+{
+  ThriftMemoryBuffer *tbuffer = NULL;
+  gint got, want, i;
+  gchar read[10];
+  gchar *b;
+  GError *error = NULL;
+
+  tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
+  for (i = 0; i < 100; ++i) {
+    assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+                                        (gpointer) TEST_DATA, 10, &error) == TRUE);
+    assert (error == NULL);
+  }
+
+  for (i = 0; i < 100; ++i) {
+    memset(read, 0, 10);
+    b = read;
+    want = 10;
+    while (want > 0) {
+      got = thrift_memory_buffer_read (THRIFT_TRANSPORT (tbuffer),
+                                       (gpointer) b, want, &error);
+      assert (got > 0 && got <= want);
+      assert (error == NULL);
+      b += got;
+      want -= got;
+    }
+    assert (memcmp (read, TEST_DATA, 10) == 0);
+  }
+  g_object_unref (tbuffer);
+}
+
+static void
+test_read_and_write_external (void)
+{
+  ThriftMemoryBuffer *tbuffer = NULL;
+  gchar *b;
+  GError *error = NULL;
+  GByteArray *buf = g_byte_array_new ();
+  assert (buf != NULL);
+
+  tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf", buf, NULL);
+  assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+                                      (gpointer) TEST_DATA, 10, &error) == TRUE);
   assert (error == NULL);
+
+  assert (memcmp (buf->data, TEST_DATA, 10) == 0);
+  g_object_unref (tbuffer);
 }
 
 int
 main(int argc, char *argv[])
 {
 #if (!GLIB_CHECK_VERSION (2, 36, 0))
-  g_type_init();
+  g_type_init ();
 #endif
 
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/testmemorybuffer/CreateAndDestroy", test_create_and_destroy);
+  g_test_add_func ("/testmemorybuffer/CreateAndDestroyLarge", test_create_and_destroy_large);
+  g_test_add_func ("/testmemorybuffer/CreateAndDestroyUnlimited", test_create_and_destroy_default);
+  g_test_add_func ("/testmemorybuffer/CreateAndDestroyExternal", test_create_and_destroy_external);
+  g_test_add_func ("/testmemorybuffer/CreateAndDestroyUnowned", test_create_and_destroy_unowned);
   g_test_add_func ("/testmemorybuffer/OpenAndClose", test_open_and_close);
   g_test_add_func ("/testmemorybuffer/ReadAndWrite", test_read_and_write);
+  g_test_add_func ("/testmemorybuffer/ReadAndWriteUnlimited", test_read_and_write_default);
+  g_test_add_func ("/testmemorybuffer/ReadAndWriteExternal", test_read_and_write_external);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Here's a pass at letting thrift_memory_buffer take its buffer as a constructor argument:

Add buf (GByteArray pointer) and owner (gboolean) to constructor-only properties.  Create buf (object member) during construction if buf (constructor-only property) is NULL, the default.  Unref buf during finalize if buf is non-NULL and owner is TRUE.

Also change semantics of buf_size slightly: default is now zero, max is G_MAXUINT32, and zero is interpreted as no limit.  (My thrift objects are often very large; setting no limit as the default seems to simplify the usage in my opinion, and I believe raising the maximum is harmless.)