### PR TITLE
THRIFT-3801: Fix exception with nodejs multiplexer

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -122,7 +122,6 @@ var Connection = exports.Connection = function(stream, options) {
         var service_name = self.seqId2Service[header.rseqid];
         if (service_name) {
           client = self.client[service_name];
-          delete self.seqId2Service[header.rseqid];
         }
         /*jshint -W083 */
         client._reqs[dummy_seqid] = function(err, success){
@@ -130,6 +129,9 @@ var Connection = exports.Connection = function(stream, options) {
 
           var callback = client._reqs[header.rseqid];
           delete client._reqs[header.rseqid];
+          if (service_name) {
+            delete self.seqId2Service[header.rseqid];
+          }
           if (callback) {
             callback(err, success);
           }


### PR DESCRIPTION
THRIFT-3801 - Node Thrift client throws exception with multiplexer and responses that are bigger than a single buffer

Supercedes https://github.com/apache/thrift/pull/1063
Supercedes https://github.com/apache/thrift/pull/773

Just want a clean CI build before merging.