### PR TITLE
THRIFT-3973: Provide some tools to make it easier to build thrift C++ on Windows

### DIFF
--- a/build/wincpp/README.md
+++ b/build/wincpp/README.md
@@ -1,0 +1,219 @@
+<!---
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Building thrift on Windows (Native)
+
+Thrift uses cmake to make it easier to build the project on multiple platforms, however to build a fully functional and production ready thrift on Windows requires a number of third party libraries to be obtained or built.  Once third party libraries are ready, the right combination of options must be passed to cmake in order to generate the correct environment.
+
+## Summary
+
+These instructions will help you build thrift for windows using Visual
+Studio 2010 or later.  The contributed batch files will help you build
+the third party libraries needed for complete thrift functionality as
+well as thrift itself.
+
+These instructions follow a directory layout that looks like the following:
+
+    workspace\
+      build\       - this is where the out-of-tree thrift cmake builds are generated
+      dist\        - this is where the thrift build results end up
+      thirdparty\  - this is where all third party binaries and libraries live
+        build\       - this is where all third party out-of-tree builds are generated
+                       (except for openssl, which only builds in-tree)
+        dist\        - this is where all third party distributions end up
+        src\         - this is where all third party source projects live
+      scripts\     - batch files used to set environment variables for builds
+      thrift\      - this is where the thrift source project lives
+
+Create a "workspace" directory somewhere on your system and then copy the contents of this
+directory to there, then clone or unpack thrift into `workspace\thrift`.
+
+## Third Party Libraries
+
+Batch scripts are provided to build some third party libraries.  You must download them and place them into the directory noted for each.  You can use different versions if you prefer; these instructions were made with the versions listed.  
+
+> TIP: To modify the versions used in the batch scripts, look in scripts\tpversions.bat.
+
+Build them in the order listed to satisfy their dependencies.
+
+### winflexbison
+
+        source: web site
+      location: https://sourceforge.net/projects/winflexbison/files/win_flex_bison-latest.zip/download
+       version: "latest"
+     directory: workspace\thirdparty\dist\winflexbison
+
+This package is required to build the compiler.  This third party package does not need to be built as it is a binary distribution of the "bison" and "flex" tools normally found on Unix boxes.
+
+> TIP: If you are only interested in building the compiler, you can skip the remaining third party libraries.
+
+### zlib
+
+        source: web site
+      location: http://zlib.net/
+       version: 1.2.9
+     directory: workspace\thirdparty\src\zlib-1.2.9
+
+To build, open the appropriate Visual Studio command prompt and then run 
+the build-zlib.bat script in thirdparty\src.
+ 
+### openssl
+
+        source: web site
+      location: https://www.openssl.org/
+       version: 1.1.0c
+     directory: workspace\thirdparty\src\openssl-1.1.0c
+    depends-on: zlib
+
+If you are using openssl-1.1.0 or later, they changed static builds to use Microsoft Static RTL for release builds.  zlib by default uses a dynamic runtime, as does libevent.  Edit the file Configurations/10-main.conf and replace the section contents for "VC-noCE-common" with what appears below to make openssl build with dynamic runtime instead:
+
+    "VC-noCE-common" => {
+        inherit_from     => [ "VC-common" ],
+        template         => 1,
+        cflags           => add(picker(default => "-DUNICODE -D_UNICODE",
+                                       debug   => "/MDd /Od -DDEBUG -D_DEBUG",
+                                       release => "/MD /O2"
+                                      )),
+        bin_cflags       => add(picker(debug   => "/MDd",
+                                       release => "/MD",
+                                      )),
+        bin_lflags       => add("/subsystem:console /opt:ref"),
+        ex_libs          => add(sub {
+            my @ex_libs = ();
+            push @ex_libs, 'ws2_32.lib' unless $disabled{sock};
+            push @ex_libs, 'gdi32.lib advapi32.lib crypt32.lib user32.lib';
+            return join(" ", @ex_libs);
+        }),
+    },
+
+To build, open the appropriate Visual Studio command prompt and then run 
+the build-openssl.bat script in thirdparty\src.
+
+### libevent
+
+        source: git
+      location: https://github.com/nmathewson/Libevent.git
+           use: commit 3821cca1a637f4da4099c9343e7326da00f6981c or later
+          date: Fri Dec 23 16:19:35 2016 +0800 or later
+       version: corresponds to 2.1.7rc + patches
+     directory: workspace\thirdparty\src\libevent-2.1.7rc2
+    depends-on: openssl, zlib
+
+To build, open the appropriate Visual Studio command prompt and then run 
+the build-libevent.bat script in thirdparty\src.
+
+### msinttypes
+
+        source: web site
+      location: https://code.google.com/archive/p/msinttypes/downloads
+       version: 26
+     directory: workspace\thirdparty\dist\msinttypes
+
+> TIP: This is only necessary for Visual Studio 2010, which did not include an <inttypes.h> header.
+
+This third party package does not need to be built as it is a distribution of header files.
+
+### boost
+
+        source: web site
+      location: http://boost.teeks99.com/
+       version: 1_62_0
+     directory: workspace\thirdparty\dist\boost_1_62_0
+
+The pre-built binary versions of boost come in self-unpacking executables.  Run each of the ones you are interested in and point them at the same thirdparty dist directory.
+
+## Building a Production thrift Compiler
+
+### Prerequisites
+
+* CMake-2.8.12.2 or later
+* Visual Studio 2010 or later
+* thrift source placed into workspace\thrift
+* winflexbison placed into workspace\thirdparty\dist
+
+### Instructions
+
+By following these instructions you will end up with a release mode thrift compiler that is suitable for distribution as it has no external dependencies.  
+
+1. Open the appropriate Visual Studio Command Prompt.
+2. `cd workspace`
+3. `build-thrift-compiler.bat`
+
+The batch file uses CMake to generate an out-of-tree build directory in `workspace\build` and then builds the compiler.  The resulting `thrift.exe` program is placed into `workspace\dist` in a path that depends on your compiler version and platform.  For example, if you use a Visual Studio 2010 x64 Command Prompt, the compiler will be placed into `workspace\dist\thrift-compiler-dev\vc100\x64\Release\thrift.exe`
+
+#### Details
+
+This section is for those who are curious about the CMake options used in the build process.
+
+CMake takes the source tree as the first argument and uses the remaining arguments for configuration.  The batch file `build-thrift-compiler` essentially performs the following commands:
+
+    C:\> CD workspace\build
+    C:\workspace\build> "C:\Program Files\CMake\bin\cmake.exe" ..\thrift 
+                          -DBISON_EXECUTABLE=..\thirdparty\dist\winflexbison\win_bison.exe
+                          -DCMAKE_BUILD_TYPE=Release
+                          -DFLEX_EXECUTABLE=..\thirdparty\dist\winflexbison\win_flex.exe
+                          -DWITH_MT=ON
+                          -DWITH_SHARED_LIB=OFF
+                          -G"NMake Makefiles"
+    C:\workspace\build> NMAKE /FMakefile thrift-compiler
+
+WITH_MT controls the dynamic or static runtime library selection.  To build a production compiler, the thrift project recommends using the static runtime library to make the executable portable.  The batch file sets this.
+
+You can build a Visual Studio project file by following the example but substituting a different generator for the "-G" option.  Run `cmake.exe --help` for a list of generators.  Typically, this is one of the following on Windows (omit "Win64" to build 32-bit instead):
+
+* "Visual Studio 10 2010 Win64"
+* "Visual Studio 11 2012 Win64"
+* "Visual Studio 12 2013 Win64"
+* "Visual Studio 14 2015 Win64"
+* "Visual Studio 15 2017 Win64"
+
+For example you can build using a Visual Studio solution file on the command line by doing:
+
+    C:\> CD workspace\build
+    C:\workspace\build> "C:\Program Files\CMake\bin\cmake.exe" ..\thrift 
+                          -DBISON_EXECUTABLE=..\thirdparty\dist\winflexbison\win_bison.exe
+                          -DCMAKE_BUILD_TYPE=Release
+                          -DFLEX_EXECUTABLE=..\thirdparty\dist\winflexbison\win_flex.exe
+                          -DWITH_MT=ON
+                          -DWITH_SHARED_LIB=OFF
+                          -G"Visual Studio 14 2015 Win64"
+    C:\workspace\build> MSBUILD "Apache Thrift.sln" /p:Configuration=Release /p:Platform=x64 /t:thrift-compiler
+
+You can also double-click on the solution file to bring it up in Visual Studio and build or debug interactively from there.
+
+## Building the thrift C++ Run-Time Library
+
+These instructions are similar to the compiler build however there are additional dependencies on third party libraries to build a feature-complete runtime.  The resulting static link library for thrift uses a dynamic Microsoft runtime.
+
+1. Open the desired Visual Studio Command Prompt.
+2. `cd workspace`
+3. `build-thrift.bat`
+
+Thrift depends on boost, libevent, openssl, and zlib in order to build with all server and transport types.  To use later versions of boost like 1.62 you will need a recent version of cmake (at least 3.7).
+
+The build-thrift script has options to build debug or release and to optionally disable any of the generation (cmake), build, or test phases.  By default, the batch file will generate an out-of-tree build directory inside `workspace\build`, then perform a release build, then run the unit tests.  The batch file accepts some option flags to control its behavior:
+
+    :: Flags you can use to change this behavior:
+    ::
+    ::   /DEBUG            - if building, perform a debug build instead
+    ::   /NOGENERATE       - skip cmake generation - useful if you
+    ::                       have already generated a solution and just
+    ::                       want to build
+    ::   /NOBUILD          - skip cmake build - useful if you just
+    ::                       want to generate a solution
+    ::   /NOTEST           - skip ctest execution
+
+For example if you want to generate the cmake environment without building or running tests:
+
+    C:\workspace> build-thrift.bat /NOBUILD /NOTEST

