### PR TITLE
THRIFT-4367 Fix missing positional argument

### DIFF
--- a/lib/py/src/Thrift.py
+++ b/lib/py/src/Thrift.py
@@ -71,7 +71,7 @@ class TMessageType(object):
 class TProcessor(object):
     """Base class for procsessor, which works on two streams."""
 
-    def process(iprot, oprot):
+    def process(self, iprot, oprot):
         pass
 
 


### PR DESCRIPTION
I think the function process in the base TProcessor is missing a "self" argument.