### PR TITLE
THRIFT-3876 haxe js/nodejs client

### DIFF
--- a/lib/haxe/README.md
+++ b/lib/haxe/README.md
@@ -36,6 +36,7 @@ enter the following commands after installing Haxe:
     haxelib install hxcpp
     haxelib install hxjava
     haxelib install hxcs
+    haxelib install hxnodejs
 
 For other targets, please consult the Haxe documentation whether or not any additional
 target libraries need to be installed and how to achieve this.
@@ -95,6 +96,7 @@ Current status
 ========================
 - tested with Haxe C++ target
 - tested with Haxe PHP target (console/web server, binary protocols)
+- tested with Haxe Javascript target (node/webjs, client only, json/binary over HTTP)
 - transports: Socket, HTTP (servers run inside PHP server/PHP target only), Stream
 - protocols: Binary, JSON, Multiplex, Compact
 - tutorial client and server available
@@ -113,9 +115,6 @@ Known restrictions
 
 Although designed with maximum portability in mind, for technical reasons some platforms
 may only support parts of the library, or not be compatible at all.
-
-Javascript:
-- tutorial fails to build because of unsupported Sys.args
 
 PHP HTTP Server notes
 ========================
@@ -161,4 +160,10 @@ transport =	new TWrappingServerTransport(
 var server = new TSimpleServer( processor, transport, transfactory, protfactory);
 server.runOnce = true;
 ```
+
+Javascript notes
+========================
+
+- non async HTTP requests are used (for Node.js every request is run in separate process and ~20x slower over javascript in browser)
+- tutorial for js uses PHP server. Please check details at [README](../../tutorial/haxe/README.md)
 

--- a/lib/haxe/src/org/apache/thrift/helper/BitConverter.hx
+++ b/lib/haxe/src/org/apache/thrift/helper/BitConverter.hx
@@ -136,15 +136,18 @@ class BitConverter {
         TestPair( 1.2345678901234569E+000,  Int64.make(cast(0x3FF3C0CA,Int),cast(0x428C59FC,Int)));
         TestPair( 1.2345678901234569E+150,  Int64.make(cast(0x5F182344,Int),cast(0xCD3CDF9F,Int)));
         TestPair( 1.2345678901234569E+300,  Int64.make(cast(0x7E3D7EE8,Int),cast(0xBCBBD352,Int)));
+        TestPair( 0.0000000000000000E+000,  Int64.make(cast(0x00000000,Int),cast(0x00000000,Int)));
+        
+        #if !js //js doesn't support values over 2^52
         TestPair( -1.7976931348623157E+308, Int64.make(cast(0xFFEFFFFF,Int),cast(0xFFFFFFFF,Int)));
         TestPair( 1.7976931348623157E+308,  Int64.make(cast(0x7FEFFFFF,Int),cast(0xFFFFFFFF,Int)));
         TestPair( 4.9406564584124654E-324,  Int64.make(cast(0x00000000,Int),cast(0x00000001,Int)));
-        TestPair( 0.0000000000000000E+000,  Int64.make(cast(0x00000000,Int),cast(0x00000000,Int)));
         TestPair( 4.94065645841247E-324,    Int64.make(cast(0x00000000,Int),cast(0x00000001,Int)));
         TestPair( 3.2378592100206092E-319,  Int64.make(cast(0x00000000,Int),cast(0x0000FFFF,Int)));
         TestPair( 1.3906711615669959E-309,  Int64.make(cast(0x0000FFFF,Int),cast(0xFFFFFFFF,Int)));
         TestPair( Math.NEGATIVE_INFINITY,   Int64.make(cast(0xFFF00000,Int),cast(0x00000000,Int)));
         TestPair( Math.POSITIVE_INFINITY,   Int64.make(cast(0x7FF00000,Int),cast(0x00000000,Int)));
+        #end
 
         // NaN is special
         var i64nan = DoubleToInt64Bits( Math.NaN);
@@ -152,6 +155,7 @@ class BitConverter {
         if ( ! Math.isNaN( Int64BitsToDouble( i64cmp)))
             throw 'BitConverter NaN-Test #1: expected NaN';
 
+        #if !js //js doesn't support values over 2^52
         // For doubles, a quiet NaN is a bit pattern
         // between 7FF8000000000000 and 7FFFFFFFFFFFFFFF
         //      or FFF8000000000000 and FFFFFFFFFFFFFFFF
@@ -163,6 +167,7 @@ class BitConverter {
         var ok2 =  (Int64.compare( min2, i64nan) <= 0) && (Int64.compare( i64nan, max2) <= 0);
         if( ! (ok1 || ok2))
             throw 'BitConverter NaN-Test #2: failed';
+        #end
     }
     #end
 

--- a/lib/haxe/src/org/apache/thrift/transport/TFileStream.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TFileStream.hx
@@ -125,7 +125,7 @@ class TFileStream implements TStream {
         var copyJsBuf = new js.node.Buffer(count);
         bytesRead = Fs.readSync(Input, copyJsBuf, 0, count, lastInputOffset);
         if(bytesRead > 0) {
-			lastInputOffset += bytesRead;
+            lastInputOffset += bytesRead;
             var readBuf = copyJsBuf.hxToBytes();
             buf.blit(offset, readBuf, 0, bytesRead);
         }

--- a/lib/haxe/src/org/apache/thrift/transport/TFileStream.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TFileStream.hx
@@ -24,6 +24,9 @@ import haxe.io.BytesBuffer;
 import haxe.io.Input;
 import haxe.io.Output;
 
+#if js
+import js.node.Fs;
+#end
 
 enum TFileMode {
     CreateNew;
@@ -36,8 +39,14 @@ class TFileStream implements TStream {
 
     public var FileName(default,null) : String;
 
+    #if !js
     private var Input  : sys.io.FileInput;
     private var Output : sys.io.FileOutput;
+    #else
+    private var Input  : Null<Int>;
+    private var Output  : Null<Int>;
+    private var lastInputOffset : Int = 0;
+    #end
 
 
     public function new( fname : String, mode : TFileMode) {
@@ -45,13 +54,25 @@ class TFileStream implements TStream {
         switch ( mode)
         {
             case TFileMode.CreateNew:
+                #if !js
                 Output = sys.io.File.write( fname, true);
+                #else
+                Output = Fs.openSync(fname, WriteCreate);
+                #end
 
             case TFileMode.Append:
+                #if !js
                 Output = sys.io.File.append( fname, true);
+                #else
+                Output = Fs.openSync(fname, AppendCreate);
+                #end
 
             case TFileMode.Read:
+                #if !js
                 Input = sys.io.File.read( fname, true);
+                #else
+                Input = Fs.openSync(fname, js.node.FsOpenFlag.Read);
+                #end
 
             default:
                 throw new TTransportException( TTransportException.UNKNOWN,
@@ -62,11 +83,19 @@ class TFileStream implements TStream {
 
     public function Close() : Void {
         if( Input != null) {
+            #if !js
             Input.close();
+            #else
+            Fs.closeSync(Input);
+            #end
             Input = null;
         }
         if( Output != null) {
+            #if !js
             Output.close();
+            #else
+            Fs.closeSync(Output);
+            #end
             Output = null;
         }
     }
@@ -75,26 +104,55 @@ class TFileStream implements TStream {
         if( Input == null)
             throw new TTransportException( TTransportException.NOT_OPEN, "File not open for input");
 
+        #if !js
         return (! Input.eof());
+        #else
+        var bytesRead = 0;
+        var copyBuf = new js.node.Buffer(1);
+        return ((bytesRead = Fs.readSync(Input, copyBuf, 0, 1, lastInputOffset)) > 0);
+        #end
+        
     }
 
     public function Read( buf : Bytes, offset : Int, count : Int) : Int {
         if( Input == null)
             throw new TTransportException( TTransportException.NOT_OPEN, "File not open for input");
 
+        #if !js
         return Input.readBytes( buf, offset, count);
+        #else
+        var bytesRead = 0;
+        var copyJsBuf = new js.node.Buffer(count);
+        bytesRead = Fs.readSync(Input, copyJsBuf, 0, count, lastInputOffset);
+        if(bytesRead > 0) {
+			lastInputOffset += bytesRead;
+            var readBuf = copyJsBuf.hxToBytes();
+            buf.blit(offset, readBuf, 0, bytesRead);
+        }
+        return bytesRead;
+        #end
     }
 
     public function Write( buf : Bytes, offset : Int, count : Int) : Void {
         if( Output == null)
             throw new TTransportException( TTransportException.NOT_OPEN, "File not open for output");
 
+        #if !js
         Output.writeBytes( buf, offset, count);
+        #else
+        var writeBuf = js.node.buffer.Buffer.hxFromBytes(buf);
+        Fs.writeSync(Output, writeBuf, offset, count);
+        #end
     }
 
     public function Flush() : Void {
-        if( Output != null)
+        if( Output != null) {
+            #if !js
             Output.flush();
+            #else
+            Fs.fsyncSync(Output);
+            #end
+        }
     }
 
 }

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -43,7 +43,10 @@ class THttpClient extends TTransport {
 
 
     public function new( requestUrl : String) : Void {
-          request_ = new Http(requestUrl);
+        request_ = new Http(requestUrl);
+        #if js
+        request_.async = false;
+        #end
         request_.addHeader( "contentType", "application/x-thrift");
     }
 

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -288,6 +288,9 @@ class JsHttp extends Http {
                 + ": value;"
             + "});";
             sendCode += "req.write(dataObj);";
+			headersCode += 'req.setHeader("Content-Length",${data.length});';
+        } else {
+			headersCode += 'req.setHeader("Content-Length", 0);';
         }
 
         var responseEncoding = 'binary';
@@ -333,9 +336,13 @@ class JsHttp extends Http {
         if (resp.err != null) {
             this.onError(resp.errorMessage);
         } else {
-            var responseBuffer = haxe.Json.parse(resp.data.text);
-            var buffer = new js.node.buffer.Buffer(responseBuffer.data);
-            this.onBinaryData(buffer.hxToBytes());
+            if(resp.data.text != '') {
+                var responseBuffer = haxe.Json.parse(resp.data.text);
+                var buffer = new js.node.buffer.Buffer(responseBuffer.data);
+                this.onBinaryData(buffer.hxToBytes());
+            } else {
+                this.onBinaryData(Bytes.alloc(0));
+            }
         }
     }
     #end

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -62,7 +62,9 @@ class THttpClient extends TTransport {
         #end
         request_.addHeader("Content-Type", "application/x-thrift");
         request_.addHeader("Accept", "application/x-thrift");
+        #if !(js && !nodejs)
         request_.addHeader("User-Agent", "Haxe/THttpClient");
+        #end
     }
 
 
@@ -238,7 +240,7 @@ class JsHttp extends Http {
 			r.setRequestHeader(h.header,h.value);
 
 		if( jsData != null ) {
-            r.send(jsData.getData());
+            r.send(new js.html.Uint8Array(jsData.getData()));
         } else {
             r.send(uri);
         }

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -39,15 +39,21 @@ class THttpClient extends TTransport {
     private var requestBuffer_  : BytesOutput = new BytesOutput();
     private var responseBuffer_ : BytesInput = null;
 
+    #if !js
     private var request_        : Http = null;
+    #else
+    private var request_        : JsHttp = null;
+    #end
 
 
     public function new( requestUrl : String) : Void {
+        #if !js
         request_ = new Http(requestUrl);
-        #if js
+        #else
+        request_ = new JsHttp(requestUrl);
         request_.async = false;
         #end
-        request_.addHeader( "contentType", "application/x-thrift");
+        request_.addHeader( "Content-Type", "application/x-thrift");
     }
 
 
@@ -97,10 +103,167 @@ class THttpClient extends TTransport {
             }
         };
 
+        #if js
+        request_.onBinaryData = function(data : Bytes) {
+            responseBuffer_ = new BytesInput(data);
+            if( callback != null) {
+                callback(null);
+            }
+        };
+
+        request_.setBinaryPostData(buffer.getBytes());
+        #else
         request_.setPostData(buffer.getBytes().toString());
+        #end
         request_.request(true/*POST*/);
     }
-
 }
 
+#if js
+/*supports sending/receiving binary data (browser) 
+  and removes dependency on browser (for node) 
+  implemented atop https://github.com/HaxeFoundation/haxe/blob/development/std/haxe/Http.hx
+  */
+class JsHttp extends Http {
+    var binaryPostData : Bytes;
+
+	public function setBinaryPostData( data : Bytes ):Http {
+		binaryPostData = data;
+		return this;
+	}
+
+    public dynamic function onBinaryData( data : Bytes ) {
+    }
+
+	public override function request( ?post : Bool ) : Void {
+		var me = this;
+		me.responseData = null;
+		var r = req = js.Browser.createXMLHttpRequest();
+		var onreadystatechange = function(_) {
+			if( r.readyState != 4 )
+				return;
+			var s = try r.status catch( e : Dynamic ) null;
+            #if !nodejs
+			if ( s != null && untyped __js__('"undefined" !== typeof window') ) {
+				// If the request is local and we have data: assume a success (jQuery approach):
+                var protocol = js.Browser.location.protocol.toLowerCase();
+				var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;
+				var isLocal = rlocalProtocol.match( protocol );
+				if ( isLocal ) {
+					s = r.responseText != null ? 200 : 404;
+				}
+			}
+            #end
+			if( s == untyped __js__("undefined") )
+				s = null;
+			if( s != null )
+				me.onStatus(s);
+			if( s != null && s >= 200 && s < 400 ) {
+				me.req = null;
+                //trace(r.response);
+                //trace(r.responseText);
+                var len = r.responseText.length;
+                //trace(len);
+                var bytes = new BytesOutput();
+                bytes.prepare(len);
+                for(i in 0 ... len) {
+                    var byte = (r.responseText.charCodeAt(i) & 255);
+                    if(byte >= 128) {
+                        byte -= 256;
+                    }
+                    //trace(byte);
+                    bytes.writeInt8(byte);
+                }
+                //bytes.writeString(r.responseText);
+                /* 
+                var arrayBuff = new js.html.ArrayBuffer(r.response);
+                trace(arrayBuff.byteLength);
+                var resBytes = Bytes.ofData(arrayBuff);
+                 */
+                var resBytes = bytes.getBytes();
+                //trace(resBytes.length);
+				me.onBinaryData(resBytes);
+				//me.onData(me.responseData = r.responseText);
+			}
+			else if ( s == null ) {
+				me.req = null;
+				me.onError("Failed to connect or resolve host");
+			}
+			else switch( s ) {
+			case 12029:
+				me.req = null;
+				me.onError("Failed to connect to host");
+			case 12007:
+				me.req = null;
+				me.onError("Unknown host");
+			default:
+				me.req = null;
+				me.responseData = r.responseText;
+				me.onError("Http Error #"+r.status);
+			}
+		};
+		if( async )
+			r.onreadystatechange = onreadystatechange;
+		var uri = postData;
+		var jsData = binaryPostData;
+		if( jsData != null )
+			post = true;
+		else for( p in params ) {
+			if( uri == null )
+				uri = "";
+			else
+				uri += "&";
+			uri += StringTools.urlEncode(p.param)+"="+StringTools.urlEncode(p.value);
+		}
+		try {
+			if( post )
+				r.open("POST",url,async);
+			else if( uri != null ) {
+				var question = url.split("?").length <= 1;
+				r.open("GET",url+(if( question ) "?" else "&")+uri,async);
+				uri = null;
+			} else
+				r.open("GET",url,async);
+		} catch( e : Dynamic ) {
+			me.req = null;
+			onError(e.toString());
+			return;
+		}
+
+        //XHR binary charset opt by Marcus Granado 2006 [http://mgran.blogspot.com]
+        #if !nodejs
+        req.overrideMimeType("text\\/plain; charset=x-user-defined");
+        #end
+
+        #if (haxe_ver >= 3.3)
+		r.withCredentials = me.withCredentials;
+        #end
+		if( !Lambda.exists(headers, function(h) return h.header == "Content-Type") && post && postData == null )
+			r.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
+
+		for( h in headers )
+			r.setRequestHeader(h.header,h.value);
+
+		if( jsData != null ) {
+            //r.responseType = js.html.XMLHttpRequestResponseType.ARRAYBUFFER;
+            //trace(jsData.length);
+            //trace(jsData.toString());
+            #if !nodejs
+            //var arrayBuffer = new js.html.ArrayBuffer(jsData.length);
+            //var bytesArray = new js.html.Uint8Array(arrayBuffer);
+            //r.send(arrayBuffer);
+            //r.send(new js.html.Blob([jsData.toString()], {type: 'text/plain'}));
+            r.send(jsData.getData());
+            #else
+            r.send(jsData.toString());
+            #end
+        } else {
+            r.send(uri);
+        }
+
+		if( !async )
+			onreadystatechange(null);
+    }
+}
+#end
     

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -53,7 +53,9 @@ class THttpClient extends TTransport {
         request_ = new JsHttp(requestUrl);
         request_.async = false;
         #end
-        request_.addHeader( "Content-Type", "application/x-thrift");
+        request_.addHeader("Content-Type", "application/x-thrift");
+        request_.addHeader("Accept", "application/x-thrift");
+        request_.addHeader("User-Agent", "Haxe/THttpClient");
     }
 
 
@@ -233,6 +235,8 @@ class JsHttp extends Http {
         //XHR binary charset opt by Marcus Granado 2006 [http://mgran.blogspot.com]
         #if !nodejs
         req.overrideMimeType("text\\/plain; charset=x-user-defined");
+        #else
+        untyped __js__('{0}.setResponseEncoding("binary");', req);
         #end
 
         #if (haxe_ver >= 3.3)
@@ -247,7 +251,7 @@ class JsHttp extends Http {
 		if( jsData != null ) {
             //r.responseType = js.html.XMLHttpRequestResponseType.ARRAYBUFFER;
             //trace(jsData.length);
-            //trace(jsData.toString());
+            //trace(jsData.toString().length);
             #if !nodejs
             //var arrayBuffer = new js.html.ArrayBuffer(jsData.length);
             //var bytesArray = new js.html.Uint8Array(arrayBuffer);
@@ -255,7 +259,26 @@ class JsHttp extends Http {
             //r.send(new js.html.Blob([jsData.toString()], {type: 'text/plain'}));
             r.send(jsData.getData());
             #else
-            r.send(jsData.toString());
+            /* 
+            var hexString = '';
+            for(i in 0 ... jsData.length) {
+                hexString += String.fromCharCode(jsData.get(i)); //'\\0x' + StringTools.hex(jsData.get(i), 2);
+            }
+            r.send(hexString);
+            */
+            var buf = js.node.buffer.Buffer.hxFromBytes(jsData);
+            //trace(untyped __typeof__(buf));
+            r.send(buf);
+            //var arr = buf.subarray(0, jsData.length);
+            //trace(untyped __typeof__(arr));
+            //r.send(arr);
+            //var binString = buf.toString('binary');
+            //trace(binString.length);
+            //r.send(binString);
+            //var arrayBuff = new js.html.ArrayBuffer(binString);
+
+            //r.send(jsData.toString());
+            //r.send(jsData.toHex());
             #end
         } else {
             r.send(uri);

--- a/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/THttpClient.hx
@@ -137,38 +137,38 @@ class THttpClient extends TTransport {
 class JsHttp extends Http {
     var binaryPostData : Bytes;
 
-	public function setBinaryPostData( data : Bytes ):Http {
-		binaryPostData = data;
-		return this;
-	}
+    public function setBinaryPostData( data : Bytes ):Http {
+        binaryPostData = data;
+        return this;
+    }
 
     public dynamic function onBinaryData( data : Bytes ) {
     }
 
     #if !nodejs
-	public override function request( ?post : Bool ) : Void {
-		var me = this;
-		me.responseData = null;
-		var r = req = js.Browser.createXMLHttpRequest();
-		var onreadystatechange = function(_) {
-			if( r.readyState != 4 )
-				return;
-			var s = try r.status catch( e : Dynamic ) null;
-			if ( s != null && untyped __js__('"undefined" !== typeof window') ) {
-				// If the request is local and we have data: assume a success (jQuery approach):
+    public override function request( ?post : Bool ) : Void {
+        var me = this;
+        me.responseData = null;
+        var r = req = js.Browser.createXMLHttpRequest();
+        var onreadystatechange = function(_) {
+            if( r.readyState != 4 )
+                return;
+            var s = try r.status catch( e : Dynamic ) null;
+            if ( s != null && untyped __js__('"undefined" !== typeof window') ) {
+                // If the request is local and we have data: assume a success (jQuery approach):
                 var protocol = js.Browser.location.protocol.toLowerCase();
-				var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;
-				var isLocal = rlocalProtocol.match( protocol );
-				if ( isLocal ) {
-					s = r.responseText != null ? 200 : 404;
-				}
-			}
-			if( s == untyped __js__("undefined") )
-				s = null;
-			if( s != null )
-				me.onStatus(s);
-			if( s != null && s >= 200 && s < 400 ) {
-				me.req = null;
+                var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;
+                var isLocal = rlocalProtocol.match( protocol );
+                if ( isLocal ) {
+                    s = r.responseText != null ? 200 : 404;
+                }
+            }
+            if( s == untyped __js__("undefined") )
+                s = null;
+            if( s != null )
+                me.onStatus(s);
+            if( s != null && s >= 200 && s < 400 ) {
+                me.req = null;
                 var len = r.responseText.length;
                 var bytes = new BytesOutput();
                 bytes.prepare(len);
@@ -180,89 +180,89 @@ class JsHttp extends Http {
                     bytes.writeInt8(byte);
                 }
                 var resBytes = bytes.getBytes();
-				me.onBinaryData(resBytes);
-			}
-			else if ( s == null ) {
-				me.req = null;
-				me.onError("Failed to connect or resolve host");
-			}
-			else switch( s ) {
-			case 12029:
-				me.req = null;
-				me.onError("Failed to connect to host");
-			case 12007:
-				me.req = null;
-				me.onError("Unknown host");
-			default:
-				me.req = null;
-				me.responseData = r.responseText;
-				me.onError("Http Error #"+r.status);
-			}
-		};
-		if( async )
-			r.onreadystatechange = onreadystatechange;
-		var uri = postData;
-		var jsData = binaryPostData;
-		if( jsData != null )
-			post = true;
-		else for( p in params ) {
-			if( uri == null )
-				uri = "";
-			else
-				uri += "&";
-			uri += StringTools.urlEncode(p.param)+"="+StringTools.urlEncode(p.value);
-		}
-		try {
-			if( post )
-				r.open("POST",url,async);
-			else if( uri != null ) {
-				var question = url.split("?").length <= 1;
-				r.open("GET",url+(if( question ) "?" else "&")+uri,async);
-				uri = null;
-			} else
-				r.open("GET",url,async);
-		} catch( e : Dynamic ) {
-			me.req = null;
-			onError(e.toString());
-			return;
-		}
+                me.onBinaryData(resBytes);
+            }
+            else if ( s == null ) {
+                me.req = null;
+                me.onError("Failed to connect or resolve host");
+            }
+            else switch( s ) {
+            case 12029:
+                me.req = null;
+                me.onError("Failed to connect to host");
+            case 12007:
+                me.req = null;
+                me.onError("Unknown host");
+            default:
+                me.req = null;
+                me.responseData = r.responseText;
+                me.onError("Http Error #"+r.status);
+            }
+        };
+        if( async )
+            r.onreadystatechange = onreadystatechange;
+        var uri = postData;
+        var jsData = binaryPostData;
+        if( jsData != null )
+            post = true;
+        else for( p in params ) {
+            if( uri == null )
+                uri = "";
+            else
+                uri += "&";
+            uri += StringTools.urlEncode(p.param)+"="+StringTools.urlEncode(p.value);
+        }
+        try {
+            if( post )
+                r.open("POST",url,async);
+            else if( uri != null ) {
+                var question = url.split("?").length <= 1;
+                r.open("GET",url+(if( question ) "?" else "&")+uri,async);
+                uri = null;
+            } else
+                r.open("GET",url,async);
+        } catch( e : Dynamic ) {
+            me.req = null;
+            onError(e.toString());
+            return;
+        }
 
         //XHR binary charset opt by Marcus Granado 2006 [http://mgran.blogspot.com]
         req.overrideMimeType("text\\/plain; charset=x-user-defined");
 
         #if (haxe_ver >= 3.3)
-		r.withCredentials = me.withCredentials;
+        r.withCredentials = me.withCredentials;
         #end
-		if( !Lambda.exists(headers, function(h) return h.header == "Content-Type") && post && postData == null )
-			r.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
+        if( !Lambda.exists(headers, function(h) return h.header == "Content-Type") && post && postData == null )
+            r.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
 
-		for( h in headers )
-			r.setRequestHeader(h.header,h.value);
+        for( h in headers )
+            r.setRequestHeader(h.header,h.value);
 
-		if( jsData != null ) {
+        if( jsData != null ) {
             r.send(new js.html.Uint8Array(jsData.getData()));
         } else {
             r.send(uri);
         }
 
-		if( !async )
-			onreadystatechange(null);
+        if( !async )
+            onreadystatechange(null);
     }
     #elseif nodejs
-	public override function request( ?post : Bool ) : Void {
+    public override function request( ?post : Bool ) : Void {
 
         var url_regexp = ~/^(https?:\/\/)?([a-zA-Z\.0-9_-]+)(:[0-9]+)?(.*)$/;
-		if( !url_regexp.match(url) ) {
-			onError("Invalid URL");
-			return;
-		}
-		var ssl = (url_regexp.matched(1) == "https://");
-		var host = url_regexp.matched(2);
-		var portString = url_regexp.matched(3);
-		var request = url_regexp.matched(4);
-		if( request == "" )
-			request = "/";
-		var port = if ( portString == null || portString == "" ) ssl ? 443 : 80 else Std.parseInt(portString.substr(1, portString.length - 1));
+        if( !url_regexp.match(url) ) {
+            onError("Invalid URL");
+            return;
+        }
+        var ssl = (url_regexp.matched(1) == "https://");
+        var host = url_regexp.matched(2);
+        var portString = url_regexp.matched(3);
+        var request = url_regexp.matched(4);
+        if( request == "" )
+            request = "/";
+        var port = if ( portString == null || portString == "" ) ssl ? 443 : 80 else Std.parseInt(portString.substr(1, portString.length - 1));
 
         var options = {
             "hostname":host,
@@ -274,8 +274,8 @@ class JsHttp extends Http {
         };
 
         var headersCode = "";
-		for( h in headers )
-			headersCode += 'req.setHeader("${h.header}","${h.value}");';
+        for( h in headers )
+            headersCode += 'req.setHeader("${h.header}","${h.value}");';
 
         // stringify data
         var sendCode = "";
@@ -290,9 +290,9 @@ class JsHttp extends Http {
                 + ": value;"
             + "});";
             sendCode += "req.write(dataObj);";
-			headersCode += 'req.setHeader("Content-Length",${data.length});';
+            headersCode += 'req.setHeader("Content-Length",${data.length});';
         } else {
-			headersCode += 'req.setHeader("Content-Length", 0);';
+            headersCode += 'req.setHeader("Content-Length", 0);';
         }
 
         var responseEncoding = 'binary';

--- a/lib/haxe/src/org/apache/thrift/transport/TServerSocket.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TServerSocket.hx
@@ -29,7 +29,7 @@ import haxe.io.Output;
 import haxe.io.Eof;
 
 //import flash.net.ServerSocket; - not yet available on Haxe 3.1.3
-#if ! (flash || html5)
+#if ! (flash || html5 || js)
 
 import sys.net.Host;
 

--- a/lib/haxe/src/org/apache/thrift/transport/TSocket.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TSocket.hx
@@ -262,7 +262,7 @@ class TSocket extends TTransport  {
     public override function open()  :  Void
     {
         #if js
-        var socket = new WebSocket();
+        var socket = new WebSocket(host);
         socket.onmessage = function( event : js.html.MessageEvent) {
             this.input = event.data;
         }
@@ -308,10 +308,13 @@ class TSocket extends TTransport  {
         #end
     }
 
-    public function setTimeout( timeout : Float ) : Void {
+    public function setTimeout( timeout : Float ) : Void 
+    {
+        #if !js
         if(isOpen()) {
             socket.setTimeout(timeout);
         }
+        #end
         this.timeout = timeout;
     }
 

--- a/lib/haxe/test/Makefile.am
+++ b/lib/haxe/test/Makefile.am
@@ -25,6 +25,7 @@ BENCHMARK = $(top_srcdir)/lib/rb/benchmark/Benchmark.thrift
 
 BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
+BIN_JS = bin/Main.js
 
 gen-haxe/thrift/test/ThriftTest.hx: $(THRIFTTEST)
 	$(THRIFTCMD) $(THRIFTTEST)
@@ -35,30 +36,33 @@ gen-haxe/thrift/test/Aggr.hx: $(AGGR)
 gen-haxe/thrift/test/BenchmarkService.hx: $(BENCHMARK)
 	$(THRIFTCMD) $(BENCHMARK)
 
-all-local: $(BIN_CPP) $(BIN_PHP)
+all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_JS)
 
-$(BIN_CPP): \
-		src/*.hx \
+HX_SRC = src/*.hx \
 		../src/org/apache/thrift/**/*.hx \
 		gen-haxe/thrift/test/ThriftTest.hx \
 		gen-haxe/thrift/test/Aggr.hx \
 		gen-haxe/thrift/test/BenchmarkService.hx
+
+$(BIN_CPP): $(HX_SRC) \
+		cpp.hxml
 	$(HAXE) --cwd .  cpp.hxml
 
-$(BIN_PHP): \
-		src/*.hx \
-		../src/org/apache/thrift/**/*.hx \
-		gen-haxe/thrift/test/ThriftTest.hx \
-		gen-haxe/thrift/test/Aggr.hx \
-		gen-haxe/thrift/test/BenchmarkService.hx
+$(BIN_PHP): $(HX_SRC) \
+		php.hxml
 	$(HAXE) --cwd .  php.hxml
+
+$(BIN_JS): $(HX_SRC) \
+		javascript.hxml
+	haxelib install hxnodejs
+	$(HAXE) --cwd .  javascript.hxml
+	
 
 
 #TODO: other haxe targets
 #    $(HAXE)  --cwd .  csharp
 #    $(HAXE)  --cwd .  flash
 #    $(HAXE)  --cwd .  java
-#    $(HAXE)  --cwd .  javascript
 #    $(HAXE)  --cwd .  neko
 #    $(HAXE)  --cwd .  python  # needs Haxe 3.2.0
 
@@ -66,9 +70,10 @@ $(BIN_PHP): \
 clean-local:
 	$(RM) -r gen-haxe bin
 
-check: $(BIN_CPP) $(BIN_PHP)
+check: $(BIN_CPP) $(BIN_PHP) $(BIN_JS)
 	$(BIN_CPP)
 	php -f $(BIN_PHP)
+	node $(BIN_JS) 
 
 EXTRA_DIST = \
              src \

--- a/lib/haxe/test/Makefile.am
+++ b/lib/haxe/test/Makefile.am
@@ -54,7 +54,7 @@ $(BIN_PHP): $(HX_SRC) \
 
 $(BIN_JS): $(HX_SRC) \
 		javascript.hxml
-	haxelib install hxnodejs
+	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
 	$(HAXE) --cwd .  javascript.hxml
 	
 

--- a/lib/haxe/test/javascript.hxml
+++ b/lib/haxe/test/javascript.hxml
@@ -22,11 +22,14 @@
 -cp ../src
 -cp gen-haxe
 
+#libs
+-lib hxnodejs
+
 #this class wil be used as entry point for your app.
 -main Main
 
 #JavaScript target
--js bin/Test.js
+-js bin/Main.js
 
 #You can use -D source-map-content (requires Haxe 3.1+) to have the .hx 
 #files directly embedded into the map file, this way you only have to 

--- a/lib/haxe/test/src/Main.hx
+++ b/lib/haxe/test/src/Main.hx
@@ -74,8 +74,10 @@ class Main
             switch( tests) {
                 case Normal:
                     StreamTest.Run(server);
+                #if !js
                 case Multiplex:
                     MultiplexTest.Run(server);
+                #end
                 default:
                     throw "Unhandled test mode $tests";
             }
@@ -85,6 +87,7 @@ class Main
         catch( e: Dynamic)
         {
             trace('$e');
+            trace(haxe.CallStack.toString(haxe.CallStack.exceptionStack()));
             #if sys
             Sys.exit(1);  // indicate error
             #end

--- a/test/haxe/Makefile.am
+++ b/test/haxe/Makefile.am
@@ -25,6 +25,7 @@ BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
 BIN_PHP_WEB = bin/php-web-server/Main-debug.php
 BIN_NODE_JS = bin/nodejs/Main.js
+BIN_JS = bin/js/Main.js
 
 gen-haxe/thrift/test/ThriftTest.hx: $(THRIFTTEST)
 	$(THRIFTCMD) $(THRIFTTEST)
@@ -53,6 +54,15 @@ $(BIN_NODE_JS): $(HX_SRC) \
 	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
 	$(HAXE) --cwd .  nodejs.hxml
 
+$(BIN_JS): $(HX_SRC) \
+		javascript.hxml
+	$(HAXE) --cwd .  javascript.hxml
+
+PHANTOMJS_BIN = node_modules/.bin/phantomjs
+
+$(PHANTOMJS_BIN):
+	npm install 
+	
 
 #TODO: other haxe targets
 #    $(HAXE)  --cwd .  csharp
@@ -64,47 +74,60 @@ $(BIN_NODE_JS): $(HX_SRC) \
 
 
 clean-local:
-	$(RM) -r gen-haxe bin
+	$(RM) -r gen-haxe bin node_modules
 
 .NOTPARALLEL:
 
 check: check_cpp \
 	check_php \
 	check_php_web \
-	check_node_web
+	check_node_web \
+	check_js_web
 
 check_cpp: $(BIN_CPP) 
-	timeout 20 $(BIN_CPP) server &
+	timeout 20 $(BIN_CPP) server & echo $$! > server.PID
 	sleep 1
 	$(BIN_CPP) client
-	sleep 10
+	kill `cat server.PID` && rm server.PID
 
 check_php: $(BIN_PHP) 
-	timeout 20 php -f $(BIN_PHP) server &
+	timeout 20 php -f $(BIN_PHP) server & echo $$! > server.PID
 	sleep 1
 	php -f $(BIN_PHP) client
-	sleep 10
+	kill `cat server.PID` && rm server.PID
 
 check_php_web: $(BIN_PHP_WEB) $(BIN_CPP)
-	timeout 20 php -S 127.0.0.1:9090 router.php &
+	timeout 20 php -S 127.0.0.1:9090 router.php & echo $$! > server.PID
 	sleep 1
 	$(BIN_CPP) client --transport http
-	sleep 10
+	kill `cat server.PID` && rm server.PID
 
 check_node_web: $(BIN_NODE_JS)
-	timeout 20 php -S 127.0.0.1:9090 router.php &
+	timeout 20 php -S 127.0.0.1:9090 router.php & echo $$! > server.PID
 	sleep 1
 	node $(BIN_NODE_JS) client --transport http --skip-speed-test
-	sleep 10
+	kill `cat server.PID` && rm server.PID
+
+check_js_web: $(BIN_JS) $(PHANTOMJS_BIN)
+	timeout 20 php -S 127.0.0.1:9090 router.php & echo $$! > server.PID
+	sleep 1
+	$(PHANTOMJS_BIN) phantom-js-client-test.js
+	kill `cat server.PID` && rm server.PID
 
 nodejs_client_http: $(BIN_NODE_JS)
 	node $(BIN_NODE_JS) client --transport http --skip-speed-test
+
+js_client_http: $(BIN_JS) $(PHANTOMJS_BIN)
+	$(PHANTOMJS_BIN) phantom-js-client-test.js
 
 php_client_http: $(BIN_PHP)
 	php -f $(BIN_PHP) client --transport http
 
 cpp_client_http: $(BIN_CPP)
 	$(BIN_CPP) client --transport http
+
+php_web_server: $(BIN_PHP_WEB) 
+	php -S 127.0.0.1:9090 router.php 
 
 
 EXTRA_DIST = \

--- a/test/haxe/Makefile.am
+++ b/test/haxe/Makefile.am
@@ -24,30 +24,34 @@ THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
 BIN_PHP_WEB = bin/php-web-server/Main-debug.php
+BIN_NODE_JS = bin/nodejs/Main.js
 
 gen-haxe/thrift/test/ThriftTest.hx: $(THRIFTTEST)
 	$(THRIFTCMD) $(THRIFTTEST)
 
 all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_PHP_WEB)
 
-$(BIN_CPP): \
+HX_SRC = \
 		src/*.hx \
 		../../lib/haxe/src/org/apache/thrift/**/*.hx \
 		gen-haxe/thrift/test/ThriftTest.hx
+
+$(BIN_CPP): $(HX_SRC) \
+		cpp.hxml
 	$(HAXE) --cwd .  cpp.hxml
 
-$(BIN_PHP): \
-		src/*.hx \
-		../../lib/haxe/src/org/apache/thrift/**/*.hx \
-		gen-haxe/thrift/test/ThriftTest.hx
+$(BIN_PHP): $(HX_SRC) \
+		php.hxml
 	$(HAXE) --cwd .  php.hxml
 
-$(BIN_PHP_WEB): \
-		src/*.hx \
-		../../lib/haxe/src/org/apache/thrift/**/*.hx \
-		gen-haxe/thrift/test/ThriftTest.hx
+$(BIN_PHP_WEB): $(HX_SRC) \
+		php-web-server.hxml
 	$(HAXE) --cwd .  php-web-server.hxml
 
+$(BIN_NODE_JS): $(HX_SRC) \
+		nodejs.hxml
+	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
+	$(HAXE) --cwd .  nodejs.hxml
 
 
 #TODO: other haxe targets
@@ -66,7 +70,8 @@ clean-local:
 
 check: check_cpp \
 	check_php \
-	check_php_web 
+	check_php_web \
+	check_node_web
 
 check_cpp: $(BIN_CPP) 
 	timeout 20 $(BIN_CPP) server &
@@ -86,6 +91,21 @@ check_php_web: $(BIN_PHP_WEB) $(BIN_CPP)
 	$(BIN_CPP) client --transport http
 	sleep 10
 
+check_node_web: $(BIN_NODE_JS)
+	timeout 20 php -S 127.0.0.1:9090 router.php &
+	sleep 1
+	node $(BIN_NODE_JS) client --transport http --skip-speed-test
+	sleep 10
+
+nodejs_client_http: $(BIN_NODE_JS)
+	node $(BIN_NODE_JS) client --transport http --skip-speed-test
+
+php_client_http: $(BIN_PHP)
+	php -f $(BIN_PHP) client --transport http
+
+cpp_client_http: $(BIN_CPP)
+	$(BIN_CPP) client --transport http
+
 
 EXTRA_DIST = \
              src \
@@ -94,6 +114,7 @@ EXTRA_DIST = \
              flash.hxml \
              java.hxml \
              javascript.hxml \
+             nodejs.hxml \
              neko.hxml \
              php.hxml \
              python.hxml \

--- a/test/haxe/javascript.hxml
+++ b/test/haxe/javascript.hxml
@@ -26,7 +26,7 @@
 -main Main
 
 #JavaScript target
--js bin/Tutorial.js
+-js bin/js/Main.js
 
 #You can use -D source-map-content (requires Haxe 3.1+) to have the .hx 
 #files directly embedded into the map file, this way you only have to 

--- a/test/haxe/nodejs.hxml
+++ b/test/haxe/nodejs.hxml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+ 
+#integrate files to classpath
+-cp src
+-cp gen-haxe
+-cp ../../lib/haxe/src
+
+#libs
+-lib hxnodejs
+
+#this class wil be used as entry point for your app.
+-main Main
+
+#JavaScript target
+-js bin/nodejs/Main.js
+
+#You can use -D source-map-content (requires Haxe 3.1+) to have the .hx 
+#files directly embedded into the map file, this way you only have to 
+#upload it, and it will be always in sync with the compiled .js even if 
+#you modify your .hx files.
+-D source-map-content
+
+#Generate source map and add debug information
+-debug
+
+#dead code elimination : remove unused code
+#"-dce no" : do not remove unused code
+#"-dce std" : remove unused code in the std lib (default)
+#"-dce full" : remove all unused code
+-dce full

--- a/test/haxe/package.json
+++ b/test/haxe/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "haxe-js-client-test",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies" : {
+	  "phantomjs-prebuilt" : "*"
+  }
+}

--- a/test/haxe/phantom-js-client-test.js
+++ b/test/haxe/phantom-js-client-test.js
@@ -1,0 +1,36 @@
+var url = 'http://localhost:9090/';
+console.log("Trying to connect to : " + url);
+
+var page = require('webpage').create();
+
+var successRun = false;
+page.onConsoleMessage = function(msg) {
+    if(msg.indexOf("Tests failed      0") !== -1) {
+        successRun = true;
+    }
+    console.log('page : ' + msg);
+};
+
+page.open(url, function(status) {
+    if(status === "success") {
+        console.log("connected. page text : " + page.plainText);
+        var jsToInject = 'bin/js/Main.js';
+        if (page.injectJs(jsToInject)) {
+            if(successRun) {
+                phantom.exit(0);
+            } else {
+                console.log("error on running tests");
+                phantom.exit(1);
+            }
+        } else {
+            console.log("error in injecting " + jsToInject);
+            phantom.exit(1);
+        }
+    } else {
+        console.log("Status: " + status);
+        console.log("Please run test web server : make php_web_server");
+        phantom.exit(1);
+    }
+});
+
+

--- a/test/haxe/src/Arguments.hx
+++ b/test/haxe/src/Arguments.hx
@@ -84,6 +84,8 @@ class Arguments
             server = true;
             transport = http;
           #end
+        #elseif js
+            transport = http;
         #else
         trace("WN: Platform does not support program arguments, using defaults.");
         #end

--- a/test/haxe/src/Arguments.hx
+++ b/test/haxe/src/Arguments.hx
@@ -71,7 +71,7 @@ class Arguments
 
 
     public function new() {
-        #if sys
+        #if (sys || nodejs)
           #if !phpwebserver
           try {
               ParseArgs();
@@ -89,7 +89,7 @@ class Arguments
         #end
     }
 
-    #if sys
+    #if (sys || nodejs)
 
     private static function GetHelp() : String {
         var sProg = Path.withoutDirectory( Sys.executablePath());

--- a/test/haxe/src/Main.hx
+++ b/test/haxe/src/Main.hx
@@ -46,7 +46,7 @@ class Main
             if( args.printHelpOnly)
                 return;
 
-            #if nodejs
+            #if js
                 TestClient.Execute(args);
             #else
             if (args.server)

--- a/test/haxe/src/Main.hx
+++ b/test/haxe/src/Main.hx
@@ -46,11 +46,14 @@ class Main
             if( args.printHelpOnly)
                 return;
 
+            #if nodejs
+                TestClient.Execute(args);
+            #else
             if (args.server)
                 TestServer.Execute(args);
             else
                 TestClient.Execute(args);
-
+            #end
             trace("Completed.");
         } catch (e : String) {
             trace(e);

--- a/test/haxe/src/TestClient.hx
+++ b/test/haxe/src/TestClient.hx
@@ -137,11 +137,13 @@ class TestClient {
         catch (e : TException)
         {
             trace('TException: $e');
+            trace(haxe.CallStack.toString(haxe.CallStack.exceptionStack()));
             exitCode = 0xFF;
         }
         catch (e : Dynamic)
         {
             trace('Exception: $e');
+            trace(haxe.CallStack.toString(haxe.CallStack.exceptionStack()));
             exitCode = 0xFF;
         }
 

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -50,13 +50,7 @@ $(BIN_PHP_WEB): $(HX_SRC) \
 		php-web-server.hxml
 	$(HAXE) --cwd .  php-web-server.hxml
 
-NODE_XMLHTTPREQUEST = node_modules/xmlhttprequest/lib/XMLHttpRequest.js
-
-$(NODE_XMLHTTPREQUEST) :
-	npm install
-
 $(BIN_NODE_JS): $(HX_SRC) \
-		$(NODE_XMLHTTPREQUEST) \
 		nodejs.hxml
 	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
 	$(HAXE) --cwd .  nodejs.hxml

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -98,7 +98,7 @@ tutorialclient_nodejs_http_json: all
 
 
 clean-local:
-	$(RM) -r gen-haxe bin
+	$(RM) -r gen-haxe bin node_modules
 
 EXTRA_DIST = \
              src \

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -29,7 +29,7 @@ BIN_NODE_JS = bin/nodejs/Main.js
 gen-haxe/tutorial/calculator.hx gen-haxe/shared/shared_service.hx: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen haxe -r $<
 
-all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_PHP_WEB) $(BIN_NODE_JS)
+all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_PHP_WEB) $(BIN_NODE_JS) $(BIN_JS)
 
 check: gen-haxe/tutorial/calculator.hx
 
@@ -60,8 +60,10 @@ $(BIN_NODE_JS): $(HX_SRC) \
 		nodejs.hxml
 	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
 	$(HAXE) --cwd .  nodejs.hxml
-	sed -i 's/window\.location\.protocol\.toLowerCase()/"http"/g' $(BIN_NODE_JS)
 
+$(BIN_JS): $(HX_SRC) \
+		javascript.hxml
+	$(HAXE) --cwd .  javascript.hxml
 
 tutorialserver: all
 	$(BIN_CPP) server

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -98,6 +98,8 @@ tutorialclient_http: all
 tutorialclient_nodejs_http_json: all
 	node $(BIN_NODE_JS) client http json
 
+tutorialclient_nodejs_http: all
+	node $(BIN_NODE_JS) client http
 
 clean-local:
 	$(RM) -r gen-haxe bin node_modules

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -22,32 +22,46 @@ THRIFT = $(top_builddir)/compiler/cpp/thrift
 BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
 BIN_PHP_WEB = bin/php-web-server/Main-debug.php
+BIN_JS = bin/js/Main.js
+BIN_NODE_JS = bin/nodejs/Main.js
 
 
 gen-haxe/tutorial/calculator.hx gen-haxe/shared/shared_service.hx: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen haxe -r $<
 
-all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_PHP_WEB)
+all-local: $(BIN_CPP) $(BIN_PHP) $(BIN_PHP_WEB) $(BIN_NODE_JS)
 
 check: gen-haxe/tutorial/calculator.hx
 
-$(BIN_CPP): \
+HX_SRC = \
 		src/*.hx \
 		../../lib/haxe/src/org/apache/thrift/**/*.hx \
 		gen-haxe/tutorial/calculator.hx
+
+$(BIN_CPP): $(HX_SRC) \
+		cpp.hxml
 	$(HAXE) --cwd .  cpp.hxml
 
-$(BIN_PHP): \
-		src/*.hx \
-		../../lib/haxe/src/org/apache/thrift/**/*.hx \
-		gen-haxe/tutorial/calculator.hx
+$(BIN_PHP): $(HX_SRC) \
+		php.hxml
 	$(HAXE) --cwd .  php.hxml
 
-$(BIN_PHP_WEB): \
-		src/*.hx \
-		../../lib/haxe/src/org/apache/thrift/**/*.hx \
-		gen-haxe/tutorial/calculator.hx
+$(BIN_PHP_WEB): $(HX_SRC) \
+		php-web-server.hxml
 	$(HAXE) --cwd .  php-web-server.hxml
+
+NODE_XMLHTTPREQUEST = node_modules/xmlhttprequest/lib/XMLHttpRequest.js
+
+$(NODE_XMLHTTPREQUEST) :
+	npm install
+
+$(BIN_NODE_JS): $(HX_SRC) \
+		$(NODE_XMLHTTPREQUEST) \
+		nodejs.hxml
+	haxelib list | grep hxnodejs > /dev/null || haxelib install hxnodejs
+	$(HAXE) --cwd .  nodejs.hxml
+	sed -i 's/window\.location\.protocol\.toLowerCase()/"http"/g' $(BIN_NODE_JS)
+
 
 tutorialserver: all
 	$(BIN_CPP) server
@@ -79,6 +93,10 @@ tutorialserver_php_http: all
 tutorialclient_http: all
 	$(BIN_CPP) client http
 
+tutorialclient_nodejs_http_json: all
+	node $(BIN_NODE_JS) client http json
+
+
 clean-local:
 	$(RM) -r gen-haxe bin
 
@@ -89,10 +107,12 @@ EXTRA_DIST = \
              flash.hxml \
              java.hxml \
              javascript.hxml \
+             nodejs.hxml \
              neko.hxml \
              php.hxml \
              python.hxml \
              project.hide \
              Tutorial.hxproj \
              make_all.bat \
-             make_all.sh
+             make_all.sh \
+			 router.php

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -89,6 +89,9 @@ tutorialserver_php_http: all
 tutorialclient_http: all
 	$(BIN_CPP) client http
 
+tutorialclient_php_http: all
+	php -f $(BIN_PHP) client http
+
 tutorialclient_nodejs_http_json: all
 	node $(BIN_NODE_JS) client http json
 

--- a/tutorial/haxe/README.md
+++ b/tutorial/haxe/README.md
@@ -1,0 +1,42 @@
+Thrift Haxe Tutorial
+==================================================
+1) Compile the library
+
+    make
+
+2) TCP/Socket transport:
+
+server:
+
+    make tutorialserver 
+
+or
+    
+    make tutorialserver_php  
+
+
+client: 
+    
+    ```
+    make tutorialclient
+    make tutorialclient_php
+    ```
+
+3) http transport 
+
+server:
+
+    make tutorialserver_php_http
+
+client:
+
+    ```
+    make tutorialclient_http
+    make tutorialclient_nodejs_http_json
+    make tutorialclient_nodejs_http
+    make tutorialclient_php_http
+    ```
+
+for browser side javascript open http://localhost:9090/javascript.html
+
+

--- a/tutorial/haxe/javascript.html
+++ b/tutorial/haxe/javascript.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Thrift Haxe-Javascript Bindings - Tutorial Example</title>
+
+
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+
+
+  <script type="text/javascript" charset="utf-8">
+  //<![CDATA[
+  $(document).ready(function(){
+      $('#repeat').click(function() {
+          $('#trace').html('');
+          var protocol = $('input[name=prot]:checked').val();
+          if(protocol == "binary") {
+              Main.setProtBinary();
+          } else {
+              Main.setProtJson();
+          }
+
+          Main.RunClient();
+      });
+  });
+
+  //]]>
+  </script>
+
+</head>
+<body>
+  <h2>Thrift Haxe-Javascript Bindings</h2>
+
+  <div>
+      <h3>For testing :</h3>
+      <ol>
+          <li> run haxe-php tutorial server : <code>make tutorialserver_php_http</code></li>
+          <li> open <a href="http://localhost:9090/javascript.html">http://localhost:9090/javascript.html</a> in browser
+          <li> click 'Test' </li>
+      </ol>
+  </div>
+
+  <h3>Protocol : </h3>
+  JSON : <input type="radio" name="prot" value="json" checked="checked" /> <br />
+  Binary : <input type="radio" name="prot" value="binary" />
+  
+  <h3></h3>
+  <input type="button" id="repeat" value="Test" />
+
+  <h3>Trace Output : </h3>
+  <div id='trace'>
+  </div>
+
+  
+  <p>This Java Script example uses <a href="https://git-wip-us.apache.org/repos/asf?p=thrift.git;a=blob;f=tutorial/tutorial.thrift;hb=HEAD">tutorial.thrift</a> and a Thrift server using JSON protocol and HTTP transport.
+  </p>
+    <p>
+        <a href="http://validator.w3.org/check/referer"><img
+            src="http://www.w3.org/Icons/valid-xhtml10"
+            alt="Valid XHTML 1.0!" height="31" width="88" /></a>
+    </p>
+  <script src="bin/js/Main.js"        type="text/javascript"></script>
+</body>
+</html>
+

--- a/tutorial/haxe/javascript.hxml
+++ b/tutorial/haxe/javascript.hxml
@@ -26,7 +26,7 @@
 -main Main
 
 #JavaScript target
--js bin/Tutorial.js
+-js bin/js/Main.js
 
 #You can use -D source-map-content (requires Haxe 3.1+) to have the .hx 
 #files directly embedded into the map file, this way you only have to 

--- a/tutorial/haxe/nodejs.hxml
+++ b/tutorial/haxe/nodejs.hxml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+ 
+#integrate files to classpath
+-cp src
+-cp gen-haxe
+-cp ../../lib/haxe/src
+
+#libs
+-lib hxnodejs
+
+#this class wil be used as entry point for your app.
+-main Main
+
+#JavaScript target
+-js bin/nodejs/Main.js
+
+#You can use -D source-map-content (requires Haxe 3.1+) to have the .hx 
+#files directly embedded into the map file, this way you only have to 
+#upload it, and it will be always in sync with the compiled .js even if 
+#you modify your .hx files.
+-D source-map-content
+
+#Generate source map and add debug information
+-debug
+
+#dead code elimination : remove unused code
+#"-dce no" : do not remove unused code
+#"-dce std" : remove unused code in the std lib (default)
+#"-dce full" : remove all unused code
+-dce full

--- a/tutorial/haxe/package.json
+++ b/tutorial/haxe/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "thrift-haxe-js-node-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "xmlhttprequest": "*"
+  }
+}

--- a/tutorial/haxe/package.json
+++ b/tutorial/haxe/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "thrift-haxe-js-node-test",
-  "version": "1.0.0",
-  "dependencies": {
-    "xmlhttprequest": "*"
-  }
-}

--- a/tutorial/haxe/src/Main.hx
+++ b/tutorial/haxe/src/Main.hx
@@ -38,14 +38,6 @@ enum Trns {
     http;
 }
 
-#if nodejs
-@:keep
-@:jsRequire("xmlhttprequest", "XMLHttpRequest")
-extern class XMLHttpRequest {
-  function new();
-}
-#end
-
 #if js
 @:expose
 @:keep
@@ -103,6 +95,7 @@ class Main {
         return;
         #end
 
+        #if ! (flash || (js && !nodejs))
         try {
             if (server)
                 RunServer();
@@ -113,6 +106,7 @@ class Main {
         }
 
         trace("Completed.");
+        #end
     }
     #if (js && !nodejs)
     private static function initJsBrowser()
@@ -252,9 +246,6 @@ class Main {
         case http:
             var uri = 'http://${targetHost}:${targetPort}';
             #if js
-            #if nodejs
-            var xhr = new XMLHttpRequest();
-            #end
             if(haxe.Json.stringify(prot) == haxe.Json.stringify(json)) {
                 uri += '/json';
             }

--- a/tutorial/haxe/src/Main.hx
+++ b/tutorial/haxe/src/Main.hx
@@ -92,7 +92,6 @@ class Main {
         trns = http;
         prot = json;
         initJsBrowser();
-        return;
         #end
 
         #if ! (flash || (js && !nodejs))


### PR DESCRIPTION
- only http transport is supported 
- testing of browser js made via phantomjs 
- tutorial of browser js uses haxe-php web server for files delivery 
- default implementation of haxe's HttpClient reimplemented/patched:
    - browser js implemented to support binary encoding (avoid any utf8 conversions)
    - for nodejs implemented non-async client (via ChildProcess.spawnSync and it's slow) 
- makefile for tests updated to avoid sleeps (it kills server when client stops) 