--- a/build/wincpp/build-thrift-compiler.bat
+++ b/build/wincpp/build-thrift-compiler.bat
@@ -1,0 +1,79 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Produces a production thrift compiler suitable for redistribution.
+:: The compiler is linked to runtime statically for maximum portability.
+:: Assumes the thirdparty files for "winflexbison" have been placed
+:: according to the README.md instructions.
+::
+:: Open a Visual Studio Command Prompt of your choosing and then
+:: run this script.  
+
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+IF NOT DEFINED PACKAGE_NAME    SET PACKAGE_NAME=thrift
+IF NOT DEFINED PACKAGE_VERSION SET PACKAGE_VERSION=dev
+IF NOT DEFINED SOURCE_DIR      SET SOURCEDIR=%~dp0%PACKAGE_NAME%
+IF NOT DEFINED WIN3P_ROOT      SET WIN3P_ROOT=%~dp0thirdparty
+
+:: Set COMPILER to (vc100 - vc140) depending on the current environment
+CALL scripts\cl_setcompiler.bat || EXIT /B
+
+:: Set ARCH to either win32 or x64 depending on the current environment
+CALL scripts\cl_setarch.bat || EXIT /B
+
+:: Set GENERATOR for CMake depending on the current environment
+CALL scripts\cl_setgenerator.bat || EXIT /B
+
+IF NOT DEFINED BUILDTYPE (
+  SET BUILDTYPE=Release
+)
+
+  SET BUILDDIR=%~dp0build\%PACKAGE_NAME%-compiler\%PACKAGE_VERSION%\%COMPILER%\
+  SET OUTDIR=%~dp0dist\%PACKAGE_NAME%-compiler-%PACKAGE_VERSION%\%COMPILER%\%ARCH%\%BUILDTYPE%\
+  SET BOOST_LIBDIR=lib%ARCH:~-2,2%-msvc-%COMPILER:~-3,2%.0
+  IF "%BUILDTYPE%" == "Debug" (SET ZLIB_STATIC_SUFFIX=d)
+
+  ECHO/
+  ECHO =========================================================================
+  ECHO     Configuration: %PACKAGE_NAME% %PACKAGE_VERSION% %COMPILER%:%ARCH%:%BUILDTYPE% "%GENERATOR%"
+IF DEFINED COMPILERONLY (
+  ECHO                    COMPILER ONLY
+)
+  ECHO   Build Directory: %BUILDDIR%
+  ECHO Install Directory: %OUTDIR%
+  ECHO  Source Directory: %SOURCEDIR%
+  ECHO =========================================================================
+  ECHO/
+
+  MKDIR "%BUILDDIR%"
+  CD "%BUILDDIR%" || EXIT /B
+
+  CMAKE.EXE %~dp0thrift ^
+    -G"%GENERATOR%" ^
+    -DBISON_EXECUTABLE=%WIN3P_ROOT%\dist\winflexbison\win_bison.exe ^
+    -DCMAKE_BUILD_TYPE=%BUILDTYPE% ^
+    -DFLEX_EXECUTABLE=%WIN3P_ROOT%\dist\winflexbison\win_flex.exe ^
+    -DWITH_MT=ON ^
+    -DWITH_SHARED_LIB=OFF || EXIT /B
+
+  CD %BUILDDIR%
+
+  CMAKE.EXE --build . --config %BUILDTYPE% --target thrift-compiler || EXIT /B
+  XCOPY /F /Y %BUILDDIR%\bin\%BUILDTYPE%\thrift.exe %OUTDIR%
+
+ENDLOCAL
+EXIT /B

