### PR TITLE
THRIFT-4033 disable compiler plug-ins for standard debian build

### DIFF
--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -84,7 +84,7 @@ if(WITH_CPP)
 endif()
 CMAKE_DEPENDENT_OPTION(BUILD_CPP "Build C++ library" ON
                        "BUILD_LIBRARIES;WITH_CPP;Boost_FOUND" OFF)
-CMAKE_DEPENDENT_OPTION(WITH_PLUGIN "Build compiler plugin support" ON
+CMAKE_DEPENDENT_OPTION(WITH_PLUGIN "Build compiler plugin support" OFF
                        "BUILD_COMPILER;BUILD_CPP" OFF)
 
 # C GLib
@@ -164,7 +164,6 @@ message(STATUS "Thrift package version:                       ${PACKAGE_VERSION}
 message(STATUS "Build configuration Summary")
 message(STATUS "  Build Thrift compiler:                      ${BUILD_COMPILER}")
 message(STATUS "  Build compiler plugin support:              ${WITH_PLUGIN}")
-MESSAGE_DEP(PLUGIN_COMPILER_NOT_TOO_OLD "Disabled due to older compiler")
 message(STATUS "  Build with unit tests:                      ${BUILD_TESTING}")
 MESSAGE_DEP(HAVE_COMPILER "Disabled because BUILD_THRIFT=OFF and no valid THRIFT_COMPILER is given")
 message(STATUS "  Build examples:                             ${BUILD_EXAMPLES}")

--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -108,11 +108,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID 
   endif()
 endif()
 
-# If gcc older than 4.8 is detected, disable new compiler plug-in support (see THRIFT-3937)
-set(PLUGIN_COMPILER_NOT_TOO_OLD ON) # simplifies messaging in DefineOptions summary
+# If gcc older than 4.8 is detected and plugin support was requested, fail fast
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8" AND WITH_PLUGIN)
-  message(STATUS "Disabling compiler plug-in support to work with older gcc compiler")
-  set(WITH_PLUGIN OFF)
-  set(PLUGIN_COMPILER_NOT_TOO_OLD OFF)
+  message(SEND_ERROR "Thrift compiler plug-in support is not possible with older gcc ( < 4.8 ) compiler")
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -528,8 +528,8 @@ fi
 AM_CONDITIONAL(WITH_TESTS, [test "$have_tests" = "yes"])
 
 AC_ARG_ENABLE([plugin],
-  AS_HELP_STRING([--enable-plugin], [build compiler plugin support [default=yes]]),
-  [], enable_plugin=yes
+  AS_HELP_STRING([--enable-plugin], [build compiler plugin support [default=no]]),
+  [], enable_plugin=no
 )
 have_plugin=yes
 if test "$have_cpp" = "no" ; then
@@ -538,9 +538,7 @@ fi
 if test "$enable_plugin" = "no"; then
   have_plugin="no"
 fi
-if test "$have_plugin" = "yes" ; then
-  AC_CONFIG_LINKS([compiler/cpp/test/plugin/t_cpp_generator.cc:compiler/cpp/src/thrift/generate/t_cpp_generator.cc])
-fi
+AC_CONFIG_LINKS([compiler/cpp/test/plugin/t_cpp_generator.cc:compiler/cpp/src/thrift/generate/t_cpp_generator.cc])
 AM_CONDITIONAL(WITH_PLUGIN, [test "$have_plugin" = "yes"])
 
 AC_ARG_ENABLE([tutorial],

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,7 @@ configure-stamp:
 
 	# Add here commands to configure the package.
 	if [ -f bootstrap.sh ]; then $(CURDIR)/bootstrap.sh; fi
-	$(CURDIR)/configure --prefix=/usr
+	$(CURDIR)/configure --prefix=/usr --enable-plugin=no
 
 	touch configure-stamp
 
@@ -42,11 +42,11 @@ build: build-arch build-indep
 build-arch: build-arch-stamp
 $(CURDIR)/compiler/cpp/thrift build-arch-stamp: configure-stamp
 
-	# Compile C++ library
-	$(MAKE) -C $(CURDIR)/lib/cpp
-
 	# Compile compiler
 	$(MAKE) -C $(CURDIR)/compiler/cpp
+
+	# Compile C++ library
+	$(MAKE) -C $(CURDIR)/lib/cpp
 
 	# Compile C (glib) library
 	$(MAKE) -C $(CURDIR)/lib/c_glib


### PR DESCRIPTION
as the thrift-compiler packaging is not ready for it yet