### PR TITLE
THRIFT-3753 Fixed a race condition in TServerFramework::stop that prevents clean server shutdown

### DIFF
--- a/lib/cpp/src/thrift/server/TServerFramework.cpp
+++ b/lib/cpp/src/thrift/server/TServerFramework.cpp
@@ -214,8 +214,10 @@ void TServerFramework::setConcurrentClientLimit(int64_t newLimit) {
 }
 
 void TServerFramework::stop() {
-  serverTransport_->interrupt();
+  // Order is important because serve() releases serverTransport_ when it is
+  // interrupted, which closes the socket that interruptChildren uses.
   serverTransport_->interruptChildren();
+  serverTransport_->interrupt();
 }
 
 void TServerFramework::newlyConnectedClient(const boost::shared_ptr<TConnectedClient>& pClient) {


### PR DESCRIPTION
This is a sequence that exposes the race condition:
(1) Thread-1: in serve(), blocked on accept()
(2) Thread-2: in stop(), calls interrupt()
(3) Thread-2: in stop(), in interruptChildren(), checked that socket is valid
(4) Thread-1: in serve(), unblocked because of interrupt(), calls releaseOneDescriptor
(5) Thread-2: in interruptChildren(), send fails so clients are not interrupted

Closing a socket while it is being polled/selected may or may not work on all platforms, so I think changing the order is better.