### PR TITLE
THRIFT-3931 If process request encounter UNKNOWN_METHOD, don't close transport.

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -27,7 +27,7 @@ import (
 
 // Simple, non-concurrent server for testing.
 type TSimpleServer struct {
-	quit chan struct{}
+	quit    chan struct{}
 	stopped int64
 
 	processorFactory       TProcessorFactory
@@ -182,6 +182,9 @@ func (p *TSimpleServer) processRequests(client TTransport) error {
 		} else if err != nil {
 			log.Printf("error processing request: %s", err)
 			return err
+		}
+		if err, ok := err.(TApplicationException); ok && err.TypeId() == UNKNOWN_METHOD {
+			continue
 		}
 		if !ok {
 			break


### PR DESCRIPTION
It will hold connection when meet unknown thrift method.