### PR TITLE
THRIFT-3983: Fix generated maven packaging

### DIFF
--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -326,7 +326,7 @@
       url="http://thrift.apache.org"
       name="Apache Thrift"
       description="Thrift is a software framework for scalable cross-language services development."
-      packaging="pom"
+      packaging="jar"
     >
       <remoteRepository refid="central"/>
       <remoteRepository refid="apache"/>


### PR DESCRIPTION
ref <https://issues.apache.org/jira/projects/THRIFT/issues/THRIFT-3983>

---
* The origin PR is <https://github.com/apache/thrift/pull/1430>, so this close #1430
* This PR depends on [THRIFT-4439](https://issues.apache.org/jira/browse/THRIFT-4439), to pass CI.