### PR TITLE
THRIFT-3476: fix missing header

### DIFF
--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -19,14 +19,15 @@
 
 #include <thrift/protocol/TJSONProtocol.h>
 
+#include <boost/lexical_cast.hpp>
+#include <boost/locale.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+#include <cmath>
 #include <limits>
 #include <locale>
 #include <sstream>
-#include <cmath>
-
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/locale.hpp>
+#include <stdexcept>
 
 #include <thrift/protocol/TBase64Utils.h>
 #include <thrift/transport/TTransportException.h>


### PR DESCRIPTION
stdexcept was missing, but std::runtime_error is used