### PR TITLE
Fix fb303 build: add lost shared_ptr.hpp

### DIFF
--- a/contrib/fb303/cpp/FacebookBase.h
+++ b/contrib/fb303/cpp/FacebookBase.h
@@ -22,6 +22,7 @@
 
 #include "FacebookService.h"
 
+#include <boost/shared_ptr.hpp>
 #include <thrift/server/TServer.h>
 #include <thrift/concurrency/Mutex.h>
 


### PR DESCRIPTION
fix error build fb303:
```
In file included from FacebookBase.cpp:20:0:
FacebookBase.h:97:30: error: field 'server_' has incomplete type 'boost::shared_ptr<apache::thrift::server::TServer>'
   boost::shared_ptr<TServer> server_;
```