### PR TITLE
export thrift::mem::TBufferTransport

### DIFF
--- a/lib/rs/src/transport/mod.rs
+++ b/lib/rs/src/transport/mod.rs
@@ -30,9 +30,9 @@ mod framed;
 mod passthru;
 mod socket;
 
-#[cfg(test)]
 pub mod mem;
 
+pub use self::mem::TBufferTransport;
 pub use self::buffered::{TBufferedTransport, TBufferedTransportFactory};
 pub use self::framed::{TFramedTransport, TFramedTransportFactory};
 pub use self::passthru::TPassThruTransport;


### PR DESCRIPTION
We need export `thrift::mem::TBufferTransport` to serialize record to a memory based buffer, then send the buffer through other transport like Kafka 