### PR TITLE
Ensuring that HTTP failures will clear the http transport outbuf var

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -50,6 +50,7 @@ module Thrift
       data = resp.body
       data = Bytes.force_binary_encoding(data)
       @inbuf = StringIO.new data
+    ensure
       @outbuf = Bytes.empty_byte_buffer
     end
   end


### PR DESCRIPTION
With the current implementation, any Net HTTP failure will raise from the #flush() method without resetting the @outbuf variable.

I think that resetting the @outbuf on these failures is more "expected" behaviour. Especially if there is a malformed request that the downstream server does not want to/can't handle. As far as I can tell, there is not way to clear the @outbuf var apart from the #flush() method, so if that fails, then you will just keep appending requests to the out buffer.
