### PR TITLE
THRIFT-4196 Support recursive types in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ project.lock.json
 /lib/rs/test/src/base_one.rs
 /lib/rs/test/src/base_two.rs
 /lib/rs/test/src/midlayer.rs
+/lib/rs/test/src/recursive.rs
 /lib/rs/test/src/ultimate.rs
 /lib/rs/*.iml
 /lib/rs/**/*.iml

--- a/lib/rs/test/Makefile.am
+++ b/lib/rs/test/Makefile.am
@@ -19,11 +19,12 @@
 
 THRIFT = $(top_builddir)/compiler/cpp/thrift
 
-stubs: thrifts/Base_One.thrift thrifts/Base_Two.thrift thrifts/Midlayer.thrift thrifts/Ultimate.thrift $(THRIFT)
+stubs: thrifts/Base_One.thrift thrifts/Base_Two.thrift thrifts/Midlayer.thrift thrifts/Ultimate.thrift $(top_builddir)/test/Recursive.thrift $(THRIFT)
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Base_One.thrift
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Base_Two.thrift
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Midlayer.thrift
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Ultimate.thrift
+	$(THRIFT) -out src --gen rs $(top_builddir)/test/Recursive.thrift
 
 check: stubs
 	$(CARGO) build

--- a/lib/rs/test/src/bin/kitchen_sink_client.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_client.rs
@@ -21,8 +21,12 @@ extern crate clap;
 extern crate kitchen_sink;
 extern crate thrift;
 
+use std::convert::Into;
+
 use kitchen_sink::base_two::{TNapkinServiceSyncClient, TRamenServiceSyncClient};
 use kitchen_sink::midlayer::{MealServiceSyncClient, TMealServiceSyncClient};
+use kitchen_sink::recursive;
+use kitchen_sink::recursive::{CoRec, CoRec2, RecList, RecTree, TTestServiceSyncClient};
 use kitchen_sink::ultimate::{FullMealServiceSyncClient, TFullMealServiceSyncClient};
 use thrift::transport::{ReadHalf, TFramedReadTransport, TFramedWriteTransport, TIoChannel,
                         TTcpChannel, WriteHalf};
@@ -47,7 +51,7 @@ fn run() -> thrift::Result<()> {
         (@arg host: --host +takes_value "Host on which the Thrift test server is located")
         (@arg port: --port +takes_value "Port on which the Thrift test server is listening")
         (@arg protocol: --protocol +takes_value "Thrift protocol implementation to use (\"binary\", \"compact\")")
-        (@arg service: --service +takes_value "Service type to contact (\"part\", \"full\")")
+        (@arg service: --service +takes_value "Service type to contact (\"part\", \"full\", \"recursive\")")
     )
             .get_matches();
 
@@ -80,8 +84,9 @@ fn run_client(
     o_prot: Box<TOutputProtocol>,
 ) -> thrift::Result<()> {
     match service {
-        "full" => run_full_meal_service(i_prot, o_prot),
-        "part" => run_meal_service(i_prot, o_prot),
+        "full" => exec_full_meal_client(i_prot, o_prot),
+        "part" => exec_meal_client(i_prot, o_prot),
+        "recursive" => exec_recursive_client(i_prot, o_prot),
         _ => Err(thrift::Error::from(format!("unknown service type {}", service)),),
     }
 }
@@ -95,7 +100,7 @@ fn tcp_channel(
     c.split()
 }
 
