### PR TITLE
THRIFT-3706: glib client/java server/crosstest multiplexed improvements

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -31,7 +31,6 @@
 enum
 {
   PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME = 1,
-  PROP_THRIFT_MULTIPLEXED_PROTOCOL_SEPARATOR,
   PROP_THRIFT_MULTIPLEXED_PROTOCOL_END
 };
 
@@ -42,114 +41,95 @@ static GParamSpec *thrift_multiplexed_protocol_obj_properties[PROP_THRIFT_MULTIP
 
 gint32
 thrift_multiplexed_protocol_write_message_begin (ThriftMultiplexedProtocol *protocol,
-		const gchar *name, const ThriftMessageType message_type,
-		const gint32 seqid, GError **error)
+    const gchar *name, const ThriftMessageType message_type,
+    const gint32 seqid, GError **error)
 {
-	gint32 ret;
-	gchar *service_name = NULL;
-	g_return_val_if_fail (THRIFT_IS_MULTIPLEXED_PROTOCOL (protocol), -1);
+  gint32 ret;
+  gchar *service_name = NULL;
+  g_return_val_if_fail (THRIFT_IS_MULTIPLEXED_PROTOCOL (protocol), -1);
 
-	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (protocol);
-	ThriftMultiplexedProtocolClass *multiplexClass = THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(self);
-	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (multiplexClass);
+  ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (protocol);
+  ThriftMultiplexedProtocolClass *multiplexClass = THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(self);
+  ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (multiplexClass);
 
-	if( (message_type == T_CALL || message_type == T_ONEWAY) && self->service_name != NULL) {
-		service_name = g_strdup_printf("%s%s%s", self->service_name, self->separator, name);
+  if( (message_type == T_CALL || message_type == T_ONEWAY) && self->service_name != NULL) {
+    service_name = g_strdup_printf("%s%s%s", self->service_name, THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR, name);
+  }else{
+    service_name = g_strdup(name);
+  }
 
-	}else{
-		service_name = g_strdup(name);
-	}
+  // relay to the protocol_decorator
+  ret = thrift_protocol_decorator_write_message_begin(protocol, service_name, message_type, seqid, error);
 
-	// relay to the protocol_decorator
-	ret = thrift_protocol_decorator_write_message_begin(protocol, service_name, message_type, seqid, error);
+  g_free(service_name);
 
-	g_free(service_name);
-
-	return ret;
+  return ret;
 }
-
-
 
 
 static void
 thrift_multiplexed_protocol_set_property (GObject      *object,
-		guint         property_id,
-		const GValue *value,
-		GParamSpec   *pspec)
+    guint         property_id,
+    const GValue *value,
+    GParamSpec   *pspec)
 {
-	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
+  ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
 
-	switch (property_id)
-	{
-	case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
-		if(self->service_name!=NULL)
-			g_free (self->service_name);
-		self->service_name= g_value_dup_string (value);
-		break;
+  switch (property_id)
+  {
+  case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
+    self->service_name = g_value_dup_string (value);
+    break;
 
-	case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SEPARATOR:
-		if(self->separator!=NULL)
-			g_free (self->separator);
-		self->separator= g_value_dup_string (value);
-		break;
-
-	default:
-		/* We don't have any other property... */
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
-		break;
-	}
+  default:
+    /* We don't have any other property... */
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    break;
+  }
 }
 
 static void
 thrift_multiplexed_protocol_get_property (GObject    *object,
-		guint       property_id,
-		GValue     *value,
-		GParamSpec *pspec)
+    guint       property_id,
+    GValue     *value,
+    GParamSpec *pspec)
 {
-	ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
+  ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (object);
 
-	switch (property_id)
-	{
-	case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
-		g_value_set_string (value, self->service_name);
-		break;
+  switch (property_id)
+  {
+  case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
+    g_value_set_string (value, self->service_name);
+    break;
 
-	case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SEPARATOR:
-		g_value_set_string (value, self->separator);
-		break;
-
-	default:
-		/* We don't have any other property... */
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
-		break;
-	}
+  default:
+    /* We don't have any other property... */
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    break;
+  }
 }
 
 
 static void
 thrift_multiplexed_protocol_init (ThriftMultiplexedProtocol *protocol)
 {
-	//  THRIFT_UNUSED_VAR (protocol);
-	protocol->separator = g_strdup (THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR);
-	protocol->service_name = NULL;
+  protocol->service_name = NULL;
 }
 
 static void
-thrift_multiplexed_protocol_finalize (ThriftMultiplexedProtocol *protocol)
+thrift_multiplexed_protocol_finalize (GObject *gobject)
 {
-	if(protocol->separator){
-		g_free(protocol->separator);
-		protocol->separator = NULL;
-	}
-	if(protocol->service_name){
-		g_free(protocol->service_name);
-		protocol->service_name = NULL;
-	}
-	/* Always chain up to the parent class; there is no need to check if
-	 * the parent class implements the dispose() virtual function: it is
-	 * always guaranteed to do so
-	 */
-	/* This fails, why? G_OBJECT_CLASS (protocol)->finalize(protocol); */
+  ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (gobject);
+
+  if (self->service_name) {
+    g_free(self->service_name);
+    self->service_name = NULL;
+  }
+
+  /* Always chain up to the parent class; as with dispose(), finalize()
+   * is guaranteed to exist on the parent's class virtual function table
+   */
+  G_OBJECT_CLASS (thrift_multiplexed_protocol_parent_class)->finalize(gobject);
 }
 
 
