### PR TITLE
THRIFT-4071: collapse and remove unnecessary build jobs in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,22 +47,10 @@ env:
       BUILD_ARG="-'(binary|header|multiplexed)'"
       BUILD_ENV="-e CC=clang -e CXX=clang++ -e THRIFT_CROSSTEST_CONCURRENCY=4"
 
-    - TEST_NAME="Cross Language Tests (Debian) (Binary, Header, Multiplexed Protocols)"
-      SCRIPT="cross-test.sh"
-      BUILD_ARG="-'(binary|header|multiplexed)'"
-      BUILD_ENV="-e CC=clang -e CXX=clang++ -e THRIFT_CROSSTEST_CONCURRENCY=4"
-      DISTRO=debian
-
     - TEST_NAME="Cross Language Tests (Compact and JSON Protocols)"
       SCRIPT="cross-test.sh"
       BUILD_ARG="-'(compact|json)'"
       BUILD_ENV="-e CC=clang -e CXX=clang++ -e THRIFT_CROSSTEST_CONCURRENCY=4"
-
-    - TEST_NAME="Cross Language Tests (Debian) (Compact and JSON Protocols)"
-      SCRIPT="cross-test.sh"
-      BUILD_ARG="-'(compact|json)'"
-      BUILD_ENV="-e CC=clang -e CXX=clang++ -e THRIFT_CROSSTEST_CONCURRENCY=4"
-      DISTRO=debian
 
     # TODO: Remove them once migrated to CMake
     # Autotools builds
@@ -70,23 +58,16 @@ env:
       SCRIPT="autotools.sh"
       BUILD_ARG="--without-dart --without-haskell --without-java --without-lua --without-nodejs --without-perl --without-php --without-php_extension --without-python --without-ruby"
 
-    - TEST_NAME="C C++ - GCC (automake)"
+    - TEST_NAME="C C++ Plugin - GCC (automake)"
       SCRIPT="autotools.sh"
-      BUILD_ARG="--without-csharp --without-java --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-haskell --without-go --without-haxe --without-d"
+      BUILD_ARG="--enable-plugin --without-csharp --without-java --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-haskell --without-go --without-haxe --without-d"
       BUILD_ENV="-e CC=gcc -e CXX=g++"
 
-    - TEST_NAME="Java Lua PHP Ruby Dart (automake)"
+    - TEST_NAME="Java Lua PHP Ruby Dart Haskell Node.js Python Perl (automake)"
       SCRIPT="autotools.sh"
-      BUILD_ARG="--without-cpp --without-haskell --without-c_glib --without-csharp --without-d --without-erlang --without-go --without-haxe --without-nodejs --without-python --without-perl"
+      BUILD_ARG="--without-cpp --without-c_glib --without-csharp --without-d --without-erlang --without-go --without-haxe"
 
-    # These are flaky (due to cabal and npm network/server failures) and also have lengthy output
-    - TEST_NAME="Haskell Node.js Python Perl (automake)"
-      SCRIPT="autotools.sh"
-      BUILD_ARG="--without-cpp --without-c_glib --without-csharp --without-d --without-dart --without-erlang --without-go --without-haxe --without-java --without-lua --without-php --without-php_extension --without-ruby"
-
-    # CMake build
-    - TEST_NAME="All"
-
+    # CMake builds
     - TEST_NAME="All (Debian)"
       DISTRO=debian
 
@@ -95,23 +76,14 @@ env:
       BUILD_ARG="-DWITH_PYTHON=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
       BUILD_ENV="-e CC=gcc -e CXX=g++"
 
-    - TEST_NAME="C++ (Boost Thread)"
-      BUILD_LIBS="CPP TESTING TUTORIALS"
-      BUILD_ARG="-DWITH_BOOSTTHREADS=ON -DWITH_PYTHON=OFF -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
-
     - TEST_NAME="C++ (Boost Thread - GCC)"
       BUILD_LIBS="CPP TESTING TUTORIALS"
       BUILD_ARG="-DWITH_BOOSTTHREADS=ON -DWITH_PYTHON=OFF -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
       BUILD_ENV="-e CC=gcc -e CXX=g++"
 
-    - TEST_NAME="C++ (Std Thread)"
+    - TEST_NAME="C++ Plugin (Std Thread)"
       BUILD_LIBS="CPP TESTING TUTORIALS"
-      BUILD_ARG="-DWITH_STDTHREADS=ON -DCMAKE_CXX_FLAGS='-std=c++11' -DWITH_PYTHON=OFF -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
-
-    - TEST_NAME="C++ (Std Thread - GCC)"
-      BUILD_LIBS="CPP TESTING TUTORIALS"
-      BUILD_ARG="-DWITH_STDTHREADS=ON -DCMAKE_CXX_FLAGS='-std=c++11' -DWITH_PYTHON=OFF -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
-      BUILD_ENV="-e CC=gcc -e CXX=g++"
+      BUILD_ARG="-DWITH_PLUGIN=ON -DWITH_STDTHREADS=ON -DWITH_PYTHON=OFF -DWITH_C_GLIB=OFF -DWITH_JAVA=OFF -DWITH_HASKELL=OFF"
 
     - TEST_NAME="Compiler (mingw)"
       BUILD_LIBS=""


### PR DESCRIPTION
Removed build jobs 2 and 4 as they were duplicates of 1 and 3 but on debian instead of ubuntu, this adds too little value to justify the expense of two 40 minute builds.

Added compiler plug-in option to job 6 to make sure it is tested in CI.

Combined jobs 7 and 8 because there is enough time in the build to support it.

Removed build job 9 but kept 10 because it uses debian in light of removing 2 and 4.

Removed build job 12 and 15 as they are redundant to 13 and 14 and add too little value to justify the expense.