### PR TITLE
THRIFT-4273 erlang:now/0: Deprecated BIF.

### DIFF
--- a/lib/erl/src/thrift_reconnecting_client.erl
+++ b/lib/erl/src/thrift_reconnecting_client.erl
@@ -36,7 +36,7 @@
           terminate/2,
           code_change/3 ]).
 
--record( state, { client = nil, 
+-record( state, { client = nil,
                   host,
                   port,
                   thrift_svc,
@@ -226,9 +226,9 @@ timer_fun() ->
   end.
 -else.
 timer_fun() ->
-  T1 = erlang:now(),
+  T1 = erlang:timestamp(),
   fun() ->
-    T2 = erlang:now(),
+    T2 = erlang:timestamp(),
     timer:now_diff(T2, T1)
   end.
 -endif.

--- a/test/erl/src/test_client.erl
+++ b/test/erl/src/test_client.erl
@@ -160,12 +160,11 @@ start(Args) ->
         ClientS4
     end,
 
-  %% Use deprecated erlang:now until we start requiring OTP18
   %% Started = erlang:monotonic_time(milli_seconds),
-  {_, StartSec, StartUSec} = erlang:now(),
+  {_, StartSec, StartUSec} = erlang:timestamp(),
   error_logger:info_msg("testOneway"),
   {Client20, {ok, ok}} = thrift_client:call(Client19, testOneway, [1]),
-  {_, EndSec, EndUSec} = erlang:now(),
+  {_, EndSec, EndUSec} = erlang:timestamp(),
   Elapsed = (EndSec - StartSec) * 1000 + (EndUSec - StartUSec) / 1000,
   if
     Elapsed > 1000 -> exit(1);


### PR DESCRIPTION
Simply following the recommendations here:

[3.7  New Time API](http://erlang.org/doc/apps/erts/time_correction.html#id79939): How to Work with the New API