### PR TITLE
THRIFT-4234 Travis build fails cross language tests with "Unsupported security protocol type"

### DIFF
--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -145,6 +145,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Add mono package repository url to get latest version of mono
 RUN echo "deb http://download.mono-project.com/repo/debian trusty main" | tee /etc/apt/sources.list.d/mono.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A6A19B38D3D831EF
 RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \
       mono-devel

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -143,7 +143,9 @@ RUN apt-get install -y --no-install-recommends \
       nodejs-dev \
       nodejs-legacy
 
-RUN apt-get install -y --no-install-recommends \
+# Add mono package repository url to get latest version of mono
+RUN echo "deb http://download.mono-project.com/repo/debian trusty main" | tee /etc/apt/sources.list.d/mono.list
+RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \
       libmono-system-web2.0-cil \
       mono-devel

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -147,7 +147,6 @@ RUN apt-get install -y --no-install-recommends \
 RUN echo "deb http://download.mono-project.com/repo/debian trusty main" | tee /etc/apt/sources.list.d/mono.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
 `# CSharp dependencies` \
-      libmono-system-web2.0-cil \
       mono-devel
 
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fix is to upgrade Mono to latest version.

See https://issues.apache.org/jira/browse/THRIFT-4234

This along with https://github.com/apache/thrift/pull/1295 should get the build green again.