### PR TITLE
THRIFT-4431 Ruby library: Finish http connection after flush in http client

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -52,6 +52,7 @@ module Thrift
       @inbuf = StringIO.new data
     ensure
       @outbuf = Bytes.empty_byte_buffer
+      http.finish
     end
   end
 end


### PR DESCRIPTION
Call Net/HTTP#finish after flush in HTTPClientTransport to release connection file descriptors.
This eliminates error "Errno::EMFILE: Failed to open TCP connection (Too many open files - getaddrinfo)" if many calls are made with a client object.