### PR TITLE
THRIFT-3812 Add option to prefix namespace Swift type names

### DIFF
--- a/compiler/cpp/src/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/generate/t_swift_generator.cc
@@ -1920,7 +1920,7 @@ void t_swift_generator::render_const_value(ostream& out,
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
   } else if (type->is_enum()) {
-    out << definition_name(value->get_identifier());
+    out << definition_name(value->get_identifier_with_parent());
   } else if (type->is_struct() || type->is_xception()) {
     
     out << type_name(type) << "(";

--- a/compiler/cpp/src/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/generate/t_swift_generator.cc
@@ -1920,7 +1920,14 @@ void t_swift_generator::render_const_value(ostream& out,
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
   } else if (type->is_enum()) {
-    out << definition_name(value->get_identifier_with_parent());
+    string enum_value = value->get_identifier_with_parent();
+    if (prefix_namespace_) {
+      t_program* program = type->get_program();
+      if (program) {
+        enum_value = program->get_namespace("swift") + enum_value;
+      }
+    }
+    out << enum_value;
   } else if (type->is_struct() || type->is_xception()) {
     
     out << type_name(type) << "(";


### PR DESCRIPTION
Swift does not appear to have a way to namespace things within a single pod.
This adds an option swift:prefix_namespace that will add Cocoa-style prefixes to the generated code if the file has a defined Swift namespace.

E.g. if a file has
"namespace swift ABC"
then the struct "MyStruct" will be renamed to "ABCMyStruct"
