### PR TITLE
THRIFT-4306 dlang: public imports for dependencies

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_d_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_d_generator.cc
@@ -103,7 +103,7 @@ protected:
     // Include type modules from other imported programs.
     const vector<t_program*>& includes = program_->get_includes();
     for (size_t i = 0; i < includes.size(); ++i) {
-      f_types_ << "import " << render_package(*(includes[i])) << includes[i]->get_name()
+      f_types_ << "public import " << render_package(*(includes[i])) << includes[i]->get_name()
                << "_types;" << endl;
     }
     if (!includes.empty())


### PR DESCRIPTION
If you have an IDL file that imports another IDL file, you can define
a service that accepts, yields, or throws types defined in the
imported file. In this case, the dlang output should ensure that the
types defined in the imported IDL module are visible in the service
interface's module.

The generator failed to do that, resulting in a failure to compile
the generated source in these situations. This was previously
accepted by the compiler due to some long-standing bugs with symbol
visibility, but the compiler bugs have been resolved.

Fixes #4306.