### PR TITLE
THRIFT-4043 ensure perl files do not end up in /usr/lib/Thrift

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -130,7 +130,8 @@ install-indep:
 
 	# Perl
 	$(MAKE) -C $(CURDIR)/lib/perl install DESTDIR=$(CURDIR)/debian/libthrift-perl
-	mv $(CURDIR)/debian/libthrift-perl/usr/local/lib/perl5 $(CURDIR)/debian/libthrift-perl/usr/lib
+	mkdir -p $(CURDIR)/debian/libthrift-perl/usr/share
+	mv $(CURDIR)/debian/libthrift-perl/usr/local/lib/perl5 $(CURDIR)/debian/libthrift-perl/usr/share
 	rmdir $(CURDIR)/debian/libthrift-perl/usr/local/lib
 	rmdir $(CURDIR)/debian/libthrift-perl/usr/local
 


### PR DESCRIPTION
Without the mkdir, perl5 was being moved to /usr/lib directly, rather than being moved INTO /usr/lib.  This caused perl to go into /usr/lib/Thrift.pm and /usr/lib/Thrift/... instead.

Also, debian wants architecture independent files in /usr/share, so I changed it to use /usr/share/perl5 to match the debian packaging desires.