### PR TITLE
THRIFT-4264: Fix PHP tests requiring sockets.so

### DIFF
--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -23,12 +23,17 @@ stubs: ../ThriftTest.thrift
 	$(MKDIR_P) gen-php-psr4
 	$(THRIFT) -out gen-php-psr4 --gen php:psr4 ../ThriftTest.thrift
 
-precross: stubs
+php_ext_dir:
+	mkdir -p php_ext_dir
+	ln -s ../../../lib/php/src/ext/thrift_protocol/modules/thrift_protocol.so php_ext_dir/
+	ln -s "$$(php-config --extension-dir)/sockets.so" php_ext_dir/
 
-check: stubs
+precross: stubs php_ext_dir
+
+check: stubs php_ext_dir
 
 clean-local:
-	$(RM) -r gen-php gen-phpi gen-php-psr4
+	$(RM) -r gen-php gen-phpi gen-php-psr4 php_ext_dir
 
-client: stubs
+client: stubs php_ext_dir
 	php TestClient.php

--- a/test/php/test_php.ini
+++ b/test/php/test_php.ini
@@ -1,0 +1,2 @@
+extension=thrift_protocol.so
+extension=sockets.so

--- a/test/tests.json
+++ b/test/tests.json
@@ -465,8 +465,8 @@
       ],
       "command": [
         "php",
-        "-dextension_dir=../../lib/php/src/ext/thrift_protocol/modules/",
-        "--php-ini=../../lib/php/thrift_protocol.ini",
+        "-dextension_dir=php_ext_dir",
+        "--php-ini=test_php.ini",
         "--no-php-ini",
         "-ddisplay_errors=stderr",
         "-dlog_errors=0",


### PR DESCRIPTION
The PHP library requires sockets.so for the socket_import_stream() function.
Make it available for the tests by symlinking in the module.

Patch: Håkon Hitland <hakon.hitland@zedge.net>

This closes #4264