### PR TITLE
Ruby: Ensure that HTTP failures will clear the http transport outbuf var

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -50,6 +50,7 @@ module Thrift
       data = resp.body
       data = Bytes.force_binary_encoding(data)
       @inbuf = StringIO.new data
+    ensure
       @outbuf = Bytes.empty_byte_buffer
     end
   end

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -78,7 +78,7 @@ describe 'Thrift::HTTPClientTransport' do
         end
       end
 
-      @client.flush rescue
+      @client.flush  rescue
       @client.instance_variable_get(:@outbuf).should eq(Thrift::Bytes.empty_byte_buffer)
     end
 

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -67,6 +67,21 @@ describe 'Thrift::HTTPClientTransport' do
       end
       @client.flush
     end
+
+    it 'should reset the outbuf on HTTP failures' do
+      @client.write "test"
+
+      Net::HTTP.should_receive(:new).with("my.domain.com", 80).and_return do
+        mock("Net::HTTP").tap do |http|
+          http.should_receive(:use_ssl=).with(false)
+          http.should_receive(:post).with("/path/to/service?param=value", "test", {"Content-Type"=>"application/x-thrift"}).and_raise(Net::ReadTimeout)
+        end
+      end
+
+      @client.flush rescue
+      @client.instance_variable_get(:@outbuf).should eq(Thrift::Bytes.empty_byte_buffer)
+    end
+
   end
 
   describe 'ssl enabled' do


### PR DESCRIPTION
With the current implementation, any Net HTTP failure will raise from the #flush() method without resetting the @outbuf variable.

I think that resetting the @outbuf on these failures is more "expected" behaviour. Especially if there is a malformed request that the downstream server does not want to/can't handle. As far as I can tell, there is not way to clear the @outbuf var apart from the #flush() method, so if that fails, then you will just keep appending requests to the out buffer.