--- a/build/wincpp/build-thrift.bat
+++ b/build/wincpp/build-thrift.bat
@@ -1,0 +1,164 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Generates a Visual Studio solution for thrift and then builds it.
+:: Assumes third party libraries have been built or placed already.
+::
+:: Open a Visual Studio Command Prompt of your choosing and then
+:: run this script.  
+::
+:: Normally the script will run cmake to generate a solution, then
+:: perform a build, then run tests on the complete thrift library
+:: in release mode.
+::
+:: Flags you can use to change this behavior:
+::
+::   /DEBUG            - debug instead of release
+::   /IDE              - launch Visual Studio with a path set
+::                       up correctly to run tests instead of
+::                       performing any other actions, i.e.
+::                       implies setting the next three flags
+::   /NOGENERATE       - skip cmake generation - useful if you
+::                       have already generated a solution and just
+::                       want to build
+::   /NOBUILD          - skip cmake build - useful if you just
+::                       want to generate a solution
+::   /NOTEST           - skip ctest execution
+::
+
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+:: Sets variables for third party versions used in build
+CALL scripts\tpversions.bat || EXIT /B
+
+IF NOT DEFINED PACKAGE_NAME    SET PACKAGE_NAME=thrift
+IF NOT DEFINED PACKAGE_VERSION SET PACKAGE_VERSION=dev
+IF NOT DEFINED SOURCE_DIR      SET SOURCEDIR=%~dp0%PACKAGE_NAME%
+IF NOT DEFINED WIN3P_ROOT      SET WIN3P_ROOT=%~dp0thirdparty
+
+:: Set COMPILER to (vc100 - vc140) depending on the current environment
+CALL scripts\cl_setcompiler.bat || EXIT /B
+
+:: Set ARCH to either win32 or x64 depending on the current environment
+CALL scripts\cl_setarch.bat || EXIT /B
+
+:: Set GENERATOR for CMake depending on the current environment
+CALL scripts\cl_setgenerator.bat || EXIT /B
+
+:: Defaults
+
+IF NOT DEFINED BUILDTYPE SET BUILDTYPE=Release
+SET OPT_IDE=0
+SET OPT_BUILD=1
+SET OPT_GENERATE=1
+SET OPT_TEST=1
+
+:: Apply Flags
+
+IF /I "%1" == "/DEBUG"        SET BUILDTYPE=Debug
+IF /I "%2" == "/DEBUG"        SET BUILDTYPE=Debug
+IF /I "%3" == "/DEBUG"        SET BUILDTYPE=Debug
+IF /I "%1" == "/IDE"          SET OPT_IDE=1
+IF /I "%2" == "/IDE"          SET OPT_IDE=1
+IF /I "%3" == "/IDE"          SET OPT_IDE=1
+IF /I "%1" == "/NOBUILD"      SET OPT_BUILD=0
+IF /I "%2" == "/NOBUILD"      SET OPT_BUILD=0
+IF /I "%3" == "/NOBUILD"      SET OPT_BUILD=0
+IF /I "%1" == "/NOGENERATE"   SET OPT_GENERATE=0
+IF /I "%2" == "/NOGENERATE"   SET OPT_GENERATE=0
+IF /I "%3" == "/NOGENERATE"   SET OPT_GENERATE=0
+IF /I "%1" == "/NOTEST"       SET OPT_TEST=0
+IF /I "%2" == "/NOTEST"       SET OPT_TEST=0
+IF /I "%3" == "/NOTEST"       SET OPT_TEST=0
+
+IF %OPT_IDE% == 1 (
+  SET OPT_GENERATE=0
+  SET OPT_BUILD=0
+  SET OPT_TEST=0
+)
+
+  SET BUILDDIR=%~dp0build\%PACKAGE_NAME%\%PACKAGE_VERSION%\%COMPILER%\%ARCH%\
+  SET OUTDIR=%~dp0dist\%PACKAGE_NAME%-%PACKAGE_VERSION%\%COMPILER%\%ARCH%\%BUILDTYPE%\
+  SET BOOST_LIBDIR=lib%ARCH:~-2,2%-msvc-%COMPILER:~-3,2%.0
+  IF "%BUILDTYPE%" == "Debug" (SET ZLIB_STATIC_SUFFIX=d)
+
+  ECHO/
+  ECHO =========================================================================
+  ECHO     Configuration: %PACKAGE_NAME% %PACKAGE_VERSION% %COMPILER%:%ARCH%:%BUILDTYPE% "%GENERATOR%"
+IF DEFINED COMPILERONLY (
+  ECHO                    COMPILER ONLY
+)
+  ECHO   Build Directory: %BUILDDIR%
+  ECHO Install Directory: %OUTDIR%
+  ECHO  Source Directory: %SOURCEDIR%
+  ECHO =========================================================================
+  ECHO/
+
+IF %OPT_IDE% == 1 (
+
+  CALL :SETRUNPATH || EXIT /B
+  CALL DEVENV "!BUILDDIR!Apache Thrift.sln" || EXIT /B
+  EXIT /B
+  
+)
+
+  MKDIR "%BUILDDIR%"
+  CD "%BUILDDIR%" || EXIT /B
+
+IF %OPT_GENERATE% == 1 (
+
+  CMAKE.EXE %~dp0thrift ^
+    -G"%GENERATOR%" ^
+    -DBISON_EXECUTABLE=%WIN3P_ROOT%\dist\winflexbison\win_bison.exe ^
+    -DBOOST_ROOT=%WIN3P_ROOT%\dist\boost_%TP_BOOST_VERSION% ^
+    -DBOOST_LIBRARYDIR=%WIN3P_ROOT%\dist\boost_%TP_BOOST_VERSION%\%BOOST_LIBDIR% ^
+    -DCMAKE_INSTALL_PREFIX=%OUTDIR% ^
+    -DCMAKE_BUILD_TYPE=%BUILDTYPE% ^
+    -DFLEX_EXECUTABLE=%WIN3P_ROOT%\dist\winflexbison\win_flex.exe ^
+    -DINTTYPES_ROOT=%WIN3P_ROOT%\dist\msinttypes ^
+    -DLIBEVENT_ROOT=%WIN3P_ROOT%\dist\libevent-%TP_LIBEVENT_VERSION%\%COMPILER%\%ARCH%\%BUILDTYPE% ^
+    -DOPENSSL_ROOT_DIR=%WIN3P_ROOT%\dist\openssl-%TP_OPENSSL_VERSION%\%COMPILER%\%ARCH%\%BUILDTYPE%\dynamic ^
+    -DOPENSSL_USE_STATIC_LIBS=OFF ^
+    -DZLIB_LIBRARY=%WIN3P_ROOT%\dist\zlib-%TP_ZLIB_VERSION%\%COMPILER%\%ARCH%\lib\zlib%ZLIB_LIB_SUFFIX%.lib ^
+    -DZLIB_ROOT=%WIN3P_ROOT%\dist\zlib-%TP_ZLIB_VERSION%\%COMPILER%\%ARCH% ^
+    -DWITH_BOOSTTHREADS=ON ^
+    -DWITH_SHARED_LIB=OFF ^
+    -DWITH_STATIC_LIB=ON || EXIT /B
+
+)
+
+IF %OPT_BUILD% == 1 (
+
+  CD %BUILDDIR%
+  CMAKE.EXE --build . --config %BUILDTYPE% --target INSTALL || EXIT /B
+
+)
+
+IF %OPT_TEST% == 1 (
+
+  CALL :SETRUNPATH || EXIT /B
+  CMAKE.EXE --build . --config %BUILDTYPE% --target RUN_TESTS || EXIT /B
+  
+)
+
+:SETRUNPATH
+  SET PATH=!PATH!;%WIN3P_ROOT%\dist\boost_%TP_BOOST_VERSION%\%BOOST_LIBDIR%
+  SET PATH=!PATH!;%WIN3P_ROOT%\dist\openssl-%TP_OPENSSL_VERSION%\%COMPILER%\%ARCH%\%BUILDTYPE%\dynamic\bin
+  SET PATH=!PATH!;%WIN3P_ROOT%\dist\zlib-%TP_ZLIB_VERSION%\%COMPILER%\%ARCH%\bin
+  EXIT /B
+
+ENDLOCAL
+EXIT /B

