### PR TITLE
THRIFT-3825 Javascript test dependency is no longer available

### DIFF
--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -134,8 +134,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
       nodejs \
       nodejs-dev \
-      nodejs-legacy \
-      npm
+      nodejs-legacy
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \
@@ -184,6 +183,9 @@ RUN mkdir -p /usr/lib/haxe && \
     chmod -R 777 /usr/lib/haxe/lib && \
     haxelib setup /usr/lib/haxe/lib && \
     haxelib install hxcpp
+
+# Node.js
+RUN curl -sSL https://www.npmjs.com/install.sh | sh
 
 # D
 RUN curl -sSL http://downloads.dlang.org/releases/2.x/2.070.0/dmd_2.070.0-0_amd64.deb -o /tmp/dmd_2.070.0-0_amd64.deb && \

--- a/configure.ac
+++ b/configure.ac
@@ -730,6 +730,7 @@ AC_CONFIG_FILES([
   lib/haxe/test/Makefile
   lib/hs/Makefile
   lib/java/Makefile
+  lib/js/Makefile
   lib/js/test/Makefile
   lib/json/Makefile
   lib/json/test/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-SUBDIRS = json xml 
+SUBDIRS = json xml
 PRECROSS_TARGET =
 
 if WITH_CPP
@@ -38,7 +38,7 @@ SUBDIRS += java
 PRECROSS_TARGET += precross-java
 # JavaScript unit test depends on java
 # so test only if java, ant & co is available
-SUBDIRS += js/test
+SUBDIRS += js
 endif
 
 if WITH_PYTHON

--- a/lib/js/Gruntfile.js
+++ b/lib/js/Gruntfile.js
@@ -44,13 +44,13 @@ module.exports = function(grunt) {
         command: 'cd ../..; npm install'
       },
       ThriftGen: {
-        command: 'thrift -gen js -gen js:node -o test ../../test/ThriftTest.thrift'
+        command: '../../compiler/cpp/thrift -gen js -gen js:node -o test ../../test/ThriftTest.thrift'
       },
       ThriftGenJQ: {
-        command: 'thrift -gen js:jquery -gen js:node -o test ../../test/ThriftTest.thrift'
+        command: '../../compiler/cpp/thrift -gen js:jquery -gen js:node -o test ../../test/ThriftTest.thrift'
       },
       ThriftGenDeepConstructor: {
-        command: 'thrift -gen js -o test ../../test/JsDeepConstructorTest.thrift'
+        command: '../../compiler/cpp/thrift -gen js -o test ../../test/JsDeepConstructorTest.thrift'
       }
     },
     external_daemon: {

--- a/lib/js/Makefile.am
+++ b/lib/js/Makefile.am
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Make sure this doesn't fail if ant is not configured.
+
+SUBDIRS = test
+
+check-local: all
+	npm install
+	./node_modules/.bin/grunt
+

--- a/lib/js/package.json
+++ b/lib/js/package.json
@@ -2,13 +2,14 @@
   "name": "thrift",
   "version": "1.0.0",
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-uglify": "~0.2.2",
-    "grunt-contrib-jshint": "~0.6.3",
-    "grunt-contrib-qunit": "~0.2.2",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-jsdoc": "^0.6.0",
-    "grunt-external-daemon": "~1.1.0",
-    "grunt-shell": "~0.6.4"
+    "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-uglify": "^1.0.1",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-qunit": "^1.2.0",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-jsdoc": "^2.0.0",
+    "grunt-external-daemon": "^1.1.0",
+    "grunt-shell": "^1.3.0"
   }
 }

--- a/lib/js/test/build.xml
+++ b/lib/js/test/build.xml
@@ -94,13 +94,8 @@
 
   <target name="jslibs" depends="init, proxy">
     <get src="http://code.jquery.com/jquery-1.11.3.min.js" dest="${build}/js/lib/jquery.js" usetimestamp="true"/>
-    <get src="http://js-test-driver.googlecode.com/svn/trunk/JsTestDriver/contrib/qunit/src/equiv.js" dest="${build}/js/lib/equiv.js" usetimestamp="true"/>
-    <get src="http://js-test-driver.googlecode.com/svn/trunk/JsTestDriver/contrib/qunit/src/QUnitAdapter.js" dest="${build}/js/lib/QUnitAdapter.js" usetimestamp="true"/>
-
     <get src="http://code.jquery.com/qunit/qunit-1.18.0.js" dest="${build}/js/lib/qunit.js" usetimestamp="true"/>
     <get src="http://code.jquery.com/qunit/qunit-1.18.0.css" dest="${build}/js/lib/qunit.css" usetimestamp="true"/>
-    <!-- js-test-driver has issues with relative path...so we need a copy -->
-    <copy file="../src/thrift.js" todir="${build}/js"/>
   </target>
 
   <target name="compile" description="compile the test suite" depends="init, generate, resolve">
@@ -155,44 +150,6 @@
           <env key="DISPLAY" value=":99"/>
           <arg line="phantomjs-qunit.js http://localhost:8088/test/test.html" />
         </exec>
-      </sequential>
-    </parallel>
-  </target>
-
-  <target name="jstestdriver-server" description="start the js-test-driver server" depends="init, resolve">
-    <echo>Starting js-test-driver Server...</echo>
-    <java jar="${build}/lib/jstestdriver-1.3.5.jar" dir="." fork="true"
-            failonerror="true" output="${build}/log/jstestdriver-server.log">
-      <arg line="--port 9876"/>
-    </java>
-  </target>
-
-  <target name="jstestdriver" description="do unit tests with js-test-driver" depends="init, jstest, jslibs">
-    <parallel>
-      <java classname="test.Httpd" fork="true" timeout="10000"
-        classpathref="test.classpath" failonerror="false" output="${build}/log/unittest.log">
-        <arg value="../" />
-      </java>
-      <sequential>
-        <sleep seconds="2"/>
-        <echo>Running Unit Tests with js-test-driver</echo>
-          <java jar="${build}/lib/jstestdriver-1.3.5.jar" dir="." fork="true"
-            failonerror="true" output="${build}/log/jstestdriver.log">
-            <arg value="--config" />
-            <arg value="jsTestDriver.conf" />
-
-            <arg value="--reset" />
-            <arg value="--verbose" />
-
-            <arg value="--runnerMode" />
-            <arg value="DEBUG" />
-
-            <arg value="--tests" />
-            <arg value="all" />
-
-            <arg value="--testOutput" />
-            <arg value="${build}/test/log/" />
-        </java>
       </sequential>
     </parallel>
   </target>
@@ -257,9 +214,6 @@
       <dependency groupId="org.apache.httpcomponents" artifactId="httpclient" version="4.0.1"/>
       <dependency groupId="com.googlecode.jslint4java" artifactId="jslint4java-ant" version="1.4.6"/>
       <dependency groupId="eu.medsea.mimeutil" artifactId="mime-util" version="2.1.3"/>
-
-      <!-- get jstestdriver.jar via maven-->
-      <dependency groupId="com.googlecode.jstd-maven-plugin" artifactId="jstd-maven-plugin" version="1.3.5.1"/>
     </artifact:dependencies>
 
     <!-- Copy the dependencies to the build/lib dir -->


### PR DESCRIPTION
Apparently the code is only available as part of entire repository download (125 MB).
https://code.google.com/archive/p/js-test-driver/source/default/source

Fortunately, the same set of tests were already ported to grunt so we can safely remove affected ant jobs.