### PR TITLE
THRIFT-3885 PHP: Error when readI64 in TCompactProtocol

### DIFF
--- a/lib/php/lib/Thrift/Protocol/TCompactProtocol.php
+++ b/lib/php/lib/Thrift/Protocol/TCompactProtocol.php
@@ -615,7 +615,7 @@ class TCompactProtocol extends TProtocol
       if ($shift >= 32) {
         $hi |= (($byte & 0x7f) << ($shift - 32));
       } elseif ($shift > 25) {
-        $hi |= (($byte & 0x7f) >> ($shift - 25));
+        $hi |= (($byte & 0x7f) >> (7 - ($shift - 25)));
       }
       if (($byte >> 7) === 0) {
         break;

--- a/lib/php/lib/Thrift/Protocol/TCompactProtocol.php
+++ b/lib/php/lib/Thrift/Protocol/TCompactProtocol.php
@@ -615,7 +615,7 @@ class TCompactProtocol extends TProtocol
       if ($shift >= 32) {
         $hi |= (($byte & 0x7f) << ($shift - 32));
       } elseif ($shift > 25) {
-        $hi |= (($byte & 0x7f) >> (7 - ($shift - 25)));
+        $hi |= (($byte & 0x7f) >> (32 - $shift));
       }
       if (($byte >> 7) === 0) {
         break;


### PR DESCRIPTION
fix bug when readI64 in TCompactProtocol of php.
see https://issues.apache.org/jira/browse/THRIFT-3885