### PR TITLE
THRIFT-3743 Java JSON protocol left in incorrect state when an exception is thrown during read or write operations

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
@@ -308,6 +308,13 @@ public class TJSONProtocol extends TProtocol {
     context_ = contextStack_.pop();
   }
 
+  // Reset the context stack to its initial state
+  private void resetContext() {
+    while (!contextStack_.isEmpty()) {
+      popContext();
+    }
+  }
+
   /**
    * Constructor
    */
@@ -503,6 +510,7 @@ public class TJSONProtocol extends TProtocol {
 
   @Override
   public void writeMessageBegin(TMessage message) throws TException {
+    resetContext(); // THRIFT-3743
     writeJSONArrayStart();
     writeJSONInteger(VERSION);
     try {
@@ -854,6 +862,7 @@ public class TJSONProtocol extends TProtocol {
 
   @Override
   public TMessage readMessageBegin() throws TException {
+    resetContext(); // THRIFT-3743
     readJSONArrayStart();
     if (readJSONInteger() != VERSION) {
       throw new TProtocolException(TProtocolException.BAD_VERSION,

--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -143,6 +143,15 @@ public class TSimpleJSONProtocol extends TProtocol {
   }
 
   /**
+   * Reset the write context stack to its initial state.
+   */
+  protected void resetWriteContext() {
+    while (!writeContextStack_.isEmpty()) {
+      popWriteContext();
+    }
+  }
+
+  /**
    * Used to make sure that we are not encountering a map whose keys are containers
    */
   protected void assertContextIsNotMapKey(String invalidKeyType) throws CollectionMapKeyException {
@@ -159,6 +168,7 @@ public class TSimpleJSONProtocol extends TProtocol {
   }
 
   public void writeMessageBegin(TMessage message) throws TException {
+    resetWriteContext(); // THRIFT-3743
     trans_.write(LBRACKET);
     pushWriteContext(new ListContext());
     writeString(message.name);


### PR DESCRIPTION
This is the same issue as THRIFT-1473 (Delphi) and THRIFT-3735 (Go) but for the Java library.

The JSON context stack may be left in an incorrect state when an exception is thrown during read or write operations. This leads to further errors while writing/reading the NEXT message, because incorrect characters may be written or expected.

@stevenosborne-wf
@markerickson-wf 
