### PR TITLE
THRIFT-4248: Import cstring in TSSLSocket

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <string>
+#include <cstring>
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
strncpy, memcmp, memset are used in TSSLSocket so cstring needs to be
imported.