### PR TITLE
Fix bug for php close socket

### DIFF
--- a/lib/php/lib/Thrift/Transport/TSocket.php
+++ b/lib/php/lib/Thrift/Transport/TSocket.php
@@ -248,10 +248,8 @@ class TSocket extends TTransport
    */
   public function close()
   {
-    if (!$this->persist_) {
       @fclose($this->handle_);
       $this->handle_ = null;
-    }
   }
 
   /**


### PR DESCRIPTION
php must close the socket, anyhow.
otherwise you will get previous reponse when the previous request timeout and the socket is reused.
