### PR TITLE
THRIFT-3730 server log error twice

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -176,7 +176,6 @@ func (p *TSimpleServer) processRequests(client TTransport) error {
 		if err, ok := err.(TTransportException); ok && err.TypeId() == END_OF_FILE {
 			return nil
 		} else if err != nil {
-			log.Printf("error processing request: %s", err)
 			return err
 		}
 		if !ok {


### PR DESCRIPTION
server log err twice  e.g

![thrift](https://cloud.githubusercontent.com/assets/4518016/13632503/fadba62c-e624-11e5-98f0-e37e54899776.png)