--- a/build/wincpp/scripts/cl_setarch.bat
+++ b/build/wincpp/scripts/cl_setarch.bat
@@ -1,0 +1,47 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Detect the architecture we're building for.
+:: Set the ARCH environment variable to one of:
+::   win32
+::   x64
+::
+:: Honors any existing ARCH environment variable
+::   setting instead of overwriting it, to allow it
+::   to be forced if needed.
+::
+:: Sets ERRORLEVEL to 0 if ARCH can be determined,
+::                 to 1 if it cannot.
+::
+
+IF DEFINED ARCH (
+  ECHO [warn ] using existing environment variable ARCH
+  EXIT /B 0
+)
+
+CALL :CHECK x64
+IF %ERRORLEVEL% == 0 (SET ARCH=x64) ELSE (SET ARCH=win32)
+
+IF NOT DEFINED ARCH (
+  ECHO [error] unable to determine the target architecture
+  EXIT /B 1
+)
+
+ECHO [info ] detected target architecture %ARCH%
+EXIT /B 0
+
+:CHECK
+cl /? 2>&1 | findstr /C:" for %1%" > nul
+EXIT /B %ERRORLEVEL%

--- a/build/wincpp/scripts/cl_setcompiler.bat
+++ b/build/wincpp/scripts/cl_setcompiler.bat
@@ -1,0 +1,58 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Detect the compiler edition we're building in.
+:: Set the COMPILER environment variable to one of:
+::   vc100 = Visual Studio 2010
+::   vc110 = Visual Studio 2012
+::   vc120 = Visual Studio 2013
+::   vc140 = Visual Studio 2015
+::   vc150 = Visual Studio 2017
+::
+:: Honors any existing COMPILER environment variable
+::   setting instead of overwriting it, to allow it
+::   to be forced if needed.
+::
+:: Sets ERRORLEVEL to 0 if COMPILER can be determined,
+::                 to 1 if it cannot.
+::
+
+IF DEFINED COMPILER (
+  ECHO [warn ] using existing environment variable COMPILER
+  EXIT /B 0
+)
+
+CALL :CHECK 16
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED COMPILER SET COMPILER=vc100)
+CALL :CHECK 17
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED COMPILER SET COMPILER=vc110)
+CALL :CHECK 18
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED COMPILER SET COMPILER=vc120)
+CALL :CHECK 19.00
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED COMPILER SET COMPILER=vc140)
+CALL :CHECK 19.10
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED COMPILER SET COMPILER=vc150)
+
+IF NOT DEFINED COMPILER (
+  ECHO [error] unable to determine the compiler edition
+  EXIT /B 1
+)
+
+ECHO [info ] detected compiler edition    %COMPILER%
+EXIT /B 0
+
+:CHECK
+cl /? 2>&1 | findstr /C:"Version %1%." > nul
+EXIT /B %ERRORLEVEL%

