### PR TITLE
THRIFT-4012: Zope implements doesn't work with Python 3; @implementer does

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1051,7 +1051,7 @@ void t_py_generator::generate_service(t_service* tservice) {
              << import_dynbase_;
 
   if (gen_twisted_) {
-    f_service_ << "from zope.interface import Interface, implements" << endl
+    f_service_ << "from zope.interface import Interface, implementer" << endl
                << "from twisted.internet import defer" << endl
                << "from thrift.transport import TTwisted" << endl;
   } else if (gen_tornado_) {
@@ -1180,8 +1180,8 @@ void t_py_generator::generate_service_client(t_service* tservice) {
   f_service_ << endl << endl;
 
   if (gen_twisted_) {
-    f_service_ << "class Client" << extends_client << ":" << endl
-               << indent_str() << "implements(Iface)" << endl
+    f_service_ << "@implementer(Iface)" << endl
+               << "class Client" << extends_client << ":" << endl
                << endl;
   } else {
     f_service_ << "class Client(" << extends_client << "Iface):" << endl;
@@ -1720,8 +1720,8 @@ void t_py_generator::generate_service_server(t_service* tservice) {
 
   // Generate the header portion
   if (gen_twisted_) {
-    f_service_ << "class Processor(" << extends_processor << "TProcessor):" << endl
-               << indent_str() << "implements(Iface)" << endl << endl;
+    f_service_ << "@implementer(Iface)" << endl
+               << "class Processor(" << extends_processor << "TProcessor):" << endl;
   } else {
     f_service_ << "class Processor(" << extends_processor << "Iface, TProcessor):" << endl;
   }

--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -20,7 +20,7 @@
 from io import BytesIO
 import struct
 
-from zope.interface import implements, Interface, Attribute
+from zope.interface import implementer, Interface, Attribute
 from twisted.internet.protocol import ServerFactory, ClientFactory, \
     connectionDone
 from twisted.internet import defer
@@ -257,9 +257,8 @@ class IThriftClientFactory(Interface):
     oprot_factory = Attribute("Output protocol factory")
 
 
+@implementer(IThriftServerFactory)
 class ThriftServerFactory(ServerFactory):
-
-    implements(IThriftServerFactory)
 
     protocol = ThriftServerProtocol
 
@@ -272,9 +271,8 @@ class ThriftServerFactory(ServerFactory):
             self.oprot_factory = oprot_factory
 
 
+@implementer(IThriftClientFactory)
 class ThriftClientFactory(ClientFactory):
-
-    implements(IThriftClientFactory)
 
     protocol = ThriftClientProtocol
 


### PR DESCRIPTION
Replace uses of implements with @implementer since the former does not
work with Python 3, while the latter works with both Python 2 and 3.