### PR TITLE
THRIFT-4399 fix plugin.thrift & assoc C++ code to respect unions

### DIFF
--- a/compiler/cpp/src/thrift/plugin/plugin.cc
+++ b/compiler/cpp/src/thrift/plugin/plugin.cc
@@ -258,11 +258,11 @@ THRIFT_CONVERSION(t_const_value, ) {
     T_CONST_VALUE_CASE(string);
   else T_CONST_VALUE_CASE(integer);
   else T_CONST_VALUE_CASE(double);
-  else {
-    T_CONST_VALUE_CASE(identifier);
-    if (from.__isset.enum_val)
-      to->set_enum(resolve_type< ::t_enum>(from.enum_val));
+  else if (from.__isset.const_identifier_val) {
+    to->set_identifier(from.const_identifier_val.identifier_val) ;
+    to->set_enum(resolve_type< ::t_enum>(from.const_identifier_val.enum_val)) ;
   }
+
 #undef T_CONST_VALUE_CASE
 }
 THRIFT_CONVERSION(t_field, resolve_type< ::t_type>(from.type), from.name, from.key) {
@@ -458,9 +458,7 @@ int GeneratorPlugin::exec(int, char* []) {
     return ::t_const_value::CV_INTEGER;
   if (v.__isset.double_val)
     return ::t_const_value::CV_DOUBLE;
-  if (v.__isset.identifier_val)
-    return ::t_const_value::CV_IDENTIFIER;
-  if (v.__isset.enum_val)
+  if (v.__isset.const_identifier_val)
     return ::t_const_value::CV_IDENTIFIER;
   throw ThriftPluginError("Unknown const value type");
 }

--- a/compiler/cpp/src/thrift/plugin/plugin.thrift
+++ b/compiler/cpp/src/thrift/plugin/plugin.thrift
@@ -105,15 +105,20 @@ enum Requiredness {
   T_OPT_IN_REQ_OUT = 2
 }
 
+struct t_const_identifier_value {
+  1: required string identifier_val
+  2: required t_type_id enum_val
+}
+
 union t_const_value {
   1: optional map<t_const_value, t_const_value> map_val
   2: optional list<t_const_value> list_val
   3: optional string string_val
   4: optional i64 integer_val
   5: optional double double_val
-  6: optional string identifier_val
-  7: optional t_type_id enum_val
+  8: optional t_const_identifier_value const_identifier_val
 }
+
 struct t_const {
   1: required string name
   2: required t_type_id type

--- a/compiler/cpp/src/thrift/plugin/plugin_output.cc
+++ b/compiler/cpp/src/thrift/plugin/plugin_output.cc
@@ -195,8 +195,18 @@ THRIFT_CONVERSION(t_const_value) {
     THRIFT_ASSIGN_N(get_string(), string_val, );
     break;
   case t_const_value::CV_IDENTIFIER:
-    THRIFT_ASSIGN_ID_N(t_type, enum_, enum_val);
-    THRIFT_ASSIGN_N(get_identifier(), identifier_val, );
+    {
+      if (from) {
+	apache::thrift::plugin::t_const_identifier_value cidval ;
+	if (from->enum_)
+	  cidval.__set_enum_val(store_type<t_type>(from->enum_));
+	cidval.__set_identifier_val(from->get_identifier());
+	to.__set_const_identifier_val(cidval) ;
+      }
+    }
+
+    //    THRIFT_ASSIGN_ID_N(t_type, enum_, enum_val);
+    //    THRIFT_ASSIGN_N(get_identifier(), identifier_val, );
     break;
   case t_const_value::CV_MAP:
     to.__isset.map_val = true;

--- a/compiler/cpp/test/plugin/conversion_test.cc
+++ b/compiler/cpp/test/plugin/conversion_test.cc
@@ -269,6 +269,12 @@ void test_const_value(t_const_value* sut) {
     T_CONST_VALUE_CASE(CV_INTEGER, integer);
     T_CONST_VALUE_CASE(CV_DOUBLE, double);
     T_CONST_VALUE_CASE(CV_STRING, string);
+
+#if 0
+  case t_const_value::CV_IDENTIFIER:
+    BOOST_CHECK_EQUAL(sut->const_identifer_val.identifier, sut2->const_identifer_val.identifier)
+      break ;
+#endif
     T_CONST_VALUE_CASE(CV_IDENTIFIER, identifier);
 #undef T_CONST_VALUE_CASE
   case t_const_value::CV_MAP:


### PR DESCRIPTION
plugin.thrift defines t_const_value as a union.  But in plugin_output.cc
and plugin.cc, the converters clearly either (a) SET NEITHER of
identifier_val & enum_val, or (b) SET BOTH.  But these are two different
fields in the union.  So clearly, the type t_const_value isn't being
treated as a union.

I think we need to fix Thrift's treatment of unions, but independently,
the plugin should use Thrift's type system in a correct manner.  This is
easy-to-fix, but since the current plugin relies on a bug, the fix will
be a breaking change.