### PR TITLE
 exchange deleted pacage to existed one.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,14 @@
 Source: thrift
 Section: devel
 Priority: extra
-Build-Depends: debhelper (>= 9), build-essential, mono-gmcs, python-dev, ant,
-    mono-devel,  libmono-system-web2.0-cil, erlang-base, ruby-dev | ruby1.9.1-dev, autoconf, automake,
+Build-Depends: debhelper (>= 9), build-essential, mono-mcs, python-dev, ant,
+    mono-devel,  libmono-system-web4.0-cil, erlang-base, ruby-dev | ruby1.9.1-dev, autoconf, automake,
     pkg-config, libtool, bison, flex, libboost-dev | libboost1.53-dev,
     python-all, python-setuptools, python-all-dev, python-all-dbg,
     python3-all, python3-setuptools, python3-all-dev, python3-all-dbg,
-    openjdk-6-jdk | java-sdk,
+    openjdk-7-jdk | openjdk-8-jdk,
     libboost-test-dev | libboost-test1.53-dev, libevent-dev, libssl-dev, perl (>= 5.8.0-7),
-    php5, php5-dev, libglib2.0-dev, qtbase5-dev, qtbase5-dev-tools
+    php5 | php-7.0, php5-dev | php-7.0-dev, libglib2.0-dev, qtbase5-dev, qtbase5-dev-tools
 Maintainer: Thrift Developer's <dev@thrift.apache.org>
 Homepage: http://thrift.apache.org/
 Vcs-Git: https://git-wip-us.apache.org/repos/asf/thrift.git
@@ -129,8 +129,8 @@ Description: Java bindings for Thrift
 Package: libthrift-cil
 Architecture: all
 Section: cli-mono
-Depends: cli-common, libmono-corlib1.0-cil (>= 1.0), libmono-system1.0-cil (>= 1.0), 
-    libmono-system-web2.0-cil, ${misc:Depends}
+Depends: cli-common, libmono-corlib4.0-cil (>= 2.10) | libmono-corlib4.5-cil (>=3.2), libmono-system4.0-cil (>= 2.10), 
+    libmono-system-web4.0-cil (>= 2.10), ${misc:Depends}
 Description: CLI bindings for Thrift
  Thrift is a software framework for scalable cross-language services
  development. It combines a software stack with a code generation engine to


### PR DESCRIPTION
mono-gmcs and libmono-*1.0-cil are no more exist in supported distributions on both Ubuntu and Debian.
(Precise supports ,but we could not compile the cpp library on it.)
I have some points to talk about:
・php7.0 doesn't have complete compatibility for php5.
・cutting off java-sdk. This is a virtual package, so some build tools mistake this not installed even if installed.