### PR TITLE
THRIFT-3589 Pass references to field names in constructor through get_field_name

### DIFF
--- a/compiler/cpp/src/generate/t_dart_generator.cc
+++ b/compiler/cpp/src/generate/t_dart_generator.cc
@@ -830,7 +830,7 @@ void t_dart_generator::generate_dart_struct_definition(ofstream& out,
     t_type* t = get_true_type((*m_iter)->get_type());
     if ((*m_iter)->get_value() != NULL) {
       print_const_value(out,
-                        "this." + (*m_iter)->get_name(),
+                        "this." + get_field_name((*m_iter)->get_name()),
                         t,
                         (*m_iter)->get_value(),
                         true,


### PR DESCRIPTION
Currently we are incorrectly handling fields that have default values and uppercase names, like `ID = -1`

@stevenosborne-wf
@ericklaus-wf
@tylertreat-wf

https://issues.apache.org/jira/browse/THRIFT-3589