@@ -157,31 +137,23 @@ thrift_multiplexed_protocol_finalize (ThriftMultiplexedProtocol *protocol)
 static void
 thrift_multiplexed_protocol_class_init (ThriftMultiplexedProtocolClass *klass)
 {
-	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-	g_debug("Current Multiplexed write_message_begin addr %p, new %p", cls->write_message_begin, thrift_multiplexed_protocol_write_message_begin);
-	cls->write_message_begin = thrift_multiplexed_protocol_write_message_begin;
+  cls->write_message_begin = thrift_multiplexed_protocol_write_message_begin;
 
+  object_class->set_property = thrift_multiplexed_protocol_set_property;
+  object_class->get_property = thrift_multiplexed_protocol_get_property;
+  object_class->finalize = thrift_multiplexed_protocol_finalize;
 
-	object_class->set_property = thrift_multiplexed_protocol_set_property;
-	object_class->get_property = thrift_multiplexed_protocol_get_property;
-	object_class->finalize = thrift_multiplexed_protocol_finalize;
+  thrift_multiplexed_protocol_obj_properties[PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME] =
+      g_param_spec_string ("service-name",
+          "Service name the protocol points to",
+          "Set the service name",
+          NULL,
+          (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
 
-	thrift_multiplexed_protocol_obj_properties[PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME] =
-			g_param_spec_string ("service-name",
-					"Service name the protocol points to",
-					"Set the service name",
-					NULL /* default value */,
-					(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
-	thrift_multiplexed_protocol_obj_properties[PROP_THRIFT_MULTIPLEXED_PROTOCOL_SEPARATOR] =
-			g_param_spec_string ("separator",
-					"Separator for service name and pointer",
-					"Set service name separator",
-					NULL /* default value */,
-					G_PARAM_READWRITE);
-
-	g_object_class_install_properties (object_class,
-			PROP_THRIFT_MULTIPLEXED_PROTOCOL_END,
-			thrift_multiplexed_protocol_obj_properties);
+  g_object_class_install_properties (object_class,
+      PROP_THRIFT_MULTIPLEXED_PROTOCOL_END,
+      thrift_multiplexed_protocol_obj_properties);
 }

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 #define THRIFT_IS_MULTIPLEXED_PROTOCOL_CLASS(c) (G_TYPE_CHECK_CLASS_TYPE ((c), THRIFT_TYPE_MULTIPLEXED_PROTOCOL))
 #define THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), THRIFT_TYPE_MULTIPLEXED_PROTOCOL, ThriftMultiplexedProtocolClass))
 
-/* version numbers */
+/* constant */
 #define THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR ":"
 
 typedef struct _ThriftMultiplexedProtocol ThriftMultiplexedProtocol;
@@ -56,7 +56,6 @@ struct _ThriftMultiplexedProtocol
   ThriftProtocolDecorator parent;
 
   gchar *service_name;
-  gchar *separator;
 };
 
 typedef struct _ThriftMultiplexedProtocolClass ThriftMultiplexedProtocolClass;

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol.c
@@ -61,15 +61,15 @@ thrift_protocol_set_property (GObject *object, guint property_id,
   switch (property_id)
   {
     case PROP_THRIFT_PROTOCOL_TRANSPORT:
-      protocol->transport = g_value_get_object (value);
+      protocol->transport = g_value_dup_object (value);
       break;
   }
 }
 
 
 gint32
-thrift_protocol_write_message_begin (ThriftProtocol *protocol, 
-                                     const gchar *name, 
+thrift_protocol_write_message_begin (ThriftProtocol *protocol,
+                                     const gchar *name,
                                      const ThriftMessageType message_type,
                                      const gint32 seqid, GError **error)
 {
@@ -243,7 +243,7 @@ thrift_protocol_write_binary (ThriftProtocol *protocol, const gpointer buf,
                                                              len, error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_message_begin (ThriftProtocol *protocol,
                                     gchar **name,
                                     ThriftMessageType *message_type,
@@ -254,7 +254,7 @@ thrift_protocol_read_message_begin (ThriftProtocol *protocol,
                                                    seqid, error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_message_end (ThriftProtocol *protocol,
                                   GError **error)
 {
@@ -262,7 +262,7 @@ thrift_protocol_read_message_end (ThriftProtocol *protocol,
                                                                  error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_struct_begin (ThriftProtocol *protocol,
                                    gchar **name,
                                    GError **error)
@@ -279,7 +279,7 @@ thrift_protocol_read_struct_end (ThriftProtocol *protocol, GError **error)
                                                                 error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_field_begin (ThriftProtocol *protocol,
                                   gchar **name,
                                   ThriftType *field_type,
@@ -293,7 +293,7 @@ thrift_protocol_read_field_begin (ThriftProtocol *protocol,
                                                                  error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_field_end (ThriftProtocol *protocol,
                                 GError **error)
 {
@@ -301,7 +301,7 @@ thrift_protocol_read_field_end (ThriftProtocol *protocol,
                                                                error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_map_begin (ThriftProtocol *protocol,
                                 ThriftType *key_type,
                                 ThriftType *value_type, guint32 *size,
@@ -311,17 +311,17 @@ thrift_protocol_read_map_begin (ThriftProtocol *protocol,
                                                                key_type,
                                                                value_type,
                                                                size,
-                                                               error); 
+                                                               error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_map_end (ThriftProtocol *protocol, GError **error)
 {
   return THRIFT_PROTOCOL_GET_CLASS (protocol)->read_map_end (protocol,
                                                              error);
 }
 
-gint32 
+gint32
 thrift_protocol_read_list_begin (ThriftProtocol *protocol,
                                  ThriftType *element_type,
                                  guint32 *size, GError **error)
@@ -412,7 +412,7 @@ thrift_protocol_read_string (ThriftProtocol *protocol,
 }
 
 gint32
-thrift_protocol_read_binary (ThriftProtocol *protocol, gpointer *buf, 
+thrift_protocol_read_binary (ThriftProtocol *protocol, gpointer *buf,
                              guint32 *len, GError **error)
 {
   return THRIFT_PROTOCOL_GET_CLASS (protocol)->read_binary (protocol, buf,
@@ -549,12 +549,27 @@ thrift_protocol_init (ThriftProtocol *protocol)
 }
 
 static void
+thrift_protocol_dispose (GObject *gobject)
+{
+  ThriftProtocol *self = THRIFT_PROTOCOL (gobject);
+
+  g_clear_object(&self->transport);
+
+  /* Always chain up to the parent class; there is no need to check if
+   * the parent class implements the dispose() virtual function: it is
+   * always guaranteed to do so
+   */
+  G_OBJECT_CLASS (thrift_protocol_parent_class)->dispose(gobject);
+}
+
+static void
 thrift_protocol_class_init (ThriftProtocolClass *cls)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (cls);
 
   gobject_class->get_property = thrift_protocol_get_property;
   gobject_class->set_property = thrift_protocol_set_property;
+  gobject_class->dispose = thrift_protocol_dispose;
 
   g_object_class_install_property (gobject_class,
       PROP_THRIFT_PROTOCOL_TRANSPORT,

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
@@ -52,9 +52,9 @@ thrift_protocol_decorator_write_message_begin (ThriftProtocol *protocol,
   ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
   ThriftProtocolClass *proto = THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol);
 
-  g_info("Concrete protocol %p | %p", self->concrete_protocol, proto);
+  g_debug("Concrete protocol %p | %p", self->concrete_protocol, proto);
 
-  return proto->write_message_begin	(self->concrete_protocol, name,
+  return proto->write_message_begin (self->concrete_protocol, name,
                                     message_type, seqid,
                                     error);
 }
@@ -62,7 +62,7 @@ thrift_protocol_decorator_write_message_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_write_message_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_message_end (self->concrete_protocol,
                                                                   error);
@@ -72,7 +72,7 @@ gint32
 thrift_protocol_decorator_write_struct_begin (ThriftProtocol *protocol, const gchar *name,
                                     GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_struct_begin (self->concrete_protocol,
                                                    name, error);
@@ -81,7 +81,7 @@ thrift_protocol_decorator_write_struct_begin (ThriftProtocol *protocol, const gc
 gint32
 thrift_protocol_decorator_write_struct_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_struct_end (self->concrete_protocol,
                                                                  error);
@@ -94,7 +94,7 @@ thrift_protocol_decorator_write_field_begin (ThriftProtocol *protocol,
                                    const gint16 field_id,
                                    GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_begin (self->concrete_protocol,
                                                    name, field_type,
                                                    field_id, error);
@@ -103,7 +103,7 @@ thrift_protocol_decorator_write_field_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_write_field_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_end (self->concrete_protocol,
                                                                 error);
@@ -112,7 +112,7 @@ thrift_protocol_decorator_write_field_end (ThriftProtocol *protocol, GError **er
 gint32
 thrift_protocol_decorator_write_field_stop (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_field_stop (self->concrete_protocol,
                                                                  error);
@@ -124,7 +124,7 @@ thrift_protocol_decorator_write_map_begin (ThriftProtocol *protocol,
                                  const ThriftType value_type,
                                  const guint32 size, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_map_begin (self->concrete_protocol,
                                                    key_type, value_type,
@@ -134,7 +134,7 @@ thrift_protocol_decorator_write_map_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_write_map_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_map_end (self->concrete_protocol,
                                                               error);
@@ -145,7 +145,7 @@ thrift_protocol_decorator_write_list_begin (ThriftProtocol *protocol,
                                   const ThriftType element_type,
                                   const guint32 size, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_list_begin (self->concrete_protocol,
                                                    element_type, size,
@@ -155,7 +155,7 @@ thrift_protocol_decorator_write_list_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_write_list_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_list_end (self->concrete_protocol,
                                                                error);
@@ -166,7 +166,7 @@ thrift_protocol_decorator_write_set_begin (ThriftProtocol *protocol,
                                  const ThriftType element_type,
                                  const guint32 size, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_set_begin (self->concrete_protocol,
                                                    element_type, size,
@@ -176,7 +176,7 @@ thrift_protocol_decorator_write_set_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_write_set_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_set_end (self->concrete_protocol,
                                                               error);
@@ -186,7 +186,7 @@ gint32
 thrift_protocol_decorator_write_bool (ThriftProtocol *protocol,
                             const gboolean value, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_bool (self->concrete_protocol, value,
                                                            error);
@@ -196,7 +196,7 @@ gint32
 thrift_protocol_decorator_write_byte (ThriftProtocol *protocol, const gint8 value,
                             GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_byte (self->concrete_protocol, value,
                                                            error);
@@ -206,7 +206,7 @@ gint32
 thrift_protocol_decorator_write_i16 (ThriftProtocol *protocol, const gint16 value,
                            GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i16 (self->concrete_protocol, value,
                                                           error);
@@ -216,7 +216,7 @@ gint32
 thrift_protocol_decorator_write_i32 (ThriftProtocol *protocol, const gint32 value,
                            GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i32 (self->concrete_protocol, value,
                                                           error);
@@ -226,7 +226,7 @@ gint32
 thrift_protocol_decorator_write_i64 (ThriftProtocol *protocol, const gint64 value,
                            GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_i64 (self->concrete_protocol, value,
                                                           error);
@@ -236,7 +236,7 @@ gint32
 thrift_protocol_decorator_write_double (ThriftProtocol *protocol,
                               const gdouble value, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_double (self->concrete_protocol,
                                                              value, error);
@@ -246,7 +246,7 @@ gint32
 thrift_protocol_decorator_write_string (ThriftProtocol *protocol,
                               const gchar *str, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_string (self->concrete_protocol, str,
                                                              error);
@@ -256,7 +256,7 @@ gint32
 thrift_protocol_decorator_write_binary (ThriftProtocol *protocol, const gpointer buf,
                               const guint32 len, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->write_binary (self->concrete_protocol, buf,
                                                              len, error);
@@ -268,7 +268,7 @@ thrift_protocol_decorator_read_message_begin (ThriftProtocol *protocol,
                                     ThriftMessageType *message_type,
                                     gint32 *seqid, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_message_begin (self->concrete_protocol,
                                                    name, message_type,
@@ -279,7 +279,7 @@ gint32
 thrift_protocol_decorator_read_message_end (ThriftProtocol *protocol,
                                   GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_message_end (self->concrete_protocol,
                                                                  error);
@@ -290,7 +290,7 @@ thrift_protocol_decorator_read_struct_begin (ThriftProtocol *protocol,
                                    gchar **name,
                                    GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_struct_begin (self->concrete_protocol,
                                                                   name,
@@ -300,7 +300,7 @@ thrift_protocol_decorator_read_struct_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_read_struct_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_struct_end (self->concrete_protocol,
                                                                 error);
@@ -313,7 +313,7 @@ thrift_protocol_decorator_read_field_begin (ThriftProtocol *protocol,
                                   gint16 *field_id,
                                   GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_field_begin (self->concrete_protocol,
                                                                  name,
@@ -326,7 +326,7 @@ gint32
 thrift_protocol_decorator_read_field_end (ThriftProtocol *protocol,
                                 GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_field_end (self->concrete_protocol,
                                                                error);
@@ -338,7 +338,7 @@ thrift_protocol_decorator_read_map_begin (ThriftProtocol *protocol,
                                 ThriftType *value_type, guint32 *size,
                                 GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_map_begin (self->concrete_protocol,
                                                                key_type,
@@ -350,7 +350,7 @@ thrift_protocol_decorator_read_map_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_read_map_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_map_end (self->concrete_protocol,
                                                              error);
@@ -361,7 +361,7 @@ thrift_protocol_decorator_read_list_begin (ThriftProtocol *protocol,
                                  ThriftType *element_type,
                                  guint32 *size, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_list_begin (self->concrete_protocol,
                                                                 element_type,
@@ -371,7 +371,7 @@ thrift_protocol_decorator_read_list_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_read_list_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_list_end (self->concrete_protocol,
                                                               error);
@@ -382,7 +382,7 @@ thrift_protocol_decorator_read_set_begin (ThriftProtocol *protocol,
                                 ThriftType *element_type,
                                 guint32 *size, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_set_begin (self->concrete_protocol,
                                                                element_type,
@@ -392,7 +392,7 @@ thrift_protocol_decorator_read_set_begin (ThriftProtocol *protocol,
 gint32
 thrift_protocol_decorator_read_set_end (ThriftProtocol *protocol, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_set_end (self->concrete_protocol,
                                                              error);
@@ -402,7 +402,7 @@ gint32
 thrift_protocol_decorator_read_bool (ThriftProtocol *protocol, gboolean *value,
                            GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_bool (self->concrete_protocol, value,
                                                           error);
@@ -412,7 +412,7 @@ gint32
 thrift_protocol_decorator_read_byte (ThriftProtocol *protocol, gint8 *value,
                            GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_byte (self->concrete_protocol, value,
                                                           error);
@@ -422,7 +422,7 @@ gint32
 thrift_protocol_decorator_read_i16 (ThriftProtocol *protocol, gint16 *value,
                           GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i16 (self->concrete_protocol, value,
                                                          error);
@@ -432,7 +432,7 @@ gint32
 thrift_protocol_decorator_read_i32 (ThriftProtocol *protocol, gint32 *value,
                           GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i32 (self->concrete_protocol, value,
                                                          error);
@@ -442,7 +442,7 @@ gint32
 thrift_protocol_decorator_read_i64 (ThriftProtocol *protocol, gint64 *value,
                           GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_i64 (self->concrete_protocol, value,
                                                          error);
@@ -452,7 +452,7 @@ gint32
 thrift_protocol_decorator_read_double (ThriftProtocol *protocol,
                              gdouble *value, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_double (self->concrete_protocol, value,
                                                             error);
@@ -462,7 +462,7 @@ gint32
 thrift_protocol_decorator_read_string (ThriftProtocol *protocol,
                              gchar **str, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_string (self->concrete_protocol, str,
                                                             error);
@@ -472,7 +472,7 @@ gint32
 thrift_protocol_decorator_read_binary (ThriftProtocol *protocol, gpointer *buf,
                              guint32 *len, GError **error)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
 
   return THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol)->read_binary (self->concrete_protocol, buf,
                                                             len, error);
@@ -481,171 +481,146 @@ thrift_protocol_decorator_read_binary (ThriftProtocol *protocol, gpointer *buf,
 
 static void
 thrift_protocol_decorator_set_property (GObject      *object,
-		guint         property_id,
-		const GValue *value,
-		GParamSpec   *pspec)
+    guint         property_id,
+    const GValue *value,
+    GParamSpec   *pspec)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
-	g_info("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
+  g_debug("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
 
-	switch (property_id)
-	{
-	case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
-		// FIXME We must finalize it first
-		//g_clear_object (&self->concrete_protocol);
-		self->concrete_protocol=g_value_get_pointer (value);
-		g_info("Setting concrete protocol %p to %p in %s",self,  self->concrete_protocol, g_type_name(G_TYPE_FROM_INSTANCE(object)));
-		// We must get the transport and set it on base class.
+  switch (property_id)
+  {
+  case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
+    self->concrete_protocol = g_value_dup_object (value);
+    g_debug("Setting concrete protocol %p to %p in %s", self, self->concrete_protocol, g_type_name(G_TYPE_FROM_INSTANCE(object)));
+    break;
 
-		break;
-	default:
-		/* We don't have any other property... */
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
-		break;
-	}
+  default:
+    /* We don't have any other property... */
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    break;
+  }
 }
 
 static void
 thrift_protocol_decorator_get_property (GObject    *object,
-		guint       property_id,
-		GValue     *value,
-		GParamSpec *pspec)
+    guint       property_id,
+    GValue     *value,
+    GParamSpec *pspec)
 {
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
-	g_info("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (object);
+  g_debug("Is protocol decorator %i", THRIFT_IS_PROTOCOL_DECORATOR(object));
 
-	switch (property_id)
-	{
-	case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
-		g_value_set_pointer (value, self->concrete_protocol);
+  switch (property_id)
+  {
+  case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
+    g_value_set_object (value, self->concrete_protocol);
+    break;
 
-		/* But we must also set our */
-
-		break;
-	default:
-		/* We don't have any other property... */
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
-		break;
-	}
+  default:
+    /* We don't have any other property... */
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+    break;
+  }
 }
 
 
 ThriftProtocol *
 thrift_protocol_decorator_get_concrete_protocol(ThriftProtocolDecorator *protocol)
 {
-	ThriftProtocol *retval = NULL;
-	if(!THRIFT_IS_PROTOCOL_DECORATOR(protocol)){
-		g_warning("The type is not protocol decorator");
-		return NULL;
-	}
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR(protocol);
-	g_info("Getting concrete protocol from %X -> %X", self, self->concrete_protocol);
+  ThriftProtocol *retval = NULL;
+  if(!THRIFT_IS_PROTOCOL_DECORATOR(protocol)){
+    g_warning("The type is not protocol decorator");
+    return NULL;
+  }
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR(protocol);
+  g_debug("Getting concrete protocol from %X -> %X", self, self->concrete_protocol);
 
-	return retval;
+  return retval;
 }
 
 
 static void
 thrift_protocol_decorator_init (ThriftProtocolDecorator *protocol)
 {
-	protocol->concrete_protocol = NULL;
-}
-
-
-
-static void
-thrift_protocol_decorator_dispose (ThriftProtocolDecorator *protocol)
-{
-	ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
-
-	/* dispose() might be called multiple times, so we must guard against
-	   * calling g_object_unref() on an invalid GObject by setting the member
-	   * NULL; g_clear_object() does this for us.
-	   */
-	if(self->concrete_protocol!=NULL)
-		g_clear_object (&self->concrete_protocol);
+  protocol->concrete_protocol = NULL;
 }
 
 static void
-thrift_protocol_decorator_finalize (ThriftProtocolDecorator *protocol)
+thrift_protocol_decorator_dispose (GObject *gobject)
 {
+  ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (gobject);
 
-//	/*
-//	 * Chain the concrete protocol finalize
-//	 */
-//	if(protocol->concrete_protocol!=NULL){
-//		G_OBJECT_CLASS (protocol->concrete_protocol)->finalize(protocol->concrete_protocol);
-//	}
-	/* Always chain up to the parent class; there is no need to check if
-	 * the parent class implements the finalize() virtual function: it is
-	 * always guaranteed to do so
-	 */
-	G_OBJECT_CLASS (protocol)->finalize(protocol);
+  g_clear_object(&self->concrete_protocol);
+
+  /* Always chain up to the parent class; there is no need to check if
+   * the parent class implements the dispose() virtual function: it is
+   * always guaranteed to do so
+   */
+  G_OBJECT_CLASS (thrift_protocol_decorator_parent_class)->dispose(gobject);
 }
 
 /* initialize the class */
 static void
 thrift_protocol_decorator_class_init (ThriftProtocolDecoratorClass *klass)
 {
-	ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
-	object_class->set_property = thrift_protocol_decorator_set_property;
-	object_class->get_property = thrift_protocol_decorator_get_property;
-	object_class->finalize = thrift_protocol_decorator_finalize;
-	object_class->dispose = thrift_protocol_decorator_dispose;
+  ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (klass);
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  object_class->set_property = thrift_protocol_decorator_set_property;
+  object_class->get_property = thrift_protocol_decorator_get_property;
+  object_class->dispose = thrift_protocol_decorator_dispose;
 
-	thrift_protocol_decorator_obj_properties[PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL] =
-			g_param_spec_pointer ("protocol",
-					"Protocol",
-					"Set the protocol to be implemented",
-					(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
+  thrift_protocol_decorator_obj_properties[PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL] =
+      g_param_spec_object ("protocol",
+          "Protocol",
+          "Set the protocol to be implemented", THRIFT_TYPE_PROTOCOL,
+          (G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
 
-	g_object_class_install_properties (object_class,
-			PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_END,
-			thrift_protocol_decorator_obj_properties);
+  g_object_class_install_properties (object_class,
+      PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_END,
+      thrift_protocol_decorator_obj_properties);
 
-	g_info("Current decorator write_message_begin addr %p, new %p", cls->write_message_begin, thrift_protocol_decorator_write_message_begin);
+  g_debug("Current decorator write_message_begin addr %p, new %p", cls->write_message_begin, thrift_protocol_decorator_write_message_begin);
 
-
-	  cls->write_message_begin = thrift_protocol_decorator_write_message_begin;
-	  cls->write_message_end = thrift_protocol_decorator_write_message_end;
-	  cls->write_struct_begin = thrift_protocol_decorator_write_struct_begin;
-	  cls->write_struct_end = thrift_protocol_decorator_write_struct_end;
-	  cls->write_field_begin = thrift_protocol_decorator_write_field_begin;
-	  cls->write_field_end = thrift_protocol_decorator_write_field_end;
-	  cls->write_field_stop = thrift_protocol_decorator_write_field_stop;
-	  cls->write_map_begin = thrift_protocol_decorator_write_map_begin;
-	  cls->write_map_end = thrift_protocol_decorator_write_map_end;
-	  cls->write_list_begin = thrift_protocol_decorator_write_list_begin;
-	  cls->write_list_end = thrift_protocol_decorator_write_list_end;
-	  cls->write_set_begin = thrift_protocol_decorator_write_set_begin;
-	  cls->write_set_end = thrift_protocol_decorator_write_set_end;
-	  cls->write_bool = thrift_protocol_decorator_write_bool;
-	  cls->write_byte = thrift_protocol_decorator_write_byte;
-	  cls->write_i16 = thrift_protocol_decorator_write_i16;
-	  cls->write_i32 = thrift_protocol_decorator_write_i32;
-	  cls->write_i64 = thrift_protocol_decorator_write_i64;
-	  cls->write_double = thrift_protocol_decorator_write_double;
-	  cls->write_string = thrift_protocol_decorator_write_string;
-	  cls->write_binary = thrift_protocol_decorator_write_binary;
-	  cls->read_message_begin = thrift_protocol_decorator_read_message_begin;
-	  cls->read_message_end = thrift_protocol_decorator_read_message_end;
-	  cls->read_struct_begin = thrift_protocol_decorator_read_struct_begin;
-	  cls->read_struct_end = thrift_protocol_decorator_read_struct_end;
-	  cls->read_field_begin = thrift_protocol_decorator_read_field_begin;
-	  cls->read_field_end = thrift_protocol_decorator_read_field_end;
-	  cls->read_map_begin = thrift_protocol_decorator_read_map_begin;
-	  cls->read_map_end = thrift_protocol_decorator_read_map_end;
-	  cls->read_list_begin = thrift_protocol_decorator_read_list_begin;
-	  cls->read_list_end = thrift_protocol_decorator_read_list_end;
-	  cls->read_set_begin = thrift_protocol_decorator_read_set_begin;
-	  cls->read_set_end = thrift_protocol_decorator_read_set_end;
-	  cls->read_bool = thrift_protocol_decorator_read_bool;
-	  cls->read_byte = thrift_protocol_decorator_read_byte;
-	  cls->read_i16 = thrift_protocol_decorator_read_i16;
-	  cls->read_i32 = thrift_protocol_decorator_read_i32;
-	  cls->read_i64 = thrift_protocol_decorator_read_i64;
-	  cls->read_double = thrift_protocol_decorator_read_double;
-	  cls->read_string = thrift_protocol_decorator_read_string;
-	  cls->read_binary = thrift_protocol_decorator_read_binary;
+  cls->write_message_begin = thrift_protocol_decorator_write_message_begin;
+  cls->write_message_end = thrift_protocol_decorator_write_message_end;
+  cls->write_struct_begin = thrift_protocol_decorator_write_struct_begin;
+  cls->write_struct_end = thrift_protocol_decorator_write_struct_end;
+  cls->write_field_begin = thrift_protocol_decorator_write_field_begin;
+  cls->write_field_end = thrift_protocol_decorator_write_field_end;
+  cls->write_field_stop = thrift_protocol_decorator_write_field_stop;
+  cls->write_map_begin = thrift_protocol_decorator_write_map_begin;
+  cls->write_map_end = thrift_protocol_decorator_write_map_end;
+  cls->write_list_begin = thrift_protocol_decorator_write_list_begin;
+  cls->write_list_end = thrift_protocol_decorator_write_list_end;
+  cls->write_set_begin = thrift_protocol_decorator_write_set_begin;
+  cls->write_set_end = thrift_protocol_decorator_write_set_end;
+  cls->write_bool = thrift_protocol_decorator_write_bool;
+  cls->write_byte = thrift_protocol_decorator_write_byte;
+  cls->write_i16 = thrift_protocol_decorator_write_i16;
+  cls->write_i32 = thrift_protocol_decorator_write_i32;
+  cls->write_i64 = thrift_protocol_decorator_write_i64;
+  cls->write_double = thrift_protocol_decorator_write_double;
+  cls->write_string = thrift_protocol_decorator_write_string;
+  cls->write_binary = thrift_protocol_decorator_write_binary;
+  cls->read_message_begin = thrift_protocol_decorator_read_message_begin;
+  cls->read_message_end = thrift_protocol_decorator_read_message_end;
+  cls->read_struct_begin = thrift_protocol_decorator_read_struct_begin;
+  cls->read_struct_end = thrift_protocol_decorator_read_struct_end;
+  cls->read_field_begin = thrift_protocol_decorator_read_field_begin;
+  cls->read_field_end = thrift_protocol_decorator_read_field_end;
+  cls->read_map_begin = thrift_protocol_decorator_read_map_begin;
+  cls->read_map_end = thrift_protocol_decorator_read_map_end;
+  cls->read_list_begin = thrift_protocol_decorator_read_list_begin;
+  cls->read_list_end = thrift_protocol_decorator_read_list_end;
+  cls->read_set_begin = thrift_protocol_decorator_read_set_begin;
+  cls->read_set_end = thrift_protocol_decorator_read_set_end;
+  cls->read_bool = thrift_protocol_decorator_read_bool;
+  cls->read_byte = thrift_protocol_decorator_read_byte;
+  cls->read_i16 = thrift_protocol_decorator_read_i16;
+  cls->read_i32 = thrift_protocol_decorator_read_i32;
+  cls->read_i64 = thrift_protocol_decorator_read_i64;
+  cls->read_double = thrift_protocol_decorator_read_double;
+  cls->read_string = thrift_protocol_decorator_read_string;
+  cls->read_binary = thrift_protocol_decorator_read_binary;
 }

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
@@ -44,33 +44,28 @@ typedef struct _ThriftProtocolDecorator ThriftProtocolDecorator;
 
 
 /*!
- * Thrift Multiplexed Protocol instance.
+ * Thrift Protocol Decorator instance.
  */
 struct _ThriftProtocolDecorator
 {
-	ThriftProtocol parent;
+  ThriftProtocol parent;
 
-	ThriftProtocol *concrete_protocol;
+  ThriftProtocol *concrete_protocol;
 };
 
 typedef struct _ThriftProtocolDecoratorClass ThriftProtocolDecoratorClass;
 
 /*!
- * Thrift Multiplexed Protocol class.
+ * Thrift Protocol Decorator class.
  */
 struct _ThriftProtocolDecoratorClass
 {
-	ThriftProtocolClass parent;
+  ThriftProtocolClass parent;
 
 };
 
 /* used by THRIFT_TYPE_PROTOCOL_DECORATOR */
 GType thrift_protocol_decorator_get_type (void);
-
-
-ThriftProtocol *
-thrift_protocol_decorator_get_concrete_protocol(ThriftProtocolDecorator *protocol);
-
 
 G_END_DECLS
 

--- a/lib/c_glib/src/thrift/c_glib/server/thrift_server.c
+++ b/lib/c_glib/src/thrift/c_glib/server/thrift_server.c
@@ -76,22 +76,22 @@ thrift_server_set_property (GObject *object, guint property_id,
   switch (property_id)
   {
     case PROP_THRIFT_SERVER_PROCESSOR:
-      server->processor = g_value_get_object (value);
+      server->processor = g_value_dup_object (value);
       break;
     case PROP_THRIFT_SERVER_SERVER_TRANSPORT:
-      server->server_transport = g_value_get_object (value);
+      server->server_transport = g_value_dup_object (value);
       break;
     case PROP_THRIFT_SERVER_INPUT_TRANSPORT_FACTORY:
-      server->input_transport_factory = g_value_get_object (value);
+      server->input_transport_factory = g_value_dup_object (value);
       break;
     case PROP_THRIFT_SERVER_OUTPUT_TRANSPORT_FACTORY:
-      server->output_transport_factory = g_value_get_object (value);
+      server->output_transport_factory = g_value_dup_object (value);
       break;
     case PROP_THRIFT_SERVER_INPUT_PROTOCOL_FACTORY:
-      server->input_protocol_factory = g_value_get_object (value);
+      server->input_protocol_factory = g_value_dup_object (value);
       break;
     case PROP_THRIFT_SERVER_OUTPUT_PROTOCOL_FACTORY:
-      server->output_protocol_factory = g_value_get_object (value);
+      server->output_protocol_factory = g_value_dup_object (value);
       break;
   }
 }
@@ -120,7 +120,27 @@ thrift_server_init (ThriftServer *server)
   server->output_protocol_factory = NULL;
 }
 
-/* class initializer for ThriftServer
+static void
+thrift_server_dispose (GObject *gobject)
+{
+  ThriftServer *self = THRIFT_SERVER (gobject);
+
+  g_clear_object(&self->output_protocol_factory);
+  g_clear_object(&self->input_protocol_factory);
+  g_clear_object(&self->output_transport_factory);
+  g_clear_object(&self->input_transport_factory);
+  g_clear_object(&self->server_transport);
+  g_clear_object(&self->processor);
+
+  /* Always chain up to the parent class; there is no need to check if
+   * the parent class implements the dispose() virtual function: it is
+   * always guaranteed to do so
+   */
+  G_OBJECT_CLASS (thrift_server_parent_class)->dispose(gobject);
+}
+
+/*
+ * class initializer for ThriftServer
  * TODO: implement ServerEventHandler as a GClosure
  */
 static void
@@ -130,6 +150,7 @@ thrift_server_class_init (ThriftServerClass *cls)
 
   gobject_class->get_property = thrift_server_get_property;
   gobject_class->set_property = thrift_server_set_property;
+  gobject_class->dispose = thrift_server_dispose;
 
   g_object_class_install_property (gobject_class,
       PROP_THRIFT_SERVER_PROCESSOR,

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
@@ -224,12 +224,12 @@ thrift_server_socket_class_init (ThriftServerSocketClass *cls)
                                   "port (construct)",
                                   "Set the port to listen to",
                                   0, /* min */
-                                  65534, /* max */
+                                  65535, /* max */
                                   9090, /* default by convention */
                                   G_PARAM_CONSTRUCT_ONLY |
                                   G_PARAM_READWRITE);
   g_object_class_install_property (gobject_class,
-                                   PROP_THRIFT_SERVER_SOCKET_PORT, 
+                                   PROP_THRIFT_SERVER_SOCKET_PORT,
                                    param_spec);
 
   param_spec = g_param_spec_uint ("backlog",

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.h
@@ -49,7 +49,7 @@ struct _ThriftServerSocket
   ThriftServerTransport parent;
 
   /* private */
-  gshort port;
+  guint port;
   gshort backlog;
   int sd;
   guint8 *buf;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.c
@@ -129,7 +129,7 @@ thrift_socket_open (ThriftTransport *transport, GError **error)
   memset (&pin, 0, sizeof(pin));
   pin.sin_family = AF_INET;
   pin.sin_addr.s_addr = ((struct in_addr *) (hp->h_addr))->s_addr;
-  pin.sin_port = htons (tsocket->port); 
+  pin.sin_port = htons (tsocket->port);
 
   /* create the socket */
   if ((tsocket->sd = socket (AF_INET, SOCK_STREAM, 0)) == -1)
@@ -210,7 +210,7 @@ thrift_socket_read_end (ThriftTransport *transport, GError **error)
 
 /* implements thrift_transport_write */
 gboolean
-thrift_socket_write (ThriftTransport *transport, const gpointer buf,     
+thrift_socket_write (ThriftTransport *transport, const gpointer buf,
                      const guint32 len, GError **error)
 {
   gint ret = 0;
@@ -315,6 +315,9 @@ thrift_socket_set_property (GObject *object, guint property_id,
   switch (property_id)
   {
     case PROP_THRIFT_SOCKET_HOSTNAME:
+      if (socket->hostname) {
+        g_free(socket->hostname);
+      }
       socket->hostname = g_strdup (g_value_get_string (value));
       break;
     case PROP_THRIFT_SOCKET_PORT:
@@ -347,8 +350,8 @@ thrift_socket_class_init (ThriftSocketClass *cls)
   param_spec = g_param_spec_uint ("port",
                                   "port (construct)",
                                   "Set the port of the remote host",
-                                  0, /* min */
-                                  65534, /* max */
+                                  0u, /* min */
+                                  65535u, /* max */
                                   9090, /* default by convention */
                                   G_PARAM_CONSTRUCT_ONLY |
                                   G_PARAM_READWRITE);

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
@@ -50,11 +50,8 @@ struct _ThriftSocket
 
   /* private */
   gchar *hostname;
-  gshort port;
+  guint port;
   int sd;
-  guint8 *buf;
-  guint32 buf_size;
-  guint32 buf_len;
 };
 
 typedef struct _ThriftSocketClass ThriftSocketClass;

--- a/lib/c_glib/test/testcontainertest.c
+++ b/lib/c_glib/test/testcontainertest.c
@@ -512,13 +512,12 @@ main(int argc, char *argv[])
                                        THRIFT_SERVER_SOCKET_ERROR_ACCEPT));
 
     /* Free our resources */
-    g_object_unref (server);
-    g_object_unref (transport_factory);
-    g_object_unref (protocol_factory);
-    g_object_unref (server_transport);
-
-    g_object_unref (processor);
-    g_object_unref (handler);
+    g_clear_object (&server);
+    g_clear_object (&protocol_factory);
+    g_clear_object (&transport_factory);
+    g_clear_object (&server_transport);
+    g_clear_object (&processor);
+    g_clear_object (&handler);
 
     /* Wait for the child process to complete and return its exit status */
     g_assert (wait (&status) == pid);

--- a/test/tests.json
+++ b/test/tests.json
@@ -6,15 +6,20 @@
     ],
     "server": {
       "command": [
-        "test_server"
+        "test_server",
+        "--lt-debug"
       ]
     },
     "client": {
       "command": [
-        "test_client"
+        "test_client",
+        "--lt-debug"
       ],
       "protocols": [
-        "multiplexed"
+        "multi",
+        "multic",
+        "multi:binary",
+        "multic:compact"
       ],
       "sockets": [
         "ip-ssl"
@@ -111,7 +116,12 @@
       "delay": 10,
       "extra_args": ["run-testserver"],
       "protocols": [
-        "multiplexed"
+        "binary:multi",
+        "compact:multic",
+        "json:multij",
+        "multi",
+        "multic",
+        "multij"
       ]
     },
     "client": {


### PR DESCRIPTION
- Added crosstest support to prove the java Multiplexed server is backwards compatible with non-multiplexed clients when registering a default processor.  This proves that standard binary/compact/json clients can connect to a Multiplexed binary/compact/json server using new code added in THRIFT-2504.
- Added SecondService as a second named service to the Java Multiplexed TestServer
- Added multiplexed test support to c_glib test_client to test a second named service
- Added testBinary(empty) and [-128..127] test cases to c_glib test_client
- Changed the multiplexed protocol separator from a property to a constant
- Changed ThriftProtocol to manage the lifetime of the Transport object it consumes
- Changed ThriftProtocolDecorator to manage the lifetime of the Protocol object it consumes
- Changed ThriftService to manage the transport, protocol, and handler objects it consumes
- Fixed the dispose and finalize chain up in many places
- Fixed ThriftServer Socket not working properly if the port number is > 32767
- Fixed the lifetime of some objects in test_client