### PR TITLE
Update connection.js

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -121,7 +121,7 @@ var Connection = exports.Connection = function(stream, options) {
         var service_name = self.seqId2Service[header.rseqid];
         if (service_name) {
           client = self.client[service_name];
-          delete self.seqId2Service[header.rseqid];
+          //delete self.seqId2Service[header.rseqid];//gfloan001 by millerliu ,bug when more than 1 package
         }
         /*jshint -W083 */
         client._reqs[dummy_seqid] = function(err, success){


### PR DESCRIPTION
bug when more than 1 package,
eg: the second package   service_name is null but the client is similar with the first