--- a/build/wincpp/scripts/cl_setgenerator.bat
+++ b/build/wincpp/scripts/cl_setgenerator.bat
@@ -1,0 +1,69 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Detect the compiler edition we're building in and then 
+:: set the GENERATOR environment variable to one of:
+::
+::  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
+::                                 Optional [arch] can be "Win64" or "ARM".
+::  Visual Studio 14 2015 [arch] = Generates Visual Studio 2015 project files.
+::                                 Optional [arch] can be "Win64" or "ARM".
+::  Visual Studio 12 2013 [arch] = Generates Visual Studio 2013 project files.
+::                                 Optional [arch] can be "Win64" or "ARM".
+::  Visual Studio 11 2012 [arch] = Generates Visual Studio 2012 project files.
+::                                 Optional [arch] can be "Win64" or "ARM".
+::  Visual Studio 10 2010 [arch] = Generates Visual Studio 2010 project files.
+::                                 Optional [arch] can be "Win64" or "IA64".
+::
+:: Honors any existing GENERATOR environment variable
+::   setting instead of overwriting it, to allow it
+::   to be forced if needed.
+::
+:: Sets ERRORLEVEL to 0 if GENERATOR can be determined,
+::                 to 1 if it cannot.
+::
+:: Requires cl_setarch.bat to have been executed or the ARCH environment
+:: variable to be set.
+::
+
+IF "%ARCH%" == "x64" (SET GENARCH= Win64)
+
+IF DEFINED GENERATOR (
+  ECHO [warn ] using existing environment variable GENERATOR
+  EXIT /B 0
+)
+
+CALL :CHECK 16
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED GENERATOR SET GENERATOR=Visual Studio 10 2010%GENARCH%)
+CALL :CHECK 17
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED GENERATOR SET GENERATOR=Visual Studio 11 2012%GENARCH%)
+CALL :CHECK 18
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED GENERATOR SET GENERATOR=Visual Studio 12 2013%GENARCH%)
+CALL :CHECK 19.00
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED GENERATOR SET GENERATOR=Visual Studio 14 2015%GENARCH%)
+CALL :CHECK 19.10
+IF %ERRORLEVEL% == 0 (IF NOT DEFINED GENERATOR SET GENERATOR=Visual Studio 15 2017%GENARCH%)
+
+IF NOT DEFINED GENERATOR (
+  ECHO [error] unable to determine the CMake generator to use
+  EXIT /B 1
+)
+
+ECHO [info ] using CMake generator        %GENERATOR%
+EXIT /B 0
+
+:CHECK
+cl /? 2>&1 | findstr /C:"Version %1%." > nul
+EXIT /B %ERRORLEVEL%

