### PR TITLE
THRIFT-3764: Ensure PHP TSimpleJSONProtocol and TMultiplexedProtocol files included during "make install"

### DIFF
--- a/lib/php/Makefile.am
+++ b/lib/php/Makefile.am
@@ -38,6 +38,8 @@ distclean-local:
 endif
 
 phpdir = $(PHP_PREFIX)/Thrift
+php_DATA = \
+  lib/Thrift/TMultiplexedProcessor.php
 
 phpbasedir = $(phpdir)/Base
 phpbase_DATA = \
@@ -69,7 +71,10 @@ phpprotocol_DATA = \
   lib/Thrift/Protocol/TBinaryProtocol.php \
   lib/Thrift/Protocol/TCompactProtocol.php \
   lib/Thrift/Protocol/TJSONProtocol.php \
-  lib/Thrift/Protocol/TProtocol.php
+  lib/Thrift/Protocol/TMultiplexedProtocol.php \
+  lib/Thrift/Protocol/TProtocol.php \
+  lib/Thrift/Protocol/TProtocolDecorator.php \
+  lib/Thrift/Protocol/TSimpleJSONProtocol.php
 
 phpprotocoljsondir = $(phpprotocoldir)/JSON
 phpprotocoljson_DATA = \
@@ -77,6 +82,14 @@ phpprotocoljson_DATA = \
   lib/Thrift/Protocol/JSON/ListContext.php \
   lib/Thrift/Protocol/JSON/LookaheadReader.php \
   lib/Thrift/Protocol/JSON/PairContext.php
+
+phpprotocolsimplejsondir = $(phpprotocoldir)/SimpleJSON
+phpprotocolsimplejson_DATA = \
+  lib/Thrift/Protocol/SimpleJSON/CollectionMapKeyException.php \
+  lib/Thrift/Protocol/SimpleJSON/Context.php \
+  lib/Thrift/Protocol/SimpleJSON/ListContext.php \
+  lib/Thrift/Protocol/SimpleJSON/MapContext.php \
+  lib/Thrift/Protocol/SimpleJSON/StructContext.php
 
 phpserializerdir = $(phpdir)/Serializer
 phpserializer_DATA = \


### PR DESCRIPTION
If using "make install" to install the PHP client libraries, these files are currently not included.