### PR TITLE
THRIFT-3626 Fix lib/cpp/test/TSocketInterruptTest.cpp to use ephemera…

### DIFF
--- a/lib/cpp/test/TSocketInterruptTest.cpp
+++ b/lib/cpp/test/TSocketInterruptTest.cpp
@@ -32,6 +32,8 @@ using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TTransportException;
 
+BOOST_AUTO_TEST_SUITE(TSocketInterruptTest)
+
 void readerWorker(boost::shared_ptr<TTransport> tt, uint32_t expectedResult) {
   uint8_t buf[4];
   BOOST_CHECK_EQUAL(expectedResult, tt->read(buf, 4));
@@ -139,3 +141,5 @@ BOOST_AUTO_TEST_CASE(test_non_interruptable_child_peek) {
   accepted->close();
   sock1.close();
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/TSocketInterruptTest.cpp
+++ b/lib/cpp/test/TSocketInterruptTest.cpp
@@ -26,14 +26,11 @@
 #include <boost/thread/thread.hpp>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TServerSocket.h>
-#include "TestPortFixture.h"
 
 using apache::thrift::transport::TServerSocket;
 using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TTransportException;
-
-BOOST_FIXTURE_TEST_SUITE(TSocketInterruptTest, TestPortFixture)
 
 void readerWorker(boost::shared_ptr<TTransport> tt, uint32_t expectedResult) {
   uint8_t buf[4];
@@ -51,9 +48,10 @@ void readerWorkerMustThrow(boost::shared_ptr<TTransport> tt) {
 }
 
 BOOST_AUTO_TEST_CASE(test_interruptable_child_read) {
-  TServerSocket sock1("localhost", m_serverPort);
+  TServerSocket sock1("localhost", 0);
   sock1.listen();
-  TSocket clientSock("localhost", m_serverPort);
+  int port = sock1.getPort();
+  TSocket clientSock("localhost", port);
   clientSock.open();
   boost::shared_ptr<TTransport> accepted = sock1.accept();
   boost::thread readThread(boost::bind(readerWorkerMustThrow, accepted));
@@ -68,10 +66,11 @@ BOOST_AUTO_TEST_CASE(test_interruptable_child_read) {
 }
 
 BOOST_AUTO_TEST_CASE(test_non_interruptable_child_read) {
-  TServerSocket sock1("localhost", m_serverPort);
+  TServerSocket sock1("localhost", 0);
   sock1.setInterruptableChildren(false); // returns to pre-THRIFT-2441 behavior
   sock1.listen();
-  TSocket clientSock("localhost", m_serverPort);
+  int port = sock1.getPort();
+  TSocket clientSock("localhost", port);
   clientSock.open();
   boost::shared_ptr<TTransport> accepted = sock1.accept();
   boost::thread readThread(boost::bind(readerWorker, accepted, 0));
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_non_interruptable_child_read) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cannot_change_after_listen) {
-  TServerSocket sock1("localhost", m_serverPort);
+  TServerSocket sock1("localhost", 0);
   sock1.listen();
   BOOST_CHECK_THROW(sock1.setInterruptableChildren(false), std::logic_error);
   sock1.close();
@@ -100,9 +99,10 @@ void peekerWorker(boost::shared_ptr<TTransport> tt, bool expectedResult) {
 }
 
 BOOST_AUTO_TEST_CASE(test_interruptable_child_peek) {
-  TServerSocket sock1("localhost", m_serverPort);
+  TServerSocket sock1("localhost", 0);
   sock1.listen();
-  TSocket clientSock("localhost", m_serverPort);
+  int port = sock1.getPort();
+  TSocket clientSock("localhost", port);
   clientSock.open();
   boost::shared_ptr<TTransport> accepted = sock1.accept();
   // peek() will return false if child is interrupted
@@ -118,10 +118,11 @@ BOOST_AUTO_TEST_CASE(test_interruptable_child_peek) {
 }
 
 BOOST_AUTO_TEST_CASE(test_non_interruptable_child_peek) {
-  TServerSocket sock1("localhost", m_serverPort);
+  TServerSocket sock1("localhost", 0);
   sock1.setInterruptableChildren(false); // returns to pre-THRIFT-2441 behavior
   sock1.listen();
-  TSocket clientSock("localhost", m_serverPort);
+  int port = sock1.getPort();
+  TSocket clientSock("localhost", port);
   clientSock.open();
   boost::shared_ptr<TTransport> accepted = sock1.accept();
   // peek() will return false when remote side is closed
@@ -138,5 +139,3 @@ BOOST_AUTO_TEST_CASE(test_non_interruptable_child_peek) {
   accepted->close();
   sock1.close();
 }
-
-BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
…l ports.

Instead of using a fixed port, use an ephemeral port to improve
robustness and make way for parallelizability.

This change has an undesirable amount of repeated code but this fact is
not different from the prior so being a bit expedient here. Ideally
setup of a `TServerSocket` listening on an ephemeral port would be DRYed
up into a helper of some sort.