### PR TITLE
THRIFT-4376: fix a few high impact coverity defects:

### DIFF
--- a/compiler/cpp/src/thrift/parse/t_function.h
+++ b/compiler/cpp/src/thrift/parse/t_function.h
@@ -34,8 +34,12 @@
 class t_function : public t_doc {
 public:
   t_function(t_type* returntype, std::string name, t_struct* arglist, bool oneway = false)
-    : returntype_(returntype), name_(name), arglist_(arglist), oneway_(oneway) {
-    xceptions_ = new t_struct(NULL);
+    : returntype_(returntype),
+      name_(name),
+      arglist_(arglist),
+      xceptions_(new t_struct(NULL)),
+      own_xceptions_(true),
+      oneway_(oneway) {
     if (oneway_ && (!returntype_->is_void())) {
       pwarning(1, "Oneway methods should return void.\n");
     }
@@ -50,6 +54,7 @@ public:
       name_(name),
       arglist_(arglist),
       xceptions_(xceptions),
+      own_xceptions_(false),
       oneway_(oneway) {
     if (oneway_ && !xceptions_->get_members().empty()) {
       throw std::string("Oneway methods can't throw exceptions.");
@@ -59,7 +64,10 @@ public:
     }
   }
 
-  ~t_function() {}
+  ~t_function() {
+    if (own_xceptions_)
+      delete xceptions_;
+  }
 
   t_type* get_returntype() const { return returntype_; }
 
@@ -78,6 +86,7 @@ private:
   std::string name_;
   t_struct* arglist_;
   t_struct* xceptions_;
+  bool own_xceptions_;
   bool oneway_;
 };
 

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -50,7 +50,6 @@ thrift_multiplexed_protocol_write_message_begin (ThriftMultiplexedProtocol *prot
 
   ThriftMultiplexedProtocol *self = THRIFT_MULTIPLEXED_PROTOCOL (protocol);
   ThriftMultiplexedProtocolClass *multiplexClass = THRIFT_MULTIPLEXED_PROTOCOL_GET_CLASS(self);
-  ThriftProtocolClass *cls = THRIFT_PROTOCOL_CLASS (multiplexClass);
 
   if( (message_type == T_CALL || message_type == T_ONEWAY) && self->service_name != NULL) {
     service_name = g_strdup_printf("%s%s%s", self->service_name, THRIFT_MULTIPLEXED_PROTOCOL_DEFAULT_SEPARATOR, name);

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.c
@@ -52,7 +52,7 @@ thrift_protocol_decorator_write_message_begin (ThriftProtocol *protocol,
   ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR (protocol);
   ThriftProtocolClass *proto = THRIFT_PROTOCOL_GET_CLASS (self->concrete_protocol);
 
-  g_debug("Concrete protocol %p | %p", self->concrete_protocol, proto);
+  g_debug("Concrete protocol %p | %p", (void *)self->concrete_protocol, (void *)proto);
 
   return proto->write_message_begin (self->concrete_protocol, name,
                                     message_type, seqid,
@@ -492,7 +492,7 @@ thrift_protocol_decorator_set_property (GObject      *object,
   {
   case PROP_THRIFT_TYPE_PROTOCOL_DECORATOR_CONCRETE_PROTOCOL:
     self->concrete_protocol = g_value_dup_object (value);
-    g_debug("Setting concrete protocol %p to %p in %s", self, self->concrete_protocol, g_type_name(G_TYPE_FROM_INSTANCE(object)));
+    g_debug("Setting concrete protocol %p to %p in %s", (void *)self, (void *)self->concrete_protocol, g_type_name(G_TYPE_FROM_INSTANCE(object)));
     break;
 
   default:
@@ -534,7 +534,7 @@ thrift_protocol_decorator_get_concrete_protocol(ThriftProtocolDecorator *protoco
     return NULL;
   }
   ThriftProtocolDecorator *self = THRIFT_PROTOCOL_DECORATOR(protocol);
-  g_debug("Getting concrete protocol from %X -> %X", self, self->concrete_protocol);
+  g_debug("Getting concrete protocol from %p -> %p", (void *)self, (void *)self->concrete_protocol);
 
   return retval;
 }

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_buffered_transport.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_buffered_transport.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -84,7 +83,7 @@ thrift_buffered_transport_read_slow (ThriftTransport *transport, gpointer buf,
   guint32 have = t->r_buf->len;
 
   /* we shouldn't hit this unless the buffer doesn't have enough to read */
-  assert (t->r_buf->len < want);
+  g_assert (t->r_buf->len < want);
 
   /* first copy what we have in our buffer. */
   if (have > 0)

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_framed_transport.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_framed_transport.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -120,7 +119,7 @@ thrift_framed_transport_read_slow (ThriftTransport *transport, gpointer buf,
   gint32 result = -1;
 
   /* we shouldn't hit this unless the buffer doesn't have enough to read */
-  assert (t->r_buf->len < want);
+  g_assert (t->r_buf->len < want);
 
   /* first copy what we have in our buffer, if there is anything left */
   if (have > 0)

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/lib/c_glib/test/testbinaryprotocol.c
+++ b/lib/c_glib/test/testbinaryprotocol.c
@@ -19,7 +19,7 @@
 
 /* Disable string-function optimizations when glibc is used, as these produce
    compiler warnings about string length when a string function is used inside
-   a call to assert () */
+   a call to g_assert () */
 #ifdef __GLIBC__
 #include <features.h>
 #define __NO_STRING_INLINES 1
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
 #include <netdb.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -96,7 +95,7 @@ test_create_and_destroy(void)
 
   /* create an object and then destroy it */
   object = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -110,11 +109,11 @@ test_initialize(void)
   /* create a ThriftTransport */
   tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost",
                           "port", 51188, NULL);
-  assert (tsocket != NULL);
+  g_assert (tsocket != NULL);
   /* create a ThriftBinaryProtocol using the Transport */
   protocol = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                            tsocket, NULL);
-  assert (protocol != NULL);
+  g_assert (protocol != NULL);
   /* fetch the properties */
   g_object_get (G_OBJECT(protocol), "transport", &temp, NULL);
   g_object_unref (temp);
@@ -139,7 +138,7 @@ test_read_and_write_primitives(void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -155,48 +154,48 @@ test_read_and_write_primitives(void)
                             "port", port, NULL);
     transport = THRIFT_TRANSPORT (tsocket);
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a ThriftBinaryTransport */
     tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                        tsocket, NULL);
     protocol = THRIFT_PROTOCOL (tb);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* write a bunch of primitives */
-    assert (thrift_binary_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
-    assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
-    assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
-    assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
-    assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
-    assert (thrift_binary_protocol_write_double (protocol, 
+    g_assert (thrift_binary_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_double (protocol, 
                                                  TEST_DOUBLE, NULL) > 0);
-    assert (thrift_binary_protocol_write_string (protocol,
+    g_assert (thrift_binary_protocol_write_string (protocol,
                                                  TEST_STRING, NULL) > 0);
-    assert (thrift_binary_protocol_write_string (protocol, "", NULL) > 0);
-    assert (thrift_binary_protocol_write_binary (protocol, binary, 
+    g_assert (thrift_binary_protocol_write_string (protocol, "", NULL) > 0);
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary, 
                                                  len, NULL) > 0);
-    assert (thrift_binary_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
-    assert (thrift_binary_protocol_write_binary (protocol, binary,
+    g_assert (thrift_binary_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
 
     /* test write errors */
     transport_write_error = 1;
-    assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, 
+    g_assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, 
                                                NULL) == -1);
-    assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) == -1);
-    assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) == -1);
-    assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) == -1);
-    assert (thrift_binary_protocol_write_double (protocol, TEST_DOUBLE,
+    g_assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) == -1);
+    g_assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) == -1);
+    g_assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) == -1);
+    g_assert (thrift_binary_protocol_write_double (protocol, TEST_DOUBLE,
                                                  NULL) == -1);
-    assert (thrift_binary_protocol_write_binary (protocol, binary, len,
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary, len,
                                                  NULL) == -1);
     transport_write_error = 0;
 
     /* test binary partial failure */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_binary_protocol_write_binary (protocol, binary,
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary,
                                                  len, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -204,8 +203,8 @@ test_read_and_write_primitives(void)
     thrift_transport_close (transport, NULL);
     g_object_unref (tsocket);
     g_object_unref (protocol);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -222,7 +221,7 @@ test_read_and_write_complex_types (void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -238,33 +237,33 @@ test_read_and_write_complex_types (void)
                             "port", port, NULL);
     transport = THRIFT_TRANSPORT (tsocket);
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a ThriftBinaryTransport */
     tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                        tsocket, NULL);
     protocol = THRIFT_PROTOCOL (tb);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* test structures */
-    assert (thrift_binary_protocol_write_struct_begin (protocol, 
+    g_assert (thrift_binary_protocol_write_struct_begin (protocol, 
                                                        NULL, NULL) == 0);
-    assert (thrift_binary_protocol_write_struct_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_struct_end (protocol, NULL) == 0);
 
-    assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID,
+    g_assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID,
                                                       1, NULL) > 0);
-    assert (thrift_binary_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_field_end (protocol, NULL) == 0);
 
     /* test write error */
     transport_write_error = 1;
-    assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID, 
+    g_assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID, 
                                                       1, NULL) == -1);
     transport_write_error = 0;
 
     /* test 2nd write error */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID,
+    g_assert (thrift_binary_protocol_write_field_begin (protocol, "test", T_VOID,
                                                       1, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -272,12 +271,12 @@ test_read_and_write_complex_types (void)
     thrift_binary_protocol_write_byte (protocol, T_VOID, NULL);
 
     /* test write_field_stop */
-    assert (thrift_binary_protocol_write_field_stop (protocol, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_field_stop (protocol, NULL) > 0);
 
     /* write a map */
-    assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
+    g_assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
                                                     1, NULL) > 0);
-    assert (thrift_binary_protocol_write_map_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_map_end (protocol, NULL) == 0);
 
     /* test 2nd read failure on a map */
     thrift_binary_protocol_write_byte (protocol, T_VOID, NULL);
@@ -288,21 +287,21 @@ test_read_and_write_complex_types (void)
 
     /* test 1st write failure on a map */
     transport_write_error = 1;
-    assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
+    g_assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
                                                     1, NULL) == -1);
     transport_write_error = 0;
 
     /* test 2nd write failure on a map */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
+    g_assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
                                                     1, NULL) == -1);
     transport_write_error_at = -1;
 
     /* test 3rd write failure on a map */
     transport_write_count = 0;
     transport_write_error_at = 2;
-    assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
+    g_assert (thrift_binary_protocol_write_map_begin (protocol, T_VOID, T_VOID,
                                                     1, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -312,9 +311,9 @@ test_read_and_write_complex_types (void)
     thrift_binary_protocol_write_i32 (protocol, -10, NULL);
 
     /* test list operations */
-    assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
+    g_assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
                                                      1, NULL) > 0);
-    assert (thrift_binary_protocol_write_list_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_list_end (protocol, NULL) == 0);
 
     /* test 2nd read failure on a list */
     thrift_binary_protocol_write_byte (protocol, T_VOID, NULL);
@@ -325,27 +324,27 @@ test_read_and_write_complex_types (void)
 
     /* test first write error on a list */
     transport_write_error = 1;
-    assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
+    g_assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
                                                      1, NULL) == -1);
     transport_write_error = 0;
 
     /* test 2nd write error on a list */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
+    g_assert (thrift_binary_protocol_write_list_begin (protocol, T_VOID,
                                                      1, NULL) == -1);
     transport_write_error_at = -1;
 
     /* test set operation s*/
