### PR TITLE
THRIFT-3959 explain simpleServer is not a typical TSimpleServer

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -25,6 +25,11 @@ import (
 	"sync"
 )
 
+/*
+This is not a typical TSimpleServer as it's not blocked after accept a socket.
+It's more like a Thread model server that can handle different connections in different goroutines.
+This will work if golang user implements a conn-pool like thing in client side.
+*/
 // Simple, non-concurrent server for testing.
 type TSimpleServer struct {
 	quit chan struct{}


### PR DESCRIPTION
l used to be confused by the name of TSimpleServer and at once thought golang is unable to use thrift cause there is no other server implementations.
However,l changed my mind after checking the code of TSimpleServer .And Then, a simple multi-client demo proved my gusses.
Thus , l try to explain this thing in annotation and hope others gophers not be confused again :)

Happened to find the same topic on issue Thrift-3959 ,hope this works.
https://issues.apache.org/jira/browse/THRIFT-3959