### PR TITLE
THRIFT-3803 - Tweak attributes that are exported from XML generator

### DIFF
--- a/compiler/cpp/src/generate/t_xml_generator.cc
+++ b/compiler/cpp/src/generate/t_xml_generator.cc
@@ -310,10 +310,8 @@ void t_xml_generator::iterate_program(t_program* program) {
   const vector<t_program*> includes = program->get_includes();
   vector<t_program*>::const_iterator inc_it;
   for (inc_it = includes.begin(); inc_it != includes.end(); ++inc_it) {
-    const string include_path = (*inc_it)->get_path();
     write_element_start("include");
     write_attribute("name", (*inc_it)->get_name());
-    write_attribute("file", include_path);
     write_element_end();
   }
 

--- a/lib/xml/thrift-idl.xsd
+++ b/lib/xml/thrift-idl.xsd
@@ -47,14 +47,14 @@
         <element name="enum" type="tns:Enum" />
       </choice>
     </sequence>
-    <attribute name="name" type="string" />
-    <attribute name="targetNamespace" type="anyURI" />
-    <attribute name="doc" type="string" />
+    <attribute name="name" type="string" use="required" />
+    <attribute name="targetNamespace" type="anyURI" use="optional" />
+    <attribute name="doc" type="string" use="optional" />
   </complexType>
 
   <complexType name="Include">
-    <attribute name="file" type="string" />
-    <attribute name="name" type="string" />
+    <attribute name="file" type="string" use="optional" />
+    <attribute name="name" type="string" use="required" />
   </complexType>
 
   <complexType name="Namespace">
@@ -62,9 +62,9 @@
       <element name="annotation" type="tns:Annotation" 
                minOccurs="0" maxOccurs="unbounded" />
     </sequence>
-    <attribute name="name" type="string" />
-    <attribute name="value" type="string" />
-    <attribute name="doc" type="string" />
+    <attribute name="name" type="string" use="required" />
+    <attribute name="value" type="string" use="required" />
+    <attribute name="doc" type="string" use="optional" />
   </complexType>
 
   <group name="AbstractStruct">
@@ -77,8 +77,8 @@
   </group>
 
   <attributeGroup name="StructAttributes">
-    <attribute name="name" type="string" />
-    <attribute name="doc" type="string" />
+    <attribute name="name" type="string" use="required" />
+    <attribute name="doc" type="string" use="optional" />
   </attributeGroup>
 
   <complexType name="Exception">
@@ -97,7 +97,7 @@
     <attribute name="targetNamespace" type="string" use="required" />
     <attribute name="parent-module" type="string" use="optional" />
     <attribute name="parent-id" type="string" use="optional" /> 
-    <attribute name="doc" type="string" />
+    <attribute name="doc" type="string" use="optional" />
   </complexType>
 
   <complexType name="Method">
@@ -111,8 +111,8 @@
                minOccurs="0" maxOccurs="unbounded" />
     </sequence>
     <attribute name="name" type="string" use="required" />
-    <attribute name="oneway" type="boolean" />
-    <attribute name="doc" type="string" />
+    <attribute name="oneway" type="boolean" use="optional" />
+    <attribute name="doc" type="string" use="optional" />
   </complexType>
 
   <complexType name="Typedef">
@@ -123,7 +123,7 @@
                    minOccurs="0" maxOccurs="unbounded" />
         </sequence>
         <attribute name="name" type="string" use="required" />
-        <attribute name="doc" type="string" />
+        <attribute name="doc" type="string" use="optional" />
       </extension>
     </complexContent>
   </complexType>


### PR DESCRIPTION
When I created the XML generator, I added an attribute named "file" to the <include /> element that has path information to the included file.

However, the information being exported into the XML file however is an absolute path that is specific to the system on which the XML file is generated, which probably should not exported. Additionally, I'm not sure that the path information has much particular use anyhow, so IMO this should just be removed (especially since it has not been in an official release yet).

Also, when running the tests for this I noticed some attributes in the XSD were not properly specified as required, so I added that information to XSD.