### PR TITLE
THRIFT-4346: Allow ZlibTransportFactory to wrap other factories

### DIFF
--- a/lib/go/thrift/zlib_transport.go
+++ b/lib/go/thrift/zlib_transport.go
@@ -42,7 +42,11 @@ type TZlibTransport struct {
 func (p *TZlibTransportFactory) GetTransport(trans TTransport) (TTransport, error) {
 	if p.factory != nil {
 		// wrap other factory
-		trans = p.TTransportFactory.GetTransport(trans)
+		var err error
+		trans, err = p.factory.GetTransport(trans)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return NewTZlibTransport(trans, p.level)
 }
@@ -54,7 +58,7 @@ func NewTZlibTransportFactory(level int) *TZlibTransportFactory {
 
 // NewTZlibTransportFactory constructs a new instance of NewTZlibTransportFactory
 // as a wrapper over existing transport factory
-func NewTZlibTransportFactory(level int, factory TTransportFactory) *TZlibTransportFactory {
+func NewTZlibTransportFactoryWithFactory(level int, factory TTransportFactory) *TZlibTransportFactory {
 	return &TZlibTransportFactory{level: level, factory: factory}
 }
 

--- a/lib/go/thrift/zlib_transport.go
+++ b/lib/go/thrift/zlib_transport.go
@@ -27,7 +27,8 @@ import (
 
 // TZlibTransportFactory is a factory for TZlibTransport instances
 type TZlibTransportFactory struct {
-	level int
+	level   int
+	factory TTransportFactory
 }
 
 // TZlibTransport is a TTransport implementation that makes use of zlib compression.
@@ -39,12 +40,22 @@ type TZlibTransport struct {
 
 // GetTransport constructs a new instance of NewTZlibTransport
 func (p *TZlibTransportFactory) GetTransport(trans TTransport) (TTransport, error) {
+	if p.factory != nil {
+		// wrap other factory
+		trans = p.TTransportFactory.GetTransport(trans)
+	}
 	return NewTZlibTransport(trans, p.level)
 }
 
 // NewTZlibTransportFactory constructs a new instance of NewTZlibTransportFactory
 func NewTZlibTransportFactory(level int) *TZlibTransportFactory {
-	return &TZlibTransportFactory{level: level}
+	return &TZlibTransportFactory{level: level, factory: nil}
+}
+
+// NewTZlibTransportFactory constructs a new instance of NewTZlibTransportFactory
+// as a wrapper over existing transport factory
+func NewTZlibTransportFactory(level int, factory TTransportFactory) *TZlibTransportFactory {
+	return &TZlibTransportFactory{level: level, factory: factory}
 }
 
 // NewTZlibTransport constructs a new instance of TZlibTransport

--- a/lib/go/thrift/zlib_transport.go
+++ b/lib/go/thrift/zlib_transport.go
@@ -56,7 +56,7 @@ func NewTZlibTransportFactory(level int) *TZlibTransportFactory {
 	return &TZlibTransportFactory{level: level, factory: nil}
 }
 
-// NewTZlibTransportFactory constructs a new instance of NewTZlibTransportFactory
+// NewTZlibTransportFactory constructs a new instance of TZlibTransportFactory
 // as a wrapper over existing transport factory
 func NewTZlibTransportFactoryWithFactory(level int, factory TTransportFactory) *TZlibTransportFactory {
 	return &TZlibTransportFactory{level: level, factory: factory}

--- a/lib/go/thrift/zlib_transport_test.go
+++ b/lib/go/thrift/zlib_transport_test.go
@@ -31,3 +31,25 @@ func TestZlibTransport(t *testing.T) {
 	}
 	TransportTest(t, trans, trans)
 }
+
+
+
+type DummyTransportFactory struct {}
+
+func (p *DummyTransportFactory) GetTransport(trans TTransport) (TTransport, error) {
+	return NewTMemoryBuffer(), nil
+}
+
+
+func TestZlibFactoryTransport(t *testing.T) {
+	factory := NewTZlibTransportFactoryWithFactory(
+		zlib.BestCompression,
+		&DummyTransportFactory{},
+	)
+	buffer := NewTMemoryBuffer()
+	trans, err := factory.GetTransport(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	TransportTest(t, trans, trans)
+}

--- a/lib/go/thrift/zlib_transport_test.go
+++ b/lib/go/thrift/zlib_transport_test.go
@@ -32,14 +32,11 @@ func TestZlibTransport(t *testing.T) {
 	TransportTest(t, trans, trans)
 }
 
-
-
-type DummyTransportFactory struct {}
+type DummyTransportFactory struct{}
 
 func (p *DummyTransportFactory) GetTransport(trans TTransport) (TTransport, error) {
 	return NewTMemoryBuffer(), nil
 }
-
 
 func TestZlibFactoryTransport(t *testing.T) {
 	factory := NewTZlibTransportFactoryWithFactory(

--- a/lib/go/thrift/zlib_transport_test.go
+++ b/lib/go/thrift/zlib_transport_test.go
@@ -38,11 +38,21 @@ func (p *DummyTransportFactory) GetTransport(trans TTransport) (TTransport, erro
 	return NewTMemoryBuffer(), nil
 }
 
-func TestZlibFactoryTransport(t *testing.T) {
+func TestZlibFactoryTransportWithFactory(t *testing.T) {
 	factory := NewTZlibTransportFactoryWithFactory(
 		zlib.BestCompression,
 		&DummyTransportFactory{},
 	)
+	buffer := NewTMemoryBuffer()
+	trans, err := factory.GetTransport(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	TransportTest(t, trans, trans)
+}
+
+func TestZlibFactoryTransportWithoutFactory(t *testing.T) {
+	factory := NewTZlibTransportFactoryWithFactory(zlib.BestCompression, nil)
 	buffer := NewTMemoryBuffer()
 	trans, err := factory.GetTransport(buffer)
 	if err != nil {


### PR DESCRIPTION
It is a case for when zlib is used with conjunction to other transport,
for example framed transport.

server: go