### PR TITLE
THRIFT-4018 corruption after ApplicationException in Ruby server

### DIFF
--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -50,6 +50,7 @@ module Thrift
     end
 
     def write_result(result, oprot, name, seqid)
+      result.validate
       oprot.write_message_begin(name, MessageTypes::REPLY, seqid)
       result.write(oprot)
       oprot.write_message_end

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -51,7 +51,7 @@ ARGV.each do|a|
 end
 ARGV=[]
 
-class SimpleClientTest < Test::Unit::TestCase
+class BaseClientTest < Test::Unit::TestCase
   def setup
     unless @socket
       @socket   = Thrift::Socket.new($host, $port)
@@ -83,6 +83,9 @@ class SimpleClientTest < Test::Unit::TestCase
     @socket.close
   end
 
+end
+
+class SimpleClientTest < BaseClientTest
   def test_void
     p 'test_void'
     @client.testVoid()
@@ -351,3 +354,20 @@ class SimpleClientTest < Test::Unit::TestCase
 
 end
 
+class CorruptedServer < BaseClientTest
+  def test_corrupted_server_response
+    begin
+      @client.testEnum(Thrift::Test::Numberz::EIGHT)
+      assert false, 'Should have raised Thrift::ApplicationException'
+    rescue Thrift::ApplicationException
+    end
+    # the next call and future calls raise Thrift::ProtocolException
+    # because the server's response can't be parsed by the client
+    begin
+      @client.testEnum(Thrift::Test::Numberz::EIGHT)
+      assert false, 'Should have raised Thrift::ApplicationException'
+    rescue Thrift::ApplicationException
+    end
+  end
+
+end

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -28,8 +28,8 @@ require 'thrift_test_types'
 
 class SimpleHandler
   [:testVoid, :testString, :testBool, :testByte, :testI32, :testI64, :testDouble, :testBinary,
-   :testStruct, :testMap, :testStringMap, :testSet, :testList, :testNest, :testEnum, :testTypedef,
-   :testEnum, :testTypedef, :testMultiException].each do |meth|
+   :testStruct, :testMap, :testStringMap, :testSet, :testList, :testNest, :testTypedef,
+   :testTypedef, :testMultiException].each do |meth|
 
     define_method(meth) do |thing|
       p meth
@@ -37,6 +37,14 @@ class SimpleHandler
       thing
     end
 
+  end
+
+  def testEnum(thing)
+    if thing == Thrift::Test::Numberz::EIGHT then
+      # intentionally raising an invalid return value to trigger THRIFT-4018
+      return 100
+    end
+    thing
   end
 
   def testVoid()


### PR DESCRIPTION
This fixes an issue where a Ruby Thrift server can corrupt connections by putting ApplicationException in the middle of a response. See https://issues.apache.org/jira/browse/THRIFT-4018 for more information.