-    assert (thrift_binary_protocol_write_set_begin (protocol, T_VOID,
+    g_assert (thrift_binary_protocol_write_set_begin (protocol, T_VOID,
                                                     1, NULL) > 0);
-    assert (thrift_binary_protocol_write_set_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_set_end (protocol, NULL) == 0);
 
     /* invalid version */
-    assert (thrift_binary_protocol_write_i32 (protocol, -1, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i32 (protocol, -1, NULL) > 0);
 
     /* sz > 0 for a message */
-    assert (thrift_binary_protocol_write_i32 (protocol, 1, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i32 (protocol, 1, NULL) > 0);
 
     /* send a valid message */
     thrift_binary_protocol_write_i32 (protocol, 0x80010000, NULL);
@@ -360,26 +359,26 @@ test_read_and_write_complex_types (void)
     thrift_binary_protocol_write_string (protocol, "test", NULL);
 
     /* send a valid message */
-    assert (thrift_binary_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_binary_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) > 0);
 
-    assert (thrift_binary_protocol_write_message_end (protocol, NULL) == 0);
+    g_assert (thrift_binary_protocol_write_message_end (protocol, NULL) == 0);
 
     /* send broken writes */
     transport_write_error = 1;
-    assert (thrift_binary_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_binary_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error = 0;
 
     transport_write_count = 0;
     transport_write_error_at = 2;
-    assert (thrift_binary_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_binary_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error_at = -1;
 
     transport_write_count = 0;
     transport_write_error_at = 3;
-    assert (thrift_binary_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_binary_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -387,8 +386,8 @@ test_read_and_write_complex_types (void)
     thrift_transport_close (transport, NULL);
     g_object_unref (tsocket);
     g_object_unref (protocol);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -408,7 +407,7 @@ test_read_and_write_many_frames (void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -422,49 +421,49 @@ test_read_and_write_many_frames (void)
     /* create a ThriftSocket */
     tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost",
                             "port", port, NULL);
-    assert (tsocket != NULL);
+    g_assert (tsocket != NULL);
     transport = THRIFT_TRANSPORT (tsocket);
 
     /* wrap in a framed transport */
     ft = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, "transport", transport,
                        "w_buf_size", 1, NULL);
-    assert (ft != NULL);
+    g_assert (ft != NULL);
     transport = THRIFT_TRANSPORT (ft);
 
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a binary protocol */
     tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                        transport, NULL);
     protocol = THRIFT_PROTOCOL (tb);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* write a bunch of primitives */
-    assert (thrift_binary_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_double (protocol,
+    g_assert (thrift_binary_protocol_write_double (protocol,
                                                  TEST_DOUBLE, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_string (protocol,
+    g_assert (thrift_binary_protocol_write_string (protocol,
                                                  TEST_STRING, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_string (protocol, "", NULL) > 0);
+    g_assert (thrift_binary_protocol_write_string (protocol, "", NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_binary (protocol, binary,
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
+    g_assert (thrift_binary_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_binary_protocol_write_binary (protocol, binary,
+    g_assert (thrift_binary_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
     thrift_transport_flush (transport, NULL);
 
@@ -474,8 +473,8 @@ test_read_and_write_many_frames (void)
     g_object_unref (ft);
     g_object_unref (tsocket);
     g_object_unref (tb);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -504,68 +503,68 @@ thrift_server_primitives (const int port)
   transport = THRIFT_SERVER_TRANSPORT (tsocket);
   thrift_server_transport_listen (transport, NULL);
   client = thrift_server_transport_accept (transport, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tbp = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                       client, NULL);
   protocol = THRIFT_PROTOCOL (tbp);
 
-  assert (thrift_binary_protocol_read_bool (protocol,
+  g_assert (thrift_binary_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (thrift_binary_protocol_read_byte (protocol, &value_byte, NULL) > 0);
-  assert (thrift_binary_protocol_read_i16 (protocol, &value_16, NULL) > 0);
-  assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) > 0);
-  assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) > 0);
-  assert (thrift_binary_protocol_read_double (protocol,
+  g_assert (thrift_binary_protocol_read_byte (protocol, &value_byte, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i16 (protocol, &value_16, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_double (protocol,
                                               &value_double, NULL) > 0);
-  assert (thrift_binary_protocol_read_string (protocol, &string, NULL) > 0);
-  assert (thrift_binary_protocol_read_string (protocol, &empty_string,
+  g_assert (thrift_binary_protocol_read_string (protocol, &string, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_string (protocol, &empty_string,
                                               NULL) > 0);
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
 
-  assert (value_boolean == TEST_BOOL);
-  assert (value_byte == TEST_BYTE);
-  assert (value_16 == TEST_I16);
-  assert (value_32 == TEST_I32);
-  assert (value_64 == TEST_I64);
-  assert (value_double == TEST_DOUBLE);
-  assert (strcmp (TEST_STRING, string) == 0);
-  assert (strcmp ("", empty_string) == 0);
-  assert (memcmp (comparator, binary, len) == 0);
+  g_assert (value_boolean == TEST_BOOL);
+  g_assert (value_byte == TEST_BYTE);
+  g_assert (value_16 == TEST_I16);
+  g_assert (value_32 == TEST_I32);
+  g_assert (value_64 == TEST_I64);
+  g_assert (value_double == TEST_DOUBLE);
+  g_assert (strcmp (TEST_STRING, string) == 0);
+  g_assert (strcmp ("", empty_string) == 0);
+  g_assert (memcmp (comparator, binary, len) == 0);
 
   g_free (string);
   g_free (empty_string);
   g_free (binary);
 
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
-  assert (binary == NULL);
-  assert (len == 0);
+  g_assert (binary == NULL);
+  g_assert (len == 0);
   g_free (binary);
 
   transport_read_count = 0;
   transport_read_error_at = 0;
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) == -1);
   transport_read_error_at = -1;
 
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) == -1);
   transport_read_error_at = -1;
 
   transport_read_error = 1;
-  assert (thrift_binary_protocol_read_bool (protocol,
+  g_assert (thrift_binary_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == -1);
-  assert (thrift_binary_protocol_read_byte (protocol,
+  g_assert (thrift_binary_protocol_read_byte (protocol,
                                             &value_byte, NULL) == -1);
-  assert (thrift_binary_protocol_read_i16 (protocol,
+  g_assert (thrift_binary_protocol_read_i16 (protocol,
                                            &value_16, NULL) == -1);
-  assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) == -1);
-  assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) == -1);
-  assert (thrift_binary_protocol_read_double (protocol,
+  g_assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) == -1);
+  g_assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) == -1);
+  g_assert (thrift_binary_protocol_read_double (protocol,
                                               &value_double, NULL) == -1);
   transport_read_error = 0;
 
@@ -603,7 +602,7 @@ thrift_server_complex_types (const int port)
   transport = THRIFT_SERVER_TRANSPORT (tsocket);
   thrift_server_transport_listen (transport, NULL);
   client = thrift_server_transport_accept (transport, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tbp = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                       client, NULL);
@@ -618,7 +617,7 @@ thrift_server_complex_types (const int port)
 
   /* test first read error on a field */
   transport_read_error = 1;
-  assert (thrift_binary_protocol_read_field_begin (protocol,
+  g_assert (thrift_binary_protocol_read_field_begin (protocol,
                                                    &field_name, &field_type,
                                                    &field_id, NULL) == -1);
   transport_read_error = 0;
@@ -629,7 +628,7 @@ thrift_server_complex_types (const int port)
   /* test 2nd read failure on a field */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_binary_protocol_read_field_begin (protocol,
+  g_assert (thrift_binary_protocol_read_field_begin (protocol,
                                                    &field_name, &field_type,
                                                    &field_id, NULL) == -1);
   transport_read_error_at = -1;
@@ -645,7 +644,7 @@ thrift_server_complex_types (const int port)
   /* test read failure on a map */
   transport_read_count = 0;
   transport_read_error_at = 0;
-  assert (thrift_binary_protocol_read_map_begin (protocol,
+  g_assert (thrift_binary_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
   transport_read_error_at = -1;
@@ -653,7 +652,7 @@ thrift_server_complex_types (const int port)
   /* test 2nd read failure on a map */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_binary_protocol_read_map_begin (protocol,
+  g_assert (thrift_binary_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
   transport_read_error_at = -1;
@@ -661,7 +660,7 @@ thrift_server_complex_types (const int port)
   /* test 3rd read failure on a map */
   transport_read_count = 0;
   transport_read_error_at = 2;
-  assert (thrift_binary_protocol_read_map_begin (protocol,
+  g_assert (thrift_binary_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
   transport_read_error_at = -1;
@@ -674,7 +673,7 @@ thrift_server_complex_types (const int port)
   thrift_binary_protocol_read_byte (protocol, &value, NULL);
 
   /* test negative map size */
-  assert (thrift_binary_protocol_read_map_begin (protocol,
+  g_assert (thrift_binary_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
 
@@ -684,7 +683,7 @@ thrift_server_complex_types (const int port)
 
   /* test read failure */
   transport_read_error = 1;
-  assert (thrift_binary_protocol_read_list_begin (protocol, &element_type,
+  g_assert (thrift_binary_protocol_read_list_begin (protocol, &element_type,
                                                   &size, NULL) == -1);
   transport_read_error = 0;
 
@@ -706,23 +705,23 @@ thrift_server_complex_types (const int port)
 
   /* broken read */
   transport_read_error = 1;
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error = 0;
 
   /* invalid protocol version */
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
 
   /* sz > 0 */
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) > 0);
 
   /* read a valid message */
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) > 0);
   g_free (message_name);
@@ -730,7 +729,7 @@ thrift_server_complex_types (const int port)
   /* broken 2nd read on a message */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error_at = -1;
@@ -738,19 +737,19 @@ thrift_server_complex_types (const int port)
   /* broken 3rd read on a message */
   transport_read_count = 0;
   transport_read_error_at = 3; /* read_string does two reads */
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   g_free (message_name);
   transport_read_error_at = -1;
 
   /* read a valid message */
-  assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid, 
                                                      NULL) > 0);
   g_free (message_name);
 
-  assert (thrift_binary_protocol_read_message_end (protocol, NULL) == 0);
+  g_assert (thrift_binary_protocol_read_message_end (protocol, NULL) == 0);
 
   /* handle 2nd write failure on a message */
   thrift_binary_protocol_read_i32 (protocol, &version, NULL);
@@ -792,44 +791,44 @@ thrift_server_many_frames (const int port)
   client = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, "transport",
                          thrift_server_transport_accept (transport, NULL),
                          "r_buf_size", 1, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tbp = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport",
                       client, NULL);
   protocol = THRIFT_PROTOCOL (tbp);
 
-  assert (thrift_binary_protocol_read_bool (protocol,
+  g_assert (thrift_binary_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (thrift_binary_protocol_read_byte (protocol, &value_byte, NULL) > 0);
-  assert (thrift_binary_protocol_read_i16 (protocol, &value_16, NULL) > 0);
-  assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) > 0);
-  assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) > 0);
-  assert (thrift_binary_protocol_read_double (protocol,
+  g_assert (thrift_binary_protocol_read_byte (protocol, &value_byte, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i16 (protocol, &value_16, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i32 (protocol, &value_32, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_i64 (protocol, &value_64, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_double (protocol,
                                               &value_double, NULL) > 0);
-  assert (thrift_binary_protocol_read_string (protocol, &string, NULL) > 0);
-  assert (thrift_binary_protocol_read_string (protocol, &empty_string,
+  g_assert (thrift_binary_protocol_read_string (protocol, &string, NULL) > 0);
+  g_assert (thrift_binary_protocol_read_string (protocol, &empty_string,
                                               NULL) > 0);
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
 
-  assert (value_boolean == TEST_BOOL);
-  assert (value_byte == TEST_BYTE);
-  assert (value_16 == TEST_I16);
-  assert (value_32 == TEST_I32);
-  assert (value_64 == TEST_I64);
-  assert (value_double == TEST_DOUBLE);
-  assert (strcmp (TEST_STRING, string) == 0);
-  assert (strcmp ("", empty_string) == 0);
-  assert (memcmp (comparator, binary, len) == 0);
+  g_assert (value_boolean == TEST_BOOL);
+  g_assert (value_byte == TEST_BYTE);
+  g_assert (value_16 == TEST_I16);
+  g_assert (value_32 == TEST_I32);
+  g_assert (value_64 == TEST_I64);
+  g_assert (value_double == TEST_DOUBLE);
+  g_assert (strcmp (TEST_STRING, string) == 0);
+  g_assert (strcmp ("", empty_string) == 0);
+  g_assert (memcmp (comparator, binary, len) == 0);
 
   g_free (string);
   g_free (empty_string);
   g_free (binary);
 
-  assert (thrift_binary_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_binary_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
-  assert (binary == NULL);
-  assert (len == 0);
+  g_assert (binary == NULL);
+  g_assert (len == 0);
   g_free (binary);
 
   thrift_transport_read_end (client, NULL);

--- a/lib/c_glib/test/testbufferedtransport.c
+++ b/lib/c_glib/test/testbufferedtransport.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <signal.h>
 #include <sys/wait.h>
@@ -43,7 +42,7 @@ test_create_and_destroy(void)
 
   GObject *object = NULL;
   object = g_object_new (THRIFT_TYPE_BUFFERED_TRANSPORT, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_get (G_OBJECT (object), "transport", &transport,
                 "r_buf_size", &r_buf_size,
                 "w_buf_size", &w_buf_size, NULL);
@@ -66,9 +65,9 @@ test_open_and_close(void)
                             "transport", THRIFT_TRANSPORT (tsocket), NULL);
 
   /* this shouldn't work */
-  assert (thrift_buffered_transport_open (transport, NULL) == FALSE);
-  assert (thrift_buffered_transport_is_open (transport) == TRUE);
-  assert (thrift_buffered_transport_close (transport, NULL) == TRUE);
+  g_assert (thrift_buffered_transport_open (transport, NULL) == FALSE);
+  g_assert (thrift_buffered_transport_is_open (transport) == TRUE);
+  g_assert (thrift_buffered_transport_close (transport, NULL) == TRUE);
   g_object_unref (transport);
   g_object_unref (tsocket);
 
@@ -80,7 +79,7 @@ test_open_and_close(void)
   transport = g_object_new (THRIFT_TYPE_BUFFERED_TRANSPORT,
                             "transport", THRIFT_TRANSPORT (tsocket), NULL);
 
-  assert (thrift_buffered_transport_open (transport, &err) == FALSE);
+  g_assert (thrift_buffered_transport_open (transport, &err) == FALSE);
   g_object_unref (transport);
   g_object_unref (tsocket);
   g_error_free (err);
@@ -98,7 +97,7 @@ test_read_and_write(void)
   guchar buf[10] = TEST_DATA; /* a buffer */
 
   pid = fork ();
-  assert ( pid >= 0 );
+  g_assert ( pid >= 0 );
 
   if ( pid == 0 )
   {
@@ -115,8 +114,8 @@ test_read_and_write(void)
                               "transport", THRIFT_TRANSPORT (tsocket),
                               "w_buf_size", 4, NULL);
 
-    assert (thrift_buffered_transport_open (transport, NULL) == TRUE);
-    assert (thrift_buffered_transport_is_open (transport));
+    g_assert (thrift_buffered_transport_open (transport, NULL) == TRUE);
+    g_assert (thrift_buffered_transport_is_open (transport));
 
     /* write 10 bytes */
     thrift_buffered_transport_write (transport, buf, 10, NULL);
@@ -149,8 +148,8 @@ test_read_and_write(void)
     g_object_unref (transport);
     g_object_unref (tsocket);
 
-    assert ( wait (&status) == pid );
-    assert ( status == 0 );
+    g_assert ( wait (&status) == pid );
+    g_assert ( status == 0 );
   }
 }
 
@@ -173,12 +172,12 @@ thrift_server (const int port)
   client = g_object_new (THRIFT_TYPE_BUFFERED_TRANSPORT, "transport",
                          thrift_server_transport_accept (transport, NULL),
                          "r_buf_size", 5, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   /* read 10 bytes */
   bytes = thrift_buffered_transport_read (client, buf, 10, NULL);
-  assert (bytes == 10); /* make sure we've read 10 bytes */
-  assert ( memcmp (buf, match, 10) == 0 ); /* make sure what we got matches */
+  g_assert (bytes == 10); /* make sure we've read 10 bytes */
+  g_assert ( memcmp (buf, match, 10) == 0 ); /* make sure what we got matches */
 
   /* read 1 byte */
   bytes = thrift_buffered_transport_read (client, buf, 1, NULL);
@@ -207,7 +206,7 @@ test_write_fail(void)
   signal(SIGPIPE, SIG_IGN);
 
   pid = fork ();
-  assert ( pid >= 0 );
+  g_assert ( pid >= 0 );
 
   if ( pid == 0 )
   {
@@ -225,7 +224,7 @@ test_write_fail(void)
     client = g_object_new (THRIFT_TYPE_BUFFERED_TRANSPORT, "transport",
         thrift_server_transport_accept (transport, NULL),
         "r_buf_size", 5, NULL);
-    assert (client != NULL);
+    g_assert (client != NULL);
 
     /* just close socket */
     thrift_buffered_transport_close (client, NULL);
@@ -243,28 +242,28 @@ test_write_fail(void)
                               "w_buf_size", 4, NULL);
 
 
-    assert (thrift_buffered_transport_open (transport, NULL) == TRUE);
-    assert (thrift_buffered_transport_is_open (transport));
+    g_assert (thrift_buffered_transport_open (transport, NULL) == TRUE);
+    g_assert (thrift_buffered_transport_is_open (transport));
 
     /* recognize disconnection */
     sleep(1);
-    assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == TRUE);
-    assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == FALSE);
+    g_assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == TRUE);
+    g_assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == FALSE);
 
     /* write and overflow buffer */
-    assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == FALSE);
+    g_assert (thrift_buffered_transport_write (transport, buf, 10, NULL) == FALSE);
 
     /* write 1 and flush */
-    assert (thrift_buffered_transport_write (transport, buf, 1, NULL) == TRUE);
-    assert (thrift_buffered_transport_flush (transport, NULL) == FALSE);
+    g_assert (thrift_buffered_transport_write (transport, buf, 1, NULL) == TRUE);
+    g_assert (thrift_buffered_transport_flush (transport, NULL) == FALSE);
 
     thrift_buffered_transport_close (transport, NULL);
 
     g_object_unref (transport);
     g_object_unref (tsocket);
 
-    assert ( wait (&status) == pid );
-    assert ( status == 0 );
+    g_assert ( wait (&status) == pid );
+    g_assert ( status == 0 );
   }
 }
 

--- a/lib/c_glib/test/testcompactprotocol.c
+++ b/lib/c_glib/test/testcompactprotocol.c
@@ -19,7 +19,7 @@
 
 /* Disable string-function optimizations when glibc is used, as these produce
    compiler warnings about string length when a string function is used inside
-   a call to assert () */
+   a call to g_assert () */
 #if !defined(__APPLE__) && !defined(__FreeBSD__) && \
     !defined(__OpenBSD__) && !defined(__NetBSD__)
 #include <features.h>
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
 #include <netdb.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -103,7 +102,7 @@ test_create_and_destroy (void)
 
   /* create an object and then destroy it */
   object = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -117,11 +116,11 @@ test_initialize (void)
   /* create a ThriftTransport */
   tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost",
                           "port", 51188, NULL);
-  assert (tsocket != NULL);
+  g_assert (tsocket != NULL);
   /* create a ThriftCompactProtocol using the Transport */
   protocol = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                            tsocket, NULL);
-  assert (protocol != NULL);
+  g_assert (protocol != NULL);
   /* fetch the properties */
   g_object_get (G_OBJECT (protocol), "transport", &temp, NULL);
   g_object_unref (temp);
@@ -146,7 +145,7 @@ test_read_and_write_primitives (void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -162,63 +161,63 @@ test_read_and_write_primitives (void)
                             "port", port, NULL);
     transport = THRIFT_TRANSPORT (tsocket);
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a ThriftCompactTransport */
     tc = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                        tsocket, NULL);
     protocol = THRIFT_PROTOCOL (tc);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* write a bunch of primitives */
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
-    assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16, NULL) > 0);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32, NULL) > 0);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64, NULL) > 0);
-    assert (thrift_compact_protocol_write_i16 (protocol, 2, NULL) > 0);
-    assert (thrift_compact_protocol_write_i32 (protocol, 2, NULL) > 0);
-    assert (thrift_compact_protocol_write_i64 (protocol, 2, NULL) > 0);
-    assert (thrift_compact_protocol_write_i16 (protocol, -2, NULL) > 0);
-    assert (thrift_compact_protocol_write_i32 (protocol, -2, NULL) > 0);
-    assert (thrift_compact_protocol_write_i64 (protocol, -2, NULL) > 0);
-    assert (thrift_compact_protocol_write_double (protocol,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_double (protocol,
                                                  TEST_DOUBLE, NULL) > 0);
-    assert (thrift_compact_protocol_write_string (protocol,
+    g_assert (thrift_compact_protocol_write_string (protocol,
                                                  TEST_STRING, NULL) > 0);
-    assert (thrift_compact_protocol_write_string (protocol, "", NULL) > 0);
-    assert (thrift_compact_protocol_write_binary (protocol, binary,
+    g_assert (thrift_compact_protocol_write_string (protocol, "", NULL) > 0);
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
-    assert (thrift_compact_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
-    assert (thrift_compact_protocol_write_binary (protocol, binary,
+    g_assert (thrift_compact_protocol_write_binary (protocol, NULL, 0, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
 
     /* test write errors */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE,
+    g_assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE,
                                                NULL) == -1);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) == -1);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) == -1);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) == -1);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16,
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) == -1);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) == -1);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) == -1);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16,
                                                NULL) == -1);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32,
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32,
                                                NULL) == -1);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64,
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64,
                                                NULL) == -1);
-    assert (thrift_compact_protocol_write_double (protocol, TEST_DOUBLE,
+    g_assert (thrift_compact_protocol_write_double (protocol, TEST_DOUBLE,
                                                  NULL) == -1);
-    assert (thrift_compact_protocol_write_binary (protocol, binary, len,
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary, len,
                                                  NULL) == -1);
     transport_write_error = 0;
 
     /* test binary partial failure */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_compact_protocol_write_binary (protocol, binary,
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary,
                                                  len, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -226,8 +225,8 @@ test_read_and_write_primitives (void)
     thrift_transport_close (transport, NULL);
     g_object_unref (tsocket);
     g_object_unref (protocol);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -244,7 +243,7 @@ test_read_and_write_complex_types (void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -260,144 +259,144 @@ test_read_and_write_complex_types (void)
                             "port", port, NULL);
     transport = THRIFT_TRANSPORT (tsocket);
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a ThriftCompactTransport */
     tc = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                        tsocket, NULL);
     protocol = THRIFT_PROTOCOL (tc);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* test structures */
-    assert (thrift_compact_protocol_write_struct_begin (protocol,
+    g_assert (thrift_compact_protocol_write_struct_begin (protocol,
                                                        NULL, NULL) == 0);
-    assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
 
     /* test field state w.r.t. deltas */
 
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE, 1, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        16, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        17, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        15, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        30, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        46, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        47, NULL) == 1);
 
     /* test fields */
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
 
     /* test field state w.r.t. structs */
 
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        16, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
 
-    assert (thrift_compact_protocol_write_struct_begin (protocol,
+    g_assert (thrift_compact_protocol_write_struct_begin (protocol,
                                                        NULL, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        17, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
 
-    assert (thrift_compact_protocol_write_struct_begin (protocol,
+    g_assert (thrift_compact_protocol_write_struct_begin (protocol,
                                                        NULL, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        18, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        19, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
 
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        18, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        25, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_struct_end (protocol, NULL) == 0);
 
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        17, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
 
     /* test field state w.r.t. bools */
 
     /* deltas */
     /* non-bool field -> bool field -> non-bool field */
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        18, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
                                                        19, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
                                                 NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        20, NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
     /* bool -> bool field -> bool */
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
                                                        21, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
                                                 NULL) == 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
 
     /* no deltas */
     /* non-bool field -> bool field -> non-bool field */
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
                                                       1, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 1);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
     /* bool -> bool field -> bool */
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test", T_BOOL,
                                                       1, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 1);
-    assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 1);
+    g_assert (thrift_compact_protocol_write_field_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL, NULL) > 0);
 
     /* test write error */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) == -1);
     transport_write_error = 0;
@@ -405,7 +404,7 @@ test_read_and_write_complex_types (void)
     /* test 2nd write error */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_compact_protocol_write_field_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_field_begin (protocol, "test",
                                                        T_DOUBLE,
                                                        1, NULL) == -1);
     transport_write_error_at = -1;
@@ -414,13 +413,13 @@ test_read_and_write_complex_types (void)
     thrift_compact_protocol_write_byte (protocol, T_DOUBLE, NULL);
 
     /* test write_field_stop */
-    assert (thrift_compact_protocol_write_field_stop (protocol, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_field_stop (protocol, NULL) > 0);
 
     /* write a map */
-    assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
                                                      T_DOUBLE,
                                                      1, NULL) > 0);
-    assert (thrift_compact_protocol_write_map_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_map_end (protocol, NULL) == 0);
 
     /* test 1st read failure on map---nothing to do on our side */
 
@@ -429,7 +428,7 @@ test_read_and_write_complex_types (void)
 
     /* test 1st write failure on a map */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
                                                      T_DOUBLE,
                                                      1, NULL) == -1);
     transport_write_error = 0;
@@ -437,7 +436,7 @@ test_read_and_write_complex_types (void)
     /* test 2nd write failure on a map */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_map_begin (protocol, T_DOUBLE,
                                                      T_DOUBLE,
                                                      1, NULL) == -1);
     transport_write_error_at = -1;
@@ -447,9 +446,9 @@ test_read_and_write_complex_types (void)
     thrift_compact_protocol_write_byte (protocol, T_DOUBLE, NULL);
 
     /* test list operations */
-    assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
                                                      15, NULL) > 0);
-    assert (thrift_compact_protocol_write_list_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_list_end (protocol, NULL) == 0);
 
     /* test 1st read failure on a small list---nothing to do on our end */
 
@@ -464,40 +463,40 @@ test_read_and_write_complex_types (void)
 
     /* test first write error on a small list */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
                                                      14, NULL) == -1);
     transport_write_error = 0;
 
     /* test first write error on a big list */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
                                                      15, NULL) == -1);
     transport_write_error = 0;
 
     /* test 2nd write error on a big list */
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_list_begin (protocol, T_DOUBLE,
                                                      15, NULL) == -1);
     transport_write_error_at = -1;
 
     /* test set operation s*/
