### PR TITLE
THRIFT-4362 check "read length" in readStringBody(int)

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -373,6 +373,7 @@ public class TBinaryProtocol extends TProtocol {
   }
 
   public String readStringBody(int size) throws TException {
+    checkStringReadLength(size);
     try {
       byte[] buf = new byte[size];
       trans_.readAll(buf, 0, size);


### PR DESCRIPTION
This fixes THRIFT-4362.

If possible, please port this fix to previous versions. 