### PR TITLE
THRIFT-4206: Fix decoding of strings in containers with py:dynamic and py:utf8strings

### DIFF
--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -268,7 +268,7 @@ class TProtocolBase(object):
         return self._TTYPE_HANDLERS[ttype] if ttype < len(self._TTYPE_HANDLERS) else (None, None, False)
 
     def _read_by_ttype(self, ttype, spec, espec):
-        reader_name, _, is_container = self._ttype_handlers(ttype, spec)
+        reader_name, _, is_container = self._ttype_handlers(ttype, espec)
         if reader_name is None:
             raise TProtocolException(type=TProtocolException.INVALID_DATA,
                                      message='Invalid type %d' % (ttype))
@@ -389,7 +389,7 @@ class TProtocolBase(object):
         self.writeStructEnd()
 
     def _write_by_ttype(self, ttype, vals, spec, espec):
-        _, writer_name, is_container = self._ttype_handlers(ttype, spec)
+        _, writer_name, is_container = self._ttype_handlers(ttype, espec)
         writer_func = getattr(self, writer_name)
         write = (lambda v: writer_func(v, espec)) if is_container else writer_func
         for v in vals:

--- a/test/py/FastbinaryTest.py
+++ b/test/py/FastbinaryTest.py
@@ -85,6 +85,10 @@ hm.big[1].a_bite = 0x22
 
 hm.contain.add(("and a one", "and a two"))
 hm.contain.add(("then a one, two", "three!", "FOUR!"))
+if sys.version_info[0] == 2 and os.environ.get('THRIFT_TEST_PY_NO_UTF8STRINGS'):
+    hm.contain.add((u"\xd7\n\a\t".encode('utf8'),))
+else:
+    hm.contain.add((u"\xd7\n\a\t",))
 hm.contain.add(())
 
 hm.bonks["nothing"] = []


### PR DESCRIPTION
_read_by_ttype and _write_by_ttype must be using the *element* spec
and not the container spec when determining the correct read/write
handler.