### PR TITLE
THRIFT-3794: Fixing exception types in library now that they have been split up.

### DIFF
--- a/lib/delphi/src/Thrift.Transport.pas
+++ b/lib/delphi/src/Thrift.Transport.pas
@@ -1585,7 +1585,7 @@ begin
   inherited;
 
   if not FTcpClient.IsOpen
-  then raise TTransportException.Create( TTransportException.TExceptionType.NotOpen);
+  then raise TTransportExceptionNotOpen.Create('not open');
 
   FTcpClient.Write(buffer[offset], count);
 end;


### PR DESCRIPTION
Needed to update a few exception types in Thrift.Socket.pas and Thrift.Transport.pas.