### PR TITLE
[THRIFT-3689] thrift_reconnecting_client start failed when server is not available

### DIFF
--- a/lib/erl/src/thrift_reconnecting_client.erl
+++ b/lib/erl/src/thrift_reconnecting_client.erl
@@ -43,7 +43,7 @@
                   thrift_opts,
                   reconn_min,
                   reconn_max,
-                  reconn_time,
+                  reconn_time = 0,
                   op_cnt_dict,
                   op_time_dict } ).
 


### PR DESCRIPTION
When first time reconnect without a success call, line 214: Backoff = 2 * R, will cause exception, because R is undefined. Set reconn_time's default value to 0 resolved this.