### PR TITLE
THRIFT-3859: Unix Domain Socket Support in Objective-C

### DIFF
--- a/lib/cocoa/src/server/TSocketServer.h
+++ b/lib/cocoa/src/server/TSocketServer.h
@@ -41,6 +41,10 @@ extern NSString *const TSockerServerTransportKey;
              protocolFactory:(id <TProtocolFactory>)protocolFactory
             processorFactory:(id <TProcessorFactory>)processorFactory;
 
+- (instancetype) initWithPath: (NSString *) path
+              protocolFactory: (id <TProtocolFactory>) protocolFactory
+             processorFactory: (id <TProcessorFactory>) processorFactory;
+
 @end
 
 

--- a/lib/cocoa/src/transport/TSocketTransport.h
+++ b/lib/cocoa/src/transport/TSocketTransport.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 -(id) initWithHostname:(NSString *)hostname
                   port:(int)port;
 
+-(id) initWithPath:(NSString *)path;
+
 @end
 
 


### PR DESCRIPTION
Existing behavior for port-based socket transport should be unchanged by this commit. TSocketServer and TSocketTransport have been refactored to support sockets created using either a port or a path.
