### PR TITLE
THRIFT-3789 Add `destroy` to Connection instance

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -163,6 +163,10 @@ Connection.prototype.end = function() {
   this.connection.end();
 };
 
+Connection.prototype.destroy = function() {
+  this.connection.destroy();
+};
+
 Connection.prototype.initialize_retry_vars = function () {
   this.retry_timer = null;
   this.retry_totaltime = 0;


### PR DESCRIPTION
This commit proxies the `destroy` method from the Thrift Connection object to its underlying socket, akin to the existing `end` method.

Without `destroy`, it's possible for a failed TLS socket to hold the Node.js process open. (Calling `end` is not sufficient to close the OS handle because `end` sends a `FIN` packet, which is never acknowledged by the server.)