### PR TITLE
THRIFT-3820 detect OTP >= 18 to use new time correction

### DIFF
--- a/lib/erl/rebar.config.script
+++ b/lib/erl/rebar.config.script
@@ -1,0 +1,7 @@
+Def0 = case not erlang:is_builtin(erlang, monotonic_time, 0) of
+           true -> [];
+           false -> [{d, time_correction}]
+       end,
+Defs = Def0,
+lists:keystore(erl_opts, 1, CONFIG,
+               {erl_opts, proplists:get_value(erl_opts, CONFIG, []) ++ Defs}).

--- a/lib/erl/src/thrift_reconnecting_client.erl
+++ b/lib/erl/src/thrift_reconnecting_client.erl
@@ -115,9 +115,9 @@ handle_call( { call, Op, Args },
              _From,
              State=#state{ client = Client } ) ->
 
-  Start = now(),
+  Timer = timer_fun(),
   Result = ( catch thrift_client:call( Client, Op, Args) ),
-  Time = timer:now_diff( now(), Start ),
+  Time = Timer(),
 
   case Result of
     { C, { ok, Reply } } ->
@@ -217,6 +217,21 @@ reconn_time( #state{ reconn_max = ReconnMax, reconn_time = R } ) ->
     false -> Backoff
   end.
 
+-ifdef(time_correction).
+timer_fun() ->
+  T1 = erlang:monotonic_time(),
+  fun() ->
+    T2 = erlang:monotonic_time(),
+    erlang:convert_time_unit(T2 - T1, native, micro_seconds)
+  end.
+-else.
+timer_fun() ->
+  T1 = erlang:now(),
+  fun() ->
+    T2 = erlang:now(),
+    timer:now_diff(T2, T1)
+  end.
+-endif.
 
 incr_stats( Op, Result, Time,
             State = #state{ op_cnt_dict  = OpCntDict,


### PR DESCRIPTION
erlang:now/0 is deprecated BIF.

See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.