### PR TITLE
THRIFT-3706 : Implement protocol multiplexor in c_glib [Rebased Master]

### DIFF
--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -35,6 +35,7 @@ libthrift_c_glib_la_SOURCES = src/thrift/c_glib/thrift.c \
                               src/thrift/c_glib/processor/thrift_processor.c \
                               src/thrift/c_glib/processor/thrift_dispatch_processor.c \
                               src/thrift/c_glib/protocol/thrift_protocol.c \
+                              src/thrift/c_glib/protocol/thrift_protocol_decorator.c \
                               src/thrift/c_glib/protocol/thrift_protocol_factory.c \
                               src/thrift/c_glib/protocol/thrift_binary_protocol.c \
                               src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c \
@@ -68,6 +69,7 @@ include_thrift_HEADERS = \
 
 include_protocoldir = $(include_thriftdir)/protocol
 include_protocol_HEADERS = src/thrift/c_glib/protocol/thrift_protocol.h \
+                           src/thrift/c_glib/protocol/thrift_protocol_decorator.h \
                            src/thrift/c_glib/protocol/thrift_protocol_factory.h \
                            src/thrift/c_glib/protocol/thrift_binary_protocol.h \
                            src/thrift/c_glib/protocol/thrift_binary_protocol_factory.h \

--- a/lib/c_glib/Makefile.am
+++ b/lib/c_glib/Makefile.am
@@ -37,6 +37,7 @@ libthrift_c_glib_la_SOURCES = src/thrift/c_glib/thrift.c \
                               src/thrift/c_glib/protocol/thrift_protocol.c \
                               src/thrift/c_glib/protocol/thrift_protocol_factory.c \
                               src/thrift/c_glib/protocol/thrift_binary_protocol.c \
+                              src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c \
                               src/thrift/c_glib/protocol/thrift_binary_protocol_factory.c \
                               src/thrift/c_glib/protocol/thrift_compact_protocol.c \
                               src/thrift/c_glib/protocol/thrift_compact_protocol_factory.c \
@@ -71,7 +72,8 @@ include_protocol_HEADERS = src/thrift/c_glib/protocol/thrift_protocol.h \
                            src/thrift/c_glib/protocol/thrift_binary_protocol.h \
                            src/thrift/c_glib/protocol/thrift_binary_protocol_factory.h \
                            src/thrift/c_glib/protocol/thrift_compact_protocol.h \
