### PR TITLE
THRIFT-4197 [Go] Transparent gzip support for HTTP transport

### DIFF
--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -19,16 +19,45 @@
 
 package thrift
 
-import "net/http"
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
 
 // NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function
 func NewThriftHandlerFunc(processor TProcessor,
 	inPfactory, outPfactory TProtocolFactory) func(w http.ResponseWriter, r *http.Request) {
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	return gz(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/x-thrift")
 
 		transport := NewStreamTransport(r.Body, w)
 		processor.Process(inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
+	})
+}
+
+// gz transparently compresses the HTTP response if the client supports it.
+func gz(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			handler(w, r)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		gzw := gzipResponseWriter{Writer: gz, ResponseWriter: w}
+		handler(gzw, r)
 	}
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
 }


### PR DESCRIPTION
Check if the client supports gzip compressed responses and compress the response if it does.