### PR TITLE
THRIFT-3629 Parser sets exitcode on errors, but generator does not

### DIFF
--- a/compiler/cpp/src/main.cc
+++ b/compiler/cpp/src/main.cc
@@ -1033,9 +1033,9 @@ void generate(t_program* program, const vector<string>& generator_strings) {
       }
     }
   } catch (string s) {
-    printf("Error: %s\n", s.c_str());
+    failure("Error: %s\n", s.c_str());
   } catch (const char* exc) {
-    printf("Error: %s\n", exc);
+    failure("Error: %s\n", exc);
   }
 }
 


### PR DESCRIPTION
Client: Compiler (general)
Patch: Jens Geyer