### PR TITLE
THRIFT-4365: Replaced indirect object syntax

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_perl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_perl_generator.cc
@@ -1259,8 +1259,8 @@ void t_perl_generator::generate_deserialize_field(ofstream& out,
 void t_perl_generator::generate_deserialize_struct(ofstream& out,
                                                    t_struct* tstruct,
                                                    string prefix) {
-  out << indent() << "$" << prefix << " = new " << perl_namespace(tstruct->get_program())
-      << tstruct->get_name() << "();" << endl << indent() << "$xfer += $" << prefix
+  out << indent() << "$" << prefix << " = " << perl_namespace(tstruct->get_program())
+      << tstruct->get_name() << "->new();" << endl << indent() << "$xfer += $" << prefix
       << "->read($input);" << endl;
 }
 


### PR DESCRIPTION
Don't use indirect object syntax as it can cause compilation errors in some cases.