### PR TITLE
THRIFT-3766: add zlib getUnderlyingTransport method

### DIFF
--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -180,6 +180,8 @@ public:
   static const int DEFAULT_UWBUF_SIZE = 128;
   static const int DEFAULT_CWBUF_SIZE = 1024;
 
+  stdcxx::shared_ptr<TTransport> getUnderlyingTransport() const { return transport_; }
+
 protected:
   inline void checkZlibRv(int status, const char* msg);
   inline void checkZlibRvNothrow(int status, const char* msg);

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -332,6 +332,12 @@ void test_no_write() {
   BOOST_CHECK_EQUAL(membuf->available_read(), (uint32_t)0);
 }
 
+void test_get_underlying_transport() {
+  shared_ptr<TMemoryBuffer> membuf(new TMemoryBuffer());
+  shared_ptr<TZlibTransport> zlib_trans(new TZlibTransport(membuf));
+  BOOST_CHECK_EQUAL(membuf.get(), zlib_trans->getUnderlyingTransport().get());
+}
+
 /*
  * Initialization
  */
@@ -436,6 +442,7 @@ bool init_unit_test_suite() {
   add_tests(suite, gen_random_buffer(buf_len), buf_len, "random");
 
   suite->add(BOOST_TEST_CASE(test_no_write));
+  suite->add(BOOST_TEST_CASE(test_get_underlying_transport));
 
   return true;
 }


### PR DESCRIPTION
Client: C++

This closes #1370