### PR TITLE
`make check` hangs in go tests

### DIFF
--- a/test/go/src/common/clientserver_test.go
+++ b/test/go/src/common/clientserver_test.go
@@ -62,14 +62,10 @@ func doUnit(t *testing.T, unit *test_unit) {
 
 	server := thrift.NewTSimpleServer4(processor, serverTransport, transportFactory, protocolFactory)
 	if err = server.Listen(); err != nil {
-		return
-	}
-	go server.AcceptLoop()
-	server.Serve()
-	if err != nil {
 		t.Errorf("Unable to start server", err)
 		t.FailNow()
 	}
+	go server.AcceptLoop()
 	defer server.Stop()
 	client, err := StartClient(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl)
 	if err != nil {


### PR DESCRIPTION
Previously tests would hang in a foreground call to `server.Serve()`.
Kill this call since `server.Listen(); go server.AcceptLoop()` is
already performed and is the equivalent of a non-blocking
`server.Serve()`.