### PR TITLE
THRIFT-2913: fix random CI build failures in lib/rb test

### DIFF
--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -97,6 +97,7 @@ describe 'Server' do
       @prot = mock("BaseProtocol")
       @client = mock("Client")
       @server = described_class.new(@processor, @server_trans, @trans, @prot)
+      sleep(0.1)
     end
 
     it "should serve inside a thread" do


### PR DESCRIPTION
'Thrift::ThreadPoolServer should serve inside a thread'
Client: rb

This closes #1429