### PR TITLE
THRIFT-3577 assertion failed at line 512 of testcontainertest.c

### DIFF
--- a/lib/c_glib/test/testcontainertest.c
+++ b/lib/c_glib/test/testcontainertest.c
@@ -507,9 +507,9 @@ main(int argc, char *argv[])
 
     /* Make sure the server stopped only because it was interrupted (by the
        child process terminating) */
-    g_assert (g_error_matches (error,
-                               THRIFT_SERVER_SOCKET_ERROR,
-                               THRIFT_SERVER_SOCKET_ERROR_ACCEPT));
+    g_assert(!error || g_error_matches(error,
+                                       THRIFT_SERVER_SOCKET_ERROR,
+                                       THRIFT_SERVER_SOCKET_ERROR_ACCEPT));
 
     /* Free our resources */
     g_object_unref (server);


### PR DESCRIPTION
While investigating THRIFT-3635, I've found the root cause of this one, as D and c_glib are in the same group on Travis-CI.
It turned out that the GError could simply be absent while we were strictly expecting one.