### PR TITLE
TNonblockingServer: Fix using uninitialized event_

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -818,10 +818,7 @@ void TNonblockingServer::TConnection::setFlags(short eventFlags) {
  * Closes a connection
  */
 void TNonblockingServer::TConnection::close() {
-  if (eventFlags_ && event_del(&event_) == -1) {
-    GlobalOutput.perror("TConnection::close() event_del", THRIFT_GET_SOCKET_ERROR);
-    return;
-  }
+  setIdle();
 
   if (serverEventHandler_) {
     serverEventHandler_->deleteContext(connectionContext_, inputProtocol_, outputProtocol_);


### PR DESCRIPTION
When there are more than one IO threads, and we have failed to notify
one IO threads, then we have to close the connection. But the event_
in that connection isn't initialized. We should use setIdle() instead.