### PR TITLE
thrift-3841: dart compact protocol incorrectly serializes doubles

### DIFF
--- a/lib/dart/lib/src/protocol/t_compact_protocol.dart
+++ b/lib/dart/lib/src/protocol/t_compact_protocol.dart
@@ -187,7 +187,7 @@ class TCompactProtocol extends TProtocol {
 
   void writeDouble(double d) {
     if (d == null) d = 0.0;
-    tempBD.setFloat64(0, d);
+    tempBD.setFloat64(0, d, Endianness.LITTLE_ENDIAN);
     transport.write(tempBD.buffer.asUint8List(), 0, 8);
   }
 
@@ -364,7 +364,7 @@ class TCompactProtocol extends TProtocol {
 
   double readDouble() {
     transport.readAll(tempList, 0, 8);
-    return tempList.buffer.asByteData().getFloat64(0);
+    return tempList.buffer.asByteData().getFloat64(0, Endianness.LITTLE_ENDIAN);
   }
 
   String readString() {

--- a/lib/dart/lib/thrift.dart
+++ b/lib/dart/lib/thrift.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert' show Utf8Codec;
 import 'dart:typed_data' show ByteData;
+import 'dart:typed_data' show Endianness;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:crypto/crypto.dart' show CryptoUtils;


### PR DESCRIPTION
The compact protocol expects doubles to be serialized/deserialized with a little endian byte order instead of with a network (big endian) byte order. This fixes that. Tested locally by running a go server and dart client with a service containing a method that sent and received a double and making sure what was received on both ends was correct.

@markerickson-wf @tylertreat-wf @stevenosborne-wf