### PR TITLE
[Ruby] Logging server-side exception message on  ApplicationException::INTERNAL_ERROR

### DIFF
--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -17,10 +17,18 @@
 # under the License.
 # 
 
+require 'logger'
+
 module Thrift
   module Processor
-    def initialize(handler)
+    def initialize(handler, logger=nil)
       @handler = handler
+      if logger.nil?
+        @logger = Logger.new(STDERR)
+        @logger.level = Logger::WARN
+      else
+        @logger = logger
+      end
     end
 
     def process(iprot, oprot)
@@ -30,6 +38,7 @@ module Thrift
           send("process_#{name}", seqid, iprot, oprot)
         rescue => e
           x = ApplicationException.new(ApplicationException::INTERNAL_ERROR, 'Internal error')
+          @logger.debug "Internal error : #{e.message}\n#{e.backtrace.join("\n")}"
           write_error(x, oprot, name, seqid)
         end
         true


### PR DESCRIPTION
## Problem
`ApplicationException::INTERNAL_ERROR` is often raised, mainly because of incompatibility between Thrift interface and payload (mistakenly using incorrect Thrift types, breaking changes on Thrift interfaces, ...).

But `ApplicationException::INTERNAL_ERROR` does not provide almost any information on what's wrong.

## Solution
Logs `e.message` and `e.backtrace`.