### PR TITLE
fix TypeError when a py3 str is passed to the function.

### DIFF
--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -127,6 +127,8 @@ class TBinaryProtocol(TProtocolBase):
         self.trans.write(buff)
 
     def writeBinary(self, str):
+        if not isinstance(str, bytes):
+            str = str.encode()
         self.writeI32(len(str))
         self.trans.write(str)
 


### PR DESCRIPTION
str of py3 is not instance of bytes, a Error will rise because cannot write a object to buffer