### PR TITLE
THRIFT-3745 The precision should be 17 for double

### DIFF
--- a/lib/php/lib/Thrift/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Thrift/Protocol/TJSONProtocol.php
@@ -290,7 +290,7 @@ class TJSONProtocol extends TProtocol
         if ($this->context_->escapeNum()) {
             $this->trans_->write(self::QUOTE);
         }
-
+        ini_set("precision",17);
         $this->trans_->write(json_encode($num));
 
         if ($this->context_->escapeNum()) {

--- a/lib/php/test/Test/Thrift/Protocol/TestTJSONProtocol.php
+++ b/lib/php/test/Test/Thrift/Protocol/TestTJSONProtocol.php
@@ -547,7 +547,7 @@ class TestTJSONProtocol_Fixtures
 
     self::$testArgsJSON['testUnicodeStringWithNonBMP'] = '{"1":{"str":"สวัสดี\/𝒯"}}';
 
-    self::$testArgsJSON['testDouble'] = '{"1":{"dbl":3.1415926535898}}';
+    self::$testArgsJSON['testDouble'] = '{"1":{"dbl":3.1415926535897931}}';
 
     self::$testArgsJSON['testByte'] = '{"1":{"i8":1}}';
 


### PR DESCRIPTION
$num= 3.1415926535897931;
$this->trans_->write(json_encode($num)); 
The value will be '3.1415926535898' and some precision lost after format operation.