### PR TITLE
Add seek function to TCompactInputProtocol

### DIFF
--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -318,7 +318,7 @@ where
 
 impl<T> io::Seek for TCompactInputProtocol<T>
 where
-    T: io::Seek + io::Read,
+    T: io::Seek + TReadTransport,
 {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         self.transport.seek(pos)

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -19,6 +19,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use integer_encoding::{VarIntReader, VarIntWriter};
 use std::convert::From;
 use try_from::TryFrom;
+use std::io;
 
 use transport::{TReadTransport, TWriteTransport};
 use super::{TFieldIdentifier, TInputProtocol, TInputProtocolFactory, TListIdentifier,
@@ -312,6 +313,17 @@ where
             .map_err(From::from)
             .map(|_| buf[0])
     }
+}
+
+
+impl<T> io::Seek for TCompactInputProtocol<T>
+where
+    T: io::Seek + io::Read,
+{
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.transport.seek(pos)
+    }
+
 }
 
 /// Factory for creating instances of `TCompactInputProtocol`.

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -323,7 +323,6 @@ where
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         self.transport.seek(pos)
     }
-
 }
 
 /// Factory for creating instances of `TCompactInputProtocol`.


### PR DESCRIPTION
When Thrift is used in encoding which combine manual and Thrift serialization, such as Apache Parquet then it is required to be able to position within a file manually. 
https://github.com/apache/parquet-format#file-format
As TCompactInputProtocol owns value of transport, it is not possible to access it outside of TCompactInputProtocol and perform seek operation.

This patch implements Seek trait for transports which support it.
  