### PR TITLE
THRIFT-4236: Add context support for go server.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN buildDeps=" \
        /thrift \
     && cmake --build . --config Release \
     && make install \
-    && curl -k -sSL "https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz" -o /tmp/go.tar.gz \
+    && curl -k -sSL "https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz" -o /tmp/go.tar.gz \
     && tar xzf /tmp/go.tar.gz -C /tmp \
     && cp /tmp/go/bin/gofmt /usr/bin/gofmt \
     && apt-get purge -y --auto-remove $buildDeps \

--- a/build/docker/centos/Dockerfile
+++ b/build/docker/centos/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -sSL http://packages.erlang-solutions.com/rpm/centos/erlang_solutions.r
       erlang-tools
 
 # Go Dependencies
-RUN curl -sSL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
+RUN curl -sSL https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 # Haskell Dependencies

--- a/build/docker/debian/Dockerfile
+++ b/build/docker/debian/Dockerfile
@@ -155,7 +155,7 @@ RUN pip2 install -U ipaddress backports.ssl_match_hostname tornado
 RUN pip3 install -U backports.ssl_match_hostname tornado
 
 # Go
-RUN curl -sSL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
+RUN curl -sSL https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 # Haxe

--- a/build/docker/ubuntu/Dockerfile
+++ b/build/docker/ubuntu/Dockerfile
@@ -175,7 +175,7 @@ RUN pip2 install -U ipaddress backports.ssl_match_hostname tornado
 RUN pip3 install -U backports.ssl_match_hostname tornado
 
 # Go
-RUN curl -sSL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
+RUN curl -sSL https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -C /usr/local/ -xz
 ENV PATH /usr/local/go/bin:$PATH
 
 # Haxe

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -883,13 +883,10 @@ string t_go_generator::go_imports_begin(bool consts) {
       "\t\"database/sql/driver\"\n"
       "\t\"errors\"\n";
   }
-  if (!consts && use_context_) {
-    extra +=
-       "\t\"context\"\n";
-  }
   return string(
       "import (\n"
       "\t\"bytes\"\n"
+      "\t\"context\"\n"
       "\t\"reflect\"\n"
       + extra +
       "\t\"fmt\"\n"
@@ -908,6 +905,7 @@ string t_go_generator::go_imports_end() {
       "// (needed to ensure safety because of naive import list construction.)\n"
       "var _ = thrift.ZERO\n"
       "var _ = fmt.Printf\n"
+      "var _ = context.Background\n"
       "var _ = reflect.DeepEqual\n"
       "var _ = bytes.Equal\n\n");
 }

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -262,7 +262,7 @@ public:
   std::string function_signature_if(t_function* tfunction,
                                     std::string prefix = "",
                                     bool addError = false,
-                                    bool disableContext = false);
+                                    bool enableContext = false);
   std::string argument_list(t_struct* tstruct);
   std::string type_to_enum(t_type* ttype);
   std::string type_to_go_type(t_type* ttype);
@@ -885,7 +885,7 @@ string t_go_generator::go_imports_begin(bool consts) {
   }
   if (!consts && use_context_) {
     extra +=
-       "\t\"golang.org/x/net/context\"\n";
+       "\t\"context\"\n";
   }
   return string(
       "import (\n"
@@ -1833,7 +1833,7 @@ void t_go_generator::generate_service_interface(t_service* tservice) {
 
     for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
       generate_go_docstring(f_types_, (*f_iter));
-      f_types_ << indent() << function_signature_if(*f_iter, "", true) << endl;
+      f_types_ << indent() << function_signature_if(*f_iter, "", true, use_context_) << endl;
     }
   }
 
