### PR TITLE
configure.ac, Makefile.am: introduce THRIFT variable to support cross…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,9 @@ AS_IF([test "x$D_IMPORT_PREFIX" = x], [D_IMPORT_PREFIX="${includedir}/d2"])
 AC_ARG_VAR([DMD_LIBEVENT_FLAGS], [DMD flags for linking libevent (auto-detected if not set).])
 AC_ARG_VAR([DMD_OPENSSL_FLAGS], [DMD flags for linking OpenSSL (auto-detected if not set).])
 
+AC_ARG_VAR([THRIFT], [Path to the thrift tool (needed for cross-compilation).])
+AS_IF([test "x$THRIFT" = x], [THRIFT=`pwd`/compiler/cpp/thrift])
+
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXX

--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -218,8 +218,6 @@ nodist_libtestgencpp_la_SOURCES = \
         gen-cpp/ThriftTest_types.h
 libtestgencpp_la_CPPFLAGS = -I../../cpp/src $(BOOST_CPPFLAGS) -I./gen-cpp
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-c_glib/t_test_container_test_types.c gen-c_glib/t_test_container_test_types.h gen-c_glib/t_test_container_service.c gen-c_glib/t_test_container_service.h: ContainerTest.thrift $(THRIFT)
 	$(THRIFT) --gen c_glib $<
 

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -256,8 +256,6 @@ include_qt_HEADERS = \
                   src/thrift/qt/TQIODeviceTransport.h \
                   src/thrift/qt/TQTcpServer.h
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 WINDOWS_DIST = \
              src/thrift/windows \
              thrift.sln \

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -333,8 +333,6 @@ OpenSSLManualInitTest_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/DebugProtoTest_types.cpp gen-cpp/DebugProtoTest_types.h gen-cpp/EmptyService.cpp gen-cpp/EmptyService.h: $(top_srcdir)/test/DebugProtoTest.thrift
 	$(THRIFT) --gen cpp $<
 

--- a/lib/csharp/test/ThriftTest/Makefile.am
+++ b/lib/csharp/test/ThriftTest/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 if MONO_MCS
 CSC=mcs
 else

--- a/lib/d/test/Makefile.am
+++ b/lib/d/test/Makefile.am
@@ -21,8 +21,6 @@ AUTOMAKE_OPTIONS = serial-tests
 
 # Thrift compiler rules
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 debug_proto_gen = $(addprefix gen-d/, DebugProtoTest_types.d)
 
 $(debug_proto_gen): $(top_srcdir)/test/DebugProtoTest.thrift

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTARGS = -out gopath/src/ --gen go:thrift_import=thrift
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/lib/haxe/test/Makefile.am
+++ b/lib/haxe/test/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) --gen haxe -r
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 AGGR = $(top_srcdir)/contrib/async-test/aggr.thrift

--- a/lib/java/Makefile.am
+++ b/lib/java/Makefile.am
@@ -19,8 +19,6 @@
 
 export CLASSPATH
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 all-local:
 	$(ANT) $(ANT_FLAGS)
 

--- a/lib/nodejs/Makefile.am
+++ b/lib/nodejs/Makefile.am
@@ -16,8 +16,6 @@
 # under the License.
 
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(top_srcdir)/test/ThriftTest.thrift
 	$(THRIFT) --gen js:node -o test/ $(top_srcdir)/test/ThriftTest.thrift
 

--- a/lib/perl/test/Makefile.am
+++ b/lib/perl/test/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = @top_builddir@/compiler/cpp/thrift
 THRIFT_IF = @top_srcdir@/test/ThriftTest.thrift
 NAME_BENCHMARKSERVICE =  @top_srcdir@/lib/rb/benchmark/Benchmark.thrift
 NAME_AGGR = @top_srcdir@/contrib/async-test/aggr.thrift

--- a/lib/php/test/Makefile.am
+++ b/lib/php/test/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../../../test/ThriftTest.thrift  TestValidators.thrift
 	mkdir -p ./packages
 	$(THRIFT) --gen php -r --out ./packages ../../../test/ThriftTest.thrift

--- a/test/c_glib/Makefile.am
+++ b/test/c_glib/Makefile.am
@@ -54,8 +54,6 @@ test_server_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-c_glib/t_test_second_service.c  gen-c_glib/t_test_second_service.h  gen-c_glib/t_test_thrift_test.c  gen-c_glib/t_test_thrift_test.h  gen-c_glib/t_test_thrift_test_types.c  gen-c_glib/t_test_thrift_test_types.h: $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen c_glib -r $<
 

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -98,8 +98,6 @@ StressTestNonBlocking_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_constants.cpp: $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen cpp:templates,cob_style -r $<
 

--- a/test/dart/Makefile.am
+++ b/test/dart/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-dart/thrift_test/lib/thrift_test.dart: ../ThriftTest.thrift
 	$(THRIFT) --gen dart ../ThriftTest.thrift
 

