### PR TITLE
Fixed TThreadedServer Memory Leak

### DIFF
--- a/lib/cpp/src/thrift/server/TThreadedServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadedServer.cpp
@@ -118,9 +118,10 @@ void TThreadedServer::drainDeadClients() {
 
 void TThreadedServer::onClientConnected(const shared_ptr<TConnectedClient>& pClient) {
   Synchronized sync(clientMonitor_);
-  ClientMap::iterator it = activeClientMap_.insert(ClientMap::value_type(pClient.get(), boost::make_shared<TConnectedClientRunner>(pClient))).first;
-  boost::shared_ptr<apache::thrift::concurrency::Thread> pThread = threadFactory_->newThread(it->second);
-  it->second->setThread(pThread);
+  boost::shared_ptr<TConnectedClientRunner> pRunnable = boost::make_shared<TConnectedClientRunner>(pClient);
+  boost::shared_ptr<Thread> pThread = threadFactory_->newThread(pRunnable);
+  pRunnable->thread(pThread);
+  activeClientMap_.insert(ClientMap::value_type(pClient.get(), pThread));
   pThread->start();
 }
 
@@ -143,18 +144,9 @@ TThreadedServer::TConnectedClientRunner::TConnectedClientRunner(const boost::sha
 TThreadedServer::TConnectedClientRunner::~TConnectedClientRunner() {
 }
 
-void TThreadedServer::TConnectedClientRunner::join() {
-  pThread_->join();
-}
-
 void TThreadedServer::TConnectedClientRunner::run() /* override */ {
   pClient_->run();  // Run the client
   pClient_.reset(); // The client is done - release it here rather than in the destructor for safety
-}
-
-void TThreadedServer::TConnectedClientRunner::setThread(
-		const boost::shared_ptr<apache::thrift::concurrency::Thread>& pThread) {
-  pThread_ = pThread;
 }
 
 }

--- a/lib/cpp/src/thrift/server/TThreadedServer.h
+++ b/lib/cpp/src/thrift/server/TThreadedServer.h
@@ -118,17 +118,14 @@ protected:
   public:
     TConnectedClientRunner(const boost::shared_ptr<TConnectedClient>& pClient);
     virtual ~TConnectedClientRunner();
-    void join();
     void run() /* override */;
-    void setThread(const boost::shared_ptr<apache::thrift::concurrency::Thread>& pThread);
   private:
     boost::shared_ptr<TConnectedClient> pClient_;
-    boost::shared_ptr<apache::thrift::concurrency::Thread> pThread_;
   };
 
   apache::thrift::concurrency::Monitor clientMonitor_;
 
-  typedef std::map<TConnectedClient *, boost::shared_ptr<TConnectedClientRunner> > ClientMap;
+  typedef std::map<TConnectedClient *, boost::shared_ptr<apache::thrift::concurrency::Thread> > ClientMap;
 
   /**
    * A map of active clients


### PR DESCRIPTION
There is memory leak in `TThreadedServer` because of reference loop between `TConnectedClientRunner` and `Thread`. A `Runnable` should hold a weak reference to `Thread`. PR should fix this issue. 
