### PR TITLE
MOD: fix the blocked bug when call Stop() twice or more

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -22,11 +22,13 @@ package thrift
 import (
 	"log"
 	"runtime/debug"
+	"sync/atomic"
 )
 
 // Simple, non-concurrent server for testing.
 type TSimpleServer struct {
-	quit chan struct{}
+	quit    chan struct{}
+	stopped int64
 
 	processorFactory       TProcessorFactory
 	serverTransport        TServerTransport
@@ -149,8 +151,10 @@ func (p *TSimpleServer) Serve() error {
 }
 
 func (p *TSimpleServer) Stop() error {
-	p.quit <- struct{}{}
-	p.serverTransport.Interrupt()
+	if atomic.CompareAndSwapInt64(&p.stopped, 0, 1) {
+		p.quit <- struct{}{}
+		p.serverTransport.Interrupt()
+	}
 	return nil
 }
 


### PR DESCRIPTION
When Stop() is called twice or more, and no new connection accepted from AcceptLoop(), the Stop() will be blocked because the quit channel is full.
Use a flag to ensure the Stop() executed only once, and no block.