### PR TITLE
THRIFT-3771 TBufferedTransport gets in invalid state on read/write errors

### DIFF
--- a/lib/go/thrift/buffered_transport.go
+++ b/lib/go/thrift/buffered_transport.go
@@ -62,8 +62,25 @@ func (p *TBufferedTransport) Close() (err error) {
 	return p.tp.Close()
 }
 
+func (p *TBufferedTransport) Read(b []byte) (int, error) {
+	n, err := p.ReadWriter.Read(b)
+	if err != nil {
+		p.ReadWriter.Reader.Reset(p.tp)
+	}
+	return n, err
+}
+
+func (p *TBufferedTransport) Write(b []byte) (int, error) {
+	n, err := p.ReadWriter.Write(b)
+	if err != nil {
+		p.ReadWriter.Writer.Reset(p.tp)
+	}
+	return n, err
+}
+
 func (p *TBufferedTransport) Flush() error {
 	if err := p.ReadWriter.Flush(); err != nil {
+		p.ReadWriter.Writer.Reset(p.tp)
 		return err
 	}
 	return p.tp.Flush()
@@ -72,4 +89,3 @@ func (p *TBufferedTransport) Flush() error {
 func (p *TBufferedTransport) RemainingBytes() (num_bytes uint64) {
 	return p.tp.RemainingBytes()
 }
-


### PR DESCRIPTION
Go's TBufferedTransport can enter an invalid state after an error occurs
while calling read, write, or flush. This is because TBufferedTransport
uses a bufio.ReadWriter, which "caches" the error returned by a call to
read or write such that subsequent calls return the same error. This can
be problematic if you wish to reuse the transport after a failed read or
write. The solution is to reset the reader/writer on failed calls.

@stevenosborne-wf @markerickson-wf 