### PR TITLE
THRIFT-3993 fix build error with gcc 6.2 and mingw

### DIFF
--- a/lib/cpp/src/thrift/transport/PlatformSocket.h
+++ b/lib/cpp/src/thrift/transport/PlatformSocket.h
@@ -65,7 +65,11 @@
 #  endif
 #  define THRIFT_SLEEP_SEC thrift_sleep
 #  define THRIFT_SLEEP_USEC thrift_usleep
-#  define THRIFT_TIMESPEC thrift_timespec
+#  ifndef timespec
+#    define THRIFT_TIMESPEC thrift_timespec
+#  else // support MinGW
+#    define THRIFT_TIMESPEC timespec
+#  endif
 #  define THRIFT_CTIME_R thrift_ctime_r
 #  define THRIFT_POLL thrift_poll
 #  if WINVER <= 0x0502 //XP, Server2003


### PR DESCRIPTION
We don't have a CI build that covers mingw and gcc 6.2 on windows... can anybody else try this to see if it works?