### PR TITLE
THRIFT-4064 Update node library dependencies

### DIFF
--- a/build/docker/debian/Dockerfile
+++ b/build/docker/debian/Dockerfile
@@ -113,12 +113,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
-      nodejs \
-      nodejs-dev \
-      nodejs-legacy \
-      npm
+      nodejs
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \

--- a/build/docker/debian/Dockerfile
+++ b/build/docker/debian/Dockerfile
@@ -113,8 +113,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-# Node.js dependencies - THRIFT-4064 says it must be >= 0.12.0
-RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
       nodejs

--- a/build/docker/debian/Dockerfile
+++ b/build/docker/debian/Dockerfile
@@ -113,8 +113,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+# Node.js dependencies - THRIFT-4064 says it must be >= 0.12.0
+RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
 RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
       nodejs

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -131,8 +131,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+# Node.js dependencies - THRIFT-4064 says it must be >= 0.12.0
+RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
 RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
       nodejs

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -131,11 +131,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
-      nodejs \
-      nodejs-dev \
-      nodejs-legacy
+      nodejs
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \
@@ -182,9 +182,6 @@ RUN mkdir -p /usr/lib/haxe && \
     chmod -R 777 /usr/lib/haxe/lib && \
     haxelib setup /usr/lib/haxe/lib && \
     haxelib install hxcpp
-
-# Node.js
-RUN curl -sSL https://www.npmjs.com/install.sh | sh
 
 # D
 RUN curl -sSL http://downloads.dlang.org/releases/2.x/2.070.0/dmd_2.070.0-0_amd64.deb -o /tmp/dmd_2.070.0-0_amd64.deb && \

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -131,8 +131,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       neko-dev \
       libneko0
 
-# Node.js dependencies - THRIFT-4064 says it must be >= 0.12.0
-RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+# Node.js dependencies - THRIFT-4064 says it must be >= 4.x
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get install -y --no-install-recommends \
 `# Node.js dependencies` \
       nodejs

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   },
   "devDependencies": {
     "buffer-equals": "^1.0.3",
-    "bufferutil": "~2.0.0",
+    "bufferutil": "1.2.x",
     "commander": "2.1.x",
     "connect": "2.7.x",
     "istanbul": "^0.3.5",
     "run-browser": "^2.0.1",
     "tape": "~3.5.0",
-    "utf-8-validate": "~3.0.0"
+    "utf-8-validate": "1.2.x"
   },
   "scripts": {
     "cover": "lib/nodejs/test/testAll.sh COVER",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "main": "./lib/nodejs/lib/thrift",
   "engines": {
-    "node": ">= 0.2.4"
+    "node": ">= 4.0.0"
   },
   "dependencies": {
-    "node-int64": "~0.3.0",
-    "q": "1.0.x",
-    "ws": "~0.4.32"
+    "node-int64": "^0.4.0",
+    "q": "^1.0.0",
+    "ws": "^2.0.0"
   },
   "devDependencies": {
     "buffer-equals": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
   },
   "devDependencies": {
     "buffer-equals": "^1.0.3",
+    "bufferutil": "~2.0.0",
     "commander": "2.1.x",
     "connect": "2.7.x",
     "istanbul": "^0.3.5",
     "run-browser": "^2.0.1",
-    "tape": "~3.5.0"
+    "tape": "~3.5.0",
+    "utf-8-validate": "~3.0.0"
   },
   "scripts": {
     "cover": "lib/nodejs/test/testAll.sh COVER",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "main": "./lib/nodejs/lib/thrift",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 0.12.0"
   },
   "dependencies": {
     "node-int64": "^0.4.0",
     "q": "^1.0.0",
-    "ws": "^2.0.0"
+    "ws": "^1.0.0"
   },
   "devDependencies": {
     "buffer-equals": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   },
   "devDependencies": {
     "buffer-equals": "^1.0.3",
-    "bufferutil": "1.2.x",
+    "bufferutil": "~2.0.0",
     "commander": "2.1.x",
     "connect": "2.7.x",
     "istanbul": "^0.3.5",
     "run-browser": "^2.0.1",
     "tape": "~3.5.0",
-    "utf-8-validate": "1.2.x"
+    "utf-8-validate": "~3.0.0"
   },
   "scripts": {
     "cover": "lib/nodejs/test/testAll.sh COVER",


### PR DESCRIPTION
* The changes to node-int64 and Q are small:
  - https://github.com/broofa/node-int64/compare/v0.3.3...v0.4.0
  - https://github.com/kriskowal/q/compare/v1.0.1...v1.4.1
* ws under went a rewrite between 0.4.32 and 2.0.1 (https://github.com/websockets/ws/compare/0.4.32...2.0.1). The API as used by thrift is backwards compatible. However, ws now uses ES6 syntax, so it requires at least Node 4.
  - Most notable change here is that ws no longer tries to install binary modules.
* Node 4 is now the minimally required version of Node, due to ws' requirement.