--- a/build/wincpp/scripts/tpversions.bat
+++ b/build/wincpp/scripts/tpversions.bat
@@ -1,0 +1,24 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Set the versions of third party libraries to use.
+::
+
+IF NOT DEFINED TP_BOOST_VERSION    SET TP_BOOST_VERSION=1_62_0
+IF NOT DEFINED TP_LIBEVENT_VERSION SET TP_LIBEVENT_VERSION=2.1.7rc2
+IF NOT DEFINED TP_OPENSSL_VERSION  SET TP_OPENSSL_VERSION=1.1.0c
+IF NOT DEFINED TP_ZLIB_VERSION     SET TP_ZLIB_VERSION=1.2.9
+
+EXIT /B 0

--- a/build/wincpp/thirdparty/src/build-libevent.bat
+++ b/build/wincpp/thirdparty/src/build-libevent.bat
@@ -1,0 +1,86 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Build script for libevent on windows
+:: Use libevent master from github which has cmake integration
+:: Uses the environment set up by a Visual Studio Command Prompt shortcut
+:: to target a specific architecture and compiler
+::
+:: Creates a static link library.
+:: Links against OpenSSL and zlib statically.
+::
+
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+:: Sets variables for third party versions used in build
+CALL ..\..\scripts\tpversions.bat || EXIT /B
+
+:: use "build-libevent.bat /yes" to skip the question part
+IF /I "%1" == "/YES"           SET NOASK=1
+
+:: Set COMPILER to (vc100 - vc140) depending on the current environment
+CALL ..\..\scripts\cl_setcompiler.bat || EXIT /B
+
+:: Set ARCH to either win32 or x64 depending on the current environment
+CALL ..\..\scripts\cl_setarch.bat || EXIT /B
+
+IF NOT DEFINED GENERATOR       SET GENERATOR=NMake Makefiles
+IF NOT DEFINED PACKAGE_NAME    SET PACKAGE_NAME=libevent
+IF NOT DEFINED PACKAGE_VERSION SET PACKAGE_VERSION=%TP_LIBEVENT_VERSION%
+IF NOT DEFINED SOURCEDIR       SET SOURCEDIR=%~dp0%PACKAGE_NAME%-%PACKAGE_VERSION%
+IF NOT DEFINED WIN3P_ROOT      SET WIN3P_ROOT=%~dp0..
+
+FOR %%X IN (
+  Debug 
+  Release
+) DO (
+  SET BUILDTYPE=%%X
+  SET BUILDDIR=%WIN3P_ROOT%\build\%PACKAGE_NAME%\%PACKAGE_VERSION%\%COMPILER%\%ARCH%\!BUILDTYPE!
+  SET OUTDIR=%WIN3P_ROOT%\dist\%PACKAGE_NAME%-%PACKAGE_VERSION%\%COMPILER%\%ARCH%\!BUILDTYPE!
+
+  IF "!BUILDTYPE!" == "Debug" (SET ZLIB_LIB_SUFFIX=d)
+
+  SET CMAKE_DEFS=^
+   -DEVENT__DISABLE_SAMPLES=ON ^
+   -DEVENT__DISABLE_TESTS=ON ^
+   -DOPENSSL_USE_STATIC_LIBS=OFF ^
+   -DOPENSSL_ROOT_DIR=%WIN3P_ROOT%\dist\openssl-%TP_OPENSSL_VERSION%\%COMPILER%\%ARCH%\!BUILDTYPE!\dynamic ^
+   -DZLIB_LIBRARY=%WIN3P_ROOT%\dist\zlib-%TP_ZLIB_VERSION%\%COMPILER%\%ARCH%\lib\zlib!ZLIB_LIB_SUFFIX!.lib ^
+   -DZLIB_ROOT=%WIN3P_ROOT%\dist\zlib-%TP_ZLIB_VERSION%\%COMPILER%\%ARCH%
+
+  ECHO/
+  ECHO =========================================================================
+  ECHO          Building: %PACKAGE_NAME% v%PACKAGE_VERSION% %COMPILER%:%ARCH%:!BUILDTYPE! "%GENERATOR%"
+  ECHO CMake Definitions: !CMAKE_DEFS!
+  ECHO   Build Directory: !BUILDDIR!
+  ECHO Install Directory: !OUTDIR!
+  ECHO  Source Directory: %SOURCEDIR%
+  ECHO =========================================================================
+  ECHO/
+
+  IF NOT DEFINED NOASK (
+    CHOICE /M "Do you want to build this configuration? " /c YN
+    IF !ERRORLEVEL! NEQ 1 (EXIT /B !ERRORLEVEL!)
+  )
+  
+  MKDIR "!BUILDDIR!"
+  CD "!BUILDDIR!" || EXIT /B
+
+  CMAKE.EXE -G"%GENERATOR%" -DCMAKE_INSTALL_PREFIX=!OUTDIR! -DCMAKE_BUILD_TYPE=!BUILDTYPE! !CMAKE_DEFS! "%SOURCEDIR%" || EXIT /B
+  NMAKE /fMakefile install || EXIT /B
+)
+
+ENDLOCAL

