### PR TITLE
THRIFT-4270: Generate Erlang mapping functions for const maps and lists

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -188,7 +188,6 @@ private:
   void export_function(t_function* tfunction, std::string prefix = "");
   void export_string(std::string name, int num);
 
-  void export_types_function(t_function* tfunction, std::string prefix = "");
   void export_types_string(std::string name, int num);
 
   /**
@@ -966,16 +965,6 @@ void t_erl_generator::export_string(string name, int num) {
     export_lines_ << ", ";
   }
   export_lines_ << name << "/" << num;
-}
-
-void t_erl_generator::export_types_function(t_function* tfunction, string prefix) {
-  t_struct::members_type::size_type num = tfunction->get_arglist()->get_members().size();
-  if (num > static_cast<t_struct::members_type::size_type>(std::numeric_limits<int>().max())) {
-    throw "integer overflow in t_erl_generator::export_types_function, name " + tfunction->get_name();
-  }
-  export_types_string(prefix + tfunction->get_name(),
-                      1 // This
-                      + static_cast<int>(num));
 }
 
 void t_erl_generator::export_types_string(string name, int num) {

--- a/lib/erl/test/test_const.erl
+++ b/lib/erl/test/test_const.erl
@@ -31,4 +31,24 @@ namespace_test() ->
   {struct, _} = constants_demo_types:struct_info('consts_Blah'),
   ok.
 
+const_map_test() ->
+  ?assertEqual(233, constants_demo_constants:gen_map(35532)),
+  ?assertError(function_clause, constants_demo_constants:gen_map(0)),
+
+  ?assertEqual(853, constants_demo_constants:gen_map(43523, default)),
+  ?assertEqual(default, constants_demo_constants:gen_map(10110, default)),
+
+  ?assertEqual(98325, constants_demo_constants:gen_map2("lkjsdf")),
+  ?assertError(function_clause, constants_demo_constants:gen_map2("nonexist")),
+
+  ?assertEqual(233, constants_demo_constants:gen_map2("hello", 321)),
+  ?assertEqual(321, constants_demo_constants:gen_map2("goodbye", 321)).
+
+const_list_test() ->
+  ?assertEqual(23598352, constants_demo_constants:gen_list(2)),
+  ?assertError(function_clause, constants_demo_constants:gen_list(0)),
+
+  ?assertEqual(3253523, constants_demo_constants:gen_list(3, default)),
+  ?assertEqual(default, constants_demo_constants:gen_list(10, default)).
+
 -endif. %% TEST


### PR DESCRIPTION
The Erlang generator now creates a new constants module containing two functions for each const map and list.

The first function takes a single argument, the key for a const map or the index for a const list, and returns the corresponding value for that key or index; it throws an exception if the key does not exist or the index is out of range.

The second function is similar to the first but takes a default second element, and returns this default instead of throwing an exception if the key does not exist or the index is out of range.

For example, if example.thrift contains the following Thrift definitions:

```thrift
const map<string, string> ALPHABET = { "a" : "apple", "b" : "banana" }
const list<string> NUMBER = [ "one", "two", "three" ]
```

then these calls will succeed:

```erlang
"apple" = example_constants:alphabet("a"),
"three" = example_constants:number(3),
```
