### PR TITLE
Add union example to ThriftTest

### DIFF
--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -116,11 +116,11 @@ struct CrazyNesting {
 }
 
 union SomeUnion {
- 1: map<Numberz, UserId> map_thing,
- 2: string string_thing,
- 3: i32 i32_thing,
- 4: Xtruct3 xtruct_thing,
- 5: Insanity insanity_thing
+  1: map<Numberz, UserId> map_thing,
+  2: string string_thing,
+  3: i32 i32_thing,
+  4: Xtruct3 xtruct_thing,
+  5: Insanity insanity_thing
 }
 
 exception Xception {

--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -115,6 +115,14 @@ struct CrazyNesting {
   4: binary binary_field
 }
 
+union SomeUnion {
+ 1: map<Numberz, UserId> map_thing,
+ 2: string string_thing,
+ 3: i32 i32_thing,
+ 4: Xtruct3 xtruct_thing,
+ 5: Insanity insanity_thing
+}
+
 exception Xception {
   1: i32 errorCode,
   2: string message


### PR DESCRIPTION
This simply adds a union definition to ThriftTest.thrift.