### PR TITLE
THRIFT-4213 Travis build fails at curl -sSL https://www.npmjs.com/ins…

### DIFF
--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -190,7 +190,8 @@ RUN mkdir -p /usr/lib/haxe && \
     haxelib install hxcpp
 
 # Node.js
-RUN curl -sSL https://www.npmjs.com/install.sh | sh
+# temporarily removed since this breaks the build (and is not needed to test C# code)
+#RUN curl -sSL https://www.npmjs.com/install.sh | sh
 
 # D
 RUN curl -sSL http://downloads.dlang.org/releases/2.x/2.070.0/dmd_2.070.0-0_amd64.deb -o /tmp/dmd_2.070.0-0_amd64.deb && \


### PR DESCRIPTION
…tall.sh | sh

Client: Build process
Patch: Jens Geyer

Temporarily removed nodejs from travis builds to get the previous commit tested. This is NOT the fix, only a workaround to minimize the impact of the problem.