### PR TITLE
THRIFT-4246 Multiplexed clients sequence id fix

### DIFF
--- a/lib/nodejs/lib/thrift/multiplexed_protocol.js
+++ b/lib/nodejs/lib/thrift/multiplexed_protocol.js
@@ -52,17 +52,17 @@ Multiplexer.prototype.createClient = function(serviceName, ServiceClient, connec
   if (ServiceClient.Client) {
     ServiceClient = ServiceClient.Client;
   }
-  var self = this;
-  ServiceClient.prototype.new_seqid = function() {
-    self.seqid += 1;
-    return self.seqid;
-  };
   var writeCb = function(buf, seqid) {
     connection.write(buf,seqid);
   };
   var transport = new connection.transport(undefined, writeCb);
   var protocolWrapper = new Wrapper(serviceName, connection.protocol, connection);
   var client = new ServiceClient(transport, protocolWrapper);
+  var self = this;
+  client.new_seqid = function() {
+    self.seqid += 1;
+    return self.seqid;
+  };
 
   if (typeof connection.client !== 'object') {
     connection.client = {};


### PR DESCRIPTION
Client: nodejs

Previously, all clients would use the latest created multiplexer
for generating sequence numbers which would create a mismatch
between the mapping of sequence number->service in the connection.

This makes the client instances use the multiplexer that is
bound to it.