### PR TITLE
THRIFT-3874 PHP Compiler: struct definition is not populated on type classes de-serialization

### DIFF
--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -78,7 +78,7 @@ public:
       } else if( iter->first.compare("nsglobal") == 0) {
         nsglobal_ = iter->second;
       } else {
-        throw "unknown option php:" + iter->first; 
+        throw "unknown option php:" + iter->first;
       }
     }
 
@@ -122,6 +122,7 @@ public:
                                       t_struct* tstruct,
                                       bool is_xception = false,
                                       bool is_result = false);
+  void generate_php_struct_wakeup(ofstream& out);
   void generate_php_struct_reader(std::ofstream& out, t_struct* tstruct, bool is_result);
   void generate_php_struct_writer(std::ofstream& out, t_struct* tstruct, bool is_result);
   void generate_php_function_helpers(t_function* tfunction);
@@ -705,10 +706,13 @@ void t_php_generator::generate_php_type_spec(ofstream& out, t_type* t) {
  * type information to generalize serialization routines.
  */
 void t_php_generator::generate_php_struct_spec(ofstream& out, t_struct* tstruct) {
-  indent(out) << "if (!isset(self::$_TSPEC)) {" << endl;
+  indent(out) << "static protected function _tspec() {" << endl;
   indent_up();
 
-  indent(out) << "self::$_TSPEC = array(" << endl;
+  indent(out) << "if (!isset(self::$_tspec)) {" << endl;
+  indent_up();
+
+  indent(out) << "self::$_tspec = array(" << endl;
   indent_up();
 
   const vector<t_field*>& members = tstruct->get_members();
@@ -727,6 +731,28 @@ void t_php_generator::generate_php_struct_spec(ofstream& out, t_struct* tstruct)
   indent(out) << "  );" << endl;
   indent_down();
   indent(out) << "}" << endl;
+
+  indent_down();
+  indent(out) << "}" << endl;
+}
+
+/**
+ * Generates the wakeup method, which populates struct specification structure
+ * on class de-serialization
+ */
+void t_php_generator::generate_php_struct_wakeup(ofstream& out) {
+  indent(out) << "public function __wakeup() {" << endl;
+  indent_up();
+
+  indent(out) << "self::_tspec();" << endl;
+  if (oop_) {
+    indent(out) << "parent::__wakeup()" << endl;
+  } else {
+    indent(out) << "self::_tspec();" << endl;
+  }
+
+  indent_down();
+  indent(out) << "}" << endl << endl;
 }
 
 /**
@@ -772,12 +798,14 @@ void t_php_generator::generate_php_struct_definition(ofstream& out,
 
   out << endl;
 
+  generate_php_struct_wakeup(out);
+
   // Generate constructor from array
   string param = (members.size() > 0) ? "$vals=null" : "";
   out << indent() << "public function __construct(" << param << ") {" << endl;
   indent_up();
 
-  generate_php_struct_spec(out, tstruct);
+  out << indent() << "self::_tspec();" << endl;
 
   if (members.size() > 0) {
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {

--- a/compiler/cpp/src/generate/t_php_generator.cc
+++ b/compiler/cpp/src/generate/t_php_generator.cc
@@ -709,10 +709,10 @@ void t_php_generator::generate_php_struct_spec(ofstream& out, t_struct* tstruct)
   indent(out) << "static protected function _tspec() {" << endl;
   indent_up();
 
-  indent(out) << "if (!isset(self::$_tspec)) {" << endl;
+  indent(out) << "if (!isset(self::$_TSPEC)) {" << endl;
   indent_up();
 
-  indent(out) << "self::$_tspec = array(" << endl;
+  indent(out) << "self::$_TSPEC = array(" << endl;
   indent_up();
 
   const vector<t_field*>& members = tstruct->get_members();

--- a/lib/php/lib/Thrift/Base/TBase.php
+++ b/lib/php/lib/Thrift/Base/TBase.php
@@ -45,6 +45,8 @@ abstract class TBase
 
   abstract public function write($output);
 
+  abstract protected static function _tspec();
+
   public function __construct($spec=null, $vals=null)
   {
     if (is_array($spec) && is_array($vals)) {


### PR DESCRIPTION
When type class which was serialized and deserialized by internal PHP functions (for example, if data was stored to memcache and then retrieved) is used in requests, thrift_extension gives an 'Attempt to send non-Thrift object as a T_STRUCT' error.

This is because thrift_extension binary_serialize() function is tries to access to the $_TSPEC static property of object to determine it's target structure. Static $_TSPEC array for generated PHP classes is populated in __construct(). But when objects are deserialized, __construct() isn't called, instead of that PHP calls __wakeup() function. So type class should be instantiated once before sending it via Thrift.

The solution is to move code that populates $_TSPEC out of constructor to the generic function, and call this function both in __construct() and __wakeup() functions.