### PR TITLE
THRIFT-3038: fix up some volatiles in cpp

### DIFF
--- a/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
@@ -69,7 +69,6 @@ TThreadPoolServer::TThreadPoolServer(const shared_ptr<TProcessorFactory>& proces
                      inputProtocolFactory,
                      outputProtocolFactory),
     threadManager_(threadManager),
-    stop_(false),
     timeout_(0),
     taskExpiration_(0) {
 }
@@ -88,7 +87,6 @@ TThreadPoolServer::TThreadPoolServer(const shared_ptr<TProcessor>& processor,
                      inputProtocolFactory,
                      outputProtocolFactory),
     threadManager_(threadManager),
-    stop_(false),
     timeout_(0),
     taskExpiration_(0) {
 }
@@ -117,17 +115,18 @@ void TThreadPoolServer::setTaskExpiration(int64_t value) {
   taskExpiration_ = value;
 }
 
-boost::shared_ptr<apache::thrift::concurrency::ThreadManager> TThreadPoolServer::getThreadManager()
-    const {
+boost::shared_ptr<apache::thrift::concurrency::ThreadManager>
+TThreadPoolServer::getThreadManager() const {
   return threadManager_;
 }
 
 void TThreadPoolServer::onClientConnected(const shared_ptr<TConnectedClient>& pClient) {
-  threadManager_->add(pClient, timeout_, taskExpiration_);
+  threadManager_->add(pClient, getTimeout(), getTaskExpiration());
 }
 
 void TThreadPoolServer::onClientDisconnected(TConnectedClient*) {
 }
+
 }
 }
 } // apache::thrift::server

--- a/lib/cpp/src/thrift/server/TThreadPoolServer.h
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.h
@@ -20,6 +20,7 @@
 #ifndef _THRIFT_SERVER_TTHREADPOOLSERVER_H_
 #define _THRIFT_SERVER_TTHREADPOOLSERVER_H_ 1
 
+#include <boost/atomic.hpp>
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/server/TServerFramework.h>
 
@@ -89,13 +90,10 @@ protected:
   virtual void onClientDisconnected(TConnectedClient* pClient) /* override */;
 
   boost::shared_ptr<apache::thrift::concurrency::ThreadManager> threadManager_;
-
-  volatile bool stop_;
-
-  volatile int64_t timeout_;
-
-  volatile int64_t taskExpiration_;
+  boost::atomic<int64_t> timeout_;
+  boost::atomic<int64_t> taskExpiration_;
 };
+
 }
 }
 } // apache::thrift::server

--- a/lib/cpp/src/thrift/transport/TFileTransport.h
+++ b/lib/cpp/src/thrift/transport/TFileTransport.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <stdio.h>
 
+#include <boost/atomic.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -352,7 +353,7 @@ private:
 
   // To keep track of whether the buffer has been flushed
   Monitor flushed_;
-  volatile bool forceFlush_;
+  boost::atomic<bool> forceFlush_;
 
   // Mutex that is grabbed when enqueueing and swapping the read/write buffers
   Mutex mutex_;
@@ -438,3 +439,4 @@ private:
 } // apache::thrift::transport
 
 #endif // _THRIFT_TRANSPORT_TFILETRANSPORT_H_
+


### PR DESCRIPTION
I addressed the concerns in TFileTransport (forceFlush_) and in TThreadPoolServer, so items #2, #4, #5 from the original issue description.