### PR TITLE
THRIFT-3886 PHP cross test client returns 0 even when failing

### DIFF
--- a/test/tests.json
+++ b/test/tests.json
@@ -416,12 +416,12 @@
       ],
       "command": [
         "php",
-	"-dextension_dir=../../lib/php/src/ext/thrift_protocol/modules/",
-	"--php-ini=../../lib/php/thrift_protocol.ini",
-	"--no-php-ini",
-	"-ddisplay_errors=stderr",
-	"-dlog_errors=0",
-	"-derror_reporting=E_ALL",
+        "-dextension_dir=../../lib/php/src/ext/thrift_protocol/modules/",
+        "--php-ini=../../lib/php/thrift_protocol.ini",
+        "--no-php-ini",
+        "-ddisplay_errors=stderr",
+        "-dlog_errors=0",
+        "-derror_reporting=E_ALL",
         "TestClient.php"
       ]
     },

--- a/test/tests.json
+++ b/test/tests.json
@@ -416,6 +416,12 @@
       ],
       "command": [
         "php",
+	"-dextension_dir=../../lib/php/src/ext/thrift_protocol/modules/",
+	"--php-ini=../../lib/php/thrift_protocol.ini",
+	"--no-php-ini",
+	"-ddisplay_errors=stderr",
+	"-dlog_errors=0",
+	"-derror_reporting=E_ALL",
         "TestClient.php"
       ]
     },


### PR DESCRIPTION
PHP tests are mostly not asserting that the returned result is as
expected, nor do they return an error for unknown protocols.

Add more assertions in the style of the existing code, and check that the
tested protocol is supported.
This requires some fixes so tests will actually run for the accelerated
binary protocol.

Fixing the tests uncovers some brokenness in compact protocol and the extension, will submit fixes as separate patches.