### PR TITLE
[THRIFT-4130] Release managed HTTP connection back to the underlying pool

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/THttpClient.java
+++ b/lib/java/src/org/apache/thrift/transport/THttpClient.java
@@ -304,6 +304,9 @@ public class THttpClient extends TTransport {
           throw new TTransportException(ioe);
         }
       }
+      if (post != null) {
+        post.releaseConnection();
+      }
     }
   }
 


### PR DESCRIPTION
There is a connection leak in the `THttpClient` when using the Apache `HttpClient` with the `PoolingClientConnectionManager`.  Without calling `releaseConnection` on the `HttpPost` object, the connections are never returned to the pool.  Under heavy load, this can lead to both failures for subsequent calls to be able to get a connection from the pool and connections being held by the underlying OS, eventually resulting in the inability to grab another client port for outgoing connections.  Per the Apache HttpClient examples/documentation:

> In order to ensure correct deallocation of system resources 
> the user MUST either fully consume the response content  or abort request 
> execution by calling HttpGet#releaseConnection().

This might have not been an issue when using the 3.x version of the HttpClient, but it's definitely an issue in the 4.x line.  See https://hc.apache.org/httpcomponents-client-4.2.x/quickstart.html for more details. 
