### PR TITLE
Ant fixes.

### DIFF
--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -276,15 +276,11 @@
     <exec executable="${thrift.compiler}" failonerror="true">
       <arg line="--gen java ${test.thrift.home}/ManyOptionals.thrift"/>
     </exec>
-    <exec executable="mkdir" failonerror="true">
-      <arg line="-p ${genfullcamel}"/>
-    </exec>
+  	<mkdir dir="${genfullcamel}"/>
     <exec executable="${thrift.compiler}" failonerror="true">
       <arg line="--gen java:fullcamel -out ${genfullcamel} ${test.thrift.home}/FullCamelTest.thrift"/>
     </exec>
-    <exec executable="mkdir" failonerror="true">
-      <arg line="-p ${genreuse}"/>
-    </exec>
+  	<mkdir dir="${genreuse}"/>
     <exec executable="${thrift.compiler}" failonerror="true">
       <arg line="--gen java:reuse-objects -out ${genreuse} ${test.thrift.home}/ReuseObjects.thrift"/>
     </exec>


### PR DESCRIPTION
Fix mkdir calls to use the mkdir Ant task. Otherwise, this does not build on Windows.