### PR TITLE
Check for joinable before attempting join in thread destructors

### DIFF
--- a/lib/cpp/src/thrift/concurrency/BoostThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/BoostThreadFactory.cpp
@@ -61,7 +61,7 @@ public:
   }
 
   ~BoostThread() {
-    if (!detached_) {
+    if (!detached_ && thread_->joinable()) {
       try {
         join();
       } catch (...) {

--- a/lib/cpp/src/thrift/concurrency/StdThreadFactory.cpp
+++ b/lib/cpp/src/thrift/concurrency/StdThreadFactory.cpp
@@ -61,7 +61,7 @@ public:
   }
 
   ~StdThread() {
-    if (!detached_) {
+    if (!detached_ && thread_->joinable()) {
       try {
         join();
       } catch (...) {


### PR DESCRIPTION
A spurious exception is thrown when shutting down TThreadedServer via drainDeadClients because threads are joined before being destroyed.