### PR TITLE
THRIFT-4237 Fix data races in Go TServerSocket

### DIFF
--- a/lib/go/Makefile.am
+++ b/lib/go/Makefile.am
@@ -31,7 +31,7 @@ install:
 	@echo '##############################################################'
 
 check-local:
-	$(GO) test ./thrift
+	$(GO) test -race ./thrift
 
 all-local:
 	$(GO) build ./thrift

--- a/lib/go/thrift/server_socket_test.go
+++ b/lib/go/thrift/server_socket_test.go
@@ -41,6 +41,16 @@ func TestSocketIsntListeningAfterInterrupt(t *testing.T) {
 	}
 }
 
+func TestSocketConcurrency(t *testing.T) {
+	host := "127.0.0.1"
+	port := 9090
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	socket := CreateServerSocket(t, addr)
+	go func() { socket.Listen() }()
+	go func() { socket.Interrupt() }()
+}
+
 func CreateServerSocket(t *testing.T, addr string) *TServerSocket {
 	socket, err := NewTServerSocket(addr)
 	if err != nil {


### PR DESCRIPTION
Incorrect lock semantics resulted in a race condition in the TServerSocket
implementation. This commit adds a unit test that detects this, and fixes up
the locking semantics.

https://issues.apache.org/jira/browse/THRIFT-4237