### PR TITLE
Fix generated maven packaging

### DIFF
--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -326,7 +326,7 @@
       url="http://thrift.apache.org"
       name="Apache Thrift"
       description="Thrift is a software framework for scalable cross-language services development."
-      packaging="pom"
+      packaging="jar"
     >
       <remoteRepository refid="central"/>
       <remoteRepository refid="apache"/>


### PR DESCRIPTION
pom packaging is for empty modules. What you're deploying on maven central is a jar artifact. Your current invalid pom.xml causes build tools such as sbt to not be able to download your library!