### PR TITLE
THRIFT-3797: Generated Delphi processor shouldn't error out on timed out exceptions

### DIFF
--- a/compiler/cpp/src/generate/t_delphi_generator.cc
+++ b/compiler/cpp/src/generate/t_delphi_generator.cc
@@ -2291,8 +2291,18 @@ void t_delphi_generator::generate_service_server(t_service* tservice) {
   indent_down_impl();
   indent_impl(s_service_impl) << "except" << endl;
   indent_up_impl();
+  indent_impl(s_service_impl) << "on TTransportExceptionTimedOut do begin" << endl;
+  indent_up_impl();
+  indent_impl(s_service_impl) << "Result := True;" << endl;
+  indent_impl(s_service_impl) << "Exit;" << endl;
+  indent_down_impl();
+  indent_impl(s_service_impl) << "end;" << endl;
+  indent_impl(s_service_impl) << "else begin" << endl;
+  indent_up_impl();
   indent_impl(s_service_impl) << "Result := False;" << endl;
   indent_impl(s_service_impl) << "Exit;" << endl;
+  indent_down_impl();
+  indent_impl(s_service_impl) << "end;" << endl;
   indent_down_impl();
   indent_impl(s_service_impl) << "end;" << endl;
   indent_impl(s_service_impl) << "Result := True;" << endl;


### PR DESCRIPTION
See extensive comment in JIRA.  However, this code mirrors what happens in TConnectedClient.cpp, where TConnectedClient.run() doesn't abort the processing loop when a timeout occurs, because a timeout isn't an error condition when waiting for a new RPC call to arrive.