### PR TITLE
THRIFT-4193 Set default max read buffer size in Java server

### DIFF
--- a/lib/java/src/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -50,7 +50,7 @@ public abstract class AbstractNonblockingServer extends TServer {
   protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
 
   public static abstract class AbstractNonblockingServerArgs<T extends AbstractNonblockingServerArgs<T>> extends AbstractServerArgs<T> {
-    public long maxReadBufferBytes = Long.MAX_VALUE;
+    public long maxReadBufferBytes = 256 * 1024 * 1024;
 
     public AbstractNonblockingServerArgs(TNonblockingServerTransport transport) {
       super(transport);


### PR DESCRIPTION
This is for the non-blocking server. This makes it so that just starting up something with all defaults won't result in it being possible to construct an input that causes it to OOME by just filling up the read buffer.