### PR TITLE
THRIFT-3705 Go map incorrect types with map typedef

### DIFF
--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -3595,8 +3595,8 @@ string t_go_generator::type_to_go_type_with_opt(t_type* type,
     return "*" + publicize(type_name(type));
   } else if (type->is_map()) {
     t_map* t = (t_map*)type;
-    string keyType = type_to_go_key_type(t->get_key_type());
-    string valueType = type_to_go_type(t->get_val_type(), true);
+    string keyType = type_to_go_key_type(t->get_key_type()->get_true_type());
+    string valueType = type_to_go_type(t->get_val_type()->get_true_type(), true);
     return maybe_pointer + string("map[") + keyType + "]" + valueType;
   } else if (type->is_set()) {
     t_set* t = (t_set*)type;


### PR DESCRIPTION
Generating the following IDL results in Go code which does not compile:

```
typedef map<Foo, Foo> FooMap
struct Foo {}

service Service {
    void foo(1: FooMap fooMap)
}
```

./service.go:278: cannot use _key4 (type *Foo) as type Foo in map index
./service.go:278: cannot use _val5 (type *Foo) as type Foo in assignment

However, if the struct precedes the typedef, the code is generated correctly:

```
struct Foo {}
typedef map<Foo, Foo> FooMap

service Service {
    void foo(1: FooMap fooMap)
}
```

https://issues.apache.org/jira/browse/THRIFT-3705

@markerickson-wf 