### PR TITLE
THRIFT-4436: port nodejs changes from THRIFT-3748 to js lib (rebased)

### DIFF
--- a/lib/js/Gruntfile.js
+++ b/lib/js/Gruntfile.js
@@ -175,12 +175,5 @@ module.exports = function(grunt) {
                               'shell:ThriftGenJQ', 'qunit:ThriftJSJQ', 'qunit:ThriftJSJQ_TLS',
                               'shell:ThriftGenES6', 'qunit:ThriftWSES6'
                              ]);
-  grunt.registerTask('default', ['jshint', 'shell:InstallThriftJS', 'shell:InstallThriftNodeJSDep', 'shell:ThriftGen',
-                                 'external_daemon:ThriftTestServer', 'external_daemon:ThriftTestServer_TLS',
-                                 'qunit:ThriftJS', 'qunit:ThriftJS_TLS',
-                                 'qunit:ThriftWS',
-                                 'shell:ThriftGenJQ', 'qunit:ThriftJSJQ', 'qunit:ThriftJSJQ_TLS',
-                                 'shell:ThriftGenES6', 'qunit:ThriftWSES6',
-                                 'concat', 'uglify', 'jsdoc'
-                                ]);
+  grunt.registerTask('default', ['test', 'concat', 'uglify', 'jsdoc']);
 };

--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -1258,7 +1258,12 @@ Thrift.Protocol.prototype = {
 
     /** Deserializes the end of a list. */
     readListEnd: function() {
-        this.readFieldEnd();
+        var pos = this.rpos.pop() - 2;
+        var st = this.rstack;
+        st.pop();
+        if (st instanceof Array && st.length > pos && st[pos].length > 0) {
+          st.push(st[pos].shift());
+        }
     },
 
     /**

--- a/lib/js/test/deep-constructor.test.js
+++ b/lib/js/test/deep-constructor.test.js
@@ -61,7 +61,13 @@ function createThriftObj() {
           DB: new Simple({value: 'k'})
         }
       ]
-    }
+    },
+
+    list_of_list_field: [
+       ['one', 'two'],
+       ['three', 'four'],
+       ['five', 'six']
+    ]
   }
   );
 }
@@ -108,7 +114,13 @@ function createJsObj() {
           DB: {value: 'k'}
         }
       ]
-    }
+    },
+
+    list_of_list_field: [
+      ['one', 'two'],
+      ['three', 'four'],
+      ['five', 'six']
+   ]
   };
 }
 
@@ -125,6 +137,12 @@ function assertValues(obj, assert) {
     assert.equal(obj.struct_nested_containers_field[0][0].C[1].value, 'i');
     assert.equal(obj.struct_nested_containers_field2.D[0].DA.value, 'j');
     assert.equal(obj.struct_nested_containers_field2.D[1].DB.value, 'k');
+    assert.equal(obj.list_of_list_field[0][0], 'one');
+    assert.equal(obj.list_of_list_field[0][1], 'two');
+    assert.equal(obj.list_of_list_field[1][0], 'three');
+    assert.equal(obj.list_of_list_field[1][1], 'four');
+    assert.equal(obj.list_of_list_field[2][0], 'five');
+    assert.equal(obj.list_of_list_field[2][1], 'six');
 }
 
 var cases = {


### PR DESCRIPTION
test for serialization of nested list,
run all tests when building js lib