### PR TITLE
THRIFT-3953 TSSLSocket::close should handle exceptions from waitForEv…

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -293,33 +293,41 @@ void TSSLSocket::open() {
 
 void TSSLSocket::close() {
   if (ssl_ != NULL) {
-    int rc;
+    try {
+      int rc;
 
-    do {
-      rc = SSL_shutdown(ssl_);
-      if (rc <= 0) {
-        int errno_copy = THRIFT_GET_SOCKET_ERROR;
-        int error = SSL_get_error(ssl_, rc);
-        switch (error) {
-          case SSL_ERROR_SYSCALL:
-            if ((errno_copy != THRIFT_EINTR)
-                && (errno_copy != THRIFT_EAGAIN)) {
-              break;
-            }
-          case SSL_ERROR_WANT_READ:
-          case SSL_ERROR_WANT_WRITE:
-            waitForEvent(error == SSL_ERROR_WANT_READ);
-                rc = 2;
-          default:;// do nothing
+      do {
+        rc = SSL_shutdown(ssl_);
+        if (rc <= 0) {
+          int errno_copy = THRIFT_GET_SOCKET_ERROR;
+          int error = SSL_get_error(ssl_, rc);
+          switch (error) {
+            case SSL_ERROR_SYSCALL:
+              if ((errno_copy != THRIFT_EINTR)
+                  && (errno_copy != THRIFT_EAGAIN)) {
+                break;
+              }
+            case SSL_ERROR_WANT_READ:
+            case SSL_ERROR_WANT_WRITE:
+              waitForEvent(error == SSL_ERROR_WANT_READ);
+              rc = 2;
+            default:;// do nothing
+          }
         }
-      }
-    } while (rc == 2);
+      } while (rc == 2);
 
-    if (rc < 0) {
-      int errno_copy = THRIFT_GET_SOCKET_ERROR;
-      string errors;
-      buildErrors(errors, errno_copy);
-      GlobalOutput(("SSL_shutdown: " + errors).c_str());
+      if (rc < 0) {
+        int errno_copy = THRIFT_GET_SOCKET_ERROR;
+        string errors;
+        buildErrors(errors, errno_copy);
+        GlobalOutput(("SSL_shutdown: " + errors).c_str());
+      }
+    } catch (TTransportException& te) {
+      // Don't emit an exception because this method is called by the
+      // destructor. There's also not much that a user can do to recover, so
+      // just clean up as much as possible without throwing, similar to the rc
+      // < 0 case above.
+      GlobalOutput.printf("SSL_shutdown: %s", te.what());
     }
     SSL_free(ssl_);
     ssl_ = NULL;


### PR DESCRIPTION
…ent because it is called by the destructor
