### PR TITLE
THRIFT-3943: resolve some high severity outstanding defects identified by coverity scan

### DIFF
--- a/lib/cpp/src/thrift/concurrency/FunctionRunner.h
+++ b/lib/cpp/src/thrift/concurrency/FunctionRunner.h
@@ -81,12 +81,12 @@ public:
    * execute the given callback.  Note that the 'void*' return value is ignored.
    */
   FunctionRunner(PthreadFuncPtr func, void* arg)
-    : func_(apache::thrift::stdcxx::bind(pthread_func_wrapper, func, arg)) {}
+    : func_(apache::thrift::stdcxx::bind(pthread_func_wrapper, func, arg)), intervalMs_(-1) {}
 
   /**
    * Given a generic callback, this FunctionRunner will execute it.
    */
-  FunctionRunner(const VoidFunc& cob) : func_(cob) {}
+  FunctionRunner(const VoidFunc& cob) : func_(cob), intervalMs_(-1) {}
 
   /**
    * Given a bool foo(...) type callback, FunctionRunner will execute

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -81,8 +81,8 @@ using namespace std;
 TSocket::TSocket(const string& host, int port)
   : host_(host),
     port_(port),
-    path_(""),
     socket_(THRIFT_INVALID_SOCKET),
+    peerPort_(0),
     connTimeout_(0),
     sendTimeout_(0),
     recvTimeout_(0),
@@ -94,10 +94,10 @@ TSocket::TSocket(const string& host, int port)
 }
 
 TSocket::TSocket(const string& path)
-  : host_(""),
-    port_(0),
+  : port_(0),
     path_(path),
     socket_(THRIFT_INVALID_SOCKET),
+    peerPort_(0),
     connTimeout_(0),
     sendTimeout_(0),
     recvTimeout_(0),
@@ -110,10 +110,9 @@ TSocket::TSocket(const string& path)
 }
 
 TSocket::TSocket()
-  : host_(""),
-    port_(0),
-    path_(""),
+  : port_(0),
     socket_(THRIFT_INVALID_SOCKET),
+    peerPort_(0),
     connTimeout_(0),
     sendTimeout_(0),
     recvTimeout_(0),
@@ -126,10 +125,9 @@ TSocket::TSocket()
 }
 
 TSocket::TSocket(THRIFT_SOCKET socket)
-  : host_(""),
-    port_(0),
-    path_(""),
+  : port_(0),
     socket_(socket),
+    peerPort_(0),
     connTimeout_(0),
     sendTimeout_(0),
     recvTimeout_(0),
@@ -148,10 +146,9 @@ TSocket::TSocket(THRIFT_SOCKET socket)
 }
 
 TSocket::TSocket(THRIFT_SOCKET socket, boost::shared_ptr<THRIFT_SOCKET> interruptListener)
-  : host_(""),
-    port_(0),
-    path_(""),
+  : port_(0),
     socket_(socket),
+    peerPort_(0),
     interruptListener_(interruptListener),
     connTimeout_(0),
     sendTimeout_(0),

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -272,15 +272,6 @@ protected:
   /** Host to connect to */
   std::string host_;
 
-  /** Peer hostname */
-  std::string peerHost_;
-
-  /** Peer address */
-  std::string peerAddress_;
-
-  /** Peer port */
-  int peerPort_;
-
   /** Port number to connect on */
   int port_;
 
@@ -289,6 +280,15 @@ protected:
 
   /** Underlying socket handle */
   THRIFT_SOCKET socket_;