--- a/build/wincpp/thirdparty/src/build-openssl.bat
+++ b/build/wincpp/thirdparty/src/build-openssl.bat
@@ -1,0 +1,106 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Build script for openssl on windows
+:: openssl uses an in-tree build so you have to clean between each one
+::
+:: Uses the environment set up by a Visual Studio Command Prompt shortcut
+:: to target a specific architecture and compiler
+::
+:: If you use Lavasoft Ad-Aware, disable it for this build.  It blocks the creation
+:: of any file named "clienthellotest.exe" for whatever reason, which breaks the build.
+::
+
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+:: Sets variables for third party versions used in build
+CALL ..\..\scripts\tpversions.bat || EXIT /B
+
+:: use "build-openssl.bat /yes" to skip the question part
+IF /I "%1" == "/YES"           SET NOASK=1
+
+IF NOT DEFINED PACKAGE_NAME    SET PACKAGE_NAME=openssl
+IF NOT DEFINED PACKAGE_VERSION SET PACKAGE_VERSION=%TP_OPENSSL_VERSION%
+IF NOT DEFINED SOURCEDIR       SET SOURCEDIR=%~dp0%PACKAGE_NAME%-%PACKAGE_VERSION%
+IF NOT DEFINED WIN3P_ROOT      SET WIN3P_ROOT=%~dp0..
+
+:: Set COMPILER to (vc100 - vc140) depending on the current environment
+CALL ..\..\scripts\cl_setcompiler.bat || EXIT /B
+
+:: Set ARCH to either win32 or x64 depending on the current environment
+CALL ..\..\scripts\cl_setarch.bat || EXIT /B
+
+IF "%ARCH%" == "x64" (
+  SET TODO=debug-VC-WIN64A VC-WIN64A
+) ELSE (
+  SET TODO=debug-VC-WIN32 VC-WIN32
+)
+
+FOR %%X IN ( !TODO! ) DO (
+  SET BUILDTYPE=%%X
+  FOR %%Y IN (
+    nt
+    ntdll
+  ) DO (
+    SET LIBTYPE=%%Y
+
+    IF "!BUILDTYPE:~0,6!" == "debug-" (
+      SET OUTBUILDTYPE=debug
+      SET ZLIBLIBSUFFIX=d
+    ) ELSE (
+      SET OUTBUILDTYPE=release
+      SET ZLIBLIBSUFFIX=
+    )
+
+    IF "!LIBTYPE!" == "ntdll" (
+      SET BUILD_OPTIONS=shared
+      SET OUTLIBTYPE=dynamic
+      SET ZLIBLIB=zlib!ZLIBLIBSUFFIX!
+      SET ZLIBOPT=zlib-dynamic
+    ) ELSE (
+      SET BUILD_OPTIONS=no-shared
+      SET OUTLIBTYPE=static
+      SET ZLIBLIB=zlibstatic!ZLIBLIBSUFFIX!.lib
+      SET ZLIBOPT=zlib
+    )
+
+    SET LIB=%~dp0..\dist\zlib-%TP_ZLIB_VERSION%\!COMPILER!\!ARCH!\lib;!LIB!
+    SET BUILD_OPTIONS=!BUILD_OPTIONS! no-asm no-unit-test !ZLIBOPT! --openssldir=ssl --with-zlib-include=%~dp0..\dist\zlib-%TP_ZLIB_VERSION%\!COMPILER!\!ARCH!\include --with-zlib-lib=!ZLIBLIB!
+    SET OUTDIR=%WIN3P_ROOT%\dist\%PACKAGE_NAME%-%PACKAGE_VERSION%\%COMPILER%\%ARCH%\!OUTBUILDTYPE!\!OUTLIBTYPE!
+
+    ECHO/
+    ECHO =========================================================================
+    ECHO          Building: %PACKAGE_NAME% %PACKAGE_VERSION% %COMPILER%:%ARCH%:!OUTBUILDTYPE!:!OUTLIBTYPE! [!BUILDTYPE!]
+    ECHO Configure Options: !BUILD_OPTIONS!
+    ECHO Install Directory: !OUTDIR!
+    ECHO  Source Directory: %SOURCEDIR%
+    ECHO =========================================================================
+    ECHO/
+
+    IF NOT DEFINED NOASK (
+      CHOICE /M "Do you want to build this configuration? " /c YN
+      IF !ERRORLEVEL! NEQ 1 (EXIT /B !ERRORLEVEL!)
+    )
+
+    CD %SOURCEDIR% || EXIT /B
+    perl Configure !BUILDTYPE! --prefix="!OUTDIR!" !BUILD_OPTIONS! || EXIT /B
+    NMAKE /FMakefile install_sw || EXIT /B
+    NMAKE /FMakefile clean || EXIT /B
+  )
+)
+
+ENDLOCAL
+EXIT /B

