### PR TITLE
THRIFT-4076: appveyor needs to pick up PATH changes and JAVA_HOME from the registry 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,6 @@ os:
 environment:
   BOOST_ROOT: C:\Libraries\boost_1_59_0
   BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
-  # Unfurtunately, this version needs manual update because old versions are quickly deleted.
-  ANT_VERSION: 1.9.8
 
 install:
 - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64'
@@ -54,8 +52,8 @@ install:
 - cd ..
 - appveyor-retry cinst -y ant
 - appveyor-retry cinst -y winflexbison3
-## appveyor DownloadFile http://www.us.apache.org/dist/ant/binaries/apache-ant-%ANT_VERSION%-bin.zip
-# 7z x apache-ant-%ANT_VERSION%-bin.zip > nul
+# installation of ant brings in the latest jdk and sets JAVA_HOME - we need to pick these up from the registry
+- refreshenv
 - cd %APPVEYOR_BUILD_FOLDER%
 # TODO: Enable Haskell build
 # - cinst HaskellPlatform -version 2014.2.0.0
@@ -64,10 +62,8 @@ install:
 build_script:
 - echo PATH=%PATH%
 - set PATH=C:\ProgramData\chocolatey\bin;%PATH%
-## installation of ant brings in the latest jdk and sets JAVA_HOME
 - echo JAVA_HOME=%JAVA_HOME%
-## set JAVA_HOME=C:\Program Files\Java\jdk1.7.0
-## set PATH=%JAVA_HOME%\bin;%PATH%
+# TODO: Enable Haskell build
 # - set PATH=%PATH%;C:\Program Files (x86)\Haskell Platform\2014.2.0.0\bin
 # - set PATH=%PATH%;C:\Program Files (x86)\Haskell Platform\2014.2.0.0\lib\extralibs\bin
 - set PATH=C:\Python27-x64\scripts;C:\Python27-x64;%PATH%


### PR DESCRIPTION
after using chocolatey to install ant (and jdk, which it depends on) we need to refresh the environment