### PR TITLE
replace 'binary' on the base types

### DIFF
--- a/compiler/cpp/src/generate/t_json_generator.cc
+++ b/compiler/cpp/src/generate/t_json_generator.cc
@@ -709,7 +709,7 @@ string t_json_generator::get_type_name(t_type* ttype) {
   }
   if (ttype->is_base_type()) {
     t_base_type* tbasetype = (t_base_type*)ttype;
-    return tbasetype->is_binary() ? "binary" : t_base_type::t_base_name(tbasetype->get_base());
+    return t_base_type::t_base_name(tbasetype->get_base());
   }
 
   return "(unknown)";


### PR DESCRIPTION
json generator creates file with "binary" type instead thrift base types. As a result, it is impossible to identify the type.