### PR TITLE
THRIFT-3974: fix ThreadSanitizer identified issues

### DIFF
--- a/lib/cpp/src/thrift/transport/TFileTransport.h
+++ b/lib/cpp/src/thrift/transport/TFileTransport.h
@@ -348,7 +348,7 @@ private:
 
   // conditions used to block when the buffer is full or empty
   Monitor notFull_, notEmpty_;
-  bool closing_;
+  boost::atomic<bool> closing_;
 
   // To keep track of whether the buffer has been flushed
   Monitor flushed_;

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -320,7 +320,7 @@ public:
   shared_ptr<TServerType> pServer;
   shared_ptr<TServerReadyEventHandler> pEventHandler;
   shared_ptr<boost::thread> pServerThread;
-  bool bStressDone;
+  boost::atomic<bool> bStressDone;
   boost::atomic_int64_t bStressConnectionCount;
   boost::atomic_int64_t bStressRequestCount;
 };


### PR DESCRIPTION
Tested with pthread, boost and std threads and -fsanitizer=thread with clang-4.0.