### PR TITLE
THRIFT-3823: Use 'pre' HTML tag when generating non escaped documentation.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_html_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_html_generator.cc
@@ -405,7 +405,7 @@ void t_html_generator::print_doc(t_doc* tdoc) {
     if (unsafe_) {
       f_out_ << tdoc->get_doc() << "<br/>";
     } else {
-      f_out_ << escape_html(tdoc->get_doc()) << "<br/>";
+      f_out_ << "<pre>" << escape_html(tdoc->get_doc()) << "</pre><br/>";
     }
   }
 }


### PR DESCRIPTION
This allow clearer documentation and avoid adding HTML tag in the .thrift comments to generate readable HTML
