### PR TITLE
THRIFT-3984 PHP7 extension causes segfault 

### DIFF
--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol7.cpp
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol7.cpp
@@ -596,6 +596,7 @@ void binary_deserialize(int8_t thrift_typeID, PHPInputTransport& transport, zval
           if (Z_TYPE(key) != IS_STRING) convert_to_string(&key);
           zend_symtable_update(Z_ARR_P(return_value), Z_STR(key), &value);
         }
+        zval_dtor(&key);
       }
       return; // return_value already populated
     }
@@ -636,6 +637,7 @@ void binary_deserialize(int8_t thrift_typeID, PHPInputTransport& transport, zval
           if (Z_TYPE(key) != IS_STRING) convert_to_string(&key);
           zend_symtable_update(Z_ARR_P(return_value), Z_STR(key), &value);
         }
+        zval_dtor(&key);
       }
       return;
     }
@@ -665,7 +667,7 @@ void binary_serialize_hashtable_key(int8_t keytype, PHPOutputTransport& transpor
   } else {
     char buf[64];
     if (res == HASH_KEY_IS_STRING) {
-      ZVAL_STR(&z, key);
+      ZVAL_STR_COPY(&z, key);
     } else {
       snprintf(buf, 64, "%ld", index);
       ZVAL_STRING(&z, buf);
@@ -822,7 +824,7 @@ void protocol_writeMessageBegin(zval* transport, zend_string* method_name, int32
   zval ret;
   zval writeMessagefn;
 
-  ZVAL_STR(&args[0], method_name);
+  ZVAL_STR_COPY(&args[0], method_name);
   ZVAL_LONG(&args[1], msgtype);
   ZVAL_LONG(&args[2], seqID);
   ZVAL_NULL(&ret);

--- a/test/php/TestClient.php
+++ b/test/php/TestClient.php
@@ -266,6 +266,39 @@ if ($mapin != $mapout) {
     $exitcode |= ERR_CONTAINERS;
 }
 
+$mapout = array();
+for ($i = 0; $i < 10; $i++) {
+    $mapout["key$i"] = "val$i";
+}
+print_r('testStringMap({');
+$first = true;
+foreach ($mapout as $key => $val) {
+  if ($first) {
+    $first = false;
+  } else {
+    print_r(", ");
+  }
+  print_r("\"$key\" => \"$val\"");
+}
+print_r("})");
+$mapin = $testClient->testStringMap($mapout);
+print_r(" = {");
+$first = true;
+foreach ($mapin as $key => $val) {
+  if ($first) {
+    $first = false;
+  } else {
+    print_r(", ");
+  }
+  print_r("\"$key\" => \"$val\"");
+}
+print_r("}\n");
+ksort($mapin);
+if ($mapin != $mapout) {
+    echo "**FAILED**\n";
+    $exitcode |= ERR_CONTAINERS;
+}
+
 /**
  * SET TEST
  */
@@ -459,7 +492,6 @@ try {
   print_r(' caught xception '.$x->errorCode.': '.$x->message."\n");
 }
 
-
 /**
  * Normal tests done.
  */
@@ -471,6 +503,19 @@ print_r("Total time: $elp ms\n");
 /**
  * Extraneous "I don't trust PHP to pack/unpack integer" tests
  */
+
+if ($protocol instanceof TBinaryProtocolAccelerated) {
+    // Regression check: check that method name is not double-freed
+    // Method name should not be an interned string.
+    $method_name = "Void";
+    $method_name = "test$method_name";
+
+    $seqid = 0;
+    $args = new \ThriftTest\ThriftTest_testVoid_args();
+    thrift_protocol_write_binary($protocol, $method_name, \Thrift\Type\TMessageType::CALL, $args, $seqid, $protocol->isStrictWrite());
+    $testClient->recv_testVoid();
+
+}
 
 // Max I32
 $num = pow(2, 30) + (pow(2, 30) - 1);


### PR DESCRIPTION
Fix a double-free when serializing string map keys or the name of called methods, and a memory leak when deserializing maps or sets.