### PR TITLE
fix lnk 200 error on windows when compile as lib

### DIFF
--- a/lib/cpp/libthrift.vcxproj
+++ b/lib/cpp/libthrift.vcxproj
@@ -53,6 +53,12 @@
     <ClCompile Include="src\thrift\server\TSimpleServer.cpp"/>
     <ClCompile Include="src\thrift\server\TThreadPoolServer.cpp"/>
     <ClCompile Include="src\thrift\server\TThreadedServer.cpp"/>
+	<ClCompile Include="src\thrift\server\TConnectedClient.cpp"/>
+	<ClCompile Include="src\thrift\server\TNonblockingServer.cpp"/>
+	<ClCompile Include="src\thrift\server\TServerFramework.cpp"/>
+	<ClCompile Include="src\thrift\server\TSimpleServer.cpp"/>
+	<ClCompile Include="src\thrift\server\TThreadedServer.cpp"/>
+	<ClCompile Include="src\thrift\server\TThreadPoolServer.cpp"/>
     <ClCompile Include="src\thrift\TApplicationException.cpp"/>
     <ClCompile Include="src\thrift\TOutput.cpp"/>
     <ClCompile Include="src\thrift\transport\TBufferTransports.cpp"/>


### PR DESCRIPTION
fix lnk 200 error on windows when compile as lib, can not link the source code such as TServerFramework.cpp