### PR TITLE
THRIFT-4240 Fix use of sync.Once in Go TSimpleServer Stop() method

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -32,6 +32,7 @@ import (
  */
 type TSimpleServer struct {
 	quit chan struct{}
+	once sync.Once
 
 	processorFactory       TProcessorFactory
 	serverTransport        TServerTransport
@@ -155,15 +156,13 @@ func (p *TSimpleServer) Serve() error {
 	return nil
 }
 
-var once sync.Once
-
 func (p *TSimpleServer) Stop() error {
 	q := func() {
 		close(p.quit)
 		p.serverTransport.Interrupt()
 		p.Wait()
 	}
-	once.Do(q)
+	p.once.Do(q)
 	return nil
 }
 

--- a/lib/go/thrift/simple_server_test.go
+++ b/lib/go/thrift/simple_server_test.go
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"testing"
+)
+
+type mockProcessor struct {
+	ProcessFunc func(in, out TProtocol) (bool, TException)
+}
+
+func (m *mockProcessor) Process(in, out TProtocol) (bool, TException) {
+	return m.ProcessFunc(in, out)
+}
+
+type mockServerTransport struct {
+	ListenFunc    func() error
+	AcceptFunc    func() (TTransport, error)
+	CloseFunc     func() error
+	InterruptFunc func() error
+}
+
+func (m *mockServerTransport) Listen() error {
+	return m.ListenFunc()
+}
+
+func (m *mockServerTransport) Accept() (TTransport, error) {
+	return m.AcceptFunc()
+}
+
+func (m *mockServerTransport) Close() error {
+	return m.CloseFunc()
+}
+
+func (m *mockServerTransport) Interrupt() error {
+	return m.InterruptFunc()
+}
+
+func TestMultipleStop(t *testing.T) {
+	proc := &mockProcessor{
+		ProcessFunc: func(in, out TProtocol) (bool, TException) {
+			return false, nil
+		},
+	}
+
+	var interruptCalled bool
+	c := make(chan struct{})
+	trans := &mockServerTransport{
+		ListenFunc: func() error {
+			return nil
+		},
+		AcceptFunc: func() (TTransport, error) {
+			<-c
+			return nil, nil
+		},
+		CloseFunc: func() error {
+			c <- struct{}{}
+			return nil
+		},
+		InterruptFunc: func() error {
+			interruptCalled = true
+			return nil
+		},
+	}
+
+	serv := NewTSimpleServer2(proc, trans)
+	go serv.Serve()
+	serv.Stop()
+	if !interruptCalled {
+		t.Error("first server transport should have been interrupted")
+	}
+
+	serv = NewTSimpleServer2(proc, trans)
+	interruptCalled = false
+	go serv.Serve()
+	serv.Stop()
+	if !interruptCalled {
+		t.Error("second server transport should have been interrupted")
+	}
+}


### PR DESCRIPTION
A package global sync.Once was used, which ensured that Stop() could only be
called once *per process*. The correct semantics should be once *per server*.

This commit makes the sync.Once a member of the server struct so that the
correct semantics are applied.

https://issues.apache.org/jira/browse/THRIFT-4240