### PR TITLE
THRIFT-3787 Fix Node.js Connection object error handling

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -82,14 +82,12 @@ var Connection = exports.Connection = function(stream, options) {
 
   this.connection.addListener("error", function(err) {
     // Only emit the error if no-one else is listening on the connection
-    // or if someone is listening on us
+    // or if someone is listening on us, because Node turns unhandled
+    // 'error' events into exceptions.
     if (self.connection.listeners('error').length === 1 ||
         self.listeners('error').length > 0) {
       self.emit("error", err);
     }
-    // "error" events get turned into exceptions if they aren't listened for.  If the user handled this error
-    // then we should try to reconnect.
-    self.connection_gone();
   });
 
   // Add a close listener
@@ -185,18 +183,17 @@ Connection.prototype.write = function(data) {
 
 Connection.prototype.connection_gone = function () {
   var self = this;
+  this.connected = false;
 
   // If a retry is already in progress, just let that happen
   if (this.retry_timer) {
     return;
   }
-  if (!this.max_attempts) {
+  // We cannot reconnect a secure socket.
+  if (!this.max_attempts || this.ssl) {
     self.emit("close");
     return;
   }
-
-  this.connected = false;
-  this.ready = false;
 
   if (this.retry_max_delay !== null && this.retry_delay >= this.retry_max_delay) {
     this.retry_delay = this.retry_max_delay;


### PR DESCRIPTION
The `connected` property on `Connection` instances was not accurately maintained if reconnection retries are not enabled. Line 194 was moved to Line 176 to fix this.

Furthermore, reconnection retries are not possible with secure sockets, so this commit returns early in that case, preventing long delays waiting for the `secureConnect` event which will never fire again. It's not explicitly stated in the Node.js documentation, but calling `connect()` on an instance of a `TLSSocket` will only reconnect the underlying TCP connection; it is not possible to cause the socket to re-handshake at the TLS layer.

(You can peruse the source for [`tls.connect`](https://github.com/nodejs/node/blob/a11d506decd2820221d6cd770990a585ca0261d5/lib/_tls_wrap.js#L964-1095) to see that it performs many more operations than just instantiating a `TLSSocket` instance and calling `connect()` on it. This stands in contrast to an ordinary TCP `Socket` instance from the `net` module, where reconnection is possible via these means.)

Supporting reconnection for secure sockets would require a deep refactor to enable the Thrift `Connection` instance to replace its underlying socket, and I didn't feel up to the challenge today.