### PR TITLE
THRIFT-4326 Allow safer reuse of BufferedTransport instances in Ruby

### DIFF
--- a/lib/rb/lib/thrift/transport/buffered_transport.rb
+++ b/lib/rb/lib/thrift/transport/buffered_transport.rb
@@ -101,7 +101,8 @@ module Thrift
         @transport.write(@wbuf)
         @wbuf = Bytes.empty_byte_buffer
       end
-      
+
+      @rbuf = Bytes.empty_byte_buffer unless @rbuf.empty?
       @transport.flush
     end
   end

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -126,6 +126,17 @@ describe 'BaseTransport' do
       btrans = Thrift::BufferedTransport.new(trans)
       btrans.flush
     end
+
+    it "should reset read buffer on flush even if there's data left in it" do
+      trans = mock("Transport")
+      trans.should_receive(:flush)
+      trans.should_receive(:read).and_return("abc", "xyz")
+
+      btrans = Thrift::BufferedTransport.new(trans)
+      btrans.read(1).should == "a"
+      btrans.flush
+      btrans.read(1).should == "x"
+    end
   end
 
   describe Thrift::BufferedTransportFactory do


### PR DESCRIPTION
Addresses [THRIFT-4326](https://issues.apache.org/jira/browse/THRIFT-4326).

## The problem

In the case where a single `Thrift::BufferedTransport` instance is re-used across multiple service calls, certain kinds of malformed responses from one service call can 'leak' into subsequent calls and cause them to fail with a `Thrift::ProtocolException`.

The most easily reproducible example is when a service returns a well-formed Thrift response for the first service call, but with N extra bytes of garbage tacked onto the end.

In such a case, the initial service call will be handled just fine (at least when using the compact protocol), however, the next N service calls that go through the same `Thrift::BufferedTransport` instance will fail with a `Thrift::ProtocolException`. This happens because the `BufferedTransport` doesn't re-set the `@rbuf` instance variable until the read buffer is fully exhausted, so each of the N subsequent service calls will attempt to read one byte identifying the protocol from the remaining buffer, and will get some bogus value from the garbage bytes at the end of the response from the initial service call.

This can also happen if reading from `@rbuf` is interrupted part-way through, while `@index` is still pointing to the middle of the read buffer (e.g. due to a Ruby timeout exception).

## Proposed solution

Re-setting the `@rbuf` instance variable to an empty byte buffer upon every call to `#flush` addresses this problem, and is conceptually similar to what happens in `HttpClientTransport#flush` (where `@inbuf` and `@outbuf` are both always reset).