### PR TITLE
THRIFT-3916 Throw proper errors from JS, not strings

### DIFF
--- a/compiler/cpp/src/generate/t_js_generator.cc
+++ b/compiler/cpp/src/generate/t_js_generator.cc
@@ -66,7 +66,7 @@ public:
       } else if( iter->first.compare("ts") == 0) {
         gen_ts_ = true;
       } else {
-        throw "unknown option js:" + iter->first; 
+        throw "unknown option js:" + iter->first;
       }
     }
 
@@ -1565,10 +1565,11 @@ void t_js_generator::generate_service_client(t_service* tservice) {
 }
 
 std::string t_js_generator::render_recv_throw(std::string var) {
+  std::string error = "new Error(" + var + ")";
   if (gen_node_) {
-    return "return callback(" + var + ");";
+    return "return callback(" + error + ");";
   } else {
-    return "throw " + var + ";";
+    return "throw " + error + ";";
   }
 }
 


### PR DESCRIPTION
I'd love to add a test for this, but I can't find where to do that.

EDIT: I'm unable to get bison to register correctly in order to run the tests locally (Mac).

Is there some Dockerfile I could use that installs dependencies and an elegant way for me to run the tests?
