### PR TITLE
THRIFT-3744 The precision should be 17 (16 bits need after dot) after dot for double type.

### DIFF
--- a/lib/d/src/thrift/protocol/json.d
+++ b/lib/d/src/thrift/protocol/json.d
@@ -133,7 +133,7 @@ final class TJsonProtocol(Transport = TTransport) if (
     bool escapeNum = value !is null || context_.escapeNum;
 
     if (value is null) {
-      value = format("%.16g", dub);
+      value = format("%.17g", dub);
     }
 
     if (escapeNum) trans_.write(STRING_DELIMITER);

--- a/lib/d/src/thrift/protocol/json.d
+++ b/lib/d/src/thrift/protocol/json.d
@@ -133,6 +133,7 @@ final class TJsonProtocol(Transport = TTransport) if (
     bool escapeNum = value !is null || context_.escapeNum;
 
     if (value is null) {
+      /* precision is 17 */
       value = format("%.17g", dub);
     }
 


### PR DESCRIPTION
The precision is lost when converting double to string.
E.g:
double PI = 3.1415926535897931;
string value = format("%.16g", PI);
The value will be '3.141592653589793' and last 1 is lost after format operation.
But expected value should be '3.1415926535897931'.
Solution:
string value = format("%.17g", PI);