--- a/test/erl/Makefile.am
+++ b/test/erl/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 THRIFT_FILES = $(wildcard ../*.thrift)
 
 if ERLANG_OTP16

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -19,7 +19,6 @@
 
 BUILT_SOURCES = gopath
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) -out src/gen --gen go:thrift_import=thrift
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/test/haxe/Makefile.am
+++ b/test/haxe/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) --gen haxe -r
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/test/hs/Makefile.am
+++ b/test/hs/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(THRIFT) ../ConstantsDemo.thrift ../DebugProtoTest.thrift ../ThriftTest.thrift ../Include.thrift
 	$(THRIFT) --gen hs ../ConstantsDemo.thrift
 	$(THRIFT) --gen hs ../DebugProtoTest.thrift

--- a/test/perl/Makefile.am
+++ b/test/perl/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../ThriftTest.thrift
 	$(THRIFT) --gen perl ../ThriftTest.thrift
 

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../ThriftTest.thrift
 	$(THRIFT) --gen php ../ThriftTest.thrift
 	$(THRIFT) --gen php:inlined ../ThriftTest.thrift

--- a/test/py.twisted/Makefile.am
+++ b/test/py.twisted/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../ThriftTest.thrift ../SmallTest.thrift
 	$(THRIFT) --gen py:twisted ../ThriftTest.thrift
 	$(THRIFT) --gen py:twisted ../SmallTest.thrift

--- a/test/py/Makefile.am
+++ b/test/py/Makefile.am
@@ -18,8 +18,6 @@
 #
 AUTOMAKE_OPTIONS = serial-tests
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 py_unit_tests = RunClientServer.py
 
 thrift_gen =                                    \

--- a/test/rb/Makefile.am
+++ b/test/rb/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(THRIFT) ../ThriftTest.thrift ../SmallTest.thrift
 	$(THRIFT) --gen rb ../ThriftTest.thrift
 	$(THRIFT) --gen rb ../SmallTest.thrift

--- a/tutorial/c_glib/Makefile.am
+++ b/tutorial/c_glib/Makefile.am
@@ -28,8 +28,6 @@ AM_CFLAGS = -g -Wall -Wextra -pedantic $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) @GCOV_CF
 AM_CPPFLAGS = -I$(top_srcdir)/lib/c_glib/src -Igen-c_glib
 AM_LDFLAGS = $(GLIB_LIBS) $(GOBJECT_LIBS) @GCOV_LDFLAGS@
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 noinst_LTLIBRARIES = \
 	libtutorialgencglib.la
 

--- a/tutorial/cpp/Makefile.am
+++ b/tutorial/cpp/Makefile.am
@@ -61,8 +61,6 @@ TutorialClient_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/Calculator.cpp gen-cpp/SharedService.cpp gen-cpp/shared_constants.cpp gen-cpp/shared_types.cpp gen-cpp/tutorial_constants.cpp gen-cpp/tutorial_types.cpp: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen cpp -r $<
 

--- a/tutorial/dart/Makefile.am
+++ b/tutorial/dart/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-dart/tutorial/lib/tutorial.dart gen-dart/shared/lib/shared.dart: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen dart -r $<
 

--- a/tutorial/go/Makefile.am
+++ b/tutorial/go/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-go/tutorial/calculator.go gen-go/shared/shared_service.go: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen go -r $<
 

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-haxe/tutorial/calculator.hx gen-haxe/shared/shared_service.hx: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen haxe -r $<
 

--- a/tutorial/nodejs/Makefile.am
+++ b/tutorial/nodejs/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-nodejs/Calculator.js gen-nodejs/SharedService.js: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen js:node -r $<
 

--- a/tutorial/py.tornado/Makefile.am
+++ b/tutorial/py.tornado/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py.tornado/tutorial/Calculator.py gen-py.tornado/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py:tornado -r $<
 

--- a/tutorial/py.twisted/Makefile.am
+++ b/tutorial/py.twisted/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/tutorial/Calculator.py gen-py/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py:twisted -r $<
 

--- a/tutorial/py/Makefile.am
+++ b/tutorial/py/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/tutorial/Calculator.py gen-py/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py -r $<
 

--- a/tutorial/rb/Makefile.am
+++ b/tutorial/rb/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/calculator.rb gen-py/shared_service.rb: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen rb -r $<
 


### PR DESCRIPTION
…-compilation

The thrift build system currently assumes that the thrift compiler is
always available in $(top_builddir)/compiler/cpp/thrift. However, in a
cross-compilation context, this location contains the thrift compiler
built for the target... which obviously will not run on the build
machine.

In order to support such cross-compilation situation, we introduce the
THRIFT variable as a an argument for the configure script (using
AC_ARG_VAR). If not specified, it defaults to the existing value of
using compiler/cpp/thrift from the build directory, but it can be
overridden when calling ./configure.

Note that $(top_builddir) cannot be used within the configure script,
so we simply use `pwd`, which is the same as the top_builddir.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>