### PR TITLE
THRIFT-4099: Derive Hash trait for Rust structs

### DIFF
--- a/lib/rs/src/transport/mem.rs
+++ b/lib/rs/src/transport/mem.rs
@@ -109,7 +109,7 @@ impl TBufferTransport {
         let buf = {
             let b = self.write_buffer_as_ref();
             let mut b_ret = vec![0; b.len()];
-            b_ret.copy_from_slice(&b);
+            b_ret.copy_from_slice(b);
             b_ret
         };
 

--- a/lib/rs/test/thrifts/Base_One.thrift
+++ b/lib/rs/test/thrifts/Base_One.thrift
@@ -31,6 +31,10 @@ const i32 BoilingPoint = 100
 
 const list<Temperature> Temperatures = [10, 11, 22, 33]
 
+// IMPORTANT: temps should end with ".0" because this tests
+// that we don't have a problem with const float list generation
+const list<double> CommonTemperatures = [300.0, 450.0]
+
 const double MealsPerDay = 2.5;
 
 struct Noodle {
@@ -46,6 +50,21 @@ const Noodle SpeltNoodle = { "flourType": "spelt", "cookTemp": 110 }
 
 struct MeasuringSpoon {
   1: Size size
+}
+
+struct MeasuringCup {
+  1: double millis
+}
+
+union MeasuringAids {
+  1: MeasuringSpoon spoon
+  2: MeasuringCup cup
+}
+
+struct CookingTemperatures {
+  1: set<double> commonTemperatures
+  2: list<double> usedTemperatures
+  3: map<double, double> fahrenheitToCentigradeConversions
 }
 
 struct Recipe {


### PR DESCRIPTION
Auto-derive `Hash` trait for all generated types. Verified that all checks listed [in the JIRA](https://issues.apache.org/jira/browse/THRIFT-4099) worked.