-    assert (thrift_compact_protocol_write_set_begin (protocol, T_DOUBLE,
+    g_assert (thrift_compact_protocol_write_set_begin (protocol, T_DOUBLE,
                                                     1, NULL) > 0);
-    assert (thrift_compact_protocol_write_set_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_set_end (protocol, NULL) == 0);
 
     /* invalid protocol */
-    assert (thrift_compact_protocol_write_byte (protocol, 0, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_byte (protocol, 0, NULL) > 0);
 
     /* invalid version */
-    assert (thrift_compact_protocol_write_byte (protocol, (gint8) 0x82u,
+    g_assert (thrift_compact_protocol_write_byte (protocol, (gint8) 0x82u,
                                                 NULL) > 0);
-    assert (thrift_compact_protocol_write_byte (protocol, 0, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_byte (protocol, 0, NULL) > 0);
 
     /* send a valid message */
-    assert (thrift_compact_protocol_write_byte (protocol, (gint8) 0x82u,
+    g_assert (thrift_compact_protocol_write_byte (protocol, (gint8) 0x82u,
                                                 NULL) > 0);
-    assert (thrift_compact_protocol_write_byte (protocol, 0x01u, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_byte (protocol, 0x01u, NULL) > 0);
     thrift_compact_protocol_write_varint32 (tc, 1, NULL);
     thrift_compact_protocol_write_string (protocol, "test", NULL);
 
@@ -514,32 +513,32 @@ test_read_and_write_complex_types (void)
     thrift_compact_protocol_write_varint32 (tc, 1, NULL);
 
     /* send a valid message */
-    assert (thrift_compact_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) > 0);
 
-    assert (thrift_compact_protocol_write_message_end (protocol, NULL) == 0);
+    g_assert (thrift_compact_protocol_write_message_end (protocol, NULL) == 0);
 
     /* send broken writes */
     transport_write_error = 1;
-    assert (thrift_compact_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error = 0;
 
     transport_write_count = 0;
     transport_write_error_at = 1;
-    assert (thrift_compact_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error_at = -1;
 
     transport_write_count = 0;
     transport_write_error_at = 2;
-    assert (thrift_compact_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error_at = -1;
 
     transport_write_count = 0;
     transport_write_error_at = 3;
-    assert (thrift_compact_protocol_write_message_begin (protocol, "test",
+    g_assert (thrift_compact_protocol_write_message_begin (protocol, "test",
                                                         T_CALL, 1, NULL) == -1);
     transport_write_error_at = -1;
 
@@ -547,8 +546,8 @@ test_read_and_write_complex_types (void)
     thrift_transport_close (transport, NULL);
     g_object_unref (tsocket);
     g_object_unref (protocol);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -568,7 +567,7 @@ test_read_and_write_many_frames (void)
 
   /* fork a server from the client */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -582,70 +581,70 @@ test_read_and_write_many_frames (void)
     /* create a ThriftSocket */
     tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost",
                             "port", port, NULL);
-    assert (tsocket != NULL);
+    g_assert (tsocket != NULL);
     transport = THRIFT_TRANSPORT (tsocket);
 
     /* wrap in a framed transport */
     ft = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, "transport", transport,
                        "w_buf_size", 1, NULL);
-    assert (ft != NULL);
+    g_assert (ft != NULL);
     transport = THRIFT_TRANSPORT (ft);
 
     thrift_transport_open (transport, NULL);
-    assert (thrift_transport_is_open (transport));
+    g_assert (thrift_transport_is_open (transport));
 
     /* create a compact protocol */
     tc = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                        transport, NULL);
     protocol = THRIFT_PROTOCOL (tc);
-    assert (protocol != NULL);
+    g_assert (protocol != NULL);
 
     /* write a bunch of primitives */
-    assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
+    g_assert (thrift_compact_protocol_write_bool (protocol, TEST_BOOL,
                                                 NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE,
+    g_assert (thrift_compact_protocol_write_byte (protocol, TEST_BYTE,
                                                 NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_I16, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_I32, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_I64, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, TEST_NI16, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, TEST_NI32, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, TEST_NI64, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i16 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, 2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i32 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, 2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i64 (protocol, 2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, 2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i16 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i16 (protocol, -2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i32 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i32 (protocol, -2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_i64 (protocol, -2, NULL) > 0);
+    g_assert (thrift_compact_protocol_write_i64 (protocol, -2, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_double (protocol,
+    g_assert (thrift_compact_protocol_write_double (protocol,
                                                  TEST_DOUBLE, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_string (protocol,
+    g_assert (thrift_compact_protocol_write_string (protocol,
                                                  TEST_STRING, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_string (protocol, "", NULL) > 0);
+    g_assert (thrift_compact_protocol_write_string (protocol, "", NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_binary (protocol, binary,
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_binary (protocol, NULL,
+    g_assert (thrift_compact_protocol_write_binary (protocol, NULL,
                                                   0, NULL) > 0);
     thrift_transport_flush (transport, NULL);
-    assert (thrift_compact_protocol_write_binary (protocol, binary,
+    g_assert (thrift_compact_protocol_write_binary (protocol, binary,
                                                  len, NULL) > 0);
     thrift_transport_flush (transport, NULL);
 
@@ -655,8 +654,8 @@ test_read_and_write_many_frames (void)
     g_object_unref (ft);
     g_object_unref (tsocket);
     g_object_unref (tc);
-    assert (wait (&status) == pid);
-    assert (status == 0);
+    g_assert (wait (&status) == pid);
+    g_assert (status == 0);
   }
 }
 
@@ -690,90 +689,90 @@ thrift_server_primitives (const int port)
   transport = THRIFT_SERVER_TRANSPORT (tsocket);
   thrift_server_transport_listen (transport, NULL);
   client = thrift_server_transport_accept (transport, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tc = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                       client, NULL);
   protocol = THRIFT_PROTOCOL (tc);
 
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &value_byte, NULL) > 0);
-  assert (thrift_compact_protocol_read_i16 (protocol, &value_16, NULL) > 0);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) > 0);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) > 0);
-  assert (thrift_compact_protocol_read_i16 (protocol, &value_n16, NULL) > 0);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) > 0);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p16, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p32, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p64, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n16, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n32, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n64, NULL) > 0);
-  assert (thrift_compact_protocol_read_double (protocol,
+  g_assert (thrift_compact_protocol_read_byte (protocol, &value_byte, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i16 (protocol, &value_16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i16 (protocol, &value_n16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_double (protocol,
                                               &value_double, NULL) > 0);
-  assert (thrift_compact_protocol_read_string (protocol, &string, NULL) > 0);
-  assert (thrift_compact_protocol_read_string (protocol, &empty_string,
+  g_assert (thrift_compact_protocol_read_string (protocol, &string, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_string (protocol, &empty_string,
                                                NULL) > 0);
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
 
-  assert (value_boolean == TEST_BOOL);
-  assert (value_byte == TEST_BYTE);
-  assert (value_16 == TEST_I16);
-  assert (value_32 == TEST_I32);
-  assert (value_64 == TEST_I64);
-  assert (value_n16 == TEST_NI16);
-  assert (value_n32 == TEST_NI32);
-  assert (value_n64 == TEST_NI64);
-  assert (zigzag_p16 == 4);
-  assert (zigzag_p32 == 4);
-  assert (zigzag_p64 == 4);
-  assert (zigzag_n16 == 3);
-  assert (zigzag_n32 == 3);
-  assert (zigzag_n64 == 3);
-  assert (value_double == TEST_DOUBLE);
-  assert (strcmp (TEST_STRING, string) == 0);
-  assert (strcmp ("", empty_string) == 0);
-  assert (memcmp (comparator, binary, len) == 0);
+  g_assert (value_boolean == TEST_BOOL);
+  g_assert (value_byte == TEST_BYTE);
+  g_assert (value_16 == TEST_I16);
+  g_assert (value_32 == TEST_I32);
+  g_assert (value_64 == TEST_I64);
+  g_assert (value_n16 == TEST_NI16);
+  g_assert (value_n32 == TEST_NI32);
+  g_assert (value_n64 == TEST_NI64);
+  g_assert (zigzag_p16 == 4);
+  g_assert (zigzag_p32 == 4);
+  g_assert (zigzag_p64 == 4);
+  g_assert (zigzag_n16 == 3);
+  g_assert (zigzag_n32 == 3);
+  g_assert (zigzag_n64 == 3);
+  g_assert (value_double == TEST_DOUBLE);
+  g_assert (strcmp (TEST_STRING, string) == 0);
+  g_assert (strcmp ("", empty_string) == 0);
+  g_assert (memcmp (comparator, binary, len) == 0);
 
   g_free (string);
   g_free (empty_string);
   g_free (binary);
 
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                                &len, NULL) > 0);
-  assert (binary == NULL);
-  assert (len == 0);
+  g_assert (binary == NULL);
+  g_assert (len == 0);
   g_free (binary);
 
   transport_read_count = 0;
   transport_read_error_at = 0;
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                               &len, NULL) == -1);
   transport_read_error_at = -1;
 
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                               &len, NULL) == -1);
   transport_read_error_at = -1;
 
   transport_read_error = 1;
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == -1);
-  assert (thrift_compact_protocol_read_byte (protocol,
+  g_assert (thrift_compact_protocol_read_byte (protocol,
                                             &value_byte, NULL) == -1);
-  assert (thrift_compact_protocol_read_i16 (protocol,
+  g_assert (thrift_compact_protocol_read_i16 (protocol,
                                            &value_16, NULL) == -1);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) == -1);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) == -1);
-  assert (thrift_compact_protocol_read_i16 (protocol,
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) == -1);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) == -1);
+  g_assert (thrift_compact_protocol_read_i16 (protocol,
                                            &value_n16, NULL) == -1);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) == -1);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) == -1);
-  assert (thrift_compact_protocol_read_double (protocol,
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) == -1);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) == -1);
+  g_assert (thrift_compact_protocol_read_double (protocol,
                                               &value_double, NULL) == -1);
   transport_read_error = 0;
 
@@ -813,7 +812,7 @@ thrift_server_complex_types (const int port)
   transport = THRIFT_SERVER_TRANSPORT (tsocket);
   thrift_server_transport_listen (transport, NULL);
   client = thrift_server_transport_accept (transport, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tc = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                       client, NULL);
@@ -827,40 +826,40 @@ thrift_server_complex_types (const int port)
   /* test field state w.r.t. deltas */
 
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_id == 1);
+  g_assert (field_id == 1);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_id == 16);
+  g_assert (field_id == 16);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_id == 17);
+  g_assert (field_id == 17);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
-  assert (field_id == 15);
+  g_assert (field_id == 15);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_id == 30);
+  g_assert (field_id == 30);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
-  assert (field_id == 46);
+  g_assert (field_id == 46);
   field_id = 0;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_id == 47);
+  g_assert (field_id == 47);
   field_id = 0;
 
   /* test field operations */
@@ -871,62 +870,62 @@ thrift_server_complex_types (const int port)
 
   /* test field state w.r.t. structs */
 
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) > 1);
-  assert (field_id == 1);
+  g_assert (field_id == 1);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) == 1);
-  assert (field_id == 16);
+  g_assert (field_id == 16);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
 
-  assert (thrift_compact_protocol_read_struct_begin (protocol,
+  g_assert (thrift_compact_protocol_read_struct_begin (protocol,
                                                      &struct_name, NULL) == 0);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) > 1);
-  assert (field_id == 17);
+  g_assert (field_id == 17);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
 
-  assert (thrift_compact_protocol_read_struct_begin (protocol,
+  g_assert (thrift_compact_protocol_read_struct_begin (protocol,
                                                      &struct_name, NULL) == 0);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) > 1);
-  assert (field_id == 18);
+  g_assert (field_id == 18);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) == 1);
-  assert (field_id == 19);
+  g_assert (field_id == 19);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_struct_end (protocol, NULL) == 0);
+  g_assert (thrift_compact_protocol_read_struct_end (protocol, NULL) == 0);
 
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) == 1);
-  assert (field_id == 18);
+  g_assert (field_id == 18);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) == 1);
-  assert (field_id == 25);
+  g_assert (field_id == 25);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_struct_end (protocol, NULL) == 0);
+  g_assert (thrift_compact_protocol_read_struct_end (protocol, NULL) == 0);
 
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                                     &field_id, NULL) == 1);
-  assert (field_id == 17);
+  g_assert (field_id == 17);
   field_id = 0;
   thrift_compact_protocol_read_field_end (protocol, NULL);
 
