### PR TITLE
THRIFT-4219 Refactor Go HTTP Client

### DIFF
--- a/lib/go/thrift/http_client.go
+++ b/lib/go/thrift/http_client.go
@@ -46,21 +46,14 @@ type THttpClient struct {
 type THttpClientTransportFactory struct {
 	options THttpClientOptions
 	url     string
-	isPost  bool
 }
 
 func (p *THttpClientTransportFactory) GetTransport(trans TTransport) (TTransport, error) {
 	if trans != nil {
 		t, ok := trans.(*THttpClient)
 		if ok && t.url != nil {
-			if t.requestBuffer != nil {
-				return NewTHttpPostClientWithOptions(t.url.String(), p.options)
-			}
 			return NewTHttpClientWithOptions(t.url.String(), p.options)
 		}
-	}
-	if p.isPost {
-		return NewTHttpPostClientWithOptions(p.url, p.options)
 	}
 	return NewTHttpClientWithOptions(p.url, p.options)
 }
@@ -75,39 +68,10 @@ func NewTHttpClientTransportFactory(url string) *THttpClientTransportFactory {
 }
 
 func NewTHttpClientTransportFactoryWithOptions(url string, options THttpClientOptions) *THttpClientTransportFactory {
-	return &THttpClientTransportFactory{url: url, isPost: false, options: options}
-}
-
-func NewTHttpPostClientTransportFactory(url string) *THttpClientTransportFactory {
-	return NewTHttpPostClientTransportFactoryWithOptions(url, THttpClientOptions{})
-}
-
-func NewTHttpPostClientTransportFactoryWithOptions(url string, options THttpClientOptions) *THttpClientTransportFactory {
-	return &THttpClientTransportFactory{url: url, isPost: true, options: options}
+	return &THttpClientTransportFactory{url: url, options: options}
 }
 
 func NewTHttpClientWithOptions(urlstr string, options THttpClientOptions) (TTransport, error) {
-	parsedURL, err := url.Parse(urlstr)
-	if err != nil {
-		return nil, err
-	}
-	response, err := http.Get(urlstr)
-	if err != nil {
-		return nil, err
-	}
-	client := options.Client
-	if client == nil {
-		client = DefaultHttpClient
-	}
-	httpHeader := map[string][]string{"Content-Type": {"application/x-thrift"}}
-	return &THttpClient{client: client, response: response, url: parsedURL, header: httpHeader}, nil
-}
-
-func NewTHttpClient(urlstr string) (TTransport, error) {
-	return NewTHttpClientWithOptions(urlstr, THttpClientOptions{})
-}
-
-func NewTHttpPostClientWithOptions(urlstr string, options THttpClientOptions) (TTransport, error) {
 	parsedURL, err := url.Parse(urlstr)
 	if err != nil {
 		return nil, err
@@ -121,8 +85,8 @@ func NewTHttpPostClientWithOptions(urlstr string, options THttpClientOptions) (T
 	return &THttpClient{client: client, url: parsedURL, requestBuffer: bytes.NewBuffer(buf), header: httpHeader}, nil
 }
 
-func NewTHttpPostClient(urlstr string) (TTransport, error) {
-	return NewTHttpPostClientWithOptions(urlstr, THttpClientOptions{})
+func NewTHttpClient(urlstr string) (TTransport, error) {
+	return NewTHttpClientWithOptions(urlstr, THttpClientOptions{})
 }
 
 // Set the HTTP Header for this specific Thrift Transport
@@ -251,4 +215,24 @@ func (p *THttpClient) RemainingBytes() (num_bytes uint64) {
 
 	const maxSize = ^uint64(0)
 	return maxSize // the thruth is, we just don't know unless framed is used
+}
+
+// Deprecated: Use NewTHttpClientTransportFactory instead.
+func NewTHttpPostClientTransportFactory(url string) *THttpClientTransportFactory {
+	return NewTHttpClientTransportFactoryWithOptions(url, THttpClientOptions{})
+}
+
+// Deprecated: Use NewTHttpClientTransportFactoryWithOptions instead.
+func NewTHttpPostClientTransportFactoryWithOptions(url string, options THttpClientOptions) *THttpClientTransportFactory {
+	return NewTHttpClientTransportFactoryWithOptions(url, options)
+}
+
+// Deprecated: Use NewTHttpClientWithOptions instead.
+func NewTHttpPostClientWithOptions(urlstr string, options THttpClientOptions) (TTransport, error) {
+	return NewTHttpClientWithOptions(urlstr, options)
+}
+
+// Deprecated: Use NewTHttpClient instead.
+func NewTHttpPostClient(urlstr string) (TTransport, error) {
+	return NewTHttpClientWithOptions(urlstr, THttpClientOptions{})
 }


### PR DESCRIPTION
As discussed in THRIFT-4219, this commit removes support for one-off GET
requests, which brings the Go HTTP client inline with implementations in
other languages.

Constructor functions with "Post" in their names are all deprecated
using the proper format [0] as all constructors now have the POST
behaviour.

Fixes THRIFT-4219.

[0] https://github.com/golang/go/issues/10909#issuecomment-136492606