### PR TITLE
THRIFT-3808 Missing `DOUBLE` in thrift type enumeration

### DIFF
--- a/lib/go/thrift/type.go
+++ b/lib/go/thrift/type.go
@@ -48,6 +48,7 @@ var typeNames = map[int]string{
 	VOID:   "VOID",
 	BOOL:   "BOOL",
 	BYTE:   "BYTE",
+	DOUBLE: "DOUBLE",
 	I16:    "I16",
 	I32:    "I32",
 	I64:    "I64",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-3808

Added `DOUBLE` thrift protocol type to enum