### PR TITLE
THRIFT-4269: Don't append '.' to Erlang namespace if it ends in '_'.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -1019,18 +1019,13 @@ string t_erl_generator::argument_list(t_struct* tstruct) {
 }
 
 string t_erl_generator::type_name(t_type* ttype) {
-  string prefix = "";
-  string erl_namespace = ttype->get_program()->get_namespace("erl");
-
-  if (erl_namespace.length() > 0) {
-    prefix = erl_namespace + ".";
+  string prefix = ttype->get_program()->get_namespace("erl");
+  size_t prefix_length = prefix.length();
+  if (prefix_length > 0 && prefix[prefix_length - 1] != '_') {
+    prefix += '.';
   }
 
   string name = ttype->get_name();
-
-  if (ttype->is_struct() || ttype->is_xception() || ttype->is_service()) {
-    name = ttype->get_name();
-  }
 
   return atomify(prefix + name);
 }

--- a/lib/erl/Makefile.am
+++ b/lib/erl/Makefile.am
@@ -19,6 +19,7 @@
 
 THRIFT = ../../compiler/cpp/thrift
 THRIFT_FILES = $(wildcard test/*.thrift) \
+		  ../../test/ConstantsDemo.thrift \
 		  ../../test/NameConflictTest.thrift \
 		  ../../test/ThriftTest.thrift
 

--- a/lib/erl/test/test_const.erl
+++ b/lib/erl/test/test_const.erl
@@ -27,8 +27,8 @@
 namespace_test() ->
   %% Verify that records produced by ConstantsDemo.thrift have the right namespace.
   io:format(user, "in namespace_test()\n", []),
-  {struct, _} = constants_demo_types:struct_info('consts.thing'),
-  {struct, _} = constants_demo_types:struct_info('consts.Blah'),
+  {struct, _} = constants_demo_types:struct_info('consts_thing'),
+  {struct, _} = constants_demo_types:struct_info('consts_Blah'),
   ok.
 
 -endif. %% TEST

--- a/lib/erl/test/test_const.erl
+++ b/lib/erl/test/test_const.erl
@@ -1,0 +1,34 @@
+%%
+%% Licensed to the Apache Software Foundation (ASF) under one
+%% or more contributor license agreements. See the NOTICE file
+%% distributed with this work for additional information
+%% regarding copyright ownership. The ASF licenses this file
+%% to you under the Apache License, Version 2.0 (the
+%% "License"); you may not use this file except in compliance
+%% with the License. You may obtain a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(test_const).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-include("gen-erl/constants_demo_types.hrl").
+
+namespace_test() ->
+  %% Verify that records produced by ConstantsDemo.thrift have the right namespace.
+  io:format(user, "in namespace_test()\n", []),
+  {struct, _} = constants_demo_types:struct_info('consts.thing'),
+  {struct, _} = constants_demo_types:struct_info('consts.Blah'),
+  ok.
+
+-endif. %% TEST

--- a/test/ConstantsDemo.thrift
+++ b/test/ConstantsDemo.thrift
@@ -18,6 +18,7 @@
  */
 
 namespace cpp yozone
+namespace erl consts
 
 struct thing {
   1: i32 hello,

--- a/test/ConstantsDemo.thrift
+++ b/test/ConstantsDemo.thrift
@@ -18,7 +18,7 @@
  */
 
 namespace cpp yozone
-namespace erl consts
+namespace erl consts_
 
 struct thing {
   1: i32 hello,


### PR DESCRIPTION
THRIFT-3834 added support for namespaces to the Erlang code generator. However, that support uses a `.` between the namespace name and the type name.  This is inconvenient because, although `.` is a valid character in an Erlang atom, atoms that contain `.` must be quoted.  This means that a struct named MyStruct in the namespace NS will generate a record named `'NS.MyStruct'`.  The rules for naming atoms in Erlang are:

> Atoms begin with a lower-case letter, and may contain alphanumeric characters, underscores (_) or at-signs (@). Alternatively atoms can be specified by enclosing them in single quotes ('), necessary when they start with an uppercase character or contain characters other than underscores and at-signs.

This pull request changes the Erlang code generator so that if an Erlang namespace ends in a `_` then no `.` is added between the namespace and the struct name when creating the record. This preserves the current behavior unless the namespace ends is a `_`, but allow users to override the normal behavior by adding an explicit `_` to the end of their namespace declarations.