@@ -1947,7 +1947,7 @@ void t_go_generator::generate_service_client(t_service* tservice) {
     // Open function
     generate_go_docstring(f_types_, (*f_iter));
     f_types_ << indent() << "func (p *" << serviceName << "Client) "
-               << function_signature_if(*f_iter, "", true, true) << " {" << endl;
+               << function_signature_if(*f_iter, "", true, false) << " {" << endl;
     indent_up();
     /*
     f_types_ <<
@@ -3453,10 +3453,10 @@ string t_go_generator::function_signature(t_function* tfunction, string prefix) 
  * @param disableContext Client doesn't suppport context for now.
  * @return String of rendered function definition
  */
-string t_go_generator::function_signature_if(t_function* tfunction, string prefix, bool addError, bool disableContext) {
+string t_go_generator::function_signature_if(t_function* tfunction, string prefix, bool addError, bool enableContext) {
   // TODO(mcslee): Nitpicky, no ',' if argument_list is empty
   string signature = publicize(prefix + tfunction->get_name()) + "(";
-  if (use_context_ && !disableContext) {
+  if (enableContext) {
     signature += "ctx context.Context, ";
   }
   signature += argument_list(tfunction->get_arglist()) + ") (";

--- a/configure.ac
+++ b/configure.ac
@@ -397,7 +397,7 @@ if test "$with_go" = "yes";  then
   AC_PATH_PROG([GO], [go])
   if [[ -x "$GO" ]] ; then
     AS_IF([test -n "$GO"],[
-      ax_go_version="1.4"
+      ax_go_version="1.7"
 
       AC_MSG_CHECKING([for Go version])
       golang_version=`$GO version 2>&1 | $SED -e 's/\(go \)\(version \)\(go\)\(@<:@0-9@:>@.@<:@0-9@:>@.@<:@0-9@:>@\)\(@<:@\*@:>@*\).*/\4/'`

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -39,5 +39,5 @@ These are only required if you choose to build the libraries for the given langu
     * Bit::Vector
     * Class::Accessor
 * Haxe 3.1.3
-* Go 1.4
+* Go 1.7
 * Delphi 2010

--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -21,6 +21,7 @@ package thrift
 
 import (
 	"compress/gzip"
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -35,6 +36,18 @@ func NewThriftHandlerFunc(processor TProcessor,
 
 		transport := NewStreamTransport(r.Body, w)
 		processor.Process(inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
+	})
+}
+
+// NewThriftHandlerFunc2 is same as NewThriftHandlerFunc but requires a Context as its first param.
+func NewThriftHandlerFunc2(ctx context.Context, processor TProcessor2,
+	inPfactory, outPfactory TProtocolFactory) func(w http.ResponseWriter, r *http.Request) {
+
+	return gz(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/x-thrift")
+
+		transport := NewStreamTransport(r.Body, w)
+		processor.Process(ctx, inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
 	})
 }
 

--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -21,11 +21,10 @@ package thrift
 
 import (
 	"compress/gzip"
+	"context"
 	"io"
 	"net/http"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 // NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function

--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -21,10 +21,11 @@ package thrift
 
 import (
 	"compress/gzip"
-	"context"
 	"io"
 	"net/http"
 	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function

--- a/lib/go/thrift/multiplexed_processor.go
+++ b/lib/go/thrift/multiplexed_processor.go
@@ -1,0 +1,85 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+/*
+TMultiplexedProcessor2 is a TProcessor allowing
+a single TServer to provide multiple services with
+context support in TProcessor.
+
+To do so, you instantiate the processor and then register additional
+processors with it, as shown in the following example:
+
+var processor = thrift.NewTMultiplexedProcessor2()
+
+firstProcessor :=
+processor.RegisterProcessor("FirstService", firstProcessor)
+
+processor.registerProcessor(
+  "Calculator",
+  Calculator.NewCalculatorProcessor(&CalculatorHandler{}),
+)
+
+processor.registerProcessor(
+  "WeatherReport",
+  WeatherReport.NewWeatherReportProcessor(&WeatherReportHandler{}),
+)
+
+serverTransport, err := thrift.NewTServerSocketTimeout(addr, TIMEOUT)
+if err != nil {
+  t.Fatal("Unable to create server socket", err)
+}
+server := thrift.NewTSimpleServer2(processor, serverTransport)
+server.Serve();
+*/
+
+type TMultiplexedProcessor2 struct {
+	serviceProcessorMap map[string]TProcessor2
+	DefaultProcessor    TProcessor2
+}
+
+func NewTMultiplexedProcessor2() *TMultiplexedProcessor2 {
+	return &TMultiplexedProcessor2{
+		serviceProcessorMap: make(map[string]TProcessor2),
+	}
+}
+
+func (t *TMultiplexedProcessor2) RegisterDefault(processor TProcessor2) {
+	t.DefaultProcessor = processor
+}
+
+func (t *TMultiplexedProcessor2) RegisterProcessor(name string, processor TProcessor2) {
+	if t.serviceProcessorMap == nil {
+		t.serviceProcessorMap = make(map[string]TProcessor2)
+	}
+	t.serviceProcessorMap[name] = processor
+}
+
+func (t *TMultiplexedProcessor2) Process(ctx context.Context, in, out TProtocol) (bool, TException) {
+	name, typeId, seqid, err := in.ReadMessageBegin()
+	if err != nil {
+		return false, err
+	}
+	if typeId != CALL && typeId != ONEWAY {
+		return false, fmt.Errorf("Unexpected message type %v", typeId)
+	}
+	//extract the service name
+	v := strings.SplitN(name, MULTIPLEXED_SEPARATOR, 2)
+	if len(v) != 2 {
+		if t.DefaultProcessor != nil {
+			smb := NewStoredMessageProtocol(in, name, typeId, seqid)
+			return t.DefaultProcessor.Process(ctx, smb, out)
+		}
+		return false, fmt.Errorf("Service name not found in message name: %s.  Did you forget to use a TMultiplexProtocol in your client?", name)
+	}
+	actualProcessor, ok := t.serviceProcessorMap[v[0]]
+	if !ok {
+		return false, fmt.Errorf("Service name not found: %s.  Did you forget to call registerProcessor()?", v[0])
+	}
+	smb := NewStoredMessageProtocol(in, v[1], typeId, seqid)
+	return actualProcessor.Process(ctx, smb, out)
+}

--- a/lib/go/thrift/multiplexed_processor.go
+++ b/lib/go/thrift/multiplexed_processor.go
@@ -1,9 +1,10 @@
 package thrift
 
 import (
-	"context"
 	"fmt"
 	"strings"
+
+	"golang.org/x/net/context"
 )
 
 /*

--- a/lib/go/thrift/multiplexed_processor.go
+++ b/lib/go/thrift/multiplexed_processor.go
@@ -1,10 +1,9 @@
 package thrift
 
 import (
+	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 /*

--- a/lib/go/thrift/multiplexed_protocol.go
+++ b/lib/go/thrift/multiplexed_protocol.go
@@ -76,33 +76,11 @@ func (t *TMultiplexedProtocol) WriteMessageBegin(name string, typeId TMessageTyp
 }
 
 /*
-TMultiplexedProcessor is a TProcessor allowing
-a single TServer to provide multiple services.
+This is the non-context version for TProcessor.
 
-To do so, you instantiate the processor and then register additional
-processors with it, as shown in the following example:
+See description at file: multiplexed_processor.go
 
-var processor = thrift.NewTMultiplexedProcessor()
-
-firstProcessor :=
-processor.RegisterProcessor("FirstService", firstProcessor)
-
-processor.registerProcessor(
-  "Calculator",
-  Calculator.NewCalculatorProcessor(&CalculatorHandler{}),
-)
-
-processor.registerProcessor(
-  "WeatherReport",
-  WeatherReport.NewWeatherReportProcessor(&WeatherReportHandler{}),
-)
-
-serverTransport, err := thrift.NewTServerSocketTimeout(addr, TIMEOUT)
-if err != nil {
-  t.Fatal("Unable to create server socket", err)
-}
-server := thrift.NewTSimpleServer2(processor, serverTransport)
-server.Serve();
+Deprecated: use TMultiplexedProcessor2 for strong server programming.
 */
 
 type TMultiplexedProcessor struct {

--- a/lib/go/thrift/processor.go
+++ b/lib/go/thrift/processor.go
@@ -19,6 +19,8 @@
 
 package thrift
 
+import "context"
+
 // A processor is a generic object which operates upon an input stream and
 // writes to some output stream.
 type TProcessor interface {
@@ -27,4 +29,13 @@ type TProcessor interface {
 
 type TProcessorFunction interface {
 	Process(seqId int32, in, out TProtocol) (bool, TException)
+}
+
+// TProcessor2 is TProcessor with ctx as its first argument.
+type TProcessor2 interface {
+	Process(ctx context.Context, in, out TProtocol) (bool, TException)
+}
+
+type TProcessorFunction2 interface {
+	Process(ctx context.Context, seqId int32, in, out TProtocol) (bool, TException)
 }

--- a/lib/go/thrift/processor.go
+++ b/lib/go/thrift/processor.go
@@ -19,7 +19,7 @@
 
 package thrift
 
-import "golang.org/x/net/context"
+import "context"
 
 // A processor is a generic object which operates upon an input stream and
 // writes to some output stream.

--- a/lib/go/thrift/processor.go
+++ b/lib/go/thrift/processor.go
@@ -19,7 +19,7 @@
 
 package thrift
 
-import "context"
+import "golang.org/x/net/context"
 
 // A processor is a generic object which operates upon an input stream and
 // writes to some output stream.

--- a/lib/go/thrift/processor_factory2.go
+++ b/lib/go/thrift/processor_factory2.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+// The default processor2 factory just returns a singleton
+// instance.
+// The TProcessorFactory2 is a context version of the orignal.
+type TProcessorFactory2 interface {
+	GetProcessor(trans TTransport) TProcessor2
+}
+
+type tProcessorFactory2 struct {
+	processor TProcessor2
+}
+
+func NewTProcessorFactory2(p TProcessor2) TProcessorFactory2 {
+	return &tProcessorFactory2{processor: p}
+}
+
+func (p *tProcessorFactory2) GetProcessor(trans TTransport) TProcessor2 {
+	return p.processor
+}
+
+/**
+ * The default processor factory2 just returns a singleton
+ * instance.
+ */
+type TProcessorFunctionFactory2 interface {
+	GetProcessorFunction(trans TTransport) TProcessorFunction2
+}
+
+type tProcessorFunctionFactory2 struct {
+	processor TProcessorFunction2
+}
+
+func NewTProcessorFunctionFactory2(p TProcessorFunction2) TProcessorFunctionFactory2 {
+	return &tProcessorFunctionFactory2{processor: p}
+}
+
+func (p *tProcessorFunctionFactory2) GetProcessorFunction(trans TTransport) TProcessorFunction2 {
+	return p.processor
+}

--- a/lib/go/thrift/server.go
+++ b/lib/go/thrift/server.go
@@ -33,3 +33,19 @@ type TServer interface {
 	// all servers are required to be cleanly stoppable.
 	Stop() error
 }
+
+// Same as TServer but use TProcessorFactory2 as processor factory.
+type TServer2 interface {
+	ProcessorFactory() TProcessorFactory2
+	ServerTransport() TServerTransport
+	InputTransportFactory() TTransportFactory
+	OutputTransportFactory() TTransportFactory
+	InputProtocolFactory() TProtocolFactory
+	OutputProtocolFactory() TProtocolFactory
+
+	// Starts the server
+	Serve() error
+	// Stops the server. This is optional on a per-implementation basis. Not
+	// all servers are required to be cleanly stoppable.
+	Stop() error
+}

--- a/lib/go/thrift/simple_server2.go
+++ b/lib/go/thrift/simple_server2.go
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"context"
+	"log"
+	"runtime/debug"
+	"sync"
+)
+
+/*
+ * This is only a simple sample same as TSimpleServer but add context
+ * usage support.
+ */
+type TSimpleServer2 struct {
+	quit chan struct{}
+
+	processorFactory       TProcessorFactory2
+	serverTransport        TServerTransport
+	inputTransportFactory  TTransportFactory
+	outputTransportFactory TTransportFactory
+	inputProtocolFactory   TProtocolFactory
+	outputProtocolFactory  TProtocolFactory
+	sync.WaitGroup
+}
+
+func NewTSimpleServerWithContext(processor TProcessor2, serverTransport TServerTransport) *TSimpleServer2 {
+	return NewTSimpleServerFactoryWithContext(NewTProcessorFactory2(processor), serverTransport)
+}
+
+func NewTSimpleServerFactoryWithContext(processorFactory TProcessorFactory2, serverTransport TServerTransport) *TSimpleServer2 {
+	return &TSimpleServer2{
+		quit:                   make(chan struct{}, 1),
+		processorFactory:       processorFactory,
+		serverTransport:        serverTransport,
+		inputTransportFactory:  NewTTransportFactory(),
+		outputTransportFactory: NewTTransportFactory(),
+		inputProtocolFactory:   NewTBinaryProtocolFactoryDefault(),
+		outputProtocolFactory:  NewTBinaryProtocolFactoryDefault(),
+	}
+}
+
+func (p *TSimpleServer2) ProcessorFactory() TProcessorFactory2 {
+	return p.processorFactory
+}
+
+func (p *TSimpleServer2) ServerTransport() TServerTransport {
+	return p.serverTransport
+}
+
+func (p *TSimpleServer2) InputTransportFactory() TTransportFactory {
+	return p.inputTransportFactory
+}
+
+func (p *TSimpleServer2) OutputTransportFactory() TTransportFactory {
+	return p.outputTransportFactory
+}
+
+func (p *TSimpleServer2) InputProtocolFactory() TProtocolFactory {
+	return p.inputProtocolFactory
+}
+
+func (p *TSimpleServer2) OutputProtocolFactory() TProtocolFactory {
+	return p.outputProtocolFactory
+}
+
+func (p *TSimpleServer2) Listen() error {
+	return p.serverTransport.Listen()
+}
+
+func (p *TSimpleServer2) AcceptLoop() error {
+	for {
+		client, err := p.serverTransport.Accept()
+		if err != nil {
+			select {
+			case <-p.quit:
+				return nil
+			default:
+			}
+			return err
+		}
+		if client != nil {
+			p.Add(1)
+			go func() {
+				if err := p.processRequests(client); err != nil {
+					log.Println("error processing request:", err)
+				}
+			}()
+		}
+	}
+}
+
+func (p *TSimpleServer2) Serve() error {
+	err := p.Listen()
+	if err != nil {
+		return err
+	}
+	p.AcceptLoop()
+	return nil
+}
+
+var once2 sync.Once
+
+func (p *TSimpleServer2) Stop() error {
+	q := func() {
+		close(p.quit)
+		p.serverTransport.Interrupt()
+		p.Wait()
+	}
+	once2.Do(q)
+	return nil
+}
+
+func (p *TSimpleServer2) processRequests(client TTransport) error {
+	defer p.Done()
+
+	processor := p.processorFactory.GetProcessor(client)
+	inputTransport, err := p.inputTransportFactory.GetTransport(client)
+	if err != nil {
+		return err
+	}
+	outputTransport, err := p.outputTransportFactory.GetTransport(client)
+	if err != nil {
+		return err
+	}
+	inputProtocol := p.inputProtocolFactory.GetProtocol(inputTransport)
+	outputProtocol := p.outputProtocolFactory.GetProtocol(outputTransport)
+	defer func() {
+		if e := recover(); e != nil {
+			log.Printf("panic in processor: %s: %s", e, debug.Stack())
+		}
+	}()
+
+	if inputTransport != nil {
+		defer inputTransport.Close()
+	}
+	if outputTransport != nil {
+		defer outputTransport.Close()
+	}
+	for {
+		select {
+		case <-p.quit:
+			return nil
+		default:
+		}
+
+		ctx := context.Background()
+		ok, err := processor.Process(ctx, inputProtocol, outputProtocol)
+		if err, ok := err.(TTransportException); ok && err.TypeId() == END_OF_FILE {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if err, ok := err.(TApplicationException); ok && err.TypeId() == UNKNOWN_METHOD {
+			continue
+		}
+		if !ok {
+			break
+		}
+	}
+	return nil
+}

--- a/lib/go/thrift/simple_server2.go
+++ b/lib/go/thrift/simple_server2.go
@@ -20,11 +20,10 @@
 package thrift
 
 import (
+	"context"
 	"log"
 	"runtime/debug"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 /*

--- a/lib/go/thrift/simple_server2.go
+++ b/lib/go/thrift/simple_server2.go
@@ -20,10 +20,11 @@
 package thrift
 
 import (
-	"context"
 	"log"
 	"runtime/debug"
 	"sync"
+
+	"golang.org/x/net/context"
 )
 
 /*


### PR DESCRIPTION
This commit add the context support for thrift server side in go.
for compatibility, added a use_context option in go's generator option
to tell compiler whether generated code should support context.
Added TProcessor2, TProcessorFactory2, TServer2, TMultiplexedProcessor2
to support ctx as first param.

See: https://issues.apache.org/jira/browse/THRIFT-4236