### PR TITLE
THRIFT-4274: Catch OSError in TSSLServerSocket.accept()

### DIFF
--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -368,7 +368,7 @@ class TSSLServerSocket(TSocket.TServerSocket, TSSLBase):
         plain_client, addr = self.handle.accept()
         try:
             client = self._wrap_socket(plain_client)
-        except ssl.SSLError:
+        except (ssl.SSLError, OSError):
             logger.exception('Error while accepting from %s', addr)
             # failed handshake/ssl wrap, close socket to client
             plain_client.close()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-4274

wrap_socket can raise OSError instead of SSLError when receiving an
invalid connection attempt, which if not caught crashes TSimpleServer
and causes the feature tests to fail.

This only seems to happen on newer versions of either OpenSSL or Python, so the Travis tests would not catch this.