### PR TITLE
THRIFT-3936: fix compile error on VS2013 and earlier

### DIFF
--- a/compiler/cpp/src/thrift/windows/config.h
+++ b/compiler/cpp/src/thrift/windows/config.h
@@ -42,4 +42,25 @@
 // squelch bool conversion performance warning
 #pragma warning(disable : 4800)
 
+// MSVC10 (2010) or later has stdint.h
+#if _MSC_VER >= 1600
+#define HAVE_STDINT_H 1
+#endif
+
+// Must be using VS2010 or later, or boost, so that C99 types are defined in the global namespace
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#else
+#include <boost/cstdint.hpp>
+
+typedef boost::int64_t int64_t;
+typedef boost::uint64_t uint64_t;
+typedef boost::int32_t int32_t;
+typedef boost::uint32_t uint32_t;
+typedef boost::int16_t int16_t;
+typedef boost::uint16_t uint16_t;
+typedef boost::int8_t int8_t;
+typedef boost::uint8_t uint8_t;
+#endif
+
 #endif // _THRIFT_WINDOWS_CONFIG_H_

--- a/lib/cpp/src/thrift/transport/PlatformSocket.h
+++ b/lib/cpp/src/thrift/transport/PlatformSocket.h
@@ -58,7 +58,11 @@
 #    define THRIFT_GAI_STRERROR gai_strerrorA
 #  endif
 #  define THRIFT_SSIZET ptrdiff_t
-#  define THRIFT_SNPRINTF _snprintf
+#  if (_MSC_VER < 1900)
+#    define THRIFT_SNPRINTF _snprintf
+#  else
+#    define THRIFT_SNPRINTF snprintf
+#  endif
 #  define THRIFT_SLEEP_SEC thrift_sleep
 #  define THRIFT_SLEEP_USEC thrift_usleep
 #  define THRIFT_TIMESPEC thrift_timespec

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -279,7 +279,7 @@ void TServerSocket::listen() {
   const struct addrinfo *res;
   int error;
   char port[sizeof("65535")];
-  snprintf(port, sizeof(port), "%d", port_);
+  THRIFT_SNPRINTF(port, sizeof(port), "%d", port_);
 
   struct addrinfo hints;
   std::memset(&hints, 0, sizeof(hints));
@@ -524,9 +524,9 @@ void TServerSocket::listen() {
   if (retries > retryLimit_) {
     char errbuf[1024];
     if (!path_.empty()) {
-      snprintf(errbuf, sizeof(errbuf), "TServerSocket::listen() PATH %s", path_.c_str());
+      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() PATH %s", path_.c_str());
     } else {
-      snprintf(errbuf, sizeof(errbuf), "TServerSocket::listen() BIND %d", port_);
+      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() BIND %d", port_);
     }
     GlobalOutput(errbuf);
     close();

--- a/lib/cpp/src/thrift/windows/config.h
+++ b/lib/cpp/src/thrift/windows/config.h
@@ -25,16 +25,20 @@
 #endif // _MSC_VER
 
 #ifndef _WIN32
-#error This is a MSVC header only.
+#error "This is a Windows header only"
 #endif
 
 // use std::thread in MSVC11 (2012) or newer
 #if _MSC_VER >= 1700
-#define HAVE_STDINT_H 1
 #define USE_STD_THREAD 1
-// otherwise use boost threads
 #else
+// otherwise use boost threads
 #define USE_BOOST_THREAD 1
+#endif
+
+// VS2010 or later has stdint.h
+#if _MSC_VER >= 1600
+#define HAVE_STDINT_H 1
 #endif
 
 #ifndef TARGET_WIN_XP
@@ -65,6 +69,7 @@
 #define HAVE_GETTIMEOFDAY 1
 #define HAVE_SYS_STAT_H 1
 
+// Must be using VS2010 or later, or boost, so that C99 types are defined in the global namespace
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #else


### PR DESCRIPTION
Submitting to replace https://github.com/apache/thrift/pull/1096.