### PR TITLE
THRIFT-4075: better support for headers-only boost with mingw

### DIFF
--- a/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
+++ b/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
@@ -63,7 +63,7 @@ namespace apache {
 namespace thrift {
 namespace transport {
 
-DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) struct TOverlappedWorkItem : public SLIST_ENTRY {
+struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) TOverlappedWorkItem : public SLIST_ENTRY {
   TOverlappedWorkItem();
 
   enum action_t {

--- a/lib/cpp/src/thrift/windows/config.h
+++ b/lib/cpp/src/thrift/windows/config.h
@@ -28,8 +28,8 @@
 #error "This is a Windows header only"
 #endif
 
-// use std::thread in MSVC11 (2012) or newer
-#if _MSC_VER >= 1700
+// use std::thread in MSVC11 (2012) or newer and in MinGW
+#if (_MSC_VER >= 1700) || defined(__MINGW32__)
 #define USE_STD_THREAD 1
 #else
 // otherwise use boost threads
@@ -39,8 +39,8 @@
 // Something that defines PRId64 is required to build
 #define HAVE_INTTYPES_H 1
 
-// VS2010 or later has stdint.h
-#if _MSC_VER >= 1600
+// VS2010 or later has stdint.h as does MinGW
+#if (_MSC_VER >= 1600) || defined(__MINGW32__)
 #define HAVE_STDINT_H 1
 #endif
 


### PR DESCRIPTION
Also fixed a warning from gcc where an alignment pragma was in the wrong place.