### PR TITLE
Fix fd leak when failing to dispatch new connections

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -1004,7 +1004,7 @@ void TNonblockingServer::handleEvent(THRIFT_SOCKET fd, short which) {
     } else {
       if (!clientConnection->notifyIOThread()) {
         GlobalOutput.perror("[ERROR] notifyIOThread failed on fresh connection, closing", errno);
-        returnConnection(clientConnection);
+        clientConnection->close();
       }
     }
 


### PR DESCRIPTION
When failing to dispatch new connections to other IO threads other
than the number 0, we returned these connections for reuse without
closing them, so the corresponding fds were leaked forever.

We should close these connections instead.