### PR TITLE
THRIFT-4395: fix rust build on xenial

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -11,9 +11,9 @@ exclude = ["Makefile*", "test/**"]
 keywords = ["thrift"]
 
 [dependencies]
-byteorder = "0.5.3"
-integer-encoding = "1.0.3"
-log = "~0.3.6"
-threadpool = "1.0"
-try_from = "0.2.0"
+byteorder = "~1.1.0"
+integer-encoding = "~1.0.4"
+log = "~0.3.8"
+threadpool = "~1.7.1"
+try_from = "~0.2.2"
 

--- a/lib/rs/test/Cargo.toml
+++ b/lib/rs/test/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false
 
 [dependencies]
-clap = "2.18.0"
+clap = "<2.28.0"
 ordered-float = "0.3.0"
 try_from = "0.2.0"
 

--- a/test/rs/Cargo.toml
+++ b/test/rs/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false
 
 [dependencies]
-clap = "2.18.0"
+clap = "<2.28.0"
 env_logger = "0.4.0"
 log = "0.3.7"
 ordered-float = "0.3.0"

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["Makefile*", "shared.rs", "tutorial.rs"]
 publish = false
 
 [dependencies]
-clap = "2.18.0"
+clap = "<2.28.0"
 ordered-float = "0.3.0"
 try_from = "0.2.0"
 


### PR DESCRIPTION
This will cause all CI builds to fail until resolved.