### PR TITLE
Fix a crash on client close

### DIFF
--- a/lib/erl/src/thrift_framed_transport.erl
+++ b/lib/erl/src/thrift_framed_transport.erl
@@ -62,7 +62,8 @@ when is_integer(Len), Len >= 0 ->
           Give = min(iolist_size(NewBinary), Len),
           {Result, Remaining} = split_binary(NewBinary, Give),
           {State#t_framed{wrapped = NewState, read_buffer = Remaining}, {ok, Result}};
-        Error -> Error
+        {NewState, Error} ->
+          {State#t_framed{wrapped = NewState}, Error}
       end;
     %% read of zero bytes
     <<>> -> {State, {ok, <<>>}};


### PR DESCRIPTION
When a client closes a connection to a framed server the server was
crashing because the fact that the transport was framed was being
lost.  Looking through the file I noticed that the block from lines
87-95, looked different from the one from 59-66.  The culprit was
that when an error was occuring in the 59-66 block it was being
propagated up without rewrapping.  That would cause a failure
much further up the chain.  This patch fixes it.