### PR TITLE
THRIFT-4222: Add Golang NewTServerSocketFromAddrTimeout

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -47,6 +47,11 @@ func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*T
 	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
 }
 
+// Creates a TServerSocket from a net.Addr
+func NewTServerSocketFromAddrTimeout(addr net.Addr, clientTimeout time.Duration) *TServerSocket {
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}
+}
+
 func (p *TServerSocket) Listen() error {
 	if p.IsListening() {
 		return nil


### PR DESCRIPTION
Adds the ability to create a new server socket from a non-TCP (eg. Unix socket)
address. Modeled after the existing NewTSocketFromAddrTimeout function.