### PR TITLE
THRIFT-3947 use sockaddr_storage with getsockname for future transport compatibility (ipv6)

### DIFF
--- a/lib/lua/src/usocket.c
+++ b/lib/lua/src/usocket.c
@@ -131,20 +131,27 @@ T_ERRCODE socket_bind(p_socket sock, p_sa addr, int addr_len) {
 }
 
 T_ERRCODE socket_get_info(p_socket sock, short *port, char *buf, size_t len) {
-  struct sockaddr_in sa;
+  struct sockaddr_storage sa;
   memset(&sa, 0, sizeof(sa));
   socklen_t addrlen = sizeof(sa);
   int rc = getsockname(*sock, (struct sockaddr*)&sa, &addrlen);
   if (!rc) {
-    char *addr = inet_ntoa(sa.sin_addr);
-    *port = ntohs(sa.sin_port);
-    if (strlen(addr) < len) {
-      len = strlen(addr);
+    if (sa.ss_family == AF_INET6) {
+      struct sockaddr_in6* sin = (struct sockaddr_in6*)(&sa);
+      if (!inet_ntop(AF_INET6, &sin->sin6_addr, buf, len)) {
+        return errno;
+      }
+      *port = ntohs(sin->sin6_port);
+    } else {
+      struct sockaddr_in* sin = (struct sockaddr_in*)(&sa);
+      if (!inet_ntop(AF_INET, &sin->sin_addr, buf, len)) {
+        return errno;
+      }
+      *port = ntohs(sin->sin_port);
     }
-    memcpy(buf, addr, len);
     return SUCCESS;
   }
-  return rc;
+  return errno;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There's also code in windows/SocketPair that uses sockaddr_in however that code is using loopback so I see no need to change it.  The rest of the codebase already changed over to use sockaddr_storage at some point in the past.  Only this lua implementation was left...