@@ -934,83 +933,83 @@ thrift_server_complex_types (const int port)
 
   /* deltas */
   /* non-bool field -> bool field -> non-bool field */
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_type == T_BOOL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (field_type == T_BOOL);
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
   thrift_compact_protocol_read_field_end (protocol, NULL);
   /* bool -> bool field -> bool */
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) == 1);
-  assert (field_type == T_BOOL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (field_type == T_BOOL);
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
 
   /* no deltas */
   /* non-bool field -> bool field -> non-bool field */
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
-  assert (field_type == T_BOOL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (field_type == T_BOOL);
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
   thrift_compact_protocol_read_field_end (protocol, NULL);
   /* bool -> bool field -> bool */
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
-  assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol, &field_name,
                                                     &field_type,
                                            &field_id, NULL) > 1);
-  assert (field_type == T_BOOL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (field_type == T_BOOL);
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) == 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
   thrift_compact_protocol_read_field_end (protocol, NULL);
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (value_boolean == TEST_BOOL);
+  g_assert (value_boolean == TEST_BOOL);
   value_boolean = ! TEST_BOOL;
 
   /* test first read error on a field */
   transport_read_error = 1;
-  assert (thrift_compact_protocol_read_field_begin (protocol,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol,
                                                    &field_name, &field_type,
                                                    &field_id, NULL) == -1);
   transport_read_error = 0;
