### PR TITLE
THRIFT-4106: fix errors concurrency_test was identifying

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ environment:
      LIBEVENT_VERSION: 2.0.22
      QT_VERSION: 5.6
      ZLIB_VERSION: 1.2.8
-     DISABLED_TESTS: StressTestNonBlocking|concurrency_test
+     DISABLED_TESTS: StressTestNonBlocking
 
    - PROFILE: MSVC2015
      PLATFORM: x64

--- a/build/docker/centos-7.3/Dockerfile
+++ b/build/docker/centos-7.3/Dockerfile
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Apache Thrift Docker build environment for Centos
+# Apache Thrift Docker build environment for CentOS
 #
 # Known missing client libraries:
 #  - dotnet (will update to 2.0.0 separately)
-#  - haxe (not in debian stretch)
+#  - haxe (not in centos)
 
 FROM centos:7.3.1611
 MAINTAINER Apache Thrift <dev@thrift.apache.org>
@@ -33,12 +33,14 @@ RUN yum install -y \
       flex \
       gcc \
       gcc-c++ \
+      gdb \
       git \
       libtool \
       m4 \
       make \
       tar \
       unzip \
+      valgrind \
       wget && \
       ln -s /usr/bin/cmake3 /usr/bin/cmake && \
       ln -s /usr/bin/cpack3 /usr/bin/cpack && \

--- a/build/docker/debian-stretch/Dockerfile
+++ b/build/docker/debian-stretch/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get install -y --no-install-recommends \
       gdb \
       ninja-build \
       pkg-config \
+      valgrind \
       vim
 
 

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get install -y --no-install-recommends \
       llvm \
       ninja-build \
       pkg-config \
+      valgrind \
       vim
 ENV PATH /usr/lib/llvm-3.8/bin:$PATH
 

--- a/lib/cpp/src/thrift/concurrency/BoostThreadFactory.h
+++ b/lib/cpp/src/thrift/concurrency/BoostThreadFactory.h
@@ -20,8 +20,8 @@
 #ifndef _THRIFT_CONCURRENCY_BOOSTTHREADFACTORY_H_
 #define _THRIFT_CONCURRENCY_BOOSTTHREADFACTORY_H_ 1
 
+#include <thrift/concurrency/Monitor.h>
 #include <thrift/concurrency/Thread.h>
