### PR TITLE
Enhancement binary_protocol with frametransport

### DIFF
--- a/lib/go/thrift/fast_binary_protocol.go
+++ b/lib/go/thrift/fast_binary_protocol.go
@@ -1,0 +1,476 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+var (
+	limitReadBytes = 15 * (1 << 20)
+
+	SafeBufferError = fmt.Errorf("Buffer is larger than the 15M")
+)
+
+type TFastFrameBinaryProtocol struct {
+	origTransport TTransport
+	frameBuf      *FastFrameBuffer
+	strictRead    bool
+	strictWrite   bool
+	buffer        [64]byte
+	useBuf        bool
+}
+
+type TFastFrameBinaryProtocolFactory struct {
+	strictRead  bool
+	strictWrite bool
+	useBuf      bool
+	bufSize     int
+}
+
+func NewTFastFrameBinaryProtocolTransport(t TTransport, bufSize int) *TFastFrameBinaryProtocol {
+	return NewTFastFrameBinaryProtocol(t, false, true, bufSize)
+}
+
+func NewTFastFrameBinaryProtocol(t TTransport, strictRead, strictWrite bool, bufSize int) *TFastFrameBinaryProtocol {
+	p := &TFastFrameBinaryProtocol{origTransport: t, strictRead: strictRead, strictWrite: strictWrite}
+	frameTransport := t.(*TFramedTransport)
+	p.frameBuf = NewFastBuffer(frameTransport, bufSize)
+	return p
+}
+
+func NewTFastFrameBinaryProtocolFactoryDefault(bufSize int) *TFastFrameBinaryProtocolFactory {
+	return NewTFastFrameBinaryProtocolFactory(false, true, bufSize)
+}
+
+func NewTFastFrameBinaryProtocolFactory(strictRead, strictWrite bool, bufSize int) *TFastFrameBinaryProtocolFactory {
+	return &TFastFrameBinaryProtocolFactory{strictRead: strictRead, strictWrite: strictWrite, bufSize: bufSize}
+}
+
+func (p *TFastFrameBinaryProtocolFactory) GetProtocol(t TTransport) TProtocol {
+	return NewTFastFrameBinaryProtocol(t, p.strictRead, p.strictWrite, p.bufSize)
+
+}
+
+/**
+ * Writing Methods
+ */
+
+func (p *TFastFrameBinaryProtocol) WriteMessageBegin(name string, typeId TMessageType, seqId int32) error {
+	if p.strictWrite {
+		version := uint32(VERSION_1) | uint32(typeId)
+		e := p.WriteI32(int32(version))
+		if e != nil {
+			return e
+		}
+		e = p.WriteString(name)
+		if e != nil {
+			return e
+		}
+		e = p.WriteI32(seqId)
+		return e
+	} else {
+		e := p.WriteString(name)
+		if e != nil {
+			return e
+		}
+		e = p.WriteByte(int8(typeId))
+		if e != nil {
+			return e
+		}
+		e = p.WriteI32(seqId)
+		return e
+	}
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteMessageEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteStructBegin(name string) error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteStructEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteFieldBegin(name string, typeId TType, id int16) error {
+	e := p.WriteByte(int8(typeId))
+	if e != nil {
+		return e
+	}
+	e = p.WriteI16(id)
+	return e
+}
+
+func (p *TFastFrameBinaryProtocol) WriteFieldEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteFieldStop() error {
+	e := p.WriteByte(STOP)
+	return e
+}
+
+func (p *TFastFrameBinaryProtocol) WriteMapBegin(keyType TType, valueType TType, size int) error {
+	e := p.WriteByte(int8(keyType))
+	if e != nil {
+		return e
+	}
+	e = p.WriteByte(int8(valueType))
+	if e != nil {
+		return e
+	}
+	e = p.WriteI32(int32(size))
+	return e
+}
+
+func (p *TFastFrameBinaryProtocol) WriteMapEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteListBegin(elemType TType, size int) error {
+	e := p.WriteByte(int8(elemType))
+	if e != nil {
+		return e
+	}
+	e = p.WriteI32(int32(size))
+	return e
+}
+
+func (p *TFastFrameBinaryProtocol) WriteListEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteSetBegin(elemType TType, size int) error {
+	e := p.WriteByte(int8(elemType))
+	if e != nil {
+		return e
+	}
+	e = p.WriteI32(int32(size))
+	return e
+}
+
+func (p *TFastFrameBinaryProtocol) WriteSetEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteBool(value bool) error {
+	if value {
+		return p.WriteByte(1)
+	}
+	return p.WriteByte(0)
+}
+
+func (p *TFastFrameBinaryProtocol) WriteByte(value int8) error {
+	p.frameBuf.WritByte(value)
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteI16(value int16) error {
+	p.frameBuf.WriteI16(uint16(value))
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteI32(value int32) error {
+	p.frameBuf.WriteI32(uint32(value))
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteI64(value int64) error {
+	p.frameBuf.WriteI64(uint64(value))
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteDouble(value float64) error {
+	return p.WriteI64(int64(math.Float64bits(value)))
+}
+
+func (p *TFastFrameBinaryProtocol) WriteString(value string) error {
+	p.frameBuf.WriteI32(uint32(len(value)))
+	p.frameBuf.WriteString(value)
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) WriteBinary(value []byte) error {
+	p.WriteI32(int32(len(value)))
+	p.frameBuf.WriteBytes(value)
+	return nil
+}
+
+/**
+ * Reading methods
+ */
+
+func (p *TFastFrameBinaryProtocol) ReadMessageBegin() (name string, typeId TMessageType, seqId int32, err error) {
+	size, e := p.ReadI32()
+	if e != nil {
+		return "", typeId, 0, NewTProtocolException(e)
+	}
+	if size < 0 {
+		typeId = TMessageType(size & 0x0ff)
+		version := int64(int64(size) & VERSION_MASK)
+		if version != VERSION_1 {
+			return name, typeId, seqId, NewTProtocolExceptionWithType(BAD_VERSION, fmt.Errorf("Bad version in ReadMessageBegin"))
+		}
+		name, e = p.ReadString()
+		if e != nil {
+			return name, typeId, seqId, NewTProtocolException(e)
+		}
+		seqId, e = p.ReadI32()
+		if e != nil {
+			return name, typeId, seqId, NewTProtocolException(e)
+		}
+		return name, typeId, seqId, nil
+	}
+	if p.strictRead {
+		return name, typeId, seqId, NewTProtocolExceptionWithType(BAD_VERSION, fmt.Errorf("Missing version in ReadMessageBegin"))
+	}
+	// TODO ?
+	name, e2 := p.readStringBody(int(size))
+	if e2 != nil {
+		return name, typeId, seqId, e2
+	}
+	b, e3 := p.ReadByte()
+	if e3 != nil {
+		return name, typeId, seqId, e3
+	}
+	typeId = TMessageType(b)
+	seqId, e4 := p.ReadI32()
+	if e4 != nil {
+		return name, typeId, seqId, e4
+	}
+	return name, typeId, seqId, nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadMessageEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadStructBegin() (name string, err error) {
+	return
+}
+
+func (p *TFastFrameBinaryProtocol) ReadStructEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadFieldBegin() (name string, typeId TType, seqId int16, err error) {
+	t, err := p.ReadByte()
+	typeId = TType(t)
+	if err != nil {
+		return name, typeId, seqId, err
+	}
+	if t != STOP {
+		seqId, err = p.ReadI16()
+	}
+	return name, typeId, seqId, err
+}
+
+func (p *TFastFrameBinaryProtocol) ReadFieldEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadMapBegin() (kType, vType TType, size int, err error) {
+	k, e := p.ReadByte()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	kType = TType(k)
+	v, e := p.ReadByte()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	vType = TType(v)
+	size32, e := p.ReadI32()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	if size32 < 0 {
+		err = invalidDataLength
+		return
+	}
+	if size32 > int32(limitReadBytes) {
+		err = SafeBufferError
+		return
+	}
+	size = int(size32)
+	return kType, vType, size, nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadMapEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadListBegin() (elemType TType, size int, err error) {
+	b, e := p.ReadByte()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	elemType = TType(b)
+	size32, e := p.ReadI32()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	if size32 < 0 {
+		err = invalidDataLength
+		return
+	}
+	if size32 > int32(limitReadBytes) {
+		err = SafeBufferError
+		return
+	}
+
+	size = int(size32)
+
+	return
+}
+
+func (p *TFastFrameBinaryProtocol) ReadListEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadSetBegin() (elemType TType, size int, err error) {
+	b, e := p.ReadByte()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	elemType = TType(b)
+	size32, e := p.ReadI32()
+	if e != nil {
+		err = NewTProtocolException(e)
+		return
+	}
+	if size32 < 0 {
+		err = invalidDataLength
+		return
+	}
+	if size32 > int32(limitReadBytes) {
+		err = SafeBufferError
+		return
+	}
+	size = int(size32)
+	return elemType, size, nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadSetEnd() error {
+	return nil
+}
+
+func (p *TFastFrameBinaryProtocol) ReadBool() (bool, error) {
+	b, e := p.ReadByte()
+	v := true
+	if b != 1 {
+		v = false
+	}
+	return v, e
+}
+
+func (p *TFastFrameBinaryProtocol) ReadByte() (value int8, err error) {
+	c, err := p.frameBuf.ReadByte()
+	return int8(c), err
+}
+
+func (p *TFastFrameBinaryProtocol) ReadI16() (value int16, err error) {
+	return p.frameBuf.ReadI16()
+}
+
+func (p *TFastFrameBinaryProtocol) ReadI32() (value int32, err error) {
+	return p.frameBuf.ReadI32()
+}
+
+func (p *TFastFrameBinaryProtocol) ReadI64() (value int64, err error) {
+	return p.frameBuf.ReadI64()
+}
+
+func (p *TFastFrameBinaryProtocol) ReadDouble() (value float64, err error) {
+	var buf []byte
+	buf, err = p.frameBuf.ReadN(8)
+	value = math.Float64frombits(binary.BigEndian.Uint64(buf))
+	return value, err
+}
+
+func (p *TFastFrameBinaryProtocol) ReadString() (value string, err error) {
+	var size int32
+	var e error
+	size, e = p.frameBuf.ReadI32()
+	if e != nil {
+		return "", e
+	}
+	if size < 0 {
+		err = invalidDataLength
+		return
+	}
+	dat, err := p.frameBuf.ReadN(int(size))
+	//  TODO  more fast way
+	return string(dat), err
+}
+
+func (p *TFastFrameBinaryProtocol) ReadBinary() ([]byte, error) {
+	var size int32
+	var e error
+	size, e = p.frameBuf.ReadI32()
+	if e != nil {
+		return nil, e
+	}
+	if size < 0 {
+		return nil, invalidDataLength
+	}
+	if size > int32(limitReadBytes) {
+		return nil, SafeBufferError
+	}
+	dat, err := p.frameBuf.ReadN(int(size))
+	return dat, err
+
+}
+
+func (p *TFastFrameBinaryProtocol) Flush() error {
+	return p.frameBuf.Flush()
+}
+
+func (p *TFastFrameBinaryProtocol) Skip(fieldType TType) (err error) {
+	return SkipDefaultDepth(p, fieldType)
+}
+
+func (p *TFastFrameBinaryProtocol) Transport() TTransport {
+	return p.origTransport
+}
+
+
+func (p *TFastFrameBinaryProtocol) readStringBody(size int) (value string, err error) {
+	if size < 0 {
+		return "", nil
+	}
+	if size > int(limitReadBytes) {
+		return "", SafeBufferError
+	}
+	buf, e := p.frameBuf.ReadN(size)
+	return string(buf), e
+}

--- a/lib/go/thrift/fast_buffer.go
+++ b/lib/go/thrift/fast_buffer.go
@@ -1,0 +1,257 @@
+package thrift
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type FastFrameBuffer struct {
+	w         *TFramedTransport //
+	b         []byte
+	wIdx      int               // write-offset, reset when Flush
+	frameSize int
+	rIdx      int     // read-offset, reset when read-new-frame
+	buf       [4]byte // only for write&read data-len
+}
+
+func NewFastBuffer(w *TFramedTransport, size int) *FastFrameBuffer {
+	return &FastFrameBuffer{
+		w:    w,
+		b:    make([]byte, size),
+		rIdx: 0,
+		wIdx: 0,
+	}
+}
+
+func (p *FastFrameBuffer) WritByte(b int8) {
+	if p.wIdx+1 > p.Cap() {
+		p.grow(2*p.Cap() + 1)
+	}
+	p.b[p.wIdx] = byte(b)
+	p.wIdx += 1
+}
+
+func (p *FastFrameBuffer) WriteBytes(b []byte) {
+	if p.wIdx+len(b) > p.Cap() {
+		p.grow(2*p.Cap() + len(b))
+	}
+	copy(p.b[p.wIdx:], b)
+	p.wIdx += len(b)
+}
+
+func (p *FastFrameBuffer) WriteI16(i uint16) {
+	if p.wIdx+2 > p.Cap() {
+		p.grow(2*p.Cap() + 2)
+	}
+	copy(p.b[p.wIdx:], []byte{byte(i >> 8), byte(i)})
+	p.wIdx += 2
+}
+
+func (p *FastFrameBuffer) WriteI32(i uint32) {
+	if p.wIdx+4 > p.Cap() {
+		p.grow(2*p.Cap() + 4)
+	}
+	copy(p.b[p.wIdx:], []byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)})
+	p.wIdx += 4
+}
+
+func (p *FastFrameBuffer) WriteI64(i uint64) {
+	if p.wIdx+8 > p.Cap() {
+		p.grow(2*p.Cap() + 8)
+	}
+	copy(p.b[p.wIdx:], []byte{byte(i >> 56), byte(i >> 48), byte(i >> 40), byte(i >> 32), byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)})
+	p.wIdx += 8
+}
+
+func (p *FastFrameBuffer) WriteString(s string) {
+	if p.wIdx+len(s) > p.Cap() {
+		p.grow(2*p.Cap() + len(s))
+	}
+	copy(p.b[p.wIdx:], str2bytes(s))
+	p.wIdx += len(s)
+}
+
+func (p *FastFrameBuffer) Len() int {
+	return len(p.b)
+}
+
+func (p *FastFrameBuffer) Cap() int {
+	return cap(p.b)
+}
+
+func (p *FastFrameBuffer) Flush() error {
+	p.buf[0] = byte(p.wIdx >> 24)
+	p.buf[1] = byte(p.wIdx >> 16)
+	p.buf[2] = byte(p.wIdx >> 8)
+	p.buf[3] = byte(p.wIdx)
+	_, err := p.w.transport.Write(p.buf[:4])
+
+	if err != nil {
+		return fmt.Errorf("Flush Write-Len failed, err: %v\n", err)
+	}
+	_, err = p.w.transport.Write(p.b[:p.wIdx])
+	if err != nil {
+		return fmt.Errorf("Flush Write-Dat failed, err: %v\n", err)
+	}
+	p.ResetWriter()
+	p.w.transport.Flush()
+	return nil
+}
+
+func (p *FastFrameBuffer) ResetWriter() {
+	p.wIdx = 0
+}
+
+func (p *FastFrameBuffer) ResetReader() {
+	p.rIdx = 0
+}
+
+func (p *FastFrameBuffer) grow(n int) {
+	b := make([]byte, n)
+	copy(b, p.b[0:])
+	p.b = b
+}
+
+func (p *FastFrameBuffer) ReadByte() (c byte, err error) {
+	if p.frameSize == 0 {
+		p.frameSize, err = p.readFrameHeader()
+		if err != nil {
+			return
+		}
+		_, err = p.readAll(p.frameSize)
+		if err != nil {
+			return
+		}
+	}
+	if p.frameSize < 1 {
+		return 0, fmt.Errorf("Not enought frame size %d to read %d bytes", p.frameSize, 1)
+	}
+	c = p.b[p.rIdx]
+	if err == nil {
+		p.frameSize--
+		p.rIdx += 1
+	}
+	return
+}
+
+// maybe read-bytes means ReadN
+func (p *FastFrameBuffer) ReadN(num int) (b []byte, err error) {
+	if p.frameSize == 0 {
+		p.frameSize, err = p.readFrameHeader()
+		if err != nil {
+			return
+		}
+		_, err = p.readAll(p.frameSize)
+		if err != nil {
+			return
+		}
+	}
+	if p.frameSize < num {
+		return nil, fmt.Errorf("Not enought frame size %d to read %d bytes", p.frameSize, num)
+	}
+	b = p.b[p.rIdx : p.rIdx+num]
+	p.frameSize = p.frameSize - num
+	if p.frameSize < 0 {
+		return nil, fmt.Errorf("Negative frame size")
+	}
+	p.rIdx += num
+	return b, nil
+}
+
+func (p *FastFrameBuffer) ReadI64() (num int64, err error) {
+	if p.frameSize == 0 {
+		p.frameSize, err = p.readFrameHeader()
+		if err != nil {
+			return
+		}
+		_, err = p.readAll(p.frameSize)
+		if err != nil {
+			return
+		}
+
+	}
+	if p.frameSize < 8 {
+		return 0, fmt.Errorf("Not enought frame size %d to read %d bytes", p.frameSize, 2)
+	}
+	num = int64(uint64(p.b[p.rIdx+7]) | uint64(p.b[p.rIdx+6])<<8 | uint64(p.b[p.rIdx+5])<<16 | uint64(p.b[p.rIdx+4])<<24 | uint64(p.b[p.rIdx+3])<<32 | uint64(p.b[p.rIdx+2])<<40 | uint64(p.b[p.rIdx+1])<<48 | uint64(p.b[p.rIdx])<<56)
+	p.frameSize = p.frameSize - 8
+	p.rIdx += 8
+	return num, nil
+}
+
+func (p *FastFrameBuffer) ReadI32() (num int32, err error) {
+	if p.frameSize == 0 {
+		p.frameSize, err = p.readFrameHeader()
+		if err != nil {
+			return
+		}
+		_, err = p.readAll(p.frameSize)
+		if err != nil {
+			return
+		}
+	}
+	if p.frameSize < 4 {
+		return 0, fmt.Errorf("Not enought frame size %d to read %d bytes", p.frameSize, 2)
+	}
+	num = int32(uint32(p.b[p.rIdx+3]) | uint32(p.b[p.rIdx+2])<<8 | uint32(p.b[p.rIdx+1])<<16 | uint32(p.b[p.rIdx])<<24)
+	p.frameSize = p.frameSize - 4
+	p.rIdx += 4
+	return num, nil
+}
+
+func (p *FastFrameBuffer) ReadI16() (num int16, err error) {
+	if p.frameSize == 0 {
+		p.frameSize, err = p.readFrameHeader()
+		if err != nil {
+			return
+		}
+		_, err = p.readAll(p.frameSize)
+		if err != nil {
+			return
+		}
+	}
+	if p.frameSize < 2 {
+		return 0, fmt.Errorf("Not enought frame size %d to read %d bytes", p.frameSize, 2)
+	}
+	num = int16(uint16(p.b[p.rIdx+1]) | uint16(p.b[p.rIdx])<<8)
+	p.frameSize = p.frameSize - 2
+	p.rIdx += 2
+	return num, nil
+}
+
+func (p *FastFrameBuffer) readFrameHeader() (int, error) {
+	p.ResetReader()
+	if _, err := p.w.transport.Read(p.buf[:4]); err != nil {
+		return 0, err
+	}
+	frameSize := int(uint32(p.buf[3]) | uint32(p.buf[2])<<8 | uint32(p.buf[1])<<16 | uint32(p.buf[0])<<24)
+	if frameSize < 0 || frameSize > DEFAULT_MAX_LENGTH {
+		return 0, fmt.Errorf("Incorrect frame size (%d)", frameSize)
+	}
+	return frameSize, nil
+}
+
+// TODO 这个方法 是否会有问题？ block? or?
+func (p *FastFrameBuffer) readAll(num int) (int, error) {
+	// 当容量不足以装下所有数据的时候, 重新申请一下
+	if cap(p.b) < num {
+		rbNew := make([]byte, 2*cap(p.b)+num)
+		copy(rbNew, p.b)
+		p.b = rbNew
+	}
+	var i = 0
+	for i < num {
+		l, err := p.w.transport.Read(p.b[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += l
+	}
+	return i, nil
+}
+
+func str2bytes(s string) []byte {
+	x := (*[2]uintptr)(unsafe.Pointer(&s))
+	h := [3]uintptr{x[0], x[1], x[1]}
+	return *(*[]byte)(unsafe.Pointer(&h))
+}


### PR DESCRIPTION
for frametransport
write method write data-length to server
read method read data-length from server

and there are lots of un-usable memory copy & system call 

i optimize this with an simple buffer, manager de write & read
with the benchmark for write improve 2times & for read improve 3times

link-for testing： https://github.com/zhiyu-he/go_performance/blob/hzy/modify/benchmark/thrift_serializer_test.go