### PR TITLE
THRIFT-4009: Use @implementer instead of implements in TTwisted.py

### DIFF
--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -20,7 +20,7 @@
 from io import BytesIO
 import struct
 
-from zope.interface import implements, Interface, Attribute
+from zope.interface import implementer, Interface, Attribute
 from twisted.internet.protocol import ServerFactory, ClientFactory, \
     connectionDone
 from twisted.internet import defer
@@ -257,9 +257,8 @@ class IThriftClientFactory(Interface):
     oprot_factory = Attribute("Output protocol factory")
 
 
+@implementer(IThriftServerFactory)
 class ThriftServerFactory(ServerFactory):
-
-    implements(IThriftServerFactory)
 
     protocol = ThriftServerProtocol
 
@@ -272,9 +271,8 @@ class ThriftServerFactory(ServerFactory):
             self.oprot_factory = oprot_factory
 
 
+@implementer(IThriftClientFactory)
 class ThriftClientFactory(ClientFactory):
-
-    implements(IThriftClientFactory)
 
     protocol = ThriftClientProtocol
 


### PR DESCRIPTION
* As per zope.interface 4.0.0 changelog
Deprecate the “class advice” APIs from zope.interface.declarations: implements, implementsOnly, and classProvides. In their place, prefer the equivalent class decorators: @implementer, @implementer_only, and @provider. Code which uses the deprecated APIs will not work as expected under Py3k.
https://pypi.python.org/pypi/zope.interface

Patch is simply output of zope-2to3 -wn lib/py/src/transport/TTwisted.py

All tests passed incl cross lang suite. Should be py2/3 compat