### PR TITLE
THRIFT-4019 Dart Makefiles should also clean pubspec.lock

### DIFF
--- a/lib/dart/Makefile.am
+++ b/lib/dart/Makefile.am
@@ -24,5 +24,6 @@ clean-local:
 	$(RM) -r .pub
 	find . -type d -name "packages" | xargs $(RM) -r
 	find . -type f -name ".packages" | xargs $(RM)
+	find . -type f -name "pubspec.lock" | xargs $(RM)
 
 check-local: all

--- a/test/dart/Makefile.am
+++ b/test/dart/Makefile.am
@@ -38,6 +38,7 @@ clean-local:
 	$(RM) -r gen-dart test_client/.pub
 	find . -type d -name "packages" | xargs $(RM) -r
 	find . -type f -name ".packages" | xargs $(RM)
+	find . -type f -name "pubspec.lock" | xargs $(RM)
 
 client: stubs
 	${DART} test_client/bin/main.dart

--- a/tutorial/dart/Makefile.am
+++ b/tutorial/dart/Makefile.am
@@ -30,6 +30,7 @@ clean-local:
 	$(RM) -r gen-*
 	find . -type d -name "packages" | xargs $(RM) -r
 	find . -type f -name ".packages" | xargs $(RM)
+	find . -type f -name "pubspec.lock" | xargs $(RM)
 
 pub-get: pub-get-gen pub-get-client pub-get-console-client pub-get-server
 


### PR DESCRIPTION
@ericklaus-wf 

FYI @allengeorge this addresses the omission that I mentioned here - https://github.com/apache/thrift/pull/1147#issuecomment-270401425