### PR TITLE
THRIFT-3657 D TFileWriterTransport close should use non-priority send

### DIFF
--- a/lib/d/src/thrift/transport/file.d
+++ b/lib/d/src/thrift/transport/file.d
@@ -637,7 +637,7 @@ final class TFileWriterTransport : TBaseTransport {
   override void close() {
     if (!isOpen) return;
 
-    prioritySend(writerThread_, ShutdownMessage(), thisTid); // FIXME: Should use normal send here.
+    send(writerThread_, ShutdownMessage(), thisTid);
     receive((ShutdownMessage msg, Tid tid){});
     isOpen_ = false;
   }


### PR DESCRIPTION
Client: D

(resubmit for nsuke)

This closes #884
This closes #1427