### PR TITLE
THRIFT-3793: move to ant-1.9.7 for appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,15 +55,15 @@ install:
 - move *.h include\
 - cd ..
 - cinst winflexbison
-- appveyor DownloadFile http://www.us.apache.org/dist//ant/binaries/apache-ant-1.9.6-bin.zip
-- 7z x apache-ant-1.9.6-bin.zip > nul
+- appveyor DownloadFile http://www.us.apache.org/dist/ant/binaries/apache-ant-1.9.7-bin.zip
+- 7z x apache-ant-1.9.7-bin.zip > nul
 - cd %APPVEYOR_BUILD_FOLDER%
 # TODO: Enable Haskell build
 # - cinst HaskellPlatform -version 2014.2.0.0
 
 
 build_script:
-- set PATH=C:\ProgramData\chocolatey\bin;C:\apache-ant-1.9.6\bin;%PATH%
+- set PATH=C:\ProgramData\chocolatey\bin;C:\apache-ant-1.9.7\bin;%PATH%
 - set JAVA_HOME=C:\Program Files\Java\jdk1.7.0
 - set PATH=%JAVA_HOME%\bin;%PATH%
 # - set PATH=%PATH%;C:\Program Files (x86)\Haskell Platform\2014.2.0.0\bin


### PR DESCRIPTION
Fixes recent build failures.