### PR TITLE
THRIFT-3879 Undefined evaluation order

### DIFF
--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -651,7 +651,9 @@ uint32_t TJSONProtocol::writeMapBegin(const TType keyType,
 }
 
 uint32_t TJSONProtocol::writeMapEnd() {
-  return writeJSONObjectEnd() + writeJSONArrayEnd();
+  uint32_t result = writeJSONObjectEnd();
+  result += writeJSONArrayEnd();
+  return result;
 }
 
 uint32_t TJSONProtocol::writeListBegin(const TType elemType, const uint32_t size) {
@@ -1015,7 +1017,9 @@ uint32_t TJSONProtocol::readMapBegin(TType& keyType, TType& valType, uint32_t& s
 }
 
 uint32_t TJSONProtocol::readMapEnd() {
-  return readJSONObjectEnd() + readJSONArrayEnd();
+  uint32_t result = readJSONObjectEnd();
+  result += readJSONArrayEnd();
+  return result;
 }
 
 uint32_t TJSONProtocol::readListBegin(TType& elemType, uint32_t& size) {


### PR DESCRIPTION
The evaluation order of f1 and f2 in `x = f1() + f2()` is undefined...