### PR TITLE
Thrift 4393 plugin renumber for stable output across runs

### DIFF
--- a/compiler/cpp/src/thrift/plugin/plugin.cc
+++ b/compiler/cpp/src/thrift/plugin/plugin.cc
@@ -124,6 +124,11 @@ struct TypeCache {
 
   std::map<int64_t, S> const* source;
 
+  void clear() {
+    source = nullptr ;
+    cache.clear() ;
+  }
+
 protected:
   std::map<int64_t, C*> cache;
 
@@ -140,6 +145,12 @@ std::map<int64_t, ::t_program*> g_program_cache;
 TypeCache< ::t_type, t_type> g_type_cache;
 TypeCache< ::t_const, t_const> g_const_cache;
 TypeCache< ::t_service, t_service> g_service_cache;
+
+void clear_global_cache() {
+  g_type_cache.clear();
+  g_const_cache.clear();
+  g_service_cache.clear();
+}
 
 void set_global_cache(const TypeRegistry& from) {
   g_type_cache.source = &from.types;

--- a/compiler/cpp/src/thrift/plugin/plugin_output.cc
+++ b/compiler/cpp/src/thrift/plugin/plugin_output.cc
@@ -170,6 +170,7 @@ T_STORE(type)
 T_STORE(const)
 T_STORE(service)
 #undef T_STORE
+// this id_generator is for gensymm-ing t_program_id
 id_generator program_cache ;
 
 #define THRIFT_ASSIGN_ID_N(t, from_name, to_name)                                                  \

--- a/compiler/cpp/src/thrift/plugin/type_util.h
+++ b/compiler/cpp/src/thrift/plugin/type_util.h
@@ -38,6 +38,7 @@ typename ToType<From>::type* convert(const From& from);
 
 class TypeRegistry;
 void set_global_cache(const TypeRegistry&);
+void clear_global_cache();
 }
 }
 }

--- a/compiler/cpp/test/Makefile.am
+++ b/compiler/cpp/test/Makefile.am
@@ -30,7 +30,7 @@ AM_CXXFLAGS = -Wall -Wextra -pedantic
 if WITH_PLUGIN
 check_PROGRAMS = plugintest
 
-noinst_PROGRAMS = thrift-gen-mycpp
+noinst_PROGRAMS = thrift-gen-mycpp thrift-gen-bincat
 
 AM_CPPFLAGS += -I$(top_srcdir)/lib/cpp/src -I$(top_builddir)/lib/cpp/src
 
@@ -43,9 +43,16 @@ thrift_gen_mycpp_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/compiler/cpp -I$(top_
 thrift_gen_mycpp_LDADD = $(top_builddir)/compiler/cpp/libthriftc.la
 
 cpp_plugin_test.sh: thrift-gen-mycpp
-TESTS = $(check_PROGRAMS) cpp_plugin_test.sh
+
+thrift-gen-bincat:
+	cp bincat.sh $@
+	chmod 755 $@
+
+plugin_stability_test.sh: thrift-gen-bincat
+
+TESTS = $(check_PROGRAMS) cpp_plugin_test.sh plugin_stability_test.sh
 
 clean-local:
-	$(RM) -rf gen-cpp gen-mycpp
+	$(RM) -rf gen-cpp gen-mycpp gen-bincat thrift-gen-bincat
 
 endif

--- a/compiler/cpp/test/Makefile.am
+++ b/compiler/cpp/test/Makefile.am
@@ -30,7 +30,9 @@ AM_CXXFLAGS = -Wall -Wextra -pedantic
 if WITH_PLUGIN
 check_PROGRAMS = plugintest
 
-noinst_PROGRAMS = thrift-gen-mycpp thrift-gen-bincat
+noinst_PROGRAMS = thrift-gen-mycpp
+
+all-local: thrift-gen-bincat
 
 AM_CPPFLAGS += -I$(top_srcdir)/lib/cpp/src -I$(top_builddir)/lib/cpp/src
 

--- a/compiler/cpp/test/bincat.sh
+++ b/compiler/cpp/test/bincat.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /bin/cat

--- a/compiler/cpp/test/plugin/conversion_test.cc
+++ b/compiler/cpp/test/plugin/conversion_test.cc
@@ -234,6 +234,8 @@ void migrate_global_cache() {
 template <typename T>
 T* round_trip(T* t) {
   typename plugin::ToType<T>::type p;
+  plugin::clear_global_cache();
+  plugin_output::clear_global_cache();
   plugin_output::convert(t, p);
   migrate_global_cache();
   return plugin::convert(p);

--- a/compiler/cpp/test/plugin_stability_test.sh
+++ b/compiler/cpp/test/plugin_stability_test.sh
@@ -20,6 +20,11 @@
 #
 
 # this file is intended to be invoked by make.
+#
+# This file runs the compiler twice, using a plugin that just invokes
+# /bin/cat, and compares the output.  If GeneratorInput is
+# nondeterminsitic, you'd expect the output to differ from run-to-run.
+# So this tests that in fact, the output is stable from run-to-run.
 set -e
 mkdir -p gen-bincat
 PATH=.:"$PATH" ../thrift -r -gen bincat ../../../test/Include.thrift > gen-bincat/1.ser

--- a/compiler/cpp/test/plugin_stability_test.sh
+++ b/compiler/cpp/test/plugin_stability_test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# this file is intended to be invoked by make.
+set -e
+mkdir -p gen-bincat
+PATH=.:"$PATH" ../thrift -r -gen bincat ../../../test/Include.thrift > gen-bincat/1.ser
+PATH=.:"$PATH" ../thrift -r -gen bincat ../../../test/Include.thrift > gen-bincat/2.ser
+diff --binary gen-bincat/1.ser gen-bincat/2.ser


### PR DESCRIPTION
added a unique ID generator in plugin_output.cc, so GeneratorInput can be uniquely numbered.  Added a unit-test that fails before and succeeds after.  Fixed-up conversion_test.cc so that global caches in both plugin & plugin_output get cleared before each test-case.