### PR TITLE
THRIFT-4374 cannot load thrift_protocol due to undefined symbol: _ZTVN10__cxxabiv120__si_class_type_infoE

### DIFF
--- a/lib/php/src/ext/thrift_protocol/config.m4
+++ b/lib/php/src/ext/thrift_protocol/config.m4
@@ -25,6 +25,8 @@ PHP_ARG_ENABLE(thrift_protocol, whether to enable the thrift_protocol extension,
 
 if test "$PHP_THRIFT_PROTOCOL" != "no"; then
   PHP_REQUIRE_CXX()
+  PHP_ADD_LIBRARY_WITH_PATH(stdc++, "", THRIFT_PROTOCOL_SHARED_LIBADD)
+  PHP_SUBST(THRIFT_PROTOCOL_SHARED_LIBADD)
   CXXFLAGS="$CXXFLAGS -std=c++11"
 
   PHP_NEW_EXTENSION(thrift_protocol, php_thrift_protocol.cpp, $ext_shared)


### PR DESCRIPTION
at Linux x86,

will cause errror:
````
# php -d extension=./thrift_protocol.so -m
PHP Warning:  PHP Startup: Unable to load dynamic library './thrift_protocol.so' - ./thrift_protocol.so: undefined symbol: _ZTVN10__cxxabiv120__si_class_type_infoE in Unknown on line 0
````

ref [commit](https://issues.apache.org/jira/browse/THRIFT-4356?focusedCommentId=16219118&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16219118)