-
 #include <thrift/stdcxx.h>
 
 namespace apache {

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -658,14 +658,21 @@ void TServerSocket::notify(THRIFT_SOCKET notifySocket) {
 }
 
 void TServerSocket::interrupt() {
-  notify(interruptSockWriter_);
+  concurrency::Guard g(rwMutex_);
+  if (interruptSockWriter_ != THRIFT_INVALID_SOCKET) {
+    notify(interruptSockWriter_);
+  }
 }
 
 void TServerSocket::interruptChildren() {
-  notify(childInterruptSockWriter_);
+  concurrency::Guard g(rwMutex_);
+  if (childInterruptSockWriter_ != THRIFT_INVALID_SOCKET) {
+    notify(childInterruptSockWriter_);
+  }
 }
 
 void TServerSocket::close() {
+  concurrency::Guard g(rwMutex_);
   if (serverSocket_ != THRIFT_INVALID_SOCKET) {
     shutdown(serverSocket_, THRIFT_SHUT_RDWR);
     ::THRIFT_CLOSESOCKET(serverSocket_);

--- a/lib/cpp/src/thrift/transport/TServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TServerSocket.h
@@ -20,6 +20,7 @@
 #ifndef _THRIFT_TRANSPORT_TSERVERSOCKET_H_
 #define _THRIFT_TRANSPORT_TSERVERSOCKET_H_ 1
 
+#include <thrift/concurrency/Mutex.h>
 #include <thrift/stdcxx.h>
 #include <thrift/transport/PlatformSocket.h>
 #include <thrift/transport/TServerTransport.h>
@@ -169,6 +170,7 @@ private:
   bool keepAlive_;
   bool listening_;
 
+  concurrency::Mutex rwMutex_;                                 // thread-safe interrupt
   THRIFT_SOCKET interruptSockWriter_;                          // is notified on interrupt()
   THRIFT_SOCKET interruptSockReader_;                          // is used in select/poll with serverSocket_ for interruptability
   THRIFT_SOCKET childInterruptSockWriter_;                     // is notified on interruptChildren()

--- a/lib/cpp/test/concurrency/Tests.cpp
+++ b/lib/cpp/test/concurrency/Tests.cpp
@@ -25,6 +25,10 @@
 #include "TimerManagerTests.h"
 #include "ThreadManagerTests.h"
 
+// The test weight, where 10 is 10 times more threads than baseline
+// and the baseline is optimized for running in valgrind
+static size_t WEIGHT = 10;
+
 int main(int argc, char** argv) {
 
   std::string arg;
@@ -37,6 +41,11 @@ int main(int argc, char** argv) {
     args[ix - 1] = std::string(argv[ix]);
   }
 
+  if (getenv("VALGRIND") != 0) {
+	  // lower the scale of every test
+	  WEIGHT = 1;
+  }
+  
   bool runAll = args[0].compare("all") == 0;
 
   if (runAll || args[0].compare("thread-factory") == 0) {
@@ -45,10 +54,10 @@ int main(int argc, char** argv) {
 
     std::cout << "ThreadFactory tests..." << std::endl;
 
-    int reapLoops = 20;
-    int reapCount = 1000;
+    int reapLoops = 2 * WEIGHT;
+    int reapCount = 100 * WEIGHT;
     size_t floodLoops = 3;
-    size_t floodCount = 20000;
+    size_t floodCount = 500 * WEIGHT;
 
     std::cout << "\t\tThreadFactory reap N threads test: N = " << reapLoops << "x" << reapCount << std::endl;
 
@@ -121,8 +130,8 @@ int main(int argc, char** argv) {
     std::cout << "ThreadManager tests..." << std::endl;
 
     {
-      size_t workerCount = 100;
-      size_t taskCount = 50000;
+      size_t workerCount = 10 * WEIGHT;
+      size_t taskCount = 500 * WEIGHT;
       int64_t delay = 10LL;
 
       ThreadManagerTests threadManagerTests;
@@ -160,13 +169,13 @@ int main(int argc, char** argv) {
 
       size_t minWorkerCount = 2;
 
-      size_t maxWorkerCount = 64;
+      size_t maxWorkerCount = 8;
 
-      size_t tasksPerWorker = 1000;
+      size_t tasksPerWorker = 100 * WEIGHT;
 
       int64_t delay = 5LL;
 
-      for (size_t workerCount = minWorkerCount; workerCount < maxWorkerCount; workerCount *= 4) {
+      for (size_t workerCount = minWorkerCount; workerCount <= maxWorkerCount; workerCount *= 4) {
 
         size_t taskCount = workerCount * tasksPerWorker;
 

--- a/lib/cpp/test/concurrency/ThreadManagerTests.h
+++ b/lib/cpp/test/concurrency/ThreadManagerTests.h
@@ -109,7 +109,7 @@ public:
     shared_ptr<ThreadManager> threadManager = ThreadManager::newSimpleThreadManager(workerCount);
 
     shared_ptr<PlatformThreadFactory> threadFactory
-        = shared_ptr<PlatformThreadFactory>(new PlatformThreadFactory());
+        = shared_ptr<PlatformThreadFactory>(new PlatformThreadFactory(false));
 
 #if !USE_BOOST_THREAD && !USE_STD_THREAD
     threadFactory->setPriority(PosixThreadFactory::HIGHEST);

--- a/test/valgrind.suppress
+++ b/test/valgrind.suppress
@@ -5,5 +5,49 @@
    fun:malloc
    fun:_ZN5boost6detail25get_once_per_thread_epochEv
 }
+{
+   boostthreads/once/ignore
+   Helgrind:Race
+   fun:_ZN5boost13thread_detail17enter_once_regionERNS_9once_flagE
+   fun:_ZN5boost6detail23get_current_thread_dataEv
+   fun:_ZN5boost6detail20interruption_checkerC1EP15pthread_mutex_tP14pthread_cond_t
+   fun:_ZN5boost22condition_variable_any4waitINS_11unique_lockINS_11timed_mutexEEEEEvRT_
+   fun:_ZN6apache6thrift11concurrency7Monitor4Impl11waitForeverEv
+   fun:_ZN6apache6thrift11concurrency7Monitor4Impl19waitForTimeRelativeEl
+   fun:_ZN6apache6thrift11concurrency7Monitor4Impl4waitEl
+   fun:_ZNK6apache6thrift11concurrency7Monitor4waitEl
+   fun:_ZN6apache6thrift11concurrency11BoostThread5startEv
+   fun:_ZN6apache6thrift11concurrency4test18ThreadFactoryTests12reapNThreadsEii
+   fun:main
+}
+{
+   pthread/creation-tls/ignore
+   Helgrind:Race
+   fun:mempcpy
+   fun:_dl_allocate_tls_init
+   fun:get_cached_stack
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.2*
+   obj:/usr/lib/valgrind/vgpreload_helgrind-amd64-linux.so
+   fun:_ZN6apache6thrift11concurrency13PthreadThread5startEv
+   fun:_ZN6apache6thrift11concurrency4test18ThreadFactoryTests12reapNThreadsEii
+   fun:main
+}
+{
+   boost-thread/creation-tls/ignore
+   Helgrind:Race
+   fun:mempcpy
+   fun:_dl_allocate_tls_init
+   fun:get_cached_stack
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.2.5
+   obj:/usr/lib/valgrind/vgpreload_helgrind-amd64-linux.so
+   fun:_ZN5boost6thread21start_thread_noexceptEv
+   fun:_ZN5boost6thread12start_threadEv
+   fun:_ZN5boost6threadC1ISt5_BindIFPFPvS3_ES3_EEEEOT_
+   fun:_ZN6apache6thrift11concurrency11BoostThread5startEv
+   fun:_ZN6apache6thrift11concurrency4test18ThreadFactoryTests12reapNThreadsEii
+   fun:main
+}
 
 


### PR DESCRIPTION
I found a serious issue hiding in the thread implementation which was exposed by some of the tests. In particular, tests that use detached threads will typically construct a shared_ptr<Runnable> followed by a shared_ptr<Thread>, and then make a thread with a thread manager, then call start(). The stack frame ends without the caller saving off the shared pointers, so they start destructing however the thread may not have gotten far enough along to reference the Runnable yet, and you have a race. I am fixing this by ensuring thread start() does not return until the thread's state is changed to started by the C style threadMain function. I also was able to run clean with valgrind for the first time on this test.  All three thread implementations were susceptible.