### PR TITLE
THRIFT-4325: simplifying compiler location and enabling cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,9 @@ AS_IF([test "x$D_IMPORT_PREFIX" = x], [D_IMPORT_PREFIX="${includedir}/d2"])
 AC_ARG_VAR([DMD_LIBEVENT_FLAGS], [DMD flags for linking libevent (auto-detected if not set).])
 AC_ARG_VAR([DMD_OPENSSL_FLAGS], [DMD flags for linking OpenSSL (auto-detected if not set).])
 
+AC_ARG_VAR([THRIFT], [Path to the thrift tool (needed for cross-compilation).])
+AS_IF([test "x$THRIFT" = x], [THRIFT=`pwd`/compiler/cpp/thrift])
+
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXX

--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -237,8 +237,6 @@ nodist_libtestgencpp_la_SOURCES = \
         gen-cpp/ThriftTest_types.h
 libtestgencpp_la_CPPFLAGS = -I../../cpp/src $(BOOST_CPPFLAGS) -I./gen-cpp
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-c_glib/t_test_container_test_types.c gen-c_glib/t_test_container_test_types.h gen-c_glib/t_test_container_service.c gen-c_glib/t_test_container_service.h: ContainerTest.thrift $(THRIFT)
 	$(THRIFT) --gen c_glib $<
 

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -265,8 +265,6 @@ include_qt_HEADERS = \
                   src/thrift/qt/TQIODeviceTransport.h \
                   src/thrift/qt/TQTcpServer.h
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 WINDOWS_DIST = \
              src/thrift/windows \
              thrift.sln \

--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -52,6 +52,8 @@ public:
     }
   }
 
+  bool operator==(const shared_ptr<Runnable> & runnable) const { return runnable_ == runnable; }
+
 private:
   shared_ptr<Runnable> runnable_;
   friend class TimerManager::Dispatcher;
@@ -290,10 +292,22 @@ void TimerManager::add(shared_ptr<Runnable> task, const struct timeval& value) {
 }
 
 void TimerManager::remove(shared_ptr<Runnable> task) {
-  (void)task;
   Synchronized s(monitor_);
   if (state_ != TimerManager::STARTED) {
     throw IllegalStateException();
+  }
+  bool found = false;
+  for (task_iterator ix = taskMap_.begin(); ix != taskMap_.end();) {
+    if (*ix->second == task) {
+      found = true;
+      taskCount_--;
+      taskMap_.erase(ix++);
+    } else {
+      ++ix;
+    }
+  }
+  if (!found) {
+    throw NoSuchTaskException();
   }
 }
 

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -360,8 +360,6 @@ OpenSSLManualInitTest_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/AnnotationTest_constants.cpp gen-cpp/AnnotationTest_constants.h gen-cpp/AnnotationTest_types.cpp gen-cpp/AnnotationTest_types.h: $(top_srcdir)/test/AnnotationTest.thrift
 	$(THRIFT) --gen cpp $<
 

--- a/lib/cpp/test/concurrency/Tests.cpp
+++ b/lib/cpp/test/concurrency/Tests.cpp
@@ -123,6 +123,20 @@ int main(int argc, char** argv) {
       std::cerr << "\t\tTimerManager tests FAILED" << std::endl;
       return 1;
     }
