### PR TITLE
THRIFT-3926 Emit an error for bad http status code

### DIFF
--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -169,6 +169,10 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
     var data = [];
     var dataLen = 0;
 
+    if (response.statusCode !== 200) {
+      this.emit("error", new THTTPException(statusCode, response));
+    }
+
     response.on('error', function (e) {
       self.emit("error", e);
     });
@@ -236,3 +240,14 @@ exports.createHttpConnection = function(host, port, options) {
 
 exports.createHttpClient = createClient
 
+
+function THTTPException(statusCode, response) {
+  thrift.TApplicationException.call(this);
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.statusCode = statusCode;
+  this.response = response;
+  this.type = thrift.TApplicationExceptionType.PROTOCOL_ERROR;
+  this.message = "Received a response with a bad HTTP status code: " + response.statusCode;
+}
+util.inherits(THTTPException, thrift.TApplicationException);


### PR DESCRIPTION
Sometimes the thrift servers is not ready to serve requests from the client. The status code of response from the services is 40x or 50x. But the client is never telled in this version of http_connections. There is no error at all even when the response protocol is bad.
