### PR TITLE
Document ability to add custom tags to thrift structs

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -64,3 +64,18 @@ As such, we provide some helpers that do just this under lib/go/thrift/. E.g.,
 
 And so on. The code generator also creates analogous helpers for user-defined
 typedefs and enums.
+
+Adding custom tags to generated Thrift structs
+==============================================
+
+You can add tags to the auto-generated thrift structs using the following format:
+
+    struct foo {
+      1: required string Bar (go.tag = "some_tag:\"some_tag_value\"")
+    }
+    
+which will generate:
+
+    type Foo struct {
+      Bar string `thrift:"bar,1,required" some_tag:"some_tag_value"`
+    }


### PR DESCRIPTION
This is a really useful feature that I only found out about because I stumbled upon this stackoverflow question: http://stackoverflow.com/questions/31319534/control-golang-annotations-in-thrift-generated-code