-fn run_meal_service(
+fn exec_meal_client(
     i_prot: Box<TInputProtocol>,
     o_prot: Box<TOutputProtocol>,
 ) -> thrift::Result<()> {
@@ -105,28 +110,155 @@ fn run_meal_service(
     // this is because the MealService struct does not contain the appropriate service marker
 
     // only the following three calls work
-    execute_call("part", "ramen", || client.ramen(50))?;
-    execute_call("part", "meal", || client.meal())?;
-    execute_call("part", "napkin", || client.napkin())?;
+    execute_call("part", "ramen", || client.ramen(50))
+        .map(|_| ())?;
+    execute_call("part", "meal", || client.meal())
+        .map(|_| ())?;
+    execute_call("part", "napkin", || client.napkin())
+        .map(|_| ())?;
 
     Ok(())
 }
 
-fn run_full_meal_service(
+fn exec_full_meal_client(
     i_prot: Box<TInputProtocol>,
     o_prot: Box<TOutputProtocol>,
 ) -> thrift::Result<()> {
     let mut client = FullMealServiceSyncClient::new(i_prot, o_prot);
 
-    execute_call("full", "ramen", || client.ramen(100))?;
-    execute_call("full", "meal", || client.meal())?;
-    execute_call("full", "napkin", || client.napkin())?;
-    execute_call("full", "full meal", || client.full_meal())?;
+    execute_call("full", "ramen", || client.ramen(100))
+        .map(|_| ())?;
+    execute_call("full", "meal", || client.meal())
+        .map(|_| ())?;
+    execute_call("full", "napkin", || client.napkin())
+        .map(|_| ())?;
+    execute_call("full", "full meal", || client.full_meal())
+        .map(|_| ())?;
 
     Ok(())
 }
 
-fn execute_call<F, R>(service_type: &str, call_name: &str, mut f: F) -> thrift::Result<()>
+fn exec_recursive_client(
+    i_prot: Box<TInputProtocol>,
+    o_prot: Box<TOutputProtocol>,
+) -> thrift::Result<()> {
+    let mut client = recursive::TestServiceSyncClient::new(i_prot, o_prot);
+
+    let tree = RecTree {
+        children: Some(
+            vec![
+                Box::new(
+                    RecTree {
+                        children: Some(
+                            vec![
+                                Box::new(
+                                    RecTree {
+                                        children: None,
+                                        item: Some(3),
+                                    },
+                                ),
+                                Box::new(
+                                    RecTree {
+                                        children: None,
+                                        item: Some(4),
+                                    },
+                                ),
+                            ],
+                        ),
+                        item: Some(2),
+                    },
+                ),
+            ],
+        ),
+        item: Some(1),
+    };
+
+    let expected_tree = RecTree {
+        children: Some(
+            vec![
+                Box::new(
+                    RecTree {
+                        children: Some(
+                            vec![
+                                Box::new(
+                                    RecTree {
+                                        children: Some(Vec::new()), // remote returns an empty list
+                                        item: Some(3),
+                                    },
+                                ),
+                                Box::new(
+                                    RecTree {
+                                        children: Some(Vec::new()), // remote returns an empty list
+                                        item: Some(4),
+                                    },
+                                ),
+                            ],
+                        ),
+                        item: Some(2),
+                    },
+                ),
+            ],
+        ),
+        item: Some(1),
+    };
+
+    let returned_tree = execute_call("recursive", "echo_tree", || client.echo_tree(tree.clone()))?;
+    if returned_tree != expected_tree {
+        return Err(
+            format!(
+                "mismatched recursive tree {:?} {:?}",
+                expected_tree,
+                returned_tree
+            )
+                    .into(),
+        );
+    }
+
+    let list = RecList {
+        nextitem: Some(
+            Box::new(
+                RecList {
+                    nextitem: Some(
+                        Box::new(
+                            RecList {
+                                nextitem: None,
+                                item: Some(3),
+                            },
+                        ),
+                    ),
+                    item: Some(2),
+                },
+            ),
+        ),
+        item: Some(1),
+    };
+    let returned_list = execute_call("recursive", "echo_list", || client.echo_list(list.clone()))?;
+    if returned_list != list {
+        return Err(format!("mismatched recursive list {:?} {:?}", list, returned_list).into(),);
+    }
+
+    let co_rec = CoRec {
+        other: Some(
+            Box::new(
+                CoRec2 {
+                    other: Some(CoRec { other: Some(Box::new(CoRec2 { other: None })) }),
+                },
+            ),
+        ),
+    };
+    let returned_co_rec = execute_call(
+        "recursive",
+        "echo_co_rec",
+        || client.echo_co_rec(co_rec.clone()),
+    )?;
+    if returned_co_rec != co_rec {
+        return Err(format!("mismatched co_rec {:?} {:?}", co_rec, returned_co_rec).into(),);
+    }
+
+    Ok(())
+}
+
+fn execute_call<F, R>(service_type: &str, call_name: &str, mut f: F) -> thrift::Result<R>
 where
     F: FnMut() -> thrift::Result<R>,
 {
@@ -144,5 +276,5 @@ where
         }
     }
 
-    res.map(|_| ())
+    res
 }

--- a/lib/rs/test/src/lib.rs
+++ b/lib/rs/test/src/lib.rs
@@ -23,6 +23,7 @@ pub mod base_one;
 pub mod base_two;
 pub mod midlayer;
 pub mod ultimate;
+pub mod recursive;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Client: rs

* Modify code generator to support recursive types
* Modify rust test (not cross-test) client to test recursive calls