@@ -1021,7 +1020,7 @@ thrift_server_complex_types (const int port)
   /* test 2nd read failure on a field */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_compact_protocol_read_field_begin (protocol,
+  g_assert (thrift_compact_protocol_read_field_begin (protocol,
                                                    &field_name, &field_type,
                                                    &field_id, NULL) == -1);
   transport_read_error_at = -1;
@@ -1039,7 +1038,7 @@ thrift_server_complex_types (const int port)
   /* test 1st read failure on a map */
   transport_read_count = 0;
   transport_read_error_at = 0;
-  assert (thrift_compact_protocol_read_map_begin (protocol,
+  g_assert (thrift_compact_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
   transport_read_error_at = -1;
@@ -1047,7 +1046,7 @@ thrift_server_complex_types (const int port)
   /* test 2nd read failure on a map */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_compact_protocol_read_map_begin (protocol,
+  g_assert (thrift_compact_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
   transport_read_error_at = -1;
@@ -1058,7 +1057,7 @@ thrift_server_complex_types (const int port)
   thrift_compact_protocol_read_byte (protocol, &value, NULL);
 
   /* test negative map size */
-  assert (thrift_compact_protocol_read_map_begin (protocol,
+  g_assert (thrift_compact_protocol_read_map_begin (protocol,
                                                  &key_type, &value_type,
                                                  &size, NULL) == -1);
 
@@ -1069,13 +1068,13 @@ thrift_server_complex_types (const int port)
 
   /* test small list 1st read failure */
   transport_read_error = 1;
-  assert (thrift_compact_protocol_read_list_begin (protocol, &element_type,
+  g_assert (thrift_compact_protocol_read_list_begin (protocol, &element_type,
                                                   &size, NULL) == -1);
   transport_read_error = 0;
 
   /* test big list 1st read failure */
   transport_read_error = 1;
-  assert (thrift_compact_protocol_read_list_begin (protocol, &element_type,
+  g_assert (thrift_compact_protocol_read_list_begin (protocol, &element_type,
                                                   &size, NULL) == -1);
   transport_read_error = 0;
 
@@ -1103,23 +1102,23 @@ thrift_server_complex_types (const int port)
 
   /* broken read */
   transport_read_error = 1;
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error = 0;
 
   /* invalid protocol */
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
 
   /* invalid version */
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
 
   /* read a valid message */
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) > 0);
   g_free (message_name);
@@ -1127,7 +1126,7 @@ thrift_server_complex_types (const int port)
   /* broken 2nd read on a message */
   transport_read_count = 0;
   transport_read_error_at = 1;
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error_at = -1;
@@ -1135,7 +1134,7 @@ thrift_server_complex_types (const int port)
   /* broken 3rd read on a message */
   transport_read_count = 0;
   transport_read_error_at = 2;
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error_at = -1;
@@ -1143,18 +1142,18 @@ thrift_server_complex_types (const int port)
   /* broken 4th read on a message */
   transport_read_count = 0;
   transport_read_error_at = 3;
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) == -1);
   transport_read_error_at = -1;
 
   /* read a valid message */
-  assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
+  g_assert (thrift_compact_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) > 0);
   g_free (message_name);
 
-  assert (thrift_compact_protocol_read_message_end (protocol, NULL) == 0);
+  g_assert (thrift_compact_protocol_read_message_end (protocol, NULL) == 0);
 
   /* handle 2nd write failure on a message */
   thrift_compact_protocol_read_byte (protocol, &protocol_id, NULL);
@@ -1205,62 +1204,62 @@ thrift_server_many_frames (const int port)
   client = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, "transport",
                          thrift_server_transport_accept (transport, NULL),
                          "r_buf_size", 1, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   tcp = g_object_new (THRIFT_TYPE_COMPACT_PROTOCOL, "transport",
                       client, NULL);
   protocol = THRIFT_PROTOCOL (tcp);
 
-  assert (thrift_compact_protocol_read_bool (protocol,
+  g_assert (thrift_compact_protocol_read_bool (protocol,
                                             &value_boolean, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &value_byte, NULL) > 0);
-  assert (thrift_compact_protocol_read_i16 (protocol, &value_16, NULL) > 0);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) > 0);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) > 0);
-  assert (thrift_compact_protocol_read_i16 (protocol, &value_n16, NULL) > 0);
-  assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) > 0);
-  assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p16, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p32, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p64, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n16, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n32, NULL) > 0);
-  assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n64, NULL) > 0);
-  assert (thrift_compact_protocol_read_double (protocol,
+  g_assert (thrift_compact_protocol_read_byte (protocol, &value_byte, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i16 (protocol, &value_16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i16 (protocol, &value_n16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i32 (protocol, &value_n32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_i64 (protocol, &value_n64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_p64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n16, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n32, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_byte (protocol, &zigzag_n64, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_double (protocol,
                                               &value_double, NULL) > 0);
-  assert (thrift_compact_protocol_read_string (protocol, &string, NULL) > 0);
-  assert (thrift_compact_protocol_read_string (protocol, &empty_string,
+  g_assert (thrift_compact_protocol_read_string (protocol, &string, NULL) > 0);
+  g_assert (thrift_compact_protocol_read_string (protocol, &empty_string,
                                                NULL) > 0);
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                               &len, NULL) > 0);
 
-  assert (value_boolean == TEST_BOOL);
-  assert (value_byte == TEST_BYTE);
-  assert (value_16 == TEST_I16);
-  assert (value_32 == TEST_I32);
-  assert (value_64 == TEST_I64);
-  assert (value_n16 == TEST_NI16);
-  assert (value_n32 == TEST_NI32);
-  assert (value_n64 == TEST_NI64);
-  assert (zigzag_p16 == 4);
-  assert (zigzag_p32 == 4);
-  assert (zigzag_p64 == 4);
-  assert (zigzag_n16 == 3);
-  assert (zigzag_n32 == 3);
-  assert (zigzag_n64 == 3);
-  assert (value_double == TEST_DOUBLE);
-  assert (strcmp (TEST_STRING, string) == 0);
-  assert (strcmp ("", empty_string) == 0);
-  assert (memcmp (comparator, binary, len) == 0);
+  g_assert (value_boolean == TEST_BOOL);
+  g_assert (value_byte == TEST_BYTE);
+  g_assert (value_16 == TEST_I16);
+  g_assert (value_32 == TEST_I32);
+  g_assert (value_64 == TEST_I64);
+  g_assert (value_n16 == TEST_NI16);
+  g_assert (value_n32 == TEST_NI32);
+  g_assert (value_n64 == TEST_NI64);
+  g_assert (zigzag_p16 == 4);
+  g_assert (zigzag_p32 == 4);
+  g_assert (zigzag_p64 == 4);
+  g_assert (zigzag_n16 == 3);
+  g_assert (zigzag_n32 == 3);
+  g_assert (zigzag_n64 == 3);
+  g_assert (value_double == TEST_DOUBLE);
+  g_assert (strcmp (TEST_STRING, string) == 0);
+  g_assert (strcmp ("", empty_string) == 0);
+  g_assert (memcmp (comparator, binary, len) == 0);
 
   g_free (string);
   g_free (empty_string);
   g_free (binary);
 
-  assert (thrift_compact_protocol_read_binary (protocol, &binary,
+  g_assert (thrift_compact_protocol_read_binary (protocol, &binary,
                                                &len, NULL) > 0);
-  assert (binary == NULL);
-  assert (len == 0);
+  g_assert (binary == NULL);
+  g_assert (len == 0);
   g_free (binary);
 
   thrift_transport_read_end (client, NULL);

--- a/lib/c_glib/test/testdebugproto.c
+++ b/lib/c_glib/test/testdebugproto.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <math.h>
 #include <string.h>
 #include <glib-object.h>
@@ -838,11 +837,11 @@ test_services_inherited (void)
                                    NULL);
 
   /* TTestInheritedClient inherits from TTestSrvClient */
-  assert (g_type_is_a (T_TEST_TYPE_INHERITED_CLIENT,
+  g_assert (g_type_is_a (T_TEST_TYPE_INHERITED_CLIENT,
                        T_TEST_TYPE_SRV_CLIENT));
 
   /* TTestInheritedClient implements TTestSrvClient's interface */
-  assert (g_type_is_a (T_TEST_TYPE_INHERITED_CLIENT,
+  g_assert (g_type_is_a (T_TEST_TYPE_INHERITED_CLIENT,
                        T_TEST_TYPE_SRV_IF));
 
   /* TTestInheritedClient's inherited properties can be set and retrieved */
@@ -856,8 +855,8 @@ test_services_inherited (void)
                 "output_protocol", &output_protocol,
                 NULL);
 
-  assert (input_protocol == G_OBJECT(protocol));
-  assert (output_protocol == G_OBJECT(protocol));
+  g_assert (input_protocol == G_OBJECT(protocol));
+  g_assert (output_protocol == G_OBJECT(protocol));
 
   g_object_unref (output_protocol);
   g_object_unref (input_protocol);

--- a/lib/c_glib/test/testfdtransport.c
+++ b/lib/c_glib/test/testfdtransport.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 
 #include <string.h>
 #include <fcntl.h>
@@ -37,7 +36,7 @@ test_create_and_destroy (void)
 {
   GObject *object;
   object = g_object_new (THRIFT_TYPE_FD_TRANSPORT, "fd", -1, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -54,7 +53,7 @@ test_open_and_close (void)
   filename = NULL;
 
   fd = g_file_open_tmp (NULL, &filename, &error);
-  assert (fd >= 0);
+  g_assert (fd >= 0);
 
   transport = THRIFT_TRANSPORT (g_object_new (THRIFT_TYPE_FD_TRANSPORT,
                                               "fd", fd,
@@ -62,20 +61,20 @@ test_open_and_close (void)
   klass = THRIFT_TRANSPORT_GET_CLASS (transport);
 
   /* open is no-op */
-  assert (klass->is_open (transport));
-  assert (klass->peek (transport, &error));
-  assert (klass->open (transport, &error));
-  assert (klass->is_open (transport));
-  assert (klass->peek (transport, &error));
+  g_assert (klass->is_open (transport));
+  g_assert (klass->peek (transport, &error));
+  g_assert (klass->open (transport, &error));
+  g_assert (klass->is_open (transport));
+  g_assert (klass->peek (transport, &error));
 
-  assert (klass->close (transport, &error));
-  assert (! klass->open (transport, &error));
-  assert (! klass->is_open (transport));
-  assert (! klass->peek (transport, &error));
+  g_assert (klass->close (transport, &error));
+  g_assert (! klass->open (transport, &error));
+  g_assert (! klass->is_open (transport));
+  g_assert (! klass->peek (transport, &error));
 
   /* already closed */
-  assert (close (fd) != 0);
-  assert (errno == EBADF);
+  g_assert (close (fd) != 0);
+  g_assert (errno == EBADF);
 
   g_object_unref (transport);
 
@@ -88,13 +87,13 @@ test_open_and_close (void)
                                               NULL));
   klass = THRIFT_TRANSPORT_GET_CLASS (transport);
 
-  assert (! klass->is_open (transport));
+  g_assert (! klass->is_open (transport));
   error = NULL;
-  assert (! klass->peek (transport, &error));
+  g_assert (! klass->peek (transport, &error));
   error = NULL;
-  assert (! klass->open (transport, &error));
+  g_assert (! klass->open (transport, &error));
   error = NULL;
-  assert (! klass->close (transport, &error));
+  g_assert (! klass->close (transport, &error));
 
   g_object_unref (transport);
 }
@@ -115,22 +114,22 @@ test_read_and_write (void)
   filename = NULL;
 
   fd = g_file_open_tmp (NULL, &filename, &error);
-  assert (fd >= 0);
+  g_assert (fd >= 0);
 
   /* write */
   transport = THRIFT_TRANSPORT (g_object_new (THRIFT_TYPE_FD_TRANSPORT,
                                               "fd", fd,
                                               NULL));
   klass = THRIFT_TRANSPORT_GET_CLASS (transport);
-  assert (klass->is_open (transport));
-  assert (klass->write (transport, (gpointer) TEST_DATA, 11, &error));
-  assert (klass->flush (transport, &error));
-  assert (klass->close (transport, &error));
+  g_assert (klass->is_open (transport));
+  g_assert (klass->write (transport, (gpointer) TEST_DATA, 11, &error));
+  g_assert (klass->flush (transport, &error));
+  g_assert (klass->close (transport, &error));
   g_object_unref (transport);
 
   /* read */
   fd = open(filename, O_RDONLY, S_IRUSR | S_IWUSR);
-  assert (fd >= 0);
+  g_assert (fd >= 0);
 
   transport = THRIFT_TRANSPORT (g_object_new (THRIFT_TYPE_FD_TRANSPORT,
                                               "fd", fd,
@@ -142,24 +141,24 @@ test_read_and_write (void)
   want = 7;
   while (want > 0) {
     got = klass->read (transport, (gpointer) b, want, &error);
-    assert (got > 0 && got <= want);
+    g_assert (got > 0 && got <= want);
     b += got;
     want -= got;
   }
-  assert (memcmp (out_buf, TEST_DATA, 7) == 0);
+  g_assert (memcmp (out_buf, TEST_DATA, 7) == 0);
 
   memset(out_buf, 0, 8);
   b = out_buf;
   want = 4;
   while (want > 0) {
     got = klass->read (transport, (gpointer) b, want, &error);
-    assert (got > 0 && got <= want);
+    g_assert (got > 0 && got <= want);
     b += got;
     want -= got;
   }
-  assert (memcmp (out_buf, TEST_DATA + 7, 4) == 0);
+  g_assert (memcmp (out_buf, TEST_DATA + 7, 4) == 0);
 
-  assert (klass->close (transport, &error));
+  g_assert (klass->close (transport, &error));
   g_object_unref (transport);
 
   /* clean up */

--- a/lib/c_glib/test/testframedtransport.c
+++ b/lib/c_glib/test/testframedtransport.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <sys/wait.h>
 
@@ -42,7 +41,7 @@ test_create_and_destroy(void)
 
   GObject *object = NULL;
   object = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_get (G_OBJECT (object), "transport", &transport,
                 "r_buf_size", &r_buf_size,
                 "w_buf_size", &w_buf_size, NULL);
@@ -65,9 +64,9 @@ test_open_and_close(void)
                             "transport", THRIFT_TRANSPORT (tsocket), NULL);
 
   /* this shouldn't work */
-  assert (thrift_framed_transport_open (transport, NULL) == FALSE);
-  assert (thrift_framed_transport_is_open (transport) == TRUE);
-  assert (thrift_framed_transport_close (transport, NULL) == TRUE);
+  g_assert (thrift_framed_transport_open (transport, NULL) == FALSE);
+  g_assert (thrift_framed_transport_is_open (transport) == TRUE);
+  g_assert (thrift_framed_transport_close (transport, NULL) == TRUE);
   g_object_unref (transport);
   g_object_unref (tsocket);
 
@@ -79,7 +78,7 @@ test_open_and_close(void)
   transport = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT,
                             "transport", THRIFT_TRANSPORT (tsocket), NULL);
 
-  assert (thrift_framed_transport_open (transport, &err) == FALSE);
+  g_assert (thrift_framed_transport_open (transport, &err) == FALSE);
   g_object_unref (transport);
   g_object_unref (tsocket);
   g_error_free (err);
@@ -97,7 +96,7 @@ test_read_and_write(void)
   guchar buf[10] = TEST_DATA; /* a buffer */
 
   pid = fork ();
-  assert ( pid >= 0 );
+  g_assert ( pid >= 0 );
 
   if ( pid == 0 )
   {
@@ -114,8 +113,8 @@ test_read_and_write(void)
                               "transport", THRIFT_TRANSPORT (tsocket),
                               "w_buf_size", 4, NULL);
 
-    assert (thrift_framed_transport_open (transport, NULL) == TRUE);
-    assert (thrift_framed_transport_is_open (transport));
+    g_assert (thrift_framed_transport_open (transport, NULL) == TRUE);
+    g_assert (thrift_framed_transport_is_open (transport));
 
     /* write 10 bytes */
     thrift_framed_transport_write (transport, buf, 10, NULL);
@@ -137,8 +136,8 @@ test_read_and_write(void)
     g_object_unref (transport);
     g_object_unref (tsocket);
 
-    assert ( wait (&status) == pid );
-    assert ( status == 0 );
+    g_assert ( wait (&status) == pid );
+    g_assert ( status == 0 );
   }
 }
 
@@ -247,12 +246,12 @@ thrift_server (const int port)
   client = g_object_new (THRIFT_TYPE_FRAMED_TRANSPORT, "transport",
                          thrift_server_transport_accept (transport, NULL),
                          "r_buf_size", 5, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   /* read 10 bytes */
   bytes = thrift_framed_transport_read (client, buf, 10, NULL);
-  assert (bytes == 10); /* make sure we've read 10 bytes */
-  assert ( memcmp (buf, match, 10) == 0 ); /* make sure what we got matches */
+  g_assert (bytes == 10); /* make sure we've read 10 bytes */
+  g_assert ( memcmp (buf, match, 10) == 0 ); /* make sure what we got matches */
 
   bytes = thrift_framed_transport_read (client, buf, 6, NULL);
   bytes = thrift_framed_transport_read (client, buf, 5, NULL);

--- a/lib/c_glib/test/testmemorybuffer.c
+++ b/lib/c_glib/test/testmemorybuffer.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 
 #include <thrift/c_glib/transport/thrift_transport.h>
@@ -37,7 +36,7 @@ test_create_and_destroy (void)
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
                          "buf_size", 10,
                          NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -48,7 +47,7 @@ test_create_and_destroy_large (void)
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
                          "buf_size", 10 * 1024 * 1024,
                          NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -57,7 +56,7 @@ test_create_and_destroy_default (void)
 {
   GObject *object = NULL;
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -66,11 +65,11 @@ test_create_and_destroy_external (void)
 {
   GObject *object = NULL;
   GByteArray *buf = g_byte_array_new ();
-  assert (buf != NULL);
+  g_assert (buf != NULL);
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
                          "buf", buf,
                          NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_unref (object);
 }
 
@@ -84,12 +83,12 @@ test_create_and_destroy_unowned (void)
   object = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
                          "owner", FALSE,
                          NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
 
   g_value_init (&val, G_TYPE_POINTER);
   g_object_get_property (object, "buf", &val);
   buf = (GByteArray*) g_value_get_pointer (&val);
-  assert (buf != NULL);
+  g_assert (buf != NULL);
 
   g_byte_array_unref (buf);
   g_value_unset (&val);
@@ -105,9 +104,9 @@ test_open_and_close (void)
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
 
   /* no-ops */
-  assert (thrift_memory_buffer_open (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
-  assert (thrift_memory_buffer_is_open (THRIFT_TRANSPORT (tbuffer)) == TRUE);
-  assert (thrift_memory_buffer_close (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
+  g_assert (thrift_memory_buffer_open (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
+  g_assert (thrift_memory_buffer_is_open (THRIFT_TRANSPORT (tbuffer)) == TRUE);
+  g_assert (thrift_memory_buffer_close (THRIFT_TRANSPORT (tbuffer), NULL) == TRUE);
 
   g_object_unref (tbuffer);
 }
@@ -122,18 +121,18 @@ test_read_and_write (void)
   GError *error = NULL;
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf_size", 5, NULL);
-  assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+  g_assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
                                       (gpointer) TEST_DATA,
                                       10, &error) == FALSE);
-  assert (error != NULL);
+  g_assert (error != NULL);
   g_error_free (error);
   error = NULL;
   g_object_unref (tbuffer);
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf_size", 15, NULL);
-  assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+  g_assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
                                       (gpointer) TEST_DATA, 10, &error) == TRUE);
-  assert (error == NULL);
+  g_assert (error == NULL);
 
   memset(read, 0, 10);
   b = read;
@@ -141,12 +140,12 @@ test_read_and_write (void)
   while (want > 0) {
     got = thrift_memory_buffer_read (THRIFT_TRANSPORT (tbuffer),
                                      (gpointer) b, want, &error);
-    assert (got > 0 && got <= want);
-    assert (error == NULL);
+    g_assert (got > 0 && got <= want);
+    g_assert (error == NULL);
     b += got;
     want -= got;
   }
-  assert (memcmp (read, TEST_DATA, 10) == 0);
+  g_assert (memcmp (read, TEST_DATA, 10) == 0);
   g_object_unref (tbuffer);
 }
 
@@ -161,9 +160,9 @@ test_read_and_write_default (void)
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, NULL);
   for (i = 0; i < 100; ++i) {
-    assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+    g_assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
                                         (gpointer) TEST_DATA, 10, &error) == TRUE);
-    assert (error == NULL);
+    g_assert (error == NULL);
   }
 
   for (i = 0; i < 100; ++i) {
@@ -173,12 +172,12 @@ test_read_and_write_default (void)
     while (want > 0) {
       got = thrift_memory_buffer_read (THRIFT_TRANSPORT (tbuffer),
                                        (gpointer) b, want, &error);
-      assert (got > 0 && got <= want);
-      assert (error == NULL);
+      g_assert (got > 0 && got <= want);
+      g_assert (error == NULL);
       b += got;
       want -= got;
     }
-    assert (memcmp (read, TEST_DATA, 10) == 0);
+    g_assert (memcmp (read, TEST_DATA, 10) == 0);
   }
   g_object_unref (tbuffer);
 }
@@ -190,14 +189,14 @@ test_read_and_write_external (void)
   gchar *b;
   GError *error = NULL;
   GByteArray *buf = g_byte_array_new ();
-  assert (buf != NULL);
+  g_assert (buf != NULL);
 
   tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf", buf, NULL);
-  assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
+  g_assert (thrift_memory_buffer_write (THRIFT_TRANSPORT (tbuffer),
                                       (gpointer) TEST_DATA, 10, &error) == TRUE);
-  assert (error == NULL);
+  g_assert (error == NULL);
 
-  assert (memcmp (buf->data, TEST_DATA, 10) == 0);
+  g_assert (memcmp (buf->data, TEST_DATA, 10) == 0);
   g_object_unref (tbuffer);
 }
 

--- a/lib/c_glib/test/testoptionalrequired.c
+++ b/lib/c_glib/test/testoptionalrequired.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <glib.h>
 
 #include <thrift/c_glib/thrift_struct.h>
@@ -76,18 +75,18 @@ test_simple (void)
 
   /* write-to-read with optional fields */
   s1->im_optional = 10;
-  assert (s1->__isset_im_default == FALSE);
-  assert (s1->__isset_im_optional == FALSE);  
+  g_assert (s1->__isset_im_default == FALSE);
+  g_assert (s1->__isset_im_optional == FALSE);  
   write_to_read (THRIFT_STRUCT (s1), THRIFT_STRUCT (s2), NULL, NULL);
-  assert (s2->__isset_im_default == TRUE);
-  assert (s2->__isset_im_optional == FALSE);
-  assert (s2->im_optional == 0);
+  g_assert (s2->__isset_im_default == TRUE);
+  g_assert (s2->__isset_im_optional == FALSE);
+  g_assert (s2->im_optional == 0);
 
   s1->__isset_im_optional = TRUE;
   write_to_read (THRIFT_STRUCT (s1), THRIFT_STRUCT (s3), NULL, NULL);
-  assert (s3->__isset_im_default == TRUE);
-  assert (s3->__isset_im_optional == TRUE);
-  assert (s3->im_optional == 10);
+  g_assert (s3->__isset_im_default == TRUE);
+  g_assert (s3->__isset_im_optional == TRUE);
+  g_assert (s3->im_optional == 10);
 
   g_object_unref (s1);
   g_object_unref (s2);
@@ -109,10 +108,10 @@ test_tricky1 (void)
   write_to_read (THRIFT_STRUCT (t2), THRIFT_STRUCT (t1), NULL, NULL);
   write_to_read (THRIFT_STRUCT (t1), THRIFT_STRUCT (t2), NULL, NULL);
 
-  assert (t1->__isset_im_default == FALSE);
-  assert (t2->__isset_im_optional == TRUE);
-  assert (t1->im_default == t2->im_optional);
-  assert (t1->im_default == 0);
+  g_assert (t1->__isset_im_default == FALSE);
+  g_assert (t2->__isset_im_optional == TRUE);
+  g_assert (t1->im_default == t2->im_optional);
+  g_assert (t1->im_default == 0);
 
   g_object_unref (t1);
   g_object_unref (t2);
@@ -133,7 +132,7 @@ test_tricky2 (void)
   write_to_read (THRIFT_STRUCT (t1), THRIFT_STRUCT (t3), NULL, NULL);
   write_to_read (THRIFT_STRUCT (t3), THRIFT_STRUCT (t1), NULL, NULL);
 
-  assert (t1->__isset_im_default == TRUE);
+  g_assert (t1->__isset_im_default == TRUE);
 
   g_object_unref (t1);
   g_object_unref (t3);
@@ -176,12 +175,12 @@ test_tricky4 (void)
 
   /* throws protocol exception */
   write_to_read (THRIFT_STRUCT (t2), THRIFT_STRUCT (t3), NULL, &read_error);
-  assert (read_error != NULL);
+  g_assert (read_error != NULL);
   g_error_free (read_error);
 
   write_to_read (THRIFT_STRUCT (t3), THRIFT_STRUCT (t2), NULL, NULL);
 
-  assert (t2->__isset_im_optional);
+  g_assert (t2->__isset_im_optional);
 
   g_object_unref (t2);
   g_object_unref (t3);

--- a/lib/c_glib/test/testsimpleserver.c
+++ b/lib/c_glib/test/testsimpleserver.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <glib.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -89,7 +88,7 @@ test_server (void)
 
   /* run the server in a child process */
   pid = fork ();
-  assert (pid >= 0);
+  g_assert (pid >= 0);
 
   if (pid == 0)
   {
@@ -103,8 +102,8 @@ test_server (void)
     g_object_unref (ss);
     g_object_unref (tss);
     g_object_unref (p);
-    assert (wait (&status) == pid);
-    assert (status == SIGINT);
+    g_assert (wait (&status) == pid);
+    g_assert (status == SIGINT);
   }
 }
 

--- a/lib/c_glib/test/teststruct.c
+++ b/lib/c_glib/test/teststruct.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <glib-object.h>
 
 #include "../src/thrift/c_glib/thrift_struct.c"
@@ -89,7 +88,7 @@ test_initialize_object (void)
   ThriftTestStruct *t = NULL;
 
   t = g_object_new (THRIFT_TYPE_TEST_STRUCT, NULL);
-  assert ( THRIFT_IS_STRUCT (t));
+  g_assert ( THRIFT_IS_STRUCT (t));
   thrift_struct_read (THRIFT_STRUCT (t), NULL, NULL);
   thrift_struct_write (THRIFT_STRUCT (t), NULL, NULL);
   thrift_test_struct_read (THRIFT_STRUCT (t), NULL, NULL);

--- a/lib/c_glib/test/testthrifttest.c
+++ b/lib/c_glib/test/testthrifttest.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <netdb.h>
 
 #include <thrift/c_glib/thrift.h>
@@ -87,14 +86,14 @@ test_thrift_handler (void)
 
   g_object_weak_ref (G_OBJECT (argument), set_indicator, (gpointer) &indicator);
 
-  assert (thrift_test_handler_test_insanity (NULL, &_return, argument, &error));
-  assert (! indicator);
+  g_assert (thrift_test_handler_test_insanity (NULL, &_return, argument, &error));
+  g_assert (! indicator);
 
   g_hash_table_unref (_return);
-  assert (! indicator);
+  g_assert (! indicator);
 
   g_object_unref (argument);
-  assert (indicator);
+  g_assert (indicator);
 }
 
 int

--- a/lib/c_glib/test/testtransportsocket.c
+++ b/lib/c_glib/test/testtransportsocket.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <sys/wait.h>
 
@@ -81,7 +80,7 @@ test_create_and_destroy(void)
 
   GObject *object = NULL;
   object = g_object_new (THRIFT_TYPE_SOCKET, NULL);
-  assert (object != NULL);
+  g_assert (object != NULL);
   g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, NULL);
   g_free (hostname);
 
@@ -100,9 +99,9 @@ test_open_and_close(void)
                           "port", 51188, NULL); 
   transport = THRIFT_TRANSPORT (tsocket);
   thrift_socket_open (transport, NULL);
-  assert (thrift_socket_is_open (transport) == TRUE);
+  g_assert (thrift_socket_is_open (transport) == TRUE);
   thrift_socket_close (transport, NULL);
-  assert (thrift_socket_is_open (transport) == FALSE);
+  g_assert (thrift_socket_is_open (transport) == FALSE);
 
   /* test close failure */
   tsocket->sd = -1;
@@ -113,7 +112,7 @@ test_open_and_close(void)
   tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost.broken",
                           NULL);
   transport = THRIFT_TRANSPORT (tsocket);
-  assert (thrift_socket_open (transport, &err) == FALSE);
+  g_assert (thrift_socket_open (transport, &err) == FALSE);
   g_object_unref (tsocket);
   g_error_free (err);
   err = NULL;
@@ -122,7 +121,7 @@ test_open_and_close(void)
   tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost", NULL);
   transport = THRIFT_TRANSPORT (tsocket);
   socket_error = 1;
-  assert (thrift_socket_open (transport, &err) == FALSE);
+  g_assert (thrift_socket_open (transport, &err) == FALSE);
   socket_error = 0;
   g_object_unref (tsocket);
   g_error_free (err);
@@ -139,7 +138,7 @@ test_read_and_write(void)
   guchar buf[10] = TEST_DATA; /* a buffer */
 
   pid = fork ();
-  assert ( pid >= 0 );
+  g_assert ( pid >= 0 );
 
   if ( pid == 0 )
   {
@@ -153,8 +152,8 @@ test_read_and_write(void)
     tsocket = g_object_new (THRIFT_TYPE_SOCKET, "hostname", "localhost",
                             "port", port, NULL);
     transport = THRIFT_TRANSPORT (tsocket);
-    assert (thrift_socket_open (transport, NULL) == TRUE);
-    assert (thrift_socket_is_open (transport));
+    g_assert (thrift_socket_open (transport, NULL) == TRUE);
+    g_assert (thrift_socket_is_open (transport));
     thrift_socket_write (transport, buf, 10, NULL);
 
     /* write fail */
@@ -167,8 +166,8 @@ test_read_and_write(void)
     thrift_socket_close (transport, NULL);
     g_object_unref (tsocket);
 
-    assert ( wait (&status) == pid );
-    assert ( status == 0 );
+    g_assert ( wait (&status) == pid );
+    g_assert ( status == 0 );
   }
 }
 
@@ -286,12 +285,12 @@ thrift_socket_server (const int port)
   transport = THRIFT_SERVER_TRANSPORT (tsocket);
   thrift_server_transport_listen (transport, NULL);
   client = thrift_server_transport_accept (transport, NULL);
-  assert (client != NULL);
+  g_assert (client != NULL);
 
   /* read 10 bytes */
   bytes = thrift_socket_read (client, buf, 10, NULL);
-  assert (bytes == 10); /* make sure we've read 10 bytes */
-  assert ( memcmp(buf, match, 10) == 0 ); /* make sure what we got matches */
+  g_assert (bytes == 10); /* make sure we've read 10 bytes */
+  g_assert ( memcmp(buf, match, 10) == 0 ); /* make sure what we got matches */
 
   /* failed read */
   recv_error = 1;

--- a/lib/c_glib/test/testtransportsslsocket.c
+++ b/lib/c_glib/test/testtransportsslsocket.c
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#include <assert.h>
 #include <netdb.h>
 #include <sys/wait.h>
 #include <sys/types.h>
@@ -40,33 +39,33 @@ static int socket_error = 0;
 int
 my_socket(int domain, int type, int protocol)
 {
-	if (socket_error == 0)
-	{
-		return socket (domain, type, protocol);
-	}
-	return -1;
+  if (socket_error == 0)
+  {
+    return socket (domain, type, protocol);
+  }
+  return -1;
 }
 
 static int recv_error = 0;
 ssize_t
 my_recv(int socket, void *buffer, size_t length, int flags)
 {
-	if (recv_error == 0)
-	{
-		return recv (socket, buffer, length, flags);
-	}
-	return -1;
+  if (recv_error == 0)
+  {
+    return recv (socket, buffer, length, flags);
+  }
+  return -1;
 }
 
 static int send_error = 0;
 ssize_t
 my_send(int socket, const void *buffer, size_t length, int flags)
 {
-	if (send_error == 0)
-	{
-		return send (socket, buffer, length, flags);
-	}
-	return -1;
+  if (send_error == 0)
+  {
+    return send (socket, buffer, length, flags);
+  }
+  return -1;
 }
 
 #define socket my_socket
@@ -83,71 +82,71 @@ static void thrift_ssl_socket_server (const int port);
 static void
 test_ssl_create_and_destroy(void)
 {
-	gchar *hostname = NULL;
-	guint port = 0;
+  gchar *hostname = NULL;
+  guint port = 0;
 
-	GObject *object = NULL;
-	object = g_object_new (THRIFT_TYPE_SSL_SOCKET, NULL);
-	assert (object != NULL);
-	g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, NULL);
-	g_free (hostname);
-	g_object_unref (object);
+  GObject *object = NULL;
+  object = g_object_new (THRIFT_TYPE_SSL_SOCKET, NULL);
+  g_assert (object != NULL);
+  g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, NULL);
+  g_free (hostname);
+  g_object_unref (object);
 }
 
 static void
 test_ssl_create_and_set_properties(void)
 {
-	gchar *hostname = NULL;
-	guint port = 0;
-	SSL_CTX* ssl_ctx= NULL;
-	GError *error=NULL;
+  gchar *hostname = NULL;
+  guint port = 0;
+  SSL_CTX* ssl_ctx= NULL;
+  GError *error=NULL;
 
-	GObject *object = NULL;
-	object = thrift_ssl_socket_new(SSLTLS, &error);
-	g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, "ssl_context", &ssl_ctx, NULL);
-	assert (ssl_ctx!=NULL);
+  GObject *object = NULL;
+  object = thrift_ssl_socket_new(SSLTLS, &error);
+  g_object_get (G_OBJECT(object), "hostname", &hostname, "port", &port, "ssl_context", &ssl_ctx, NULL);
+  g_assert (ssl_ctx!=NULL);
 