+
+    std::cout << "\t\tTimerManager test01" << std::endl;
+
+    if (!timerManagerTests.test01()) {
+      std::cerr << "\t\tTimerManager tests FAILED" << std::endl;
+      return 1;
+    }
+
+    std::cout << "\t\tTimerManager test02" << std::endl;
+
+    if (!timerManagerTests.test02()) {
+      std::cerr << "\t\tTimerManager tests FAILED" << std::endl;
+      return 1;
+    }
   }
 
   if (runAll || args[0].compare("thread-manager") == 0) {

--- a/lib/csharp/test/Multiplex/Makefile.am
+++ b/lib/csharp/test/Multiplex/Makefile.am
@@ -24,8 +24,6 @@ GENERATED = \
 
 BUILT_SOURCES = $(GENERATED)
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-csharp/Aggr.cs: $(top_srcdir)/contrib/async-test/aggr.thrift
 	$(THRIFT) --gen csharp $<
 

--- a/lib/d/test/Makefile.am
+++ b/lib/d/test/Makefile.am
@@ -24,8 +24,6 @@ BUILT_SOURCES = trusted-ca-certificate.pem server-certificate.pem
 
 # Thrift compiler rules
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 debug_proto_gen = $(addprefix gen-d/, DebugProtoTest_types.d)
 
 $(debug_proto_gen): $(top_srcdir)/test/DebugProtoTest.thrift

--- a/lib/erl/Makefile.am
+++ b/lib/erl/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = ../../compiler/cpp/thrift
 THRIFT_OMIT_FILE = test/Thrift_omit_without.thrift
 THRIFT_FILES = $(wildcard test/*.thrift) \
 		  $(THRIFT_OMIT_FILE) \

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -21,7 +21,6 @@ if GOVERSION_LT_17
 COMPILER_EXTRAFLAG=",legacy_context"
 endif
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTARGS = -out gopath/src/ --gen go:thrift_import=thrift$(COMPILER_EXTRAFLAG)
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/lib/haxe/test/Makefile.am
+++ b/lib/haxe/test/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) --gen haxe -r
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 AGGR = $(top_srcdir)/contrib/async-test/aggr.thrift

--- a/lib/java/Makefile.am
+++ b/lib/java/Makefile.am
@@ -19,8 +19,6 @@
 
 export CLASSPATH
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 all-local:
 	$(ANT) $(ANT_FLAGS)
 

--- a/lib/netcore/Makefile.am
+++ b/lib/netcore/Makefile.am
@@ -19,8 +19,6 @@
 
 SUBDIRS = . 
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 TESTDIR = Tests/Thrift.PublicInterfaces.Compile.Tests
 GENDIR = $(TESTDIR)/gen-netcore
 

--- a/lib/nodejs/Makefile.am
+++ b/lib/nodejs/Makefile.am
@@ -16,8 +16,6 @@
 # under the License.
 
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(top_srcdir)/test/ThriftTest.thrift
 	$(THRIFT) --gen js:node -o test/ $(top_srcdir)/test/ThriftTest.thrift
 

--- a/lib/perl/Makefile.am
+++ b/lib/perl/Makefile.am
@@ -62,7 +62,6 @@ EXTRA_DIST = \
 	lib/Thrift/Transport.pm \
 	README.md
 
-THRIFT = @top_builddir@/compiler/cpp/thrift
 THRIFT_IF = @top_srcdir@/test/ThriftTest.thrift
 NAME_BENCHMARKSERVICE =  @top_srcdir@/lib/rb/benchmark/Benchmark.thrift
 NAME_AGGR = @top_srcdir@/contrib/async-test/aggr.thrift

--- a/lib/php/test/Makefile.am
+++ b/lib/php/test/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../../../test/ThriftTest.thrift  TestValidators.thrift
 	mkdir -p ./packages
 	$(THRIFT) --gen php -r --out ./packages ../../../test/ThriftTest.thrift

--- a/lib/rs/test/Makefile.am
+++ b/lib/rs/test/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: thrifts/Base_One.thrift thrifts/Base_Two.thrift thrifts/Midlayer.thrift thrifts/Ultimate.thrift $(top_builddir)/test/Recursive.thrift $(THRIFT)
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Base_One.thrift
 	$(THRIFT) -I ./thrifts -out src --gen rs thrifts/Base_Two.thrift

--- a/test/c_glib/Makefile.am
+++ b/test/c_glib/Makefile.am
@@ -54,8 +54,6 @@ test_server_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-c_glib/t_test_second_service.c  gen-c_glib/t_test_second_service.h  gen-c_glib/t_test_thrift_test.c  gen-c_glib/t_test_thrift_test.h  gen-c_glib/t_test_thrift_test_types.c  gen-c_glib/t_test_thrift_test_types.h: $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen c_glib -r $<
 

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -98,8 +98,6 @@ StressTestNonBlocking_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_constants.cpp: $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen cpp:templates,cob_style -r $<
 

--- a/test/csharp/Makefile.am
+++ b/test/csharp/Makefile.am
@@ -62,8 +62,6 @@ endif
 
 LIBDIR = $(top_builddir)/lib/csharp
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 $(GENERATED): $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen csharp -o . $<
 

--- a/test/dart/Makefile.am
+++ b/test/dart/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-dart/thrift_test/lib/thrift_test.dart: ../ThriftTest.thrift
 	$(THRIFT) --gen dart ../ThriftTest.thrift
 

--- a/test/erl/Makefile.am
+++ b/test/erl/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 THRIFT_FILES = $(wildcard ../*.thrift)
 
 if ERLANG_OTP16

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -22,7 +22,6 @@ if GOVERSION_LT_17
 COMPILER_EXTRAFLAG=",legacy_context"
 endif
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) -out src/gen --gen go:thrift_import=thrift$(COMPILER_EXTRAFLAG)
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/test/haxe/Makefile.am
+++ b/test/haxe/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 THRIFTCMD = $(THRIFT) --gen haxe -r
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 

--- a/test/hs/Makefile.am
+++ b/test/hs/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(THRIFT) ../ConstantsDemo.thrift ../DebugProtoTest.thrift ../ThriftTest.thrift ../Include.thrift
 	$(THRIFT) --gen hs ../ConstantsDemo.thrift
 	$(THRIFT) --gen hs ../DebugProtoTest.thrift

--- a/test/lua/Makefile.am
+++ b/test/lua/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 # Remove "MapType =" line to ignore some map bug for now
 stubs: ../ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen lua $<

--- a/test/netcore/Makefile.am
+++ b/test/netcore/Makefile.am
@@ -19,8 +19,6 @@
 
 SUBDIRS = . 
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 GENDIR = ThriftTest/gen-netcore
 
 # Due to a known issue with "dotnet restore" the Thrift.dll dependency cannot be resolved from cmdline.

--- a/test/perl/Makefile.am
+++ b/test/perl/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../ThriftTest.thrift
 	$(THRIFT) --gen perl ../ThriftTest.thrift
 

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: ../ThriftTest.thrift
 	$(THRIFT) --gen php ../ThriftTest.thrift
 	$(THRIFT) --gen php:inlined ../ThriftTest.thrift

--- a/test/py.tornado/Makefile.am
+++ b/test/py.tornado/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_srcdir)/compiler/cpp/thrift
-
 thrift_gen: ../ThriftTest.thrift ../SmallTest.thrift
 	$(THRIFT) --gen py:tornado ../ThriftTest.thrift
 	$(THRIFT) --gen py:tornado ../SmallTest.thrift

--- a/test/py.twisted/Makefile.am
+++ b/test/py.twisted/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 TRIAL ?= trial
 
 stubs: ../ThriftTest.thrift ../SmallTest.thrift

--- a/test/py/Makefile.am
+++ b/test/py/Makefile.am
@@ -18,8 +18,6 @@
 #
 AUTOMAKE_OPTIONS = serial-tests
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 py_unit_tests = RunClientServer.py
 
 thrift_gen =                                    \

--- a/test/rb/Makefile.am
+++ b/test/rb/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 stubs: $(THRIFT) ../ThriftTest.thrift ../SmallTest.thrift
 	$(THRIFT) --gen rb ../ThriftTest.thrift
 	$(THRIFT) --gen rb ../SmallTest.thrift

--- a/test/rs/Makefile.am
+++ b/test/rs/Makefile.am
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
 
 stubs: ../ThriftTest.thrift
 	$(THRIFT) -I ./thrifts -out src --gen rs ../ThriftTest.thrift

--- a/tutorial/c_glib/Makefile.am
+++ b/tutorial/c_glib/Makefile.am
@@ -28,8 +28,6 @@ AM_CFLAGS = -g -Wall -Wextra -pedantic $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) $(OPENSS
 AM_CPPFLAGS = -I$(top_srcdir)/lib/c_glib/src -Igen-c_glib
 AM_LDFLAGS = $(GLIB_LIBS) $(GOBJECT_LIBS) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS) @GCOV_LDFLAGS@
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 noinst_LTLIBRARIES = \
 	libtutorialgencglib.la
 

--- a/tutorial/cpp/Makefile.am
+++ b/tutorial/cpp/Makefile.am
@@ -61,8 +61,6 @@ TutorialClient_LDADD = \
 #
 # Common thrift code generation rules
 #
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-cpp/Calculator.cpp gen-cpp/SharedService.cpp gen-cpp/shared_constants.cpp gen-cpp/shared_types.cpp gen-cpp/tutorial_constants.cpp gen-cpp/tutorial_types.cpp: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen cpp -r $<
 

--- a/tutorial/dart/Makefile.am
+++ b/tutorial/dart/Makefile.am
@@ -19,8 +19,6 @@
 
 BUILT_SOURCES = gen-dart/tutorial/lib/tutorial.dart gen-dart/shared/lib/shared.dart
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-dart/tutorial/lib/tutorial.dart gen-dart/shared/lib/shared.dart: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen dart -r $<
 

--- a/tutorial/go/Makefile.am
+++ b/tutorial/go/Makefile.am
@@ -21,8 +21,6 @@ if GOVERSION_LT_17
 COMPILER_EXTRAFLAG=":legacy_context"
 endif
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-go/tutorial/calculator.go gen-go/shared/shared_service.go: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen go$(COMPILER_EXTRAFLAG) -r $<
 

--- a/tutorial/haxe/Makefile.am
+++ b/tutorial/haxe/Makefile.am
@@ -17,12 +17,9 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
 BIN_PHP_WEB = bin/php-web-server/Main-debug.php
-
 
 gen-haxe/tutorial/calculator.hx gen-haxe/shared/shared_service.hx: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen haxe -r $<

--- a/tutorial/netcore/Makefile.am
+++ b/tutorial/netcore/Makefile.am
@@ -19,8 +19,6 @@
 
 SUBDIRS = . 
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 GENDIR = Interfaces/gen-netcore
 
 # Due to a known issue with "dotnet restore" the Thrift.dll dependency cannot be resolved from cmdline.

--- a/tutorial/nodejs/Makefile.am
+++ b/tutorial/nodejs/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-nodejs/Calculator.js gen-nodejs/SharedService.js: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen js:node -r $<
 

--- a/tutorial/py.tornado/Makefile.am
+++ b/tutorial/py.tornado/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py.tornado/tutorial/Calculator.py gen-py.tornado/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py:tornado -r $<
 

--- a/tutorial/py.twisted/Makefile.am
+++ b/tutorial/py.twisted/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/tutorial/Calculator.py gen-py/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py:twisted -r $<
 

--- a/tutorial/py/Makefile.am
+++ b/tutorial/py/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/tutorial/Calculator.py gen-py/shared/SharedService.py: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen py -r $<
 

--- a/tutorial/rb/Makefile.am
+++ b/tutorial/rb/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-py/calculator.rb gen-py/shared_service.rb: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen rb -r $<
 

--- a/tutorial/rs/Makefile.am
+++ b/tutorial/rs/Makefile.am
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-THRIFT = $(top_builddir)/compiler/cpp/thrift
-
 gen-rs/tutorial.rs gen-rs/shared.rs: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) -out src --gen rs -r $<
 


### PR DESCRIPTION
This is the application of #1336 merged into master - the original PR from @tpetazzoni was a little stale so I fixed the conflicts and wanted to run it through CI again before committing it.