### PR TITLE
THRIFT-4446: JSONProtocol Base64 Encoding: Do not trim padding on encode.

### DIFF
--- a/lib/csharp/src/Protocol/TJSONProtocol.cs
+++ b/lib/csharp/src/Protocol/TJSONProtocol.cs
@@ -544,11 +544,6 @@ namespace Thrift.Protocol
             int len = b.Length;
             int off = 0;
 
-            // Ignore padding
-            int bound = len >= 2 ? len - 2 : 0;
-            for (int i = len - 1; i >= bound && b[i] == '='; --i) {
-                --len;
-            }
             while (len >= 3)
             {
                 // Encode 3 bytes at a time

--- a/lib/netcore/Thrift/Protocols/TJSONProtocol.cs
+++ b/lib/netcore/Thrift/Protocols/TJSONProtocol.cs
@@ -384,14 +384,6 @@ namespace Thrift.Protocols
             var len = b.Length;
             var off = 0;
 
-            // Ignore padding
-            var bound = len >= 2 ? len - 2 : 0;
-
-            for (var i = len - 1; i >= bound && b[i] == '='; --i)
-            {
-                --len;
-            }
-
             while (len >= 3)
             {
                 // Encode 3 bytes at a time


### PR DESCRIPTION
* In the C# and .NET Core libraries, the JSONProtocol's Binary Encoding to Base64 trims padding from the user provided byte arrays before encoding into Base64. This behavior is incorrect, as the user provided data should be encoded exactly as provided. Otherwise, data may be lost.

* Fixed by no longer trimming padding on encode. Padding must still be trimmed on decode, in accordance with the Base64 specification.

* For example:
  * Before this patch, encoding the byte array `[0x01, 0x3d, 0x3d]` yields `[0x01]` upon decode. This is incorrect, as I should decode the exact data that I encoded.
  * After this patch, it yields `[0x01, 0x3d, 0x3d]`, as expected.