### PR TITLE
THRIFT-3873: fix compiler warnings on windows with VS2010

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -23,11 +23,11 @@ include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
-# If AI_ADDRCONFIG is not defined we define it as 0
-check_symbol_exists(AI_ADDRCONFIG "sys/types.h;sys/socket.h;netdb.h" HAVE_AI_ADDRCONFIG)
-if(NOT HAVE_AI_ADDRCONFIG)
-set(AI_ADDRCONFIG 1)
-endif(NOT HAVE_AI_ADDRCONFIG)
+if(MSVC)
+  check_symbol_exists(AI_ADDRCONFIG "winsock2.h" HAVE_AI_ADDRCONFIG)
+else(MSVC)
+  check_symbol_exists(AI_ADDRCONFIG "sys/types.h;sys/socket.h;netdb.h" HAVE_AI_ADDRCONFIG)
+endif(MSVC)
 
 check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_file(fcntl.h HAVE_FCNTL_H)

--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -68,6 +68,9 @@ if(MSVC)
       message (FATAL_ERROR "Windows build does not support shared library output yet, please set -DWITH_SHARED_LIB=off")
     endif()
 
+    add_definitions("/MP") # parallel build
+    add_definitions("/W3") # warning level 3
+
 elseif(UNIX)
   find_program( MEMORYCHECK_COMMAND valgrind )
   set( MEMORYCHECK_COMMAND_OPTIONS "--gen-suppressions=all --leak-check=full" )

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -45,7 +45,7 @@
 #define PACKAGE_STRING "${PACKAGE_STRING}"
 
 /* Version number of package */
-#define VERSION "${VERSION}"
+#define THRIFT_VERSION "${VERSION}"
 
 /************************** DEFINES *************************/
 

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -20,6 +20,15 @@
 # Windows has a different header
 if(MSVC)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/windows/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+    
+    # The winflexbison generator outputs some macros that conflict with the Visual Studio 2010 copy of stdint.h
+    # This might be fixed in later versions of Visual Studio, but an easy solution is to include stdint.h first
+    if(HAVE_STDINT_H)
+        add_definitions(/FI"stdint.h")
+    endif(HAVE_STDINT_H)
+
+    # The generated code also causes a size type warning we cannot work around easily
+    set_source_files_properties(thriftl.cc PROPERTIES COMPILE_FLAGS /wd4267)
 else()
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 endif()

--- a/compiler/cpp/src/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/generate/t_erl_generator.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <assert.h>
 #include <string>
 #include <fstream>
 #include <iostream>
@@ -968,10 +969,11 @@ void t_erl_generator::export_string(string name, int num) {
 }
 
 void t_erl_generator::export_types_function(t_function* tfunction, string prefix) {
-
+  t_struct::members_type::size_type num = tfunction->get_arglist()->get_members().size();
+  assert(num <= INT32_MAX);
   export_types_string(prefix + tfunction->get_name(),
                       1 // This
-                      + ((tfunction->get_arglist())->get_members()).size());
+                      + static_cast<int>(num));
 }
 
 void t_erl_generator::export_types_string(string name, int num) {
@@ -984,10 +986,11 @@ void t_erl_generator::export_types_string(string name, int num) {
 }
 
 void t_erl_generator::export_function(t_function* tfunction, string prefix) {
-
+  t_struct::members_type::size_type num = tfunction->get_arglist()->get_members().size();
+  assert(num <= INT32_MAX);
   export_string(prefix + tfunction->get_name(),
                 1 // This
-                + ((tfunction->get_arglist())->get_members()).size());
+                + static_cast<int>(num));
 }
 
 /**

--- a/compiler/cpp/src/generate/t_go_generator.cc
+++ b/compiler/cpp/src/generate/t_go_generator.cc
@@ -25,6 +25,7 @@
  * guide for ensuring uniformity and readability.
  */
 
+#include <assert.h>
 #include <string>
 #include <fstream>
 #include <iostream>