--- a/build/wincpp/thirdparty/src/build-zlib.bat
+++ b/build/wincpp/thirdparty/src/build-zlib.bat
@@ -1,0 +1,75 @@
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+:: 
+::     http://www.apache.org/licenses/LICENSE-2.0
+:: 
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+:: 
+
+::
+:: Build script for zlib on windows.
+:: Uses the environment set up by a Visual Studio Command Prompt shortcut
+:: to target a specific architecture and compiler.
+::
+
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+:: Sets variables for third party versions used in build
+CALL ..\..\scripts\tpversions.bat || EXIT /B
+
+:: use "build-zlib.bat /yes" to skip the question part
+IF /I "%1" == "/YES"           SET NOASK=1
+
+IF NOT DEFINED GENERATOR       SET GENERATOR=NMake Makefiles
+IF NOT DEFINED PACKAGE_NAME    SET PACKAGE_NAME=zlib
+IF NOT DEFINED PACKAGE_VERSION SET PACKAGE_VERSION=%TP_ZLIB_VERSION%
+IF NOT DEFINED SOURCE_DIR      SET SOURCEDIR=%~dp0%PACKAGE_NAME%-%PACKAGE_VERSION%
+IF NOT DEFINED WIN3P_ROOT      SET WIN3P_ROOT=%~dp0..
+
+:: Set COMPILER to (vc100 - vc140) depending on the current environment
+CALL ..\..\scripts\cl_setcompiler.bat || EXIT /B
+
+:: Set ARCH to either win32 or x64 depending on the current environment
+CALL ..\..\scripts\cl_setarch.bat || EXIT /B
+
+FOR %%X IN (
+  Debug 
+  Release
+) DO (
+  SET BUILDTYPE=%%X
+  SET BUILDDIR=%WIN3P_ROOT%\build\%PACKAGE_NAME%\%PACKAGE_VERSION%\%COMPILER%\%ARCH%\!BUILDTYPE!
+  SET OUTDIR=%WIN3P_ROOT%\dist\%PACKAGE_NAME%-%PACKAGE_VERSION%\%COMPILER%\%ARCH%
+
+  ECHO/
+  ECHO =========================================================================
+  ECHO          Building: %PACKAGE_NAME% v%PACKAGE_VERSION% %COMPILER%:%ARCH%:!BUILDTYPE! "%GENERATOR%"
+  ECHO   Build Directory: !BUILDDIR!
+  ECHO Install Directory: !OUTDIR!
+  ECHO  Source Directory: %SOURCEDIR%
+  ECHO =========================================================================
+  ECHO/
+
+  IF NOT DEFINED NOASK (
+    CHOICE /M "Do you want to build this configuration? " /c YN
+    IF !ERRORLEVEL! NEQ 1 (EXIT /B !ERRORLEVEL!)
+  )
+
+  MKDIR "!BUILDDIR!"
+  CD "!BUILDDIR!" || EXIT /B
+
+  CMAKE.EXE -G"%GENERATOR%" -DCMAKE_INSTALL_PREFIX=!OUTDIR! -DCMAKE_BUILD_TYPE=!BUILDTYPE! "%SOURCEDIR%" || EXIT /B
+  NMAKE /fMakefile install || EXIT /B
+
+  IF "!BUILDTYPE!" == "Debug" (
+    COPY "!BUILDDIR!\zlibd.pdb" "!OUTDIR!\bin\" || EXIT /B
+  )
+)
+
+ENDLOCAL


### PR DESCRIPTION
As a contributor and committer on the project with a focus on C++ and CMake, I needed a way to build thrift C++ on windows with all the bells and whistles.  While cmake is a great tool for generating build environments on different platforms, there is still an ecosystem of third party libraries surrounding thrift that need to be acquired or built.

I was not certain if these files should end up in build/wincpp or in contrib/wincpp.  These files are not used in any of our CI builds.  They simply exist as a guide to make it easier to build thrift C++ on windows, including how to build a redistributable thrift compiler for windows without any dependencies, and how to generate Visual Studio projects for thrift on windows.

As part of this effort, the current C++ MSVC projects that are distributed with the project will be removed once folks are happy with this toolset.

The README.md file contains information that can eventually be posted on:
https://thrift.apache.org/docs/install/windows
and the content there will be split into "older build information" and this would be the current.

With these tools can decide what version of Visual Studio and what platform (x86, x64) you want to work with simply by opening a Visual Studio Command Prompt of the appropriate type, and then the scripts will auto-configure to that.  I have Visual Studio 2010, 2012, 2013, and 2015 installed and I have tested all of the combinations.

The CI build is superfluous because these are not used by anything.  They are for interactive use right now.  Eventually we might be able to have the appveyor build leverage them.  I'm not sure if "wincpp" is the right name but I had to start somewhere.