### PR TITLE
THRIFT-3786 Fix premature firing of `connect` event for secure sockets

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -36,6 +36,7 @@ var Connection = exports.Connection = function(stream, options) {
 
   this.seqId2Service = {};
   this.connection = stream;
+  this.ssl = (stream instanceof tls.TLSSocket);
   this.options = options || {};
   this.transport = this.options.transport || TBufferedTransport;
   this.protocol = this.options.protocol || TBinaryProtocol;
@@ -61,7 +62,8 @@ var Connection = exports.Connection = function(stream, options) {
       this.options.connect_timeout > 0) {
      this.connect_timeout = +this.options.connect_timeout;
   }
-  this.connection.addListener("connect", function() {
+
+  this.connection.addListener(this.ssl ? "secureConnect" : "connect", function() {
     self.connected = true;
 
     this.setTimeout(self.options.timeout || 0);
@@ -77,24 +79,6 @@ var Connection = exports.Connection = function(stream, options) {
 
     self.emit("connect");
   });
-
-  this.connection.addListener("secureConnect", function() {
-    self.connected = true;
-
-    this.setTimeout(self.options.timeout || 0);
-    this.setNoDelay();
-    this.frameLeft = 0;
-    this.framePos = 0;
-    this.frame = null;
-    self.initialize_retry_vars();
-
-    self.offline_queue.forEach(function(data) {
-      self.connection.write(data);
-    });
-
-    self.emit("connect");
-  });
-
 
   this.connection.addListener("error", function(err) {
     // Only emit the error if no-one else is listening on the connection


### PR DESCRIPTION
`tls.connect()` returns a socket that will fire a `connect` event when the initial socket is connected, followed by a `secureConnect` event when the TLS handshake is complete

This commit causes the Thrift connection to wait until `secureConnect` to broadcast its own `connect` event and begin using the secure socket. This helps to resolve a race condition where commands issued after `connect` but before `secureConnect` are lost. It also fixes loss of commands in the offline queue, as well as double-broadcasting due to the same handler running on both underlying `connect` events.