### PR TITLE
Update TSSLSocket.cpp

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -471,8 +471,10 @@ void TSSLSocket::checkHandshake() {
       }
     } while (rc == 2);
   } else {
-    // set the SNI hostname
-    SSL_set_tlsext_host_name(ssl_, getHost().c_str());
+    /* OpenSSL < 1.0.0 does not have SSL_set_tlsext_host_name() */
+    #if defined(SSL_set_tlsext_host_name) // set the SNI hostname
+      SSL_set_tlsext_host_name(ssl_, getHost().c_str());
+    #endif
     do {
       rc = SSL_connect(ssl_);
       if (rc <= 0) {

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -471,7 +471,7 @@ void TSSLSocket::checkHandshake() {
       }
     } while (rc == 2);
   } else {
-    /* OpenSSL < 1.0.0 does not have SSL_set_tlsext_host_name() */
+    /* OpenSSL < 0.9.8f does not have SSL_set_tlsext_host_name() */
     #if defined(SSL_set_tlsext_host_name) // set the SNI hostname
       SSL_set_tlsext_host_name(ssl_, getHost().c_str());
     #endif


### PR DESCRIPTION
Older version of Open SSL may create problem because they do not support 'SSL_set_tlsext_host_name()'.