-	g_free (hostname);
-	g_object_unref (object);
+  g_free (hostname);
+  g_object_unref (object);
 }
 
 static void
 test_ssl_open_and_close(void)
 {
-	ThriftSSLSocket *tSSLSocket = NULL;
-	ThriftTransport *transport = NULL;
-	GError *error=NULL;
+  ThriftSSLSocket *tSSLSocket = NULL;
+  ThriftTransport *transport = NULL;
+  GError *error=NULL;
 
-	/* open a connection and close it */
-	tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
+  /* open a connection and close it */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
 
-	transport = THRIFT_TRANSPORT (tSSLSocket);
-	thrift_ssl_socket_open (transport, NULL);
-	assert (thrift_ssl_socket_is_open (transport) == TRUE);
-	thrift_ssl_socket_close (transport, NULL);
-	assert (thrift_ssl_socket_is_open (transport) == FALSE);
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  thrift_ssl_socket_open (transport, NULL);
+  g_assert (thrift_ssl_socket_is_open (transport) == TRUE);
+  thrift_ssl_socket_close (transport, NULL);
+  g_assert (thrift_ssl_socket_is_open (transport) == FALSE);
 
-	/* test close failure */
-	THRIFT_SOCKET(tSSLSocket)->sd = -1;
-	thrift_ssl_socket_close (transport, NULL);
-	g_object_unref (tSSLSocket);
+  /* test close failure */
+  THRIFT_SOCKET(tSSLSocket)->sd = -1;
+  thrift_ssl_socket_close (transport, NULL);
+  g_object_unref (tSSLSocket);
 
-	/* try a hostname lookup failure */
-	tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost.broken", 51188, &error);
-	transport = THRIFT_TRANSPORT (tSSLSocket);
-	assert (thrift_ssl_socket_open (transport, &error) == FALSE);
-	g_object_unref (tSSLSocket);
-	g_error_free (error);
-	error = NULL;
+  /* try a hostname lookup failure */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost.broken", 51188, &error);
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  g_assert (thrift_ssl_socket_open (transport, &error) == FALSE);
+  g_object_unref (tSSLSocket);
+  g_error_free (error);
+  error = NULL;
 
-	/* try an error call to socket() */
-	tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
-	transport = THRIFT_TRANSPORT (tSSLSocket);
-	socket_error = 1;
-	assert (thrift_ssl_socket_open (transport, &error) == FALSE);
-	socket_error = 0;
-	g_object_unref (tSSLSocket);
-	g_error_free (error);
+  /* try an error call to socket() */
+  tSSLSocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", 51188, &error);
+  transport = THRIFT_TRANSPORT (tSSLSocket);
+  socket_error = 1;
+  g_assert (thrift_ssl_socket_open (transport, &error) == FALSE);
+  socket_error = 0;
+  g_object_unref (tSSLSocket);
+  g_error_free (error);
 }
 
 