@@ -433,7 +434,9 @@ std::string t_go_generator::camelcase(const std::string& value) const {
       if (islower(value2[i + 1])) {
         value2.replace(i, 2, 1, toupper(value2[i + 1]));
       }
-      fix_common_initialism(value2, i);
+
+      assert(i <= INT32_MAX);
+      fix_common_initialism(value2, static_cast<int>(i));
     }
   }
 
@@ -2302,7 +2305,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
     f_remote << indent() << "}" << endl;
 
     for (std::vector<t_field*>::size_type i = 0; i < num_args; ++i) {
-      int flagArg = i + 1;
+      std::vector<t_field*>::size_type flagArg = i + 1;
       t_type* the_type(args[i]->get_type());
       t_type* the_type2(get_true_type(the_type));
 

--- a/lib/cpp/src/thrift/protocol/THeaderProtocol.h
+++ b/lib/cpp/src/thrift/protocol/THeaderProtocol.h
@@ -46,7 +46,7 @@ public:
   explicit THeaderProtocol(const boost::shared_ptr<TTransport>& trans,
                            uint16_t protoId = T_COMPACT_PROTOCOL)
     : TVirtualProtocol<THeaderProtocol>(boost::shared_ptr<TTransport>(new THeaderTransport(trans))),
-      trans_(boost::dynamic_pointer_cast<THeaderTransport>(this->getTransport())),
+      trans_(boost::dynamic_pointer_cast<THeaderTransport>(getTransport())),
       protoId_(protoId) {
     trans_->setProtocolId(protoId);
     resetProtocol();
@@ -57,7 +57,7 @@ public:
                   uint16_t protoId = T_COMPACT_PROTOCOL)
     : TVirtualProtocol<THeaderProtocol>(
           boost::shared_ptr<TTransport>(new THeaderTransport(inTrans, outTrans))),
-      trans_(boost::dynamic_pointer_cast<THeaderTransport>(this->getTransport())),
+      trans_(boost::dynamic_pointer_cast<THeaderTransport>(getTransport())),
       protoId_(protoId) {
     trans_->setProtocolId(protoId);
     resetProtocol();

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -523,7 +523,7 @@ namespace {
 std::string doubleToString(double d) {
   std::ostringstream str;
   str.imbue(std::locale::classic());
-  const double max_digits10 = 2 + std::numeric_limits<double>::digits10;
+  const std::streamsize max_digits10 = 2 + std::numeric_limits<double>::digits10;
   str.precision(max_digits10);
   str << d;
   return str.str();

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -135,8 +135,9 @@ public:
   void transform(uint8_t* ptr, uint32_t sz);
 
   uint16_t getNumTransforms() const {
-    int trans = writeTrans_.size();
-    return trans;
+    std::vector<uint16_t>::size_type trans = writeTrans_.size();
+    assert(trans <= UINT16_MAX);
+    return static_cast<uint16_t>(trans);
   }
 
   void setTransform(uint16_t transId) { writeTrans_.push_back(transId); }
@@ -204,7 +205,7 @@ protected:
   /**
    * Returns the maximum number of bytes that write k/v headers can take
    */
-  size_t getMaxWriteHeadersSize() const;
+  uint32_t getMaxWriteHeadersSize() const;
 
   struct infoIdType {
     enum idType {

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 
+#include <thrift/config.h>
 #include <thrift/transport/THttpClient.h>
 #include <thrift/transport/TSocket.h>
 
@@ -102,7 +103,7 @@ void THttpClient::flush() {
   std::ostringstream h;
   h << "POST " << path_ << " HTTP/1.1" << CRLF << "Host: " << host_ << CRLF
     << "Content-Type: application/x-thrift" << CRLF << "Content-Length: " << len << CRLF
-    << "Accept: application/x-thrift" << CRLF << "User-Agent: Thrift/" << VERSION
+    << "Accept: application/x-thrift" << CRLF << "User-Agent: Thrift/" << THRIFT_VERSION
     << " (C++/THttpClient)" << CRLF << CRLF;
   string header = h.str();
 

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <iostream>
 
+#include <thrift/config.h>
 #include <thrift/transport/THttpServer.h>
 #include <thrift/transport/TSocket.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
@@ -124,7 +125,7 @@ void THttpServer::flush() {
   // Construct the HTTP header
   std::ostringstream h;
   h << "HTTP/1.1 200 OK" << CRLF << "Date: " << getTimeRFC1123() << CRLF << "Server: Thrift/"
-    << VERSION << CRLF << "Access-Control-Allow-Origin: *" << CRLF
+    << THRIFT_VERSION << CRLF << "Access-Control-Allow-Origin: *" << CRLF
     << "Content-Type: application/x-thrift" << CRLF << "Content-Length: " << len << CRLF
     << "Connection: Keep-Alive" << CRLF << CRLF;
   string header = h.str();

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -60,7 +60,7 @@
 #endif // _WIN32
 #endif
 
-#if defined(_WIN32) && (_WIN32_WINNT < 0x0600)
+#if defined(_WIN32) && (_WIN32_WINNT < 0x0600) && !defined(AI_ADDRCONFIG)
   #define AI_ADDRCONFIG 0x0400
 #endif
 

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -53,7 +53,7 @@
 #endif // _WIN32
 #endif
 
-#if defined(_WIN32) && (_WIN32_WINNT < 0x0600)
+#if defined(_WIN32) && (_WIN32_WINNT < 0x0600) && !defined(AI_ADDRCONFIG)
   #define AI_ADDRCONFIG 0x0400
 #endif
 

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -262,8 +262,10 @@ BOOST_AUTO_TEST_CASE(test_json_proto_8) {
   ":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2,3]},\"14\":{\"lst\":[\"i64"
   "\",3,1,2,3]}}";
 
+  size_t bufSiz = strlen(json_string)*sizeof(char);
+  assert(bufSiz <= UINT32_MAX);
   boost::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(
-    (uint8_t*)(json_string), strlen(json_string)*sizeof(char)));
+    (uint8_t*)(json_string), static_cast<uint32_t>(bufSiz)));
   boost::shared_ptr<TJSONProtocol> proto(new TJSONProtocol(buffer));
 
   OneOfEach ooe2;

--- a/lib/cpp/test/TFileTransportTest.cpp
+++ b/lib/cpp/test/TFileTransportTest.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(test_destructor) {
 
   unsigned int num_over = 0;
   for (unsigned int n = 0; n < NUM_ITERATIONS; ++n) {
-    ftruncate(f.getFD(), 0);
+    BOOST_CHECK_EQUAL(0, ftruncate(f.getFD(), 0));
 
     TFileTransport* transport = new TFileTransport(f.getPath());
 

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -23,7 +23,15 @@
 #define _GNU_SOURCE // needed for getopt_long
 #endif
 
+#if (_MSC_VER <= 1700)
+// polynomial and std::fill_t warning happens in MSVC 2010, 2013, maybe others
+// https://svn.boost.org/trac/boost/ticket/11426
+#pragma warning(disable:4996)
+#endif
+
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
+#endif
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif

--- a/lib/cpp/test/concurrency/Tests.cpp
+++ b/lib/cpp/test/concurrency/Tests.cpp
@@ -45,25 +45,25 @@ int main(int argc, char** argv) {
 
     std::cout << "ThreadFactory tests..." << std::endl;
 
-    size_t count = 1000;
+    int count = 1000;
     size_t floodLoops = 1;
     size_t floodCount = 100000;
 
     std::cout << "\t\tThreadFactory reap N threads test: N = " << count << std::endl;
 
-    assert(threadFactoryTests.reapNThreads(count));
+    threadFactoryTests.reapNThreads(count);				// throws if something goes wrong
 
     std::cout << "\t\tThreadFactory floodN threads test: N = " << floodCount << std::endl;
 
-    assert(threadFactoryTests.floodNTest(floodLoops, floodCount));
+    if (!threadFactoryTests.floodNTest(floodLoops, floodCount)) { exit(1); }
 
     std::cout << "\t\tThreadFactory synchronous start test" << std::endl;
 
-    assert(threadFactoryTests.synchStartTest());
+    threadFactoryTests.synchStartTest();				// throws if something goes wrong
 
     std::cout << "\t\tThreadFactory monitor timeout test" << std::endl;
 
-    assert(threadFactoryTests.monitorTimeoutTest());
+    if (!threadFactoryTests.monitorTimeoutTest()) { exit(1); }
   }
 
   if (runAll || args[0].compare("util") == 0) {
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
 
     TimerManagerTests timerManagerTests;
 
-    assert(timerManagerTests.test00());
+    timerManagerTests.test00();		// throws if something goes wrong
   }
 
   if (runAll || args[0].compare("thread-manager") == 0) {
@@ -117,12 +117,12 @@ int main(int argc, char** argv) {
 
       ThreadManagerTests threadManagerTests;
 
-      assert(threadManagerTests.loadTest(taskCount, delay, workerCount));
+      if (!threadManagerTests.loadTest(taskCount, delay, workerCount)) { std::cerr << "loadTest returned false" << std::endl << std::flush; exit(1); }
 
       std::cout << "\t\tThreadManager block test: worker count: " << workerCount
                 << " delay: " << delay << std::endl;
 
-      assert(threadManagerTests.blockTest(delay, workerCount));
+      if (!threadManagerTests.blockTest(delay, workerCount)) { std::cerr << "blockTest returned false" << std::endl << std::flush; exit(1); }
     }
   }
 

--- a/lib/cpp/test/concurrency/ThreadFactoryTests.h
+++ b/lib/cpp/test/concurrency/ThreadFactoryTests.h
@@ -23,7 +23,6 @@
 #include <thrift/concurrency/Monitor.h>
 #include <thrift/concurrency/Util.h>
 
-#include <assert.h>
 #include <iostream>
 #include <set>
 
@@ -98,7 +97,7 @@ public:
     int& _count;
   };
 
-  bool reapNThreads(int loop = 1, int count = 10) {
+  void reapNThreads(int loop = 1, int count = 10) {
 
     PlatformThreadFactory threadFactory = PlatformThreadFactory();
 
@@ -148,8 +147,6 @@ public:
     }
 
     std::cout << "\t\t\tSuccess!" << std::endl;
-
-    return true;
   }
 
   class SynchStartTask : public Runnable {
@@ -186,7 +183,7 @@ public:
     volatile STATE& _state;
   };
 
-  bool synchStartTest() {
+  void synchStartTest() {
 
     Monitor monitor;
 
@@ -213,7 +210,7 @@ public:
       }
     }
 
-    assert(state != SynchStartTask::STARTING);
+    if (state == SynchStartTask::STARTING) { std::cerr << "state = STARTING and should not" << std::endl << std::flush; exit(1); }
 
     {
       Synchronized s(monitor);
@@ -235,13 +232,7 @@ public:
       }
     }
 
-    assert(state == SynchStartTask::STOPPED);
-
-    bool success = true;
-
-    std::cout << "\t\t\t" << (success ? "Success" : "Failure") << "!" << std::endl;
-
-    return true;
+    if (state != SynchStartTask::STOPPED) { std::cerr << "state = " << static_cast<int>(state) << " and should be STOPPED (4)" << std::endl << std::flush; exit(1); }
   }
 
   /** See how accurate monitor timeout is. */


### PR DESCRIPTION
Also fixed: concurrency tests were using assert() in a bad way limiting them to debug builds only
Also fixed: changed config.h VERSION to THRIFT_VERSION to avoid conflicts with windows or third party headers

With this pull request in a CMake build on Windows VS2010 or on Linux (Ubuntu 14.04) the C++ code compiles clean with /W3 level warnings enabled.