### PR TITLE
THRIFT-3709 Comment syntax can produce broken code

### DIFF
--- a/compiler/cpp/compiler.vcxproj
+++ b/compiler/cpp/compiler.vcxproj
@@ -50,7 +50,7 @@
     <ClInclude Include="src\windows\version.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\audit\t_audit.cpp"/>
+    <ClCompile Include="src\audit\t_audit.cpp" />
     <ClCompile Include="src\generate\t_as3_generator.cc" />
     <ClCompile Include="src\generate\t_cocoa_generator.cc" />
     <ClCompile Include="src\generate\t_cpp_generator.cc" />
@@ -77,7 +77,7 @@
     <ClCompile Include="src\generate\t_py_generator.cc" />
     <ClCompile Include="src\generate\t_rb_generator.cc" />
     <ClCompile Include="src\generate\t_st_generator.cc" />
-	<ClCompile Include="src\generate\t_swift_generator.cc" />
+    <ClCompile Include="src\generate\t_swift_generator.cc" />
     <ClCompile Include="src\generate\t_xml_generator.cc" />
     <ClCompile Include="src\generate\t_xsd_generator.cc" />
     <ClCompile Include="src\main.cc" />

--- a/compiler/cpp/compiler.vcxproj.filters
+++ b/compiler/cpp/compiler.vcxproj.filters
@@ -16,7 +16,6 @@
     </ClInclude>
     <ClInclude Include="src\globals.h" />
     <ClInclude Include="src\main.h" />
-    <ClInclude Include="src\md5.h" />
     <ClInclude Include="src\parse\t_base_type.h">
       <Filter>parse</Filter>
     </ClInclude>
@@ -171,8 +170,10 @@
     <ClCompile Include="src\generate\t_xsd_generator.cc">
       <Filter>generate</Filter>
     </ClCompile>
+    <ClCompile Include="src\generate\t_xml_generator.cc">
+      <Filter>generate</Filter>
+    </ClCompile>
     <ClCompile Include="src\main.cc" />
-    <ClCompile Include="src\md5.c" />
     <ClCompile Include="src\parse\parse.cc">
       <Filter>parse</Filter>
     </ClCompile>

--- a/test/DocTest.thrift
+++ b/test/DocTest.thrift
@@ -254,4 +254,34 @@ typedef i32 TestFor3501a
  */
 typedef i32 TestFor3501b
 
+
+/* Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_00 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_01 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_02 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_03 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_04 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_05 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_06 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_07 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_08 { /* ? */ 1: i32 foo }
+
+struct TestFor3709 {
+  /** This is a comment */
+  1: required string id,
+  /** This is also a comment **/
+  2: required string typeId,
+  /** Yet another comment! */
+  3: required i32 endTimestamp
+}
+
+
 /* THE END */


### PR DESCRIPTION
Client: Compiler(general)
Patch: Jens Geyer