### PR TITLE
THRIFT-3703 Unions Field Count Does Not Consider Map/Set/List Fields

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1445,7 +1445,9 @@ void t_go_generator::generate_countsetfields_helper(ofstream& out,
     if ((*f_iter)->get_req() == t_field::T_REQUIRED)
       continue;
 
-    if (!is_pointer_field(*f_iter))
+    t_type* type = (*f_iter)->get_type()->get_true_type();
+
+    if (!(is_pointer_field(*f_iter) || type->is_map() || type->is_set() || type->is_list()))
       continue;
 
     const string field_name(publicize(escape_string((*f_iter)->get_name())));


### PR DESCRIPTION
Even though maps and slices are not pointer fields in the generated
code, they are still nullable. Adding an extra check for map/set/list
types fixes the generated Count* methods.

Sample IDL:
```thrift
union Foo{
    1: map<bool,bool> u1
    2: set<bool> u2
    3: list<bool> u3
    4: bool u4
}
```

Generated code before fix:
```go
func (p *Foo) CountSetFieldsFoo() int {
	count := 0
	if p.IsSetU4() {
		count++
	}
	return count
}
```

After fix:
```go
func (p *Foo) CountSetFieldsFoo() int {
	count := 0
	if p.IsSetU1() {
		count++
	}
	if p.IsSetU2() {
		count++
	}
	if p.IsSetU3() {
		count++
	}
	if p.IsSetU4() {
		count++
	}
	return count
}
```

Fixes THRIFT-3703.