### PR TITLE
THRIFT-3755 TDebugProtocol::writeString hits assert in isprint on Windows with debug CRT

### DIFF
--- a/lib/cpp/src/thrift/protocol/TDebugProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TDebugProtocol.cpp
@@ -347,7 +347,9 @@ uint32_t TDebugProtocol::writeString(const string& str) {
       output += "\\\\";
     } else if (*it == '"') {
       output += "\\\"";
-    } else if (std::isprint(*it)) {
+      // passing characters <0 to std::isprint causes asserts. isprint takes an
+      // int, so we need to be careful of sign extension
+    } else if (std::isprint((unsigned char)*it)) {
       output += *it;
     } else {
       switch (*it) {


### PR DESCRIPTION
Passing characters <0 to std::isprint causes asserts.