### PR TITLE
THRIFT-3667 C++: Add TLS SNI support to clients

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -469,6 +469,8 @@ void TSSLSocket::checkHandshake() {
       }
     } while (rc == 2);
   } else {
+    // set the SNI hostname
+    SSL_set_tlsext_host_name(ssl_, getHost().c_str());
     do {
       rc = SSL_connect(ssl_);
       if (rc <= 0) {


### PR DESCRIPTION
For C++ OpenSSL clients, set the TSocket's requested hostname as the TLS extension "server_name" to support TLS SNI. This reveals the requested hostname within the clear-text TLS request, but supports most TLS-proxy services that support multiple virtual hosts.