### PR TITLE
THRIFT-4279: Fix include path in generated Erlang Thrift sources.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -266,8 +266,8 @@ void t_erl_generator::init_generator() {
                 << "-module(" << program_module_name << "_types)." << endl
                 << erl_imports() << endl;
 
-  f_types_file_ << "-include(\"" << f_types_hrl_name << "\")." << endl
-                << endl;
+  f_types_file_ << "-include(\"" << program_module_name << "_types.hrl\")." << endl
+                  << endl;
 
   f_types_hrl_file_ << render_includes() << endl;
 
@@ -281,11 +281,11 @@ void t_erl_generator::init_generator() {
   f_consts_file_ << erl_autogen_comment() << endl
                  << "-module(" << program_module_name << "_constants)." << endl
                  << erl_imports() << endl
-                 << "-include(\"" << f_types_hrl_name << "\")." << endl
+                 << "-include(\"" << program_module_name << "_types.hrl\")." << endl
                  << endl;
 
   f_consts_hrl_file_ << erl_autogen_comment() << endl << erl_imports() << endl
-                     << "-include(\"" << f_types_hrl_name << "\")." << endl << endl;
+                     << "-include(\"" << program_module_name << "_types.hrl\")." << endl << endl;
 }
 
 /**


### PR DESCRIPTION
The change in THRIFT-4270 inadvertantly modified the include directives in the generated Erlang sources to include the gen-erl directory in the path to the include file.  This commit restores the
previous behavior.

Example include directive before the THRIFT-4270 change:
```erlang
-include("constants_demo_types.hrl").
```

Example include directive after the THRIFT-4270 change:
```erlang
-include("test/gen-erl/constants_demo_types.hrl").
```
