### PR TITLE
THRIFT-3112 [Java] AsyncMethodCallback should be typed in generated AsyncIface

### DIFF
--- a/compiler/cpp/src/generate/t_java_generator.cc
+++ b/compiler/cpp/src/generate/t_java_generator.cc
@@ -2987,7 +2987,8 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
 
     // TAsyncMethod object for this function call
     indent(f_service_) << "public static class " + funclassname
-                          + " extends org.apache.thrift.async.TAsyncMethodCall {" << endl;
+                          + " extends org.apache.thrift.async.TAsyncMethodCall<"
+                          + type_name((*f_iter)->get_returntype(), true) + "> {" << endl;
     indent_up();
 
     // Member variables
@@ -3040,7 +3041,7 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
     indent(f_service_) << "}" << endl << endl;
 
     // Return method
-    indent(f_service_) << "public " + type_name(ret_type) + " getResult() throws ";
+    indent(f_service_) << "public " + type_name(ret_type, true) + " getResult() throws ";
     vector<t_field*>::const_iterator x_iter;
     for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
       f_service_ << type_name((*x_iter)->get_type(), false, false) + ", ";
@@ -3057,12 +3058,11 @@ void t_java_generator::generate_service_async_client(t_service* tservice) {
            "org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());" << endl
         << indent() << "org.apache.thrift.protocol.TProtocol prot = "
                        "client.getProtocolFactory().getProtocol(memoryTransport);" << endl;
-    if (!(*f_iter)->is_oneway()) {
-      indent(f_service_);
-      if (!ret_type->is_void()) {
-        f_service_ << "return ";
-      }
-      f_service_ << "(new Client(prot)).recv" + sep + javaname + "();" << endl;
+    indent(f_service_);
+    if (ret_type->is_void()) { // NB: Includes oneways which always return void.
+      f_service_ << "return null;" << endl;
+    } else {
+      f_service_ << "return (new Client(prot)).recv" + sep + javaname + "();" << endl;
     }
 
     // Close function
@@ -4182,7 +4182,8 @@ string t_java_generator::async_function_call_arglist(t_function* tfunc,
   }
 
   if (include_types) {
-    arglist += "org.apache.thrift.async.AsyncMethodCallback ";
+    arglist += "org.apache.thrift.async.AsyncMethodCallback<";
+    arglist += type_name(tfunc->get_returntype(), true) + "> ";
   }
   arglist += "resultHandler";
 
@@ -4237,7 +4238,8 @@ string t_java_generator::async_argument_list(t_function* tfunct,
     result += ", ";
   }
   if (include_types) {
-    result += "org.apache.thrift.async.AsyncMethodCallback ";
+    result += "org.apache.thrift.async.AsyncMethodCallback<";
+    result += type_name(tfunct->get_returntype(), true) + "> ";
   }
   result += "resultHandler";
   return result;

--- a/lib/java/src/org/apache/thrift/async/AsyncMethodCallback.java
+++ b/lib/java/src/org/apache/thrift/async/AsyncMethodCallback.java
@@ -18,22 +18,34 @@
  */
 package org.apache.thrift.async;
 
-
+/**
+ * A handler interface asynchronous clients can implement to receive future
+ * notice of the results of an asynchronous method call.
+ *
+ * @param <T> The return type of the asynchronously invoked method.
+ */
 public interface AsyncMethodCallback<T> {
   /**
    * This method will be called when the remote side has completed invoking
-   * your method call and the result is fully read. For oneway method calls,
-   * this method will be called as soon as we have completed writing out the
-   * request.
-   * @param response
+   * your method call and the result is fully read. For {@code oneway} method
+   * calls, this method will be called as soon as we have completed writing out
+   * the request.
+   *
+   * @param response The return value of the asynchronously invoked method;
+   *                 {@code null} for void methods which includes
+   *                 {@code oneway} methods.
    */
-  public void onComplete(T response);
+  void onComplete(T response);
 
   /**
-   * This method will be called when there is an unexpected clientside
-   * exception. This does not include application-defined exceptions that
-   * appear in the IDL, but rather things like IOExceptions.
-   * @param exception
+   * This method will be called when there is either an unexpected client-side
+   * exception like an IOException or else when the remote method raises an
+   * exception, either declared in the IDL or due to an unexpected server-side
+   * error.
+   *
+   * @param exception The exception encountered processing the the asynchronous
+   *                  method call, may be a local exception or an unmarshalled
+   *                  remote exception.
    */
-  public void onError(Exception exception);
+  void onError(Exception exception);
 }

--- a/lib/java/src/org/apache/thrift/async/TAsyncMethodCall.java
+++ b/lib/java/src/org/apache/thrift/async/TAsyncMethodCall.java
@@ -33,11 +33,15 @@ import org.apache.thrift.transport.TNonblockingTransport;
 import org.apache.thrift.transport.TTransportException;
 
 /**
- * Encapsulates an async method call
+ * Encapsulates an async method call.
+ * <p>
  * Need to generate:
- *   - private void write_args(TProtocol protocol)
- *   - public T getResult() throws <Exception_1>, <Exception_2>, ...
- * @param <T>
+ * <ul>
+ *   <li>protected abstract void write_args(TProtocol protocol)</li>
+ *   <li>protected abstract T getResult() throws <Exception_1>, <Exception_2>, ...</li>
+ * </ul>
+ *
+ * @param <T> The return type of the encapsulated method call.
  */
 public abstract class TAsyncMethodCall<T> {
 
@@ -112,6 +116,8 @@ public abstract class TAsyncMethodCall<T> {
   }
 
   protected abstract void write_args(TProtocol protocol) throws TException;
+
+  protected abstract T getResult() throws Exception;
 
   /**
    * Initialize buffers.
@@ -225,8 +231,13 @@ public abstract class TAsyncMethodCall<T> {
     key.interestOps(0);
     // this ensures that the TAsyncMethod instance doesn't hang around
     key.attach(null);
-    client.onComplete();
-    callback.onComplete((T)this);
+    try {
+      T result = this.getResult();
+      client.onComplete();
+      callback.onComplete(result);
+    } catch (Exception e) {
+      onError(e);
+    }
   }
 
   private void doReadingResponseSize() throws IOException {

--- a/lib/java/test/org/apache/thrift/protocol/ProtocolTestBase.java
+++ b/lib/java/test/org/apache/thrift/protocol/ProtocolTestBase.java
@@ -327,6 +327,11 @@ public abstract class ProtocolTestBase extends TestCase {
       @Override
       public void onewayMethod() throws TException {
       }
+
+      @Override
+      public boolean declaredExceptionMethod(boolean shouldThrow) throws TException {
+        return shouldThrow;
+      }
     };
 
     Srv.Processor testProcessor = new Srv.Processor(handler);

--- a/lib/java/test/org/apache/thrift/server/ServerTestBase.java
+++ b/lib/java/test/org/apache/thrift/server/ServerTestBase.java
@@ -563,124 +563,124 @@ public abstract class ServerTestBase extends TestCase {
   }
 
 
-    public static class AsyncTestHandler implements ThriftTest.AsyncIface {
+  public static class AsyncTestHandler implements ThriftTest.AsyncIface {
 
-        TestHandler handler = new TestHandler();
+    TestHandler handler = new TestHandler();
 
-        @Override
-        public void testVoid(AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(null);
-        }
-
-        @Override
-        public void testString(String thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testString(thing));
-        }
-
-        @Override
-        public void testBool(boolean thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testBool(thing));
-        }
-
-        @Override
-        public void testByte(byte thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testByte(thing));
-        }
-
-        @Override
-        public void testI32(int thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testI32(thing));
-        }
-
-        @Override
-        public void testI64(long thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testI64(thing));
-        }
-
-        @Override
-        public void testDouble(double thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testDouble(thing));
-        }
-
-        @Override 
-        public void testBinary(ByteBuffer thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testBinary(thing));
-        }
-
-        @Override
-        public void testStruct(Xtruct thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testStruct(thing));
-        }
-
-        @Override
-        public void testNest(Xtruct2 thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testNest(thing));
-        }
-
-        @Override
-        public void testMap(Map<Integer, Integer> thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testMap(thing));
-        }
-
-        @Override
-        public void testStringMap(Map<String, String> thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testStringMap(thing));
-        }
-
-        @Override
-        public void testSet(Set<Integer> thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testSet(thing));
-        }
-
-        @Override
-        public void testList(List<Integer> thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testList(thing));
-        }
-
-        @Override
-        public void testEnum(Numberz thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testEnum(thing));
-        }
-
-        @Override
-        public void testTypedef(long thing, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testTypedef(thing));
-        }
-
-        @Override
-        public void testMapMap(int hello, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testMapMap(hello));
-        }
-
-        @Override
-        public void testInsanity(Insanity argument, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testInsanity(argument));
-        }
-
-        @Override
-        public void testMulti(byte arg0, int arg1, long arg2, Map<Short, String> arg3, Numberz arg4, long arg5, AsyncMethodCallback resultHandler) throws TException {
-            resultHandler.onComplete(handler.testMulti(arg0,arg1,arg2,arg3,arg4,arg5));
-        }
-
-        @Override
-        public void testException(String arg, AsyncMethodCallback resultHandler) throws TException {
-            try {
-               // handler.testException();
-            } catch (Exception e) {
-
-            }
-        }
-
-        @Override
-        public void testMultiException(String arg0, String arg1, AsyncMethodCallback resultHandler) throws TException {
-            //To change body of implemented methods use File | Settings | File Templates.
-        }
-
-        @Override
-        public void testOneway(int secondsToSleep, AsyncMethodCallback resultHandler) throws TException {
-            handler.testOneway(secondsToSleep);
-            resultHandler.onComplete(null);
-        }
+    @Override
+    public void testVoid(AsyncMethodCallback<Void> resultHandler) throws TException {
+      resultHandler.onComplete(null);
     }
+
+    @Override
+    public void testString(String thing, AsyncMethodCallback<String> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testString(thing));
+    }
+
+    @Override
+    public void testBool(boolean thing, AsyncMethodCallback<Boolean> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testBool(thing));
+    }
+
+    @Override
+    public void testByte(byte thing, AsyncMethodCallback<Byte> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testByte(thing));
+    }
+
+    @Override
+    public void testI32(int thing, AsyncMethodCallback<Integer> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testI32(thing));
+    }
+
+    @Override
+    public void testI64(long thing, AsyncMethodCallback<Long> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testI64(thing));
+    }
+
+    @Override
+    public void testDouble(double thing, AsyncMethodCallback<Double> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testDouble(thing));
+    }
+
+    @Override
+    public void testBinary(ByteBuffer thing, AsyncMethodCallback<ByteBuffer> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testBinary(thing));
+    }
+
+    @Override
+    public void testStruct(Xtruct thing, AsyncMethodCallback<Xtruct> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testStruct(thing));
+    }
+
+    @Override
+    public void testNest(Xtruct2 thing, AsyncMethodCallback<Xtruct2> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testNest(thing));
+    }
+
+    @Override
+    public void testMap(Map<Integer, Integer> thing, AsyncMethodCallback<Map<Integer, Integer>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testMap(thing));
+    }
+
+    @Override
+    public void testStringMap(Map<String, String> thing, AsyncMethodCallback<Map<String, String>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testStringMap(thing));
+    }
+
+    @Override
+    public void testSet(Set<Integer> thing, AsyncMethodCallback<Set<Integer>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testSet(thing));
+    }
+
+    @Override
+    public void testList(List<Integer> thing, AsyncMethodCallback<List<Integer>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testList(thing));
+    }
+
+    @Override
+    public void testEnum(Numberz thing, AsyncMethodCallback<Numberz> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testEnum(thing));
+    }
+
+    @Override
+    public void testTypedef(long thing, AsyncMethodCallback<Long> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testTypedef(thing));
+    }
+
+    @Override
+    public void testMapMap(int hello, AsyncMethodCallback<Map<Integer,Map<Integer,Integer>>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testMapMap(hello));
+    }
+
+    @Override
+    public void testInsanity(Insanity argument, AsyncMethodCallback<Map<Long, Map<Numberz,Insanity>>> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testInsanity(argument));
+    }
+
+    @Override
+    public void testMulti(byte arg0, int arg1, long arg2, Map<Short, String> arg3, Numberz arg4, long arg5, AsyncMethodCallback<Xtruct> resultHandler) throws TException {
+      resultHandler.onComplete(handler.testMulti(arg0,arg1,arg2,arg3,arg4,arg5));
+    }
+
+    @Override
+    public void testException(String arg, AsyncMethodCallback<Void> resultHandler) throws TException {
+      try {
+        // handler.testException();
+      } catch (Exception e) {
+
+      }
+    }
+
+    @Override
+    public void testMultiException(String arg0, String arg1, AsyncMethodCallback<Xtruct> resultHandler) throws TException {
+      //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public void testOneway(int secondsToSleep, AsyncMethodCallback<Void> resultHandler) throws TException {
+      handler.testOneway(secondsToSleep);
+      resultHandler.onComplete(null);
+    }
+  }
 
 }

--- a/test/DebugProtoTest.thrift
+++ b/test/DebugProtoTest.thrift
@@ -248,6 +248,8 @@ service Srv {
   void methodWithDefaultArgs(1: i32 something = MYCONST);
 
   oneway void onewayMethod();
+
+  bool declaredExceptionMethod(1: bool shouldThrow) throws (1: ExceptionWithAMap xwamap);
 }
 
 service Inherited extends Srv {


### PR DESCRIPTION
The parametrization brings the existing actual parametrization with
client call implementation objects to the fore and so this change
also fixes that parametrization to be a simple parametrization over
the return type as is done in the server-side AsyncProcessor code.

NB: This is a breaking change in both generated code and the client
libs.