### PR TITLE
THRIFT-4218: Set TCP_NODELAY for PHP client socket

### DIFF
--- a/lib/php/lib/Thrift/Transport/TSocket.php
+++ b/lib/php/lib/Thrift/Transport/TSocket.php
@@ -241,6 +241,9 @@ class TSocket extends TTransport
       }
       throw new TException($error);
     }
+
+    $socket = socket_import_stream($this->handle_);
+    socket_set_option($socket, SOL_TCP, TCP_NODELAY, 1);
   }
 
   /**


### PR DESCRIPTION
Client: PHP

Until now, the PHP client hadn't set the `TCP_NODELAY` socket option
like e.g. C++, C#, Ruby, or Java.

This enables `TCP_NODELAY` for the client socket.

This closes #4218