+
+  /** Peer hostname */
+  std::string peerHost_;
+
+  /** Peer address */
+  std::string peerAddress_;
+
+  /** Peer port */
+  int peerPort_;
 
   /**
    * A shared socket pointer that will interrupt a blocking read if data

--- a/lib/cpp/test/TFileTransportTest.cpp
+++ b/lib/cpp/test/TFileTransportTest.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(test_destructor) {
 
   unsigned int num_over = 0;
   for (unsigned int n = 0; n < NUM_ITERATIONS; ++n) {
-    ftruncate(f.getFD(), 0);
+    BOOST_CHECK_EQUAL(0, ftruncate(f.getFD(), 0));
 
     TFileTransport* transport = new TFileTransport(f.getPath());
 
@@ -392,21 +392,21 @@ void parse_args(int argc, char* argv[]) {
 #ifdef BOOST_TEST_DYN_LINK
 static int myArgc = 0;
 static char **myArgv = NULL;
- 
+
 bool init_unit_test_suite() {
   boost::unit_test::framework::master_test_suite().p_name.value = "TFileTransportTest";
- 
+
   // Parse arguments
   parse_args(myArgc,myArgv);
   return true;
 }
- 
+
 int main( int argc, char* argv[] ) {
   myArgc = argc;
   myArgv = argv;
   return ::boost::unit_test::unit_test_main(&init_unit_test_suite,argc,argv);
 }
-#else 
+#else
 boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
   boost::unit_test::framework::master_test_suite().p_name.value = "TFileTransportTest";
 

--- a/lib/cpp/test/concurrency/ThreadFactoryTests.h
+++ b/lib/cpp/test/concurrency/ThreadFactoryTests.h
@@ -102,7 +102,7 @@ public:
 
     PlatformThreadFactory threadFactory = PlatformThreadFactory();
 
-    Monitor* monitor = new Monitor();
+    shared_ptr<Monitor> monitor(new Monitor);
 
     for (int lix = 0; lix < loop; lix++) {
 

--- a/lib/cpp/test/concurrency/ThreadManagerTests.h
+++ b/lib/cpp/test/concurrency/ThreadManagerTests.h
@@ -45,7 +45,7 @@ public:
 
   public:
     Task(Monitor& monitor, size_t& count, int64_t timeout)
-      : _monitor(monitor), _count(count), _timeout(timeout), _done(false) {}
+      : _monitor(monitor), _count(count), _timeout(timeout), _startTime(0), _endTime(0), _done(false) {}
 
     void run() {
 

--- a/lib/cpp/test/concurrency/TimerManagerTests.h
+++ b/lib/cpp/test/concurrency/TimerManagerTests.h
@@ -42,6 +42,7 @@ public:
     Task(Monitor& monitor, int64_t timeout)
       : _timeout(timeout),
         _startTime(Util::currentTime()),
+        _endTime(0),
         _monitor(monitor),
         _success(false),
         _done(false) {}

--- a/lib/cpp/test/processor/EventLog.cpp
+++ b/lib/cpp/test/processor/EventLog.cpp
@@ -19,22 +19,26 @@
 #include "EventLog.h"
 
 #include <stdarg.h>
+#include <stdlib.h>
 
 using namespace std;
 using namespace apache::thrift::concurrency;
 
 namespace {
 
+// Define environment variable DEBUG_EVENTLOG to enable debug logging
+// ex: $ DEBUG_EVENTLOG=1 processor_test
+static const char * DEBUG_EVENTLOG = getenv("DEBUG_EVENTLOG");
+
 void debug(const char* fmt, ...) {
-  // Comment out this return to enable debug logs from the test code.
-  return;
+  if (DEBUG_EVENTLOG) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
 
-  va_list ap;
-  va_start(ap, fmt);
-  vfprintf(stderr, fmt, ap);
-  va_end(ap);
-
-  fprintf(stderr, "\n");
+    fprintf(stderr, "\n");
+  }
 }
 }
 

--- a/lib/lua/src/usocket.c
+++ b/lib/lua/src/usocket.c
@@ -58,13 +58,14 @@ T_ERRCODE socket_wait(p_socket sock, int mode, int timeout) {
 
   end = __gettime() + timeout/1000;
   do {
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+
     // Specify what I/O operations we care about
     if (mode & WAIT_MODE_R) {
-      FD_ZERO(&rfds);
       FD_SET(*sock, &rfds);
     }
     if (mode & WAIT_MODE_W) {
-      FD_ZERO(&wfds);
       FD_SET(*sock, &wfds);
     }
 
@@ -131,8 +132,8 @@ T_ERRCODE socket_bind(p_socket sock, p_sa addr, int addr_len) {
 
 T_ERRCODE socket_get_info(p_socket sock, short *port, char *buf, size_t len) {
   struct sockaddr_in sa;
-  socklen_t addrlen;
   memset(&sa, 0, sizeof(sa));
+  socklen_t addrlen = sizeof(sa);
   int rc = getsockname(*sock, (struct sockaddr*)&sa, &addrlen);
   if (!rc) {
     char *addr = inet_ntoa(sa.sin_addr);


### PR DESCRIPTION
https://scan7.coverity.com/reports.htm#v15415/p10216/fileInstanceId=3547531&defectInstanceId=1023429&mergedDefectId=748818

Coverity Scan identified 9 issues of high severity.
I dismissed 4 of them as false positives; coverity lost track of the handling of socket file descriptors across multiple layers of calls; this left 5 issues, and I took care of a number of insignificant issues as well:

1295822 - memory leak in ThreadFactoryTests
1216842 - uninitialized rfds fd_set is passed to select if mode is not WAIT_MODE_C (R+W)
1216841 - uninitialized wfds fd_set is passed to select if mode is not WAIT_MODE_C (R+W)
1216840 - getsockname is always passed uninitialized addrlen
1295810 - uninitialized variables in test
1295808 - uninitialized variable in test
1295804 - structurally dead code in processor test event log - changed to use environment variable
excuded:
1174563 - memory leak in compiler class handling functions
1174671 - uninitialized variable in FunctionRunner (intervalMs_)
1174669, 1174763, 1295806, 1295807, 1295809 - uninitialized variable in TSocket (peerPort_)