### PR TITLE
THRIFT-3960: Inherited services in Lua generator are not named correctly

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -644,7 +644,7 @@ void t_lua_generator::generate_service_processor(ofstream& out, t_service* tserv
   // Define processor table
   out << endl << classname << " = __TObject.new(";
   if (extends_s != NULL) {
-    out << extends_s << "Processor" << endl;
+    out << extends_s->get_name() << "Processor" << endl;
   } else {
     out << "__TProcessor" << endl;
   }


### PR DESCRIPTION
In the Lua generator, services that are inherited have an incorrectly named processor (the pointer to the parent service is being output to stream instead of the name of parent service)