### PR TITLE
THRIFT-4207: Make sure Python Accelerated protocol does not allow invalid UTF-8

### DIFF
--- a/lib/py/src/ext/protocol.tcc
+++ b/lib/py/src/ext/protocol.tcc
@@ -428,16 +428,17 @@ bool ProtocolBase<Impl>::encodeValue(PyObject* value, TType type, PyObject* type
         return false;
       }
     } else {
-      Py_INCREF(value);
       if (isUtf8(typeargs)) {
         if (PyBytes_AsStringAndSize(value, &str, &len) < 0) {
           return false;
         }
         // Check that input is a valid UTF-8 string.
-        if (!PyUnicode_DecodeUTF8(str, len, 0)) {
+        nval.reset(PyUnicode_DecodeUTF8(str, len, 0));
+        if (!nval) {
           return false;
         }
       }
+      Py_INCREF(value);
       nval.reset(value);
     }
 

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -118,6 +118,8 @@ class TProtocolBase(object):
         pass
 
     def writeString(self, str_val):
+        if isinstance(str_val, bytes):
+            str_val = str_val.decode('utf8')
         self.writeBinary(str_to_binary(str_val))
 
     def writeBinary(self, str_val):


### PR DESCRIPTION
The accelerated version of Binary and Compact protocol fails to validate
the input string for UTF-8 fields.