### PR TITLE
THRIFT-4416: Automate and fix CPAN packaging

### DIFF
--- a/lib/perl/MANIFEST.SKIP
+++ b/lib/perl/MANIFEST.SKIP
@@ -1,0 +1,13 @@
+blib/.*$
+build-cpan-dist.sh
+FixupDist.pl
+MANIFEST.bak
+MANIFEST.SKIP
+MYMETA.json
+Makefile
+Makefile.am
+Makefile.in
+pm_to_blib
+test/Makefile.am
+test/Makefile.in
+tools/FixupDist.pl

--- a/lib/perl/build-cpan-dist.sh
+++ b/lib/perl/build-cpan-dist.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 #
 # This script is intended to be used after tagging the repository and updating
-# the version files for a release.  It will create a CPAN archive.
+# the version files for a release.  It will create a CPAN archive.  Run this
+# from inside a docker image like ubuntu-xenial.
+#
+
+set -e
+
+rm MANIFEST
+rm -rf Thrift-*
+
+# setup cpan without a prompt
+echo | cpan
+cpan install HTTP::Date
+cpan install CPAN
+cpan install CPAN::Meta ExtUtils::MakeMaker JSON::PP
 
 perl Makefile.PL
+rm MYMETA.yml
 make
 make manifest
 make dist
+
+#
+# We unpack the archive so we can add version metadata for CPAN
+# so that it properly indexes Thrift and remove unnecessary files.
+#
+
+echo '-----------------------------------------------------------'
+set -x
+
+DISTFILE=$(ls Thrift*.gz)
+tar xzf Thrift-*.gz
+rm Thrift-*.gz
+DISTDIR=$(ls -d Thrift*)
+cd $DISTDIR
+perl ../tools/FixupDist.pl
+cd ..
+tar cvzf $DISTFILE $DISTDIR
+rm -r $DISTDIR

--- a/lib/perl/tools/FixupDist.pl
+++ b/lib/perl/tools/FixupDist.pl
@@ -17,20 +17,19 @@
 # under the License.
 #
 
+#
+# This will fix up the distribution so that CPAN properly
+# indexes Thrift.
+#
+
 use 5.10.0;
 use strict;
 use warnings;
+use utf8;
 
-use ExtUtils::MakeMaker;
+use Data::Dumper;
+use CPAN::Meta;
 
-WriteMakefile( ABSTRACT => 'Apache Thrift is a software framework for scalable cross-language services development.',
-               AUTHOR => 'Apache Thrift <dev@thrift.apache.org>',
-               LICENSE => 'apache_2_0',
-               MIN_PERL_VERSION => '5.010000',
-               NAME => 'Thrift',
-               NEEDS_LINKING => 0,
-               PREREQ_PM => {
-                   'Bit::Vector'     => 0,
-                   'Class::Accessor' => 0
-               },
-               VERSION_FROM => 'lib/Thrift.pm' );
+my $meta = CPAN::Meta->load_file('META.json');
+$meta->{'provides'} = { 'Thrift' => { 'file' => 'lib/Thrift.pm', 'version' => $meta->version() } };
+$meta->save('META.json');


### PR DESCRIPTION
* Ensures only necessary files are in the manifest.
* Ensures that META.json has the syntactic sugar to properly index Thrift as a single package.
* Shell script is now designed to be run inside one of the docker images, grabbing some things from CPAN to ensure a solid delivery.

Note: None of these files are involved in our build CI processes today.