### PR TITLE
THRIFT-4372 Pipe write operations across a network are limited to 65,…

### DIFF
--- a/lib/csharp/src/Transport/TNamedPipeServerTransport.cs
+++ b/lib/csharp/src/Transport/TNamedPipeServerTransport.cs
@@ -239,40 +239,51 @@ namespace Thrift.Transport
                     throw new TTransportException(TTransportException.ExceptionType.NotOpen);
                 }
 
-                if (asyncMode)
+                // if necessary, send the data in chunks
+                // there's a system limit around 0x10000 bytes that we hit otherwise
+                // MSDN: "Pipe write operations across a network are limited to 65,535 bytes per write. For more information regarding pipes, see the Remarks section."
+                var nBytes = Math.Min(len, 15 * 4096);  // 16 would exceed the limit
+                while (nBytes > 0)
                 {
-                    Exception eOuter = null;
-                    var evt = new ManualResetEvent(false);
 
-                    stream.BeginWrite(buf, off, len, asyncResult =>
+                    if (asyncMode)
                     {
-                        try
+                        Exception eOuter = null;
+                        var evt = new ManualResetEvent(false);
+
+                        stream.BeginWrite(buf, off, nBytes, asyncResult =>
                         {
-                            if (stream != null)
-                                stream.EndWrite(asyncResult);
-                            else
-                                eOuter = new TTransportException(TTransportException.ExceptionType.Interrupted);
-                        }
-                        catch (Exception e)
-                        {
-                            if (stream != null)
-                                eOuter = e;
-                            else
-                                eOuter = new TTransportException(TTransportException.ExceptionType.Interrupted, e.Message);
-                        }
-                        evt.Set();
-                    }, null);
+                            try
+                            {
+                                if (stream != null)
+                                    stream.EndWrite(asyncResult);
+                                else
+                                    eOuter = new TTransportException(TTransportException.ExceptionType.Interrupted);
+                            }
+                            catch (Exception e)
+                            {
+                                if (stream != null)
+                                    eOuter = e;
+                                else
+                                    eOuter = new TTransportException(TTransportException.ExceptionType.Interrupted, e.Message);
+                            }
+                            evt.Set();
+                        }, null);
 
-                    evt.WaitOne();
+                        evt.WaitOne();
 
-                    if (eOuter != null)
-                        throw eOuter; // rethrow exception
+                        if (eOuter != null)
+                            throw eOuter; // rethrow exception
+                    }
+                    else
+                    {
+                        stream.Write(buf, off, nBytes);
+                    }
+
+                    off += nBytes;
+                    len -= nBytes;
+                    nBytes = Math.Min(len, nBytes);
                 }
-                else
-                {
-                    stream.Write(buf, off, len);
-                }
-
             }
 
             protected override void Dispose(bool disposing)

--- a/test/csharp/TestServer.cs
+++ b/test/csharp/TestServer.cs
@@ -41,27 +41,28 @@ namespace Test
         public static int _clientID = -1;
         public delegate void TestLogDelegate(string msg, params object[] values);
 
-    public class TradeServerEventHandler : TServerEventHandler
-    {
-      public int callCount = 0;
-      public void preServe()
-      {
-        callCount++;
-      }
-      public Object createContext(Thrift.Protocol.TProtocol input, Thrift.Protocol.TProtocol output)
-      {
-        callCount++;
-        return null;
-      }
-      public void deleteContext(Object serverContext, Thrift.Protocol.TProtocol input, Thrift.Protocol.TProtocol output)
-      {
-        callCount++;
-      }
-      public void processContext(Object serverContext, Thrift.Transport.TTransport transport)
-      {
-        callCount++;
-      }
-    };
+        public class TradeServerEventHandler : TServerEventHandler
+        {
+            public int callCount = 0;
+            public void preServe()
+            {
+                callCount++;
+            }
+            public Object createContext(Thrift.Protocol.TProtocol input, Thrift.Protocol.TProtocol output)
+            {
+                callCount++;
+                return null;
+            }
+            public void deleteContext(Object serverContext, Thrift.Protocol.TProtocol input, Thrift.Protocol.TProtocol output)
+            {
+                callCount++;
+            }
+            public void processContext(Object serverContext, Thrift.Transport.TTransport transport)
+            {
+                callCount++;
+            }
+        };
+
 
         public class TestHandler : ThriftTest.Iface, Thrift.TControllingHandler
         {


### PR DESCRIPTION
…535 bytes per write

Client: C#
Patch: Jens Geyer