### PR TITLE
THRIFT-3801: Fix exception with nodejs multiplexer

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -121,7 +121,6 @@ var Connection = exports.Connection = function(stream, options) {
         var service_name = self.seqId2Service[header.rseqid];
         if (service_name) {
           client = self.client[service_name];
-          delete self.seqId2Service[header.rseqid];
         }
         /*jshint -W083 */
         client._reqs[dummy_seqid] = function(err, success){
@@ -129,6 +128,9 @@ var Connection = exports.Connection = function(stream, options) {
 
           var callback = client._reqs[header.rseqid];
           delete client._reqs[header.rseqid];
+          if (service_name) {
+            delete self.seqId2Service[header.rseqid];
+          }
           if (callback) {
             callback(err, success);
           }


### PR DESCRIPTION
THRIFT-3801 - Node Thrift client throws exception with multiplexer and responses that are bigger than a single buffer

This fix was suggested by someone else. Unfortunately I don't know enough about Thrift to know if this will cause an issue. Hopefully we can discuss here :)
