### PR TITLE
THRIFT-3977 PHP extension creates undefined values when deserializing…

### DIFF
--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol7.cpp
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol7.cpp
@@ -626,7 +626,7 @@ void binary_deserialize(int8_t thrift_typeID, PHPInputTransport& transport, zval
 
       for (uint32_t s = 0; s < size; ++s) {
         zval key, value;
-        ZVAL_UNDEF(&value);
+        ZVAL_TRUE(&value);
 
         binary_deserialize(type, transport, &key, elemspec);
 


### PR DESCRIPTION
… sets

Fix to set values to 'true' instead of undefined, matching the comment
and old behaviour.