### PR TITLE
THRIFT-4010 Q.fcall messing up with *this* pointer inside called func…

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -1118,7 +1118,7 @@ void t_js_generator::generate_process_function(t_service* tservice, t_function* 
   f_service_ << indent() << "if (this._handler." << tfunction->get_name()
              << ".length === " << fields.size() << ") {" << endl;
   indent_up();
-  indent(f_service_) << "Q.fcall(this._handler." << tfunction->get_name();
+  indent(f_service_) << "Q.fcall(this._handler." << tfunction->get_name() << ".bind(this._handler)";
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     f_service_ << ", args." << (*f_iter)->get_name();


### PR DESCRIPTION
Example: I define a basic service

```
namespace js Auth

service AuthSrv {
    string signin(
        1:string email,
        2:string password
    )
}
```

And set up a Auth es6 class that gonna handle the requests like this:

```
module.exports = class AuthSrv {
    constructor() {
        this.db = .........
    }

    async signin(email, password) {
        try {
            let user = await this.db.findOne(....)
        }
        
        ....
    }
}
```

and instantiate a thrift server like this:

```
let server = thrift.createServer(AuthProcessor, new AuthSrv());
```

In this scenario, i'm getting that *this* pointer is **undefined** when signin function is called. Looking at thrift generated code for the processor i saw this line:

```
if (this._handler.signin.length === 2) {
    Q.fcall(this._handler.signin, args.email, args.password)
    .then(.....)
}
```

If i change the fcall to:

```
if (this._handler.signin.length === 2) {
    Q.fcall(this._handler.signin.bind(this._handler), args.email, args.password)
    .then(.....)
}
```

everything works like a charm and *this* pointer is correctly assinged inside signin function call.