-                           src/thrift/c_glib/protocol/thrift_compact_protocol_factory.h
+                           src/thrift/c_glib/protocol/thrift_compact_protocol_factory.h \
+                           src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h 
 
 include_transportdir = $(include_thriftdir)/transport
 include_transport_HEADERS = src/thrift/c_glib/transport/thrift_buffered_transport.h \

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include <thrift/c_glib/thrift.h>
+#include <thrift/c_glib/protocol/thrift_protocol.h>
+#include <thrift/c_glib/protocol/thrift_multiplexed_protocol.h>
+
+G_DEFINE_TYPE(ThriftMultiplexedProtocol, thrift_multiplexed_protocol, THRIFT_TYPE_PROTOCOL)
+
+
+static GParamSpec *thrift_multiplexed_protocol_obj_properties[N_PROPERTIES] = { NULL, };
+
+gint32
+thrift_multiplexed_protocol_write_message_begin (ThriftProtocol *protocol,
+		const gchar *name, const ThriftMessageType message_type,
+		const gint32 seqid, GError **error)
+{
+	gint32 version = (THRIFT_MULTIPLEXED_PROTOCOL_VERSION_1)
+                				   | ((gint32) message_type);
+	gint32 ret;
+	gint32 xfer = 0;
+
+	g_return_val_if_fail (THRIFT_IS_MULTIPLEXED_PROTOCOL (protocol), -1);
+
+	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (protocol);
+
+
+
+	if ((ret = thrift_protocol_write_i32 (protocol, version, error)) < 0)
+	{
+		return -1;
+	}
+	xfer += ret;
+
+	if( (message_type == T_CALL || message_type == T_ONEWAY) && self->service_name != NULL) {
+		gchar *service_name = g_strdup_printf("%s%s%s", self->service_name, self->separator, name);
+		if ((ret = thrift_protocol_write_string (protocol, name, error)) < 0)
+		{
+			g_free(service_name);
+			return -1;
+		}
+		g_free(service_name);
+
+	}else{
+		if ((ret = thrift_protocol_write_string (protocol, name, error)) < 0)
+		{
+			return -1;
+		}
+	}
+	xfer += ret;
+
+	if ((ret = thrift_protocol_write_i32 (protocol, seqid, error)) < 0)
+	{
+		return -1;
+	}
+	xfer += ret;
+	return xfer;
+}
+
+
+
+
+static void
+thrift_multiplexed_protocol_set_property (GObject      *object,
+		guint         property_id,
+		const GValue *value,
+		GParamSpec   *pspec)
+{
+	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
+
+	switch (property_id)
+	{
+	case PROP_SERVICE_NAME:
+		if(self->service_name!=NULL)
+			g_free (self->service_name);
+		self->service_name= g_value_dup_string (value);
+		break;
+
+	case PROP_SEPARATOR:
+		if(self->separator!=NULL)
+			g_free (self->separator);
+		self->separator= g_value_dup_string (value);
+		break;
+
+	default:
+		/* We don't have any other property... */
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+		break;
+	}
+}
+
+static void
+thrift_multiplexed_protocol_get_property (GObject    *object,
+		guint       property_id,
+		GValue     *value,
+		GParamSpec *pspec)
+{
+	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
+
+	switch (property_id)
+	{
+	case PROP_SERVICE_NAME:
+		g_value_set_string (value, self->service_name);
+		break;
+
+	case PROP_SEPARATOR:
+		g_value_set_string (value, self->separator);
+		break;
+
+	default:
+		/* We don't have any other property... */
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+		break;
+	}
+}
+
+
+static void
+thrift_multiplexed_protocol_init (ThriftMultiplexedProtocol *protocol)
+{
+	//  THRIFT_UNUSED_VAR (protocol);
+	protocol->separator = g_value_dup_string (THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR);
+	protocol->service_name = NULL;
+}
+
+static void
+thrift_multiplexed_protocol_finalize (ThriftMultiplexedProtocol *protocol)
+{
+	if(protocol->separator){
+		g_free(protocol->separator);
+		protocol->separator = NULL;
+	}
+	if(protocol->service_name){
+		g_free(protocol->service_name);
+		protocol->service_name = NULL;
+	}
+	/* Always chain up to the parent class; there is no need to check if
+	 * the parent class implements the dispose() virtual function: it is
+	 * always guaranteed to do so
+	 */
+	G_OBJECT_CLASS (protocol)->finalize(protocol);
+}
+
+/* initialize the class */
+static void
+thrift_multiplexed_protocol_class_init (ThriftMultiplexedProtocolClass *klass)
+{
+	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	cls->write_message_begin = thrift_multiplexed_protocol_write_message_begin;
+
+
+	object_class->set_property = thrift_multiplexed_protocol_set_property;
+	object_class->get_property = thrift_multiplexed_protocol_get_property;
+	object_class->finalize = thrift_multiplexed_protocol_finalize;
+
+	thrift_multiplexed_protocol_obj_properties[PROP_SERVICE_NAME] =
+			g_param_spec_string ("service-name",
+					"Service name the protocol points to",
+					"Set the service name",
+					NULL /* default value */,
+					(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+	thrift_multiplexed_protocol_obj_properties[PROP_SEPARATOR] =
+			g_param_spec_string ("separator",
+					"Separator for service name and pointer",
+					"Set service name separator",
+					NULL /* default value */,
+					G_PARAM_READWRITE);
+
+	g_object_class_install_properties (object_class,
+			N_PROPERTIES,
+			thrift_multiplexed_protocol_obj_properties);
+}

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -160,7 +160,7 @@ thrift_multiplexed_protocol_class_init (ThriftMultiplexedProtocolClass *klass)
 	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-	g_info("Current Multiplexed write_message_begin addr %p, new %p", cls->write_message_begin, thrift_multiplexed_protocol_write_message_begin);
+	g_debug("Current Multiplexed write_message_begin addr %p, new %p", cls->write_message_begin, thrift_multiplexed_protocol_write_message_begin);
 	cls->write_message_begin = thrift_multiplexed_protocol_write_message_begin;
 
 

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
@@ -23,6 +23,7 @@
 #include <glib-object.h>
 
 #include <thrift/c_glib/protocol/thrift_protocol.h>
+#include <thrift/c_glib/protocol/thrift_protocol_decorator.h>
 #include <thrift/c_glib/transport/thrift_transport.h>
 
 G_BEGIN_DECLS
@@ -41,27 +42,18 @@ G_BEGIN_DECLS
 #define THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), THRIFT_TYPE_MULTIPLEXED_PROTOCOL, ThriftMultiplexedProtocolClass))
 
 /* version numbers */
-#define THRIFT_MULTIPLEXED_PROTOCOL_VERSION_1 0x90010000
-#define THRIFT_MULTIPLEXED_PROTOCOL_VERSION_MASK 0xffff0000
-
 #define THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR ":"
 
 typedef struct _ThriftMultiplexedProtocol ThriftMultiplexedProtocol;
 
 
-enum
-{
-  PROP_SERVICE_NAME = 1,
-  PROP_SEPARATOR,
-  N_PROPERTIES
-};
 
 /*!
  * Thrift Multiplexed Protocol instance.
  */
 struct _ThriftMultiplexedProtocol
 {
-  ThriftProtocol parent;
+  ThriftProtocolDecorator parent;
 
   gchar *service_name;
   gchar *separator;
@@ -74,8 +66,7 @@ typedef struct _ThriftMultiplexedProtocolClass ThriftMultiplexedProtocolClass;
  */
 struct _ThriftMultiplexedProtocolClass
 {
-  ThriftProtocolClass parent;
-
+  ThriftProtocolDecoratorClass parent;
 };
 
 /* used by THRIFT_TYPE_MULTIPLEXED_PROTOCOL */

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _THRIFT_MULTIPLEXED_PROTOCOL_H
+#define _THRIFT_MULTIPLEXED_PROTOCOL_H
+
+#include <glib-object.h>
+
+#include <thrift/c_glib/protocol/thrift_protocol.h>
+#include <thrift/c_glib/transport/thrift_transport.h>
+
+G_BEGIN_DECLS
+
+/*! \file thrift_multiplexed_protocol.h
+ *  \brief Multiplexed protocol implementation of a Thrift protocol.  Implements the
+ *         ThriftProtocol interface.
+ */
+
+/* type macros */
+#define THRIFT_TYPE_MULTIPLEXED_PROTOCOL (thrift_multiplexed_protocol_get_type ())
+#define THRIFT_MULTIPLEXED_PROTOCOL(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), THRIFT_TYPE_MULTIPLEXED_PROTOCOL, ThriftMultiplexedProtocol))
+#define THRIFT_IS_MULTIPLEXED_PROTOCOL(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), THRIFT_TYPE_MULTIPLEXED_PROTOCOL))
+#define THRIFT_MULTIPLEXED_PROTOCOL_CLASS(c) (G_TYPE_CHECK_CLASS_CAST ((c), THRIFT_TYPE_MULTIPLEXED_PROTOCOL, ThriftMultiplexedProtocolClass))
+#define THRIFT_IS_MULTIPLEXED_PROTOCOL_CLASS(c) (G_TYPE_CHECK_CLASS_TYPE ((c), THRIFT_TYPE_MULTIPLEXED_PROTOCOL))
+#define THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), THRIFT_TYPE_MULTIPLEXED_PROTOCOL, ThriftMultiplexedProtocolClass))
+
+/* version numbers */
+#define THRIFT_MULTIPLEXED_PROTOCOL_VERSION_1 0x90010000
+#define THRIFT_MULTIPLEXED_PROTOCOL_VERSION_MASK 0xffff0000
+
+#define THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR ":"
+
+typedef struct _ThriftMultiplexedProtocol ThriftMultiplexedProtocol;
+
+
+enum
+{
+  PROP_SERVICE_NAME = 1,
+  PROP_SEPARATOR,
+  N_PROPERTIES
+};
+
+/*!
+ * Thrift Multiplexed Protocol instance.
+ */
+struct _ThriftMultiplexedProtocol
+{
+  ThriftProtocol parent;
+
+  gchar *service_name;
+  gchar *separator;
+};
+
+typedef struct _ThriftMultiplexedProtocolClass ThriftMultiplexedProtocolClass;
+
+/*!
+ * Thrift Multiplexed Protocol class.
+ */
+struct _ThriftMultiplexedProtocolClass
+{
+  ThriftProtocolClass parent;
+
+};
+
+/* used by THRIFT_TYPE_MULTIPLEXED_PROTOCOL */
+GType thrift_multiplexed_protocol_get_type (void);
+
+G_END_DECLS
+
+#endif /* _THRIFT_MULTIPLEXED_PROTOCOL_H */

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
@@ -1,0 +1,650 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include <thrift/c_glib/thrift.h>
+#include <thrift/c_glib/protocol/thrift_protocol.h>
+#include <thrift/c_glib/protocol/thrift_binary_protocol.h>
+#include <thrift/c_glib/protocol/thrift_protocol_decorator.h>
+
+G_DEFINE_TYPE(ThriftProtocolDecorator, thrift_protocol_decorator, THRIFT_TYPE_PROTOCOL)
+
+
+enum
+{
+  PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL = 1,
+  PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_END
+};
+
+static GParamSpec *thrift_protocol_decorator_obj_properties[PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_END] = { NULL, };
+
+
+
+
+
+gint32
+thrift_protocol_decorator_write_message_begin (ThriftProtocol *protocol,
+                                     const gchar *name,
+                                     const ThriftMessageType message_type,
+                                     const gint32 seqid, GError **error)
+{
+
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolClass *proto = THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol);
+
+  g_info("Concrete protocol %p | %p", self->concrete_protocol, proto);
+
+  return proto->write_message_begin	(self->concrete_protocol, name,
+                                    message_type, seqid,
+                                    error);
+}
+
+gint32
+thrift_protocol_decorator_write_message_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_message_end (self->concrete_protocol,
+                                                                  error);
+}
+
+gint32
+thrift_protocol_decorator_write_struct_begin (ThriftProtocol *protocol, const gchar *name,
+                                    GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_struct_begin (self->concrete_protocol,
+                                                   name, error);
+}
+
+gint32
+thrift_protocol_decorator_write_struct_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_struct_end (self->concrete_protocol,
+                                                                 error);
+}
+
+gint32
+thrift_protocol_decorator_write_field_begin (ThriftProtocol *protocol,
+                                   const gchar *name,
+                                   const ThriftType field_type,
+                                   const gint16 field_id,
+                                   GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_begin (self->concrete_protocol,
+                                                   name, field_type,
+                                                   field_id, error);
+}
+
+gint32
+thrift_protocol_decorator_write_field_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_end (self->concrete_protocol,
+                                                                error);
+}
+
+gint32
+thrift_protocol_decorator_write_field_stop (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_stop (self->concrete_protocol,
+                                                                 error);
+}
+
+gint32
+thrift_protocol_decorator_write_map_begin (ThriftProtocol *protocol,
+                                 const ThriftType key_type,
+                                 const ThriftType value_type,
+                                 const guint32 size, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_map_begin (self->concrete_protocol,
+                                                   key_type, value_type,
+                                                   size, error);
+}
+
+gint32
+thrift_protocol_decorator_write_map_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_map_end (self->concrete_protocol,
+                                                              error);
+}
+
+gint32
+thrift_protocol_decorator_write_list_begin (ThriftProtocol *protocol,
+                                  const ThriftType element_type,
+                                  const guint32 size, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_list_begin (self->concrete_protocol,
+                                                   element_type, size,
+                                                   error);
+}
+
+gint32
+thrift_protocol_decorator_write_list_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_list_end (self->concrete_protocol,
+                                                               error);
+}
+
+gint32
+thrift_protocol_decorator_write_set_begin (ThriftProtocol *protocol,
+                                 const ThriftType element_type,
+                                 const guint32 size, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_set_begin (self->concrete_protocol,
+                                                   element_type, size,
+                                                   error);
+}
+
+gint32
+thrift_protocol_decorator_write_set_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_set_end (self->concrete_protocol,
+                                                              error);
+}
+
+gint32
+thrift_protocol_decorator_write_bool (ThriftProtocol *protocol,
+                            const gboolean value, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_bool (self->concrete_protocol, value,
+                                                           error);
+}
+
+gint32
+thrift_protocol_decorator_write_byte (ThriftProtocol *protocol, const gint8 value,
+                            GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_byte (self->concrete_protocol, value,
+                                                           error);
+}
+
+gint32
+thrift_protocol_decorator_write_i16 (ThriftProtocol *protocol, const gint16 value,
+                           GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i16 (self->concrete_protocol, value,
+                                                          error);
+}
+
+gint32
+thrift_protocol_decorator_write_i32 (ThriftProtocol *protocol, const gint32 value,
+                           GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i32 (self->concrete_protocol, value,
+                                                          error);
+}
+
+gint32
+thrift_protocol_decorator_write_i64 (ThriftProtocol *protocol, const gint64 value,
+                           GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i64 (self->concrete_protocol, value,
+                                                          error);
+}
+
+gint32
+thrift_protocol_decorator_write_double (ThriftProtocol *protocol,
+                              const gdouble value, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_double (self->concrete_protocol,
+                                                             value, error);
+}
+
+gint32
+thrift_protocol_decorator_write_string (ThriftProtocol *protocol,
+                              const gchar *str, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_string (self->concrete_protocol, str,
+                                                             error);
+}
+
+gint32
+thrift_protocol_decorator_write_binary (ThriftProtocol *protocol, const gpointer buf,
+                              const guint32 len, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_binary (self->concrete_protocol, buf,
+                                                             len, error);
+}
+
+gint32
+thrift_protocol_decorator_read_message_begin (ThriftProtocol *protocol,
+                                    gchar **name,
+                                    ThriftMessageType *message_type,
+                                    gint32 *seqid, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_message_begin (self->concrete_protocol,
+                                                   name, message_type,
+                                                   seqid, error);
+}
+
+gint32
+thrift_protocol_decorator_read_message_end (ThriftProtocol *protocol,
+                                  GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_message_end (self->concrete_protocol,
+                                                                 error);
+}
+
+gint32
+thrift_protocol_decorator_read_struct_begin (ThriftProtocol *protocol,
+                                   gchar **name,
+                                   GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_struct_begin (self->concrete_protocol,
+                                                                  name,
+                                                                  error);
+}
+
+gint32
+thrift_protocol_decorator_read_struct_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_struct_end (self->concrete_protocol,
+                                                                error);
+}
+
+gint32
+thrift_protocol_decorator_read_field_begin (ThriftProtocol *protocol,
+                                  gchar **name,
+                                  ThriftType *field_type,
+                                  gint16 *field_id,
+                                  GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_field_begin (self->concrete_protocol,
+                                                                 name,
+                                                                 field_type,
+                                                                 field_id,
+                                                                 error);
+}
+
+gint32
+thrift_protocol_decorator_read_field_end (ThriftProtocol *protocol,
+                                GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_field_end (self->concrete_protocol,
+                                                               error);
+}
+
+gint32
+thrift_protocol_decorator_read_map_begin (ThriftProtocol *protocol,
+                                ThriftType *key_type,
+                                ThriftType *value_type, guint32 *size,
+                                GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_map_begin (self->concrete_protocol,
+                                                               key_type,
+                                                               value_type,
+                                                               size,
+                                                               error);
+}
+
+gint32
+thrift_protocol_decorator_read_map_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_map_end (self->concrete_protocol,
+                                                             error);
+}
+
+gint32
+thrift_protocol_decorator_read_list_begin (ThriftProtocol *protocol,
+                                 ThriftType *element_type,
+                                 guint32 *size, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_list_begin (self->concrete_protocol,
+                                                                element_type,
+                                                                size, error);
+}
+
+gint32
+thrift_protocol_decorator_read_list_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_list_end (self->concrete_protocol,
+                                                              error);
+}
+
+gint32
+thrift_protocol_decorator_read_set_begin (ThriftProtocol *protocol,
+                                ThriftType *element_type,
+                                guint32 *size, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_set_begin (self->concrete_protocol,
+                                                               element_type,
+                                                               size, error);
+}
+
+gint32
+thrift_protocol_decorator_read_set_end (ThriftProtocol *protocol, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_set_end (self->concrete_protocol,
+                                                             error);
+}
+
+gint32
+thrift_protocol_decorator_read_bool (ThriftProtocol *protocol, gboolean *value,
+                           GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_bool (self->concrete_protocol, value,
+                                                          error);
+}
+
+gint32
+thrift_protocol_decorator_read_byte (ThriftProtocol *protocol, gint8 *value,
+                           GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_byte (self->concrete_protocol, value,
+                                                          error);
+}
+
+gint32
+thrift_protocol_decorator_read_i16 (ThriftProtocol *protocol, gint16 *value,
+                          GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i16 (self->concrete_protocol, value,
+                                                         error);
+}
+
+gint32
+thrift_protocol_decorator_read_i32 (ThriftProtocol *protocol, gint32 *value,
+                          GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i32 (self->concrete_protocol, value,
+                                                         error);
+}
+
+gint32
+thrift_protocol_decorator_read_i64 (ThriftProtocol *protocol, gint64 *value,
+                          GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i64 (self->concrete_protocol, value,
+                                                         error);
+}
+
+gint32
+thrift_protocol_decorator_read_double (ThriftProtocol *protocol,
+                             gdouble *value, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_double (self->concrete_protocol, value,
+                                                            error);
+}
+
+gint32
+thrift_protocol_decorator_read_string (ThriftProtocol *protocol,
+                             gchar **str, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_string (self->concrete_protocol, str,
+                                                            error);
+}
+
+gint32
+thrift_protocol_decorator_read_binary (ThriftProtocol *protocol, gpointer *buf,
+                             guint32 *len, GError **error)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+  return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_binary (self->concrete_protocol, buf,
+                                                            len, error);
+}
+
+
+static void
+thrift_protocol_decorator_set_property (GObject      *object,
+		guint         property_id,
+		const GValue *value,
+		GParamSpec   *pspec)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
+	g_info("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
+
+	switch (property_id)
+	{
+	case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
+		// FIXME We must finalize it first
+		//g_clear_object (&self->concrete_protocol);
+		self->concrete_protocol=g_value_get_pointer (value);
+		g_info("Setting concrete protocol %p to %p in %s",self,  self->concrete_protocol, g_type_name(G_TYPE_FROM_INSTANCE(object)));
+		// We must get the transport and set it on base class.
+
+		break;
+	default:
+		/* We don't have any other property... */
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+		break;
+	}
+}
+
+static void
+thrift_protocol_decorator_get_property (GObject    *object,
+		guint       property_id,
+		GValue     *value,
+		GParamSpec *pspec)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
+	g_info("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
+
+	switch (property_id)
+	{
+	case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
+		g_value_set_pointer (value, self->concrete_protocol);
+
+		/* But we must also set our */
+
+		break;
+	default:
+		/* We don't have any other property... */
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+		break;
+	}
+}
+
+
+ThriftProtocol *
+thrift_protocol_decorator_get_concrete_protocol(ThriftProtocolDecorator *protocol)
+{
+	ThriftProtocol *retval = NULL;
+	if(!THRIFT_IS_PROTOCOL_DECORATOR(protocol)){
+		g_warning("The type is not protocol decorator");
+		return NULL;
+	}
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR(protocol);
+	g_info("Getting concrete protocol from %X -> %X", self, self->concrete_protocol);
+
+	return retval;
+}
+
+
+static void
+thrift_protocol_decorator_init (ThriftProtocolDecorator *protocol)
+{
+	protocol->concrete_protocol = NULL;
+}
+
+
+
+static void
+thrift_protocol_decorator_dispose (ThriftProtocolDecorator *protocol)
+{
+	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+
+	/* dispose() might be called multiple times, so we must guard against
+	   * calling g_object_unref() on an invalid GObject by setting the member
+	   * NULL; g_clear_object() does this for us.
+	   */
+	if(self->concrete_protocol!=NULL)
+		g_clear_object (&self->concrete_protocol);
+}
+
+static void
+thrift_protocol_decorator_finalize (ThriftProtocolDecorator *protocol)
+{
+
+//	/*
+//	 * Chain the concrete protocol finalize
+//	 */
+//	if(protocol->concrete_protocol!=NULL){
+//		G_OBJECT_CLASS (protocol->concrete_protocol)->finalize(protocol->concrete_protocol);
+//	}
+	/* Always chain up to the parent class; there is no need to check if
+	 * the parent class implements the finalize() virtual function: it is
+	 * always guaranteed to do so
+	 */
+	G_OBJECT_CLASS (protocol)->finalize(protocol);
+}
+
+/* initialize the class */
+static void
+thrift_protocol_decorator_class_init (ThriftProtocolDecoratorClass *klass)
+{
+	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->set_property = thrift_protocol_decorator_set_property;
+	object_class->get_property = thrift_protocol_decorator_get_property;
+	object_class->finalize = thrift_protocol_decorator_finalize;
+	object_class->dispose = thrift_protocol_decorator_dispose;
+
+	thrift_protocol_decorator_obj_properties[PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL] =
+			g_param_spec_pointer ("protocol",
+					"Protocol",
+					"Set the protocol to be implemented",
+					(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+
+	g_object_class_install_properties (object_class,
+			PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_END,
+			thrift_protocol_decorator_obj_properties);
+
+	g_info("Current decorator write_message_begin addr %p, new %p", cls->write_message_begin, thrift_protocol_decorator_write_message_begin);
+
+
+	  cls->write_message_begin = thrift_protocol_decorator_write_message_begin;
+	  cls->write_message_end = thrift_protocol_decorator_write_message_end;
+	  cls->write_struct_begin = thrift_protocol_decorator_write_struct_begin;
+	  cls->write_struct_end = thrift_protocol_decorator_write_struct_end;
+	  cls->write_field_begin = thrift_protocol_decorator_write_field_begin;
+	  cls->write_field_end = thrift_protocol_decorator_write_field_end;
+	  cls->write_field_stop = thrift_protocol_decorator_write_field_stop;
+	  cls->write_map_begin = thrift_protocol_decorator_write_map_begin;
+	  cls->write_map_end = thrift_protocol_decorator_write_map_end;
+	  cls->write_list_begin = thrift_protocol_decorator_write_list_begin;
+	  cls->write_list_end = thrift_protocol_decorator_write_list_end;
+	  cls->write_set_begin = thrift_protocol_decorator_write_set_begin;
+	  cls->write_set_end = thrift_protocol_decorator_write_set_end;
+	  cls->write_bool = thrift_protocol_decorator_write_bool;
+	  cls->write_byte = thrift_protocol_decorator_write_byte;
+	  cls->write_i16 = thrift_protocol_decorator_write_i16;
+	  cls->write_i32 = thrift_protocol_decorator_write_i32;
+	  cls->write_i64 = thrift_protocol_decorator_write_i64;
+	  cls->write_double = thrift_protocol_decorator_write_double;
+	  cls->write_string = thrift_protocol_decorator_write_string;
+	  cls->write_binary = thrift_protocol_decorator_write_binary;
+	  cls->read_message_begin = thrift_protocol_decorator_read_message_begin;
+	  cls->read_message_end = thrift_protocol_decorator_read_message_end;
+	  cls->read_struct_begin = thrift_protocol_decorator_read_struct_begin;
+	  cls->read_struct_end = thrift_protocol_decorator_read_struct_end;
+	  cls->read_field_begin = thrift_protocol_decorator_read_field_begin;
+	  cls->read_field_end = thrift_protocol_decorator_read_field_end;
+	  cls->read_map_begin = thrift_protocol_decorator_read_map_begin;
+	  cls->read_map_end = thrift_protocol_decorator_read_map_end;
+	  cls->read_list_begin = thrift_protocol_decorator_read_list_begin;
+	  cls->read_set_begin = thrift_protocol_decorator_read_set_begin;
+	  cls->read_set_end = thrift_protocol_decorator_read_set_end;
+	  cls->read_bool = thrift_protocol_decorator_read_bool;
+	  cls->read_byte = thrift_protocol_decorator_read_byte;
+	  cls->read_i16 = thrift_protocol_decorator_read_i16;
+	  cls->read_i32 = thrift_protocol_decorator_read_i32;
+	  cls->read_i64 = thrift_protocol_decorator_read_i64;
+	  cls->read_double = thrift_protocol_decorator_read_double;
+	  cls->read_string = thrift_protocol_decorator_read_string;
+	  cls->read_binary = thrift_protocol_decorator_read_binary;
+}

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
@@ -637,6 +637,7 @@ thrift_protocol_decorator_class_init (ThriftProtocolDecoratorClass *klass)
 	  cls->read_map_begin = thrift_protocol_decorator_read_map_begin;
 	  cls->read_map_end = thrift_protocol_decorator_read_map_end;
 	  cls->read_list_begin = thrift_protocol_decorator_read_list_begin;
+	  cls->read_list_end = thrift_protocol_decorator_read_list_end;
 	  cls->read_set_begin = thrift_protocol_decorator_read_set_begin;
 	  cls->read_set_end = thrift_protocol_decorator_read_set_end;
 	  cls->read_bool = thrift_protocol_decorator_read_bool;

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _THRIFT_PROTOCOL_DECORATOR_H
+#define _THRIFT_PROTOCOL_DECORATOR_H
+
+#include <glib-object.h>
+
+#include <thrift/c_glib/protocol/thrift_protocol.h>
+#include <thrift/c_glib/transport/thrift_transport.h>
+
+G_BEGIN_DECLS
+
+/*! \file thrift_protocol_decorator.h
+ *  \brief Multiplexed protocol implementation of a Thrift protocol.  Implements the
+ *         ThriftProtocol interface.
+ */
+
+/* type macros */
+#define THRIFT_TYPE_PROTOCOL_DECORATOR (thrift_protocol_decorator_get_type ())
+#define THRIFT_PROTOCOL_DECORATOR(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), THRIFT_TYPE_PROTOCOL_DECORATOR, ThriftProtocolDecorator))
+#define THRIFT_IS_PROTOCOL_DECORATOR(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), THRIFT_TYPE_PROTOCOL_DECORATOR))
+#define THRIFT_PROTOCOL_DECORATOR_CLASS(c) (G_TYPE_CHECK_CLASS_CAST ((c), THRIFT_TYPE_PROTOCOL_DECORATOR, ThriftProtocolDecoratorClass))
+#define THRIFT_IS_PROTOCOL_DECORATOR_CLASS(c) (G_TYPE_CHECK_CLASS_TYPE ((c), THRIFT_TYPE_PROTOCOL_DECORATOR))
+#define THRIFT_PROTOCOL_DECORATOR_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), THRIFT_TYPE_PROTOCOL_DECORATOR, ThriftProtocolDecoratorClass))
+
+typedef struct _ThriftProtocolDecorator ThriftProtocolDecorator;
+
+
+/*!
+ * Thrift Multiplexed Protocol instance.
+ */
+struct _ThriftProtocolDecorator
+{
+	ThriftProtocol parent;
+
+	ThriftProtocol *concrete_protocol;
+};
+
+typedef struct _ThriftProtocolDecoratorClass ThriftProtocolDecoratorClass;
+
+/*!
+ * Thrift Multiplexed Protocol class.
+ */
+struct _ThriftProtocolDecoratorClass
+{
+	ThriftProtocolClass parent;
+
+};
+
+/* used by THRIFT_TYPE_PROTOCOL_DECORATOR */
+GType thrift_protocol_decorator_get_type (void);
+
+
+ThriftProtocol *
+thrift_protocol_decorator_get_concrete_protocol(ThriftProtocolDecorator *protocol);
+
+
+G_END_DECLS
+
+#endif /* _THRIFT_PROTOCOL_DECORATOR_H */


### PR DESCRIPTION
 This patch implements protocol multiplexor for the client. For the server there's a need for a processor that currently we don't have. So a test of this can only be tested against other language that already has this in place. We did testing against Java.

Example of use:

/*

```
We will use binary encoding
*/
ThriftBinaryProtocol *binary_protocol= g_object_new (THRIFT_TYPE_BINARY_PROTOCOL,
"transport", manager->transport,
NULL);
```

/*

```
FIXME Transport in the multiplexed should be got from binary_protocol
*/
ThriftMultiplexedProtocol *multiplexed_protocol= g_object_new (THRIFT_TYPE_MULTIPLEXED_PROTOCOL,
"transport", manager->transport,
"protocol", binary_protocol,
"service-name", "MyService",
NULL);
```