@@ -157,27 +156,27 @@ test_ssl_open_and_close(void)
  */
 unsigned char * get_cn_name(X509_NAME* const name)
 {
-	int idx = -1;
-	unsigned char *utf8 = NULL;
+  int idx = -1;
+  unsigned char *utf8 = NULL;
 
-	do
-	{
-		if(!name) break; /* failed */
+  do
+  {
+    if(!name) break; /* failed */
 
-		idx = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
-		if(!(idx > -1))  break; /* failed */
+    idx = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+    if(!(idx > -1))  break; /* failed */
 
-		X509_NAME_ENTRY* entry = X509_NAME_get_entry(name, idx);
-		if(!entry) break; /* failed */
+    X509_NAME_ENTRY* entry = X509_NAME_get_entry(name, idx);
+    if(!entry) break; /* failed */
 
-		ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
-		if(!data) break; /* failed */
+    ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
+    if(!data) break; /* failed */
 
-		int length = ASN1_STRING_to_UTF8(&utf8, data);
-		if(!utf8 || !(length > 0))  break; /* failed */
+    int length = ASN1_STRING_to_UTF8(&utf8, data);
+    if(!utf8 || !(length > 0))  break; /* failed */
 
-	} while (0);
-	return utf8;
+  } while (0);
+  return utf8;
 }
 
 /*
@@ -185,77 +184,77 @@ unsigned char * get_cn_name(X509_NAME* const name)
  */
 void *get_in_addr(struct sockaddr *sa)
 {
-	if (sa->sa_family == AF_INET)
-		return &(((struct sockaddr_in*)sa)->sin_addr);
-	return &(((struct sockaddr_in6*)sa)->sin6_addr);
+  if (sa->sa_family == AF_INET)
+    return &(((struct sockaddr_in*)sa)->sin_addr);
+  return &(((struct sockaddr_in6*)sa)->sin6_addr);
 }
 
 int verify_ip(char * hostname, struct sockaddr_storage *addr)
 {
-	struct addrinfo *addr_info,*p;
-	struct addrinfo hints;
-	int res;
-	int retval = 0;
+  struct addrinfo *addr_info,*p;
+  struct addrinfo hints;
+  int res;
+  int retval = 0;
 
 
-	memset(&hints, 0, sizeof hints);
-	hints.ai_family = AF_UNSPEC; // use AF_INET6 to force IPv6
-	hints.ai_socktype = SOCK_STREAM;
+  memset(&hints, 0, sizeof hints);
+  hints.ai_family = AF_UNSPEC; // use AF_INET6 to force IPv6
+  hints.ai_socktype = SOCK_STREAM;
 
 
-	if ( (res = getaddrinfo(hostname, NULL, &hints, &addr_info) ) != 0)
-	{
-		// get the host info
-		g_error("Cannot get the host address");
-		return retval;
-	}
-	// loop through all the results and connect to the first we can
-	char dnshost[INET6_ADDRSTRLEN]; // bigger addr supported IPV6
-	char socket_ip[INET6_ADDRSTRLEN];
-	if(inet_ntop(addr->ss_family, get_in_addr(addr), socket_ip, INET6_ADDRSTRLEN)==socket_ip){
-		g_debug("We are connected to host %s checking against certificate...", socket_ip);
-		int sizeip = socket_ip!=NULL ? strlen(socket_ip) : 0;
-		for(p = addr_info; p != NULL; p = p->ai_next) {
-			if(inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), dnshost, INET6_ADDRSTRLEN)==dnshost){
-				if(dnshost!=NULL){
-					g_info("DNS address [%i -> %s]", p->ai_addr, dnshost);
-					if(!strncmp(dnshost, socket_ip, sizeip)){
-						retval=1;
-						break; // if we get here, we must have connected successfully
-					}
-				}
-			}
-		}
-	}
+  if ( (res = getaddrinfo(hostname, NULL, &hints, &addr_info) ) != 0)
+  {
+    // get the host info
+    g_error("Cannot get the host address");
+    return retval;
+  }
+  // loop through all the results and connect to the first we can
+  char dnshost[INET6_ADDRSTRLEN]; // bigger addr supported IPV6
+  char socket_ip[INET6_ADDRSTRLEN];
+  if(inet_ntop(addr->ss_family, get_in_addr(addr), socket_ip, INET6_ADDRSTRLEN)==socket_ip){
+    g_debug("We are connected to host %s checking against certificate...", socket_ip);
+    int sizeip = socket_ip!=NULL ? strlen(socket_ip) : 0;
+    for(p = addr_info; p != NULL; p = p->ai_next) {
+      if(inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr), dnshost, INET6_ADDRSTRLEN)==dnshost){
+        if(dnshost!=NULL){
+          g_info("DNS address [%i -> %s]", p->ai_addr, dnshost);
+          if(!strncmp(dnshost, socket_ip, sizeip)){
+            retval=1;
+            break; // if we get here, we must have connected successfully
+          }
+        }
+      }
+    }
+  }
 
-	if(addr_info)
-		freeaddrinfo(addr_info);
+  if(addr_info)
+    freeaddrinfo(addr_info);
 
-	return retval;
+  return retval;
 }
 
 static void
 read_from_file(char *buffer, long size, const char *file_name)
 {
-	   char ch;
-	   long index=0;
-	   FILE *fp;
+     char ch;
+     long index=0;
+     FILE *fp;
 
-	   fp = fopen(file_name,"r"); // read mode
+     fp = fopen(file_name,"r"); // read mode
 
-	   if( fp == NULL )
-	   {
-	      perror("Error while opening the file.\n");
-	      exit(EXIT_FAILURE);
-	   }
+     if( fp == NULL )
+     {
+        perror("Error while opening the file.\n");
+        exit(EXIT_FAILURE);
+     }
 
-	   printf("The contents of %s file are :\n", file_name);
+     printf("The contents of %s file are :\n", file_name);
 
-	   while(index<size && ( ch = fgetc(fp) ) != EOF ){
-		   buffer[index++] = ch;
-	   }
+     while(index<size && ( ch = fgetc(fp) ) != EOF ){
+       buffer[index++] = ch;
+     }
 
-	   fclose(fp);
+     fclose(fp);
 }
 
 #define ISSUER_CN_PINNING "The Apache Software Foundation"
