### PR TITLE
THRIFT-3850: All apache builds are failing when initiated from a github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,3 +198,4 @@ matrix:
         # System Info
         - dpkg -l
         - uname -a
+


### PR DESCRIPTION
THRIFT-3850: All apache builds are failing when initiated from a github pull request to Jenkins

Disabled jenkins jobs, added blank line to .travis.yml and triggering builds to get baseline for fixing travis.