### PR TITLE
THRIFT-3927 Emitting an error instead of throwing in the async callback

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -150,7 +150,7 @@ var Connection = exports.Connection = function(stream, options) {
         transport_with_data.rollbackPosition();
       }
       else {
-        throw e;
+        self.emit('error', e);
       }
     }
   }));

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -157,7 +157,7 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       if (e instanceof InputBufferUnderrunError) {
         transport_with_data.rollbackPosition();
       } else {
-        throw e;
+        self.emit('error', e);
       }
     }
   }


### PR DESCRIPTION
Because the data event of a connection is async handled, throw an exception can not tell the code the error. emit the error should be the correct way to handle the errors.