### PR TITLE
Minimal C# library version for .NET Standard 1.4, 1.6, .NET 4.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,4 @@ project.lock.json
 /tutorial/rs/target
 /tutorial/rs/Cargo.lock
 /ylwrap
+/lib/csharp/src/.vs

--- a/lib/csharp/src/Collections/THashSet.cs
+++ b/lib/csharp/src/Collections/THashSet.cs
@@ -29,10 +29,12 @@ namespace Thrift.Collections
 {
 #if SILVERLIGHT
     [DataContract]
+#elif THRIFTCORE
+
 #else
-    [Serializable]
+   [Serializable]
 #endif
-    public class THashSet<T> : ICollection<T>
+   public class THashSet<T> : ICollection<T>
     {
 #if NET_2_0 || SILVERLIGHT
 #if SILVERLIGHT

--- a/lib/csharp/src/Thrift.sln
+++ b/lib/csharp/src/Thrift.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.12
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift", "Thrift.csproj", "{499EB63C-D74C-47E8-AE48-A2FC94538E9D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThriftTest", "..\test\ThriftTest\ThriftTest.csproj", "{48DD757F-CA95-4DD7-BDA4-58DB6F108C2C}"
@@ -10,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Thrift.45", "Thrift.45.csproj", "{EBCE35DA-CF6A-42BC-A357-A9C09B534299}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThriftMVCTest", "..\test\ThriftMVCTest\ThriftMVCTest.csproj", "{891B4487-C7BA-427E-BBC8-4C596C229A10}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThriftNetStandard", "ThriftNetStandard.csproj", "{2DFDA60B-072C-4265-9CE0-956A3B5131DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,9 +41,16 @@ Global
 		{891B4487-C7BA-427E-BBC8-4C596C229A10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{891B4487-C7BA-427E-BBC8-4C596C229A10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{891B4487-C7BA-427E-BBC8-4C596C229A10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DFDA60B-072C-4265-9CE0-956A3B5131DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DFDA60B-072C-4265-9CE0-956A3B5131DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DFDA60B-072C-4265-9CE0-956A3B5131DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DFDA60B-072C-4265-9CE0-956A3B5131DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {56011C04-B3F6-4D82-A325-E6DB70E21605}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		        StartupItem = Thrift.csproj

--- a/lib/csharp/src/ThriftNetStandard.csproj
+++ b/lib/csharp/src/ThriftNetStandard.csproj
@@ -1,0 +1,45 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.4;netstandard1.6;net451</TargetFrameworks>
+    <SignAssembly>False</SignAssembly>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <DefineConstants>THRIFTCORE</DefineConstants>
+    
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    
+    <PackageId>Apache.Thrift</PackageId>
+    <Version>1.0.2</Version>
+    <Authors>The Apache Software Foundation. Custom build by @aloneguid</Authors>
+    <Copyright>The Apache Software Foundation</Copyright>
+    <RepositoryType>GitHub</RepositoryType>
+    <PackageReleaseNotes>This cusom build only includes the minimum code to run Thrift, with no dependencies on any libraries.</PackageReleaseNotes>
+
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="AssemblyInfo.cs" />
+    <Compile Remove="Server/**/*" />
+    <Compile Remove="TControllingHandler.cs" />
+    <Compile Remove="Transport/*Http*.cs" />
+    <Compile Remove="Transport/*NamedPipe*.cs" />
+    <Compile Remove="Transport/*TLS*.cs" />
+    <Compile Remove="Transport/*Socket*.cs" />
+    <Compile Remove="Transport/TMemoryBuffer.cs" />
+    <Compile Remove="Transport/TFramedTransport.cs" />
+    <Compile Remove="Transport/TBufferedTransport.cs" />
+    <Compile Remove="TProcessorFactory.cs" />
+    <Compile Remove="TPrototypeProcessorFactory.cs" />
+    <Compile Remove="TSingletonProcessorFactory.cs" />
+  </ItemGroup>
+</Project>

--- a/lib/csharp/src/Transport/TStreamTransport.cs
+++ b/lib/csharp/src/Transport/TStreamTransport.cs
@@ -64,12 +64,16 @@ namespace Thrift.Transport
         {
             if (inputStream != null)
             {
-                inputStream.Close();
+#if !NETSTANDARD
+            inputStream.Close();
+#endif
                 inputStream = null;
             }
             if (outputStream != null)
             {
+#if !NETSTANDARD
                 outputStream.Close();
+#endif
                 outputStream = null;
             }
         }
@@ -105,7 +109,7 @@ namespace Thrift.Transport
         }
 
 
-    #region " IDisposable Support "
+#region " IDisposable Support "
     private bool _IsDisposed;
 
     // IDisposable
@@ -123,6 +127,6 @@ namespace Thrift.Transport
       }
       _IsDisposed = true;
     }
-    #endregion
+#endregion
   }
 }


### PR DESCRIPTION
This adds another project type to C# library which allows it to be build for .NET Standard 1.4, 1.6 and .NET 4.5.1. The project turns off all dependencies (only the new project, existing ones are untouched) to build the core thrift library.