@@ -264,98 +263,98 @@ read_from_file(char *buffer, long size, const char *file_name)
 
 gboolean verify_certificate_sn(X509 *cert, const unsigned char *serial_number)
 {
-	gboolean retval = FALSE;
+  gboolean retval = FALSE;
 
-	ASN1_INTEGER *serial = X509_get_serialNumber(cert);
+  ASN1_INTEGER *serial = X509_get_serialNumber(cert);
 
-	BIGNUM *bn = ASN1_INTEGER_to_BN(serial, NULL);
-	if (!bn) {
-		fprintf(stderr, "unable to convert ASN1INTEGER to BN\n");
-		return EXIT_FAILURE;
-	}
-	char *tmp = BN_bn2dec(bn);
-	if (!tmp) {
-		g_warning(stderr, "unable to convert BN to decimal string.\n");
-		BN_free(bn);
-		return EXIT_FAILURE;
-	}
-//	if (strlen(tmp) >= len) {
-//		g_warn(stderr, "buffer length shorter than serial number\n");
-//		BN_free(bn);
-//		OPENSSL_free(tmp);
-//		return EXIT_FAILURE;
-//	}
-	if(!strncmp(serial_number, tmp, strlen(serial_number))){
-		retval=TRUE;
-	}else{
-		g_warning("Serial number is not valid");
-	}
+  BIGNUM *bn = ASN1_INTEGER_to_BN(serial, NULL);
+  if (!bn) {
+    fprintf(stderr, "unable to convert ASN1INTEGER to BN\n");
+    return EXIT_FAILURE;
+  }
+  char *tmp = BN_bn2dec(bn);
+  if (!tmp) {
+    g_warning(stderr, "unable to convert BN to decimal string.\n");
+    BN_free(bn);
+    return EXIT_FAILURE;
+  }
+//  if (strlen(tmp) >= len) {
+//    g_warn(stderr, "buffer length shorter than serial number\n");
+//    BN_free(bn);
+//    OPENSSL_free(tmp);
+//    return EXIT_FAILURE;
+//  }
+  if(!strncmp(serial_number, tmp, strlen(serial_number))){
+    retval=TRUE;
+  }else{
+    g_warning("Serial number is not valid");
+  }
 
-	BN_free(bn);
-	OPENSSL_free(tmp);
-	return retval;
+  BN_free(bn);
+  OPENSSL_free(tmp);
+  return retval;
 }
 
 gboolean my_access_manager(ThriftTransport * transport, X509 *cert, struct sockaddr_storage *addr, GError **error)
 {
-	ThriftSSLSocket *sslSocket = THRIFT_SSL_SOCKET (transport);
+  ThriftSSLSocket *sslSocket = THRIFT_SSL_SOCKET (transport);
 
-	g_info("Processing access to the server");
-	X509_NAME* iname = cert ? X509_get_issuer_name(cert) : NULL;
-	X509_NAME* sname = cert ? X509_get_subject_name(cert) : NULL;
+  g_info("Processing access to the server");
+  X509_NAME* iname = cert ? X509_get_issuer_name(cert) : NULL;
+  X509_NAME* sname = cert ? X509_get_subject_name(cert) : NULL;
 
-	/* Issuer is the authority we trust that warrants nothing useful */
-	const unsigned char * issuer = get_cn_name(iname);
-	if(issuer){
-		gboolean valid = TRUE;
-		g_info("Issuer (cn) %s", issuer);
+  /* Issuer is the authority we trust that warrants nothing useful */
+  const unsigned char * issuer = get_cn_name(iname);
+  if(issuer){
+    gboolean valid = TRUE;
+    g_info("Issuer (cn) %s", issuer);
 
-		// Issuer pinning
-		if(strncmp(ISSUER_CN_PINNING, issuer, strlen(ISSUER_CN_PINNING))){
-			g_warning("The Issuer of the certificate is not valid");
-			valid=FALSE;
-		}
-		OPENSSL_free(issuer);
-		if(!valid)
-			return valid;
-	}
+    // Issuer pinning
+    if(strncmp(ISSUER_CN_PINNING, issuer, strlen(ISSUER_CN_PINNING))){
+      g_warning("The Issuer of the certificate is not valid");
+      valid=FALSE;
+    }
+    OPENSSL_free(issuer);
+    if(!valid)
+      return valid;
+  }
 
 
-	/* Subject is who the certificate is issued to by the authority  */
-	const unsigned char * subject = get_cn_name(sname);
-	if(subject){
-		g_info("Subject (cn) %s", subject);
-		gboolean valid = TRUE;
+  /* Subject is who the certificate is issued to by the authority  */
+  const unsigned char * subject = get_cn_name(sname);
+  if(subject){
+    g_info("Subject (cn) %s", subject);
+    gboolean valid = TRUE;
 
-		// Subject pinning
-		if(strncmp(SUBJECT_CN_PINNING, subject, strlen(SUBJECT_CN_PINNING))){
-			g_warning("The subject of the certificate is not valid");
-			valid=FALSE;
-		}
+    // Subject pinning
+    if(strncmp(SUBJECT_CN_PINNING, subject, strlen(SUBJECT_CN_PINNING))){
+      g_warning("The subject of the certificate is not valid");
+      valid=FALSE;
+    }
 
-		if(!valid)
-			return valid;
+    if(!valid)
+      return valid;
 
-		// Host pinning
-		if(verify_ip(subject, addr)){
-			g_info("Verified subject");
-		}else{
-			g_info("Cannot verify subject");
-			valid=FALSE;
-		}
-		OPENSSL_free(subject);
+    // Host pinning
+    if(verify_ip(subject, addr)){
+      g_info("Verified subject");
+    }else{
+      g_info("Cannot verify subject");
+      valid=FALSE;
+    }
+    OPENSSL_free(subject);
 
-		if(!valid)
-			return valid;
-	}
+    if(!valid)
+      return valid;
+  }
 
-	if(!verify_certificate_sn(cert, CERT_SERIAL_NUMBER)){
-		return FALSE;
-	}else{
-		g_info("Verified serial number");
-	}
+  if(!verify_certificate_sn(cert, CERT_SERIAL_NUMBER)){
+    return FALSE;
+  }else{
+    g_info("Verified serial number");
+  }
 
-	return TRUE;
+  return TRUE;
 
 }
 
@@ -366,57 +365,57 @@ gboolean my_access_manager(ThriftTransport * transport, X509 *cert, struct socka
 static void
 test_ssl_authorization_manager(void)
 {
-	int status=0;
-	pid_t pid;
-	ThriftSSLSocket *tSSLsocket = NULL;
-	ThriftTransport *transport = NULL;
-	//  int port = 51199;
-	int port = 443;
-	GError *error=NULL;
+  int status=0;
+  pid_t pid;
+  ThriftSSLSocket *tSSLsocket = NULL;
+  ThriftTransport *transport = NULL;
+  //  int port = 51199;
+  int port = 443;
+  GError *error=NULL;
 
-	guchar buf[17] = TEST_DATA; /* a buffer */
+  guchar buf[17] = TEST_DATA; /* a buffer */
 
-	//  pid = fork ();
-	//  assert ( pid >= 0 );
-	//
-	//  if ( pid == 0 )
-	//  {
-	//    /* child listens */
-	//    thrift_ssl_socket_server (port);
-	//    exit (0);
-	//  } else {
-	/* parent connects, wait a bit for the socket to be created */
-	sleep (1);
+  //  pid = fork ();
+  //  g_assert ( pid >= 0 );
+  //
+  //  if ( pid == 0 )
+  //  {
+  //    /* child listens */
+  //    thrift_ssl_socket_server (port);
+  //    exit (0);
+  //  } else {
+  /* parent connects, wait a bit for the socket to be created */
+  sleep (1);
 
-	// Test against level2 owncloud certificate
-	tSSLsocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", port, &error);
-	thrift_ssl_socket_set_manager(tSSLsocket, my_access_manager); 					// Install pinning manager
-	//thrift_ssl_load_cert_from_file(tSSLsocket, "./owncloud.level2crm.pem");
-	unsigned char cert_buffer[65534];
-	read_from_file(cert_buffer, 65534, "../../keys/client.pem");
-	if(!thrift_ssl_load_cert_from_buffer(tSSLsocket, cert_buffer)){
-		g_warning("Certificates cannot be loaded!");
-	}
+  // Test against level2 owncloud certificate
+  tSSLsocket = thrift_ssl_socket_new_with_host(SSLTLS, "localhost", port, &error);
+  thrift_ssl_socket_set_manager(tSSLsocket, my_access_manager);           // Install pinning manager
+  //thrift_ssl_load_cert_from_file(tSSLsocket, "./owncloud.level2crm.pem");
+  unsigned char cert_buffer[65534];
+  read_from_file(cert_buffer, 65534, "../../keys/client.pem");
+  if(!thrift_ssl_load_cert_from_buffer(tSSLsocket, cert_buffer)){
+    g_warning("Certificates cannot be loaded!");
+  }
 
-	transport = THRIFT_TRANSPORT (tSSLsocket);
-	assert (thrift_ssl_socket_open (transport, NULL) == TRUE);
-	assert (thrift_ssl_socket_is_open (transport));
+  transport = THRIFT_TRANSPORT (tSSLsocket);
+  g_assert (thrift_ssl_socket_open (transport, NULL) == TRUE);
+  g_assert (thrift_ssl_socket_is_open (transport));
 
-	thrift_ssl_socket_write (transport, buf, 17, NULL);
+  thrift_ssl_socket_write (transport, buf, 17, NULL);
 
-	/* write fail */
-	send_error = 1;
-	//    thrift_ssl_socket_write (transport, buf, 1, NULL);
-	//   send_error = 0;
+  /* write fail */
+  send_error = 1;
+  //    thrift_ssl_socket_write (transport, buf, 1, NULL);
+  //   send_error = 0;
 
-	//    thrift_ssl_socket_write_end (transport, NULL);
-	//    thrift_ssl_socket_flush (transport, NULL);
-	thrift_ssl_socket_close (transport, NULL);
-	g_object_unref (tSSLsocket);
+  //    thrift_ssl_socket_write_end (transport, NULL);
+  //    thrift_ssl_socket_flush (transport, NULL);
+  thrift_ssl_socket_close (transport, NULL);
+  g_object_unref (tSSLsocket);
 
-	//    assert ( wait (&status) == pid );
-	assert ( status == 0 );
-	//  }
+  //    g_assert ( wait (&status) == pid );
+  g_assert ( status == 0 );
+  //  }
 }
 #endif
 
@@ -523,59 +522,59 @@ test_ssl_authorization_manager(void)
 static void
 thrift_ssl_socket_server (const int port)
 {
-	int bytes = 0;
-	ThriftServerTransport *transport = NULL;
-	ThriftTransport *client = NULL;
-	guchar buf[10]; /* a buffer */
-	guchar match[10] = TEST_DATA;
+  int bytes = 0;
+  ThriftServerTransport *transport = NULL;
+  ThriftTransport *client = NULL;
+  guchar buf[10]; /* a buffer */
+  guchar match[10] = TEST_DATA;
 
-	ThriftServerSocket *tsocket = g_object_new (THRIFT_TYPE_SERVER_SOCKET,
-			"port", port, NULL);
+  ThriftServerSocket *tsocket = g_object_new (THRIFT_TYPE_SERVER_SOCKET,
+      "port", port, NULL);
 
-	transport = THRIFT_SERVER_TRANSPORT (tsocket);
-	thrift_server_transport_listen (transport, NULL);
-	client = thrift_server_transport_accept (transport, NULL);
-	assert (client != NULL);
+  transport = THRIFT_SERVER_TRANSPORT (tsocket);
+  thrift_server_transport_listen (transport, NULL);
+  client = thrift_server_transport_accept (transport, NULL);
+  g_assert (client != NULL);
 
-	/* read 10 bytes */
-	bytes = thrift_ssl_socket_read (client, buf, 10, NULL);
-	assert (bytes == 10); /* make sure we've read 10 bytes */
-	assert ( memcmp(buf, match, 10) == 0 ); /* make sure what we got matches */
+  /* read 10 bytes */
+  bytes = thrift_ssl_socket_read (client, buf, 10, NULL);
+  g_assert (bytes == 10); /* make sure we've read 10 bytes */
+  g_assert ( memcmp(buf, match, 10) == 0 ); /* make sure what we got matches */
 
-	/* failed read */
-	recv_error = 1;
-	thrift_ssl_socket_read (client, buf, 1, NULL);
-	recv_error = 0;
+  /* failed read */
+  recv_error = 1;
+  thrift_ssl_socket_read (client, buf, 1, NULL);
+  recv_error = 0;
 
-	thrift_ssl_socket_read_end (client, NULL);
-	thrift_ssl_socket_close (client, NULL);
-	g_object_unref (tsocket);
-	g_object_unref (client);
+  thrift_ssl_socket_read_end (client, NULL);
+  thrift_ssl_socket_close (client, NULL);
+  g_object_unref (tsocket);
+  g_object_unref (client);
 }
 
 int
 main(int argc, char *argv[])
 {
-	int retval;
+  int retval;
 #if (!GLIB_CHECK_VERSION (2, 36, 0))
-	g_type_init();
+  g_type_init();
 #endif
 
-	g_test_init (&argc, &argv, NULL);
+  g_test_init (&argc, &argv, NULL);
 
-	thrift_ssl_socket_initialize_openssl();
+  thrift_ssl_socket_initialize_openssl();
 
-	g_test_add_func ("/testtransportsslsocket/CreateAndDestroy", test_ssl_create_and_destroy);
-	g_test_add_func ("/testtransportsslsocket/CreateAndSetProperties", test_ssl_create_and_set_properties);
-	g_test_add_func ("/testtransportsslsocket/OpenAndClose", test_ssl_open_and_close);
-	// This test is disabled because server is not ready
-	// g_test_add_func ("/testtransportsslsocket/AuthorizationManagerPinning", test_ssl_authorization_manager);
-	//  g_test_add_func ("/testtransportsslsocket/Peek", test_ssl_peek);
+  g_test_add_func ("/testtransportsslsocket/CreateAndDestroy", test_ssl_create_and_destroy);
+  g_test_add_func ("/testtransportsslsocket/CreateAndSetProperties", test_ssl_create_and_set_properties);
+  g_test_add_func ("/testtransportsslsocket/OpenAndClose", test_ssl_open_and_close);
+  // This test is disabled because server is not ready
+  // g_test_add_func ("/testtransportsslsocket/AuthorizationManagerPinning", test_ssl_authorization_manager);
+  //  g_test_add_func ("/testtransportsslsocket/Peek", test_ssl_peek);
 
-	retval = g_test_run ();
+  retval = g_test_run ();
 
-	thrift_ssl_socket_finalize_openssl();
+  thrift_ssl_socket_finalize_openssl();
 
-	return retval;
+  return retval;
 }
 

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -773,7 +773,7 @@ uint32_t TJSONProtocol::readJSONString(std::string& str, bool skipContext) {
         continue;
       } else {
         size_t pos = kEscapeChars.find(ch);
-        if (pos == std::string::npos) {
+        if (pos == kEscapeChars.npos) {
           throw TProtocolException(TProtocolException::INVALID_DATA,
                                    "Expected control char, got '" + std::string((const char*)&ch, 1)
                                    + "'.");

--- a/test/known_failures_Linux.json
+++ b/test/known_failures_Linux.json
@@ -131,6 +131,8 @@
   "d-py_json_buffered-ip-ssl",
   "d-py_json_framed-ip",
   "d-py_json_framed-ip-ssl",
+  "erl-csharp_binary_buffered-ip",
+  "erl-csharp_compact_buffered-ip",
   "erl-nodejs_binary_buffered-ip",
   "erl-nodejs_compact_buffered-ip",
   "erl-rb_binary-accel_buffered-ip",
@@ -167,6 +169,10 @@
   "java-d_compact_buffered-ip",
   "java-d_compact_buffered-ip-ssl",
   "java-d_compact_framed-ip",
+  "rs-csharp_binary_buffered-ip",
+  "rs-csharp_compact_buffered-ip",
+  "rs-csharp_binary_framed-ip",
+  "rs-csharp_compact_framed-ip",
   "rs-dart_binary_framed-ip",
   "rs-dart_compact_framed-ip"
 ]


### PR DESCRIPTION
1458947: memory leak in compiler
1458787: resource leak in c_glib led to discovery of assert() abuse
1459090: fix string.find result check in JSON processor (unlikely)

This closes #1404