### PR TITLE
THRIFT-4473 Move Thrift.Console.pas out of the Library

### DIFF
--- a/lib/delphi/test/ConsoleHelper.pas
+++ b/lib/delphi/test/ConsoleHelper.pas
@@ -17,7 +17,7 @@
  * under the License.
  *)
 
-unit Thrift.Console;
+unit ConsoleHelper;
 
 interface
 

--- a/lib/delphi/test/TestClient.pas
+++ b/lib/delphi/test/TestClient.pas
@@ -37,6 +37,7 @@ uses
   DateUtils,
   Generics.Collections,
   TestConstants,
+  ConsoleHelper,
   Thrift,
   Thrift.Protocol.Compact,
   Thrift.Protocol.JSON,
@@ -46,8 +47,7 @@ uses
   Thrift.Stream,
   Thrift.Test,
   Thrift.Utils,
-  Thrift.Collections,
-  Thrift.Console;
+  Thrift.Collections;
 
 type
   TThreadConsole = class

--- a/lib/delphi/test/TestServer.pas
+++ b/lib/delphi/test/TestServer.pas
@@ -29,7 +29,6 @@ interface
 uses
   Windows, SysUtils,
   Generics.Collections,
-  Thrift.Console,
   Thrift.Server,
   Thrift.Transport,
   Thrift.Transport.Pipes,
@@ -42,6 +41,7 @@ uses
   Thrift,
   TestConstants,
   TestServerEvents,
+  ConsoleHelper,
   Contnrs;
 
 type

--- a/lib/delphi/test/TestServerEvents.pas
+++ b/lib/delphi/test/TestServerEvents.pas
@@ -27,7 +27,7 @@ uses
   Thrift.Protocol,
   Thrift.Transport,
   Thrift.Server,
-  Thrift.Console;
+  ConsoleHelper;
 
 type
   TRequestEventsImpl = class( TInterfacedObject, IRequestEvents)

--- a/lib/delphi/test/client.dpr
+++ b/lib/delphi/test/client.dpr
@@ -37,7 +37,6 @@ uses
   Thrift.Collections in '..\src\Thrift.Collections.pas',
   Thrift.Server in '..\src\Thrift.Server.pas',
   Thrift.Stream in '..\src\Thrift.Stream.pas',
-  Thrift.Console in '..\src\Thrift.Console.pas',
   Thrift.TypeRegistry in '..\src\Thrift.TypeRegistry.pas',
   Thrift.Utils in '..\src\Thrift.Utils.pas';
 

--- a/lib/delphi/test/multiplexed/Multiplex.Server.Main.pas
+++ b/lib/delphi/test/multiplexed/Multiplex.Server.Main.pas
@@ -28,7 +28,6 @@ interface
 uses
   Windows, SysUtils,
   Generics.Collections,
-  Thrift.Console,
   Thrift.Server,
   Thrift.Transport,
   Thrift.Transport.Pipes,
@@ -41,6 +40,7 @@ uses
   Benchmark,  // in gen-delphi folder
   Aggr,       // in gen-delphi folder
   Multiplex.Test.Common,
+  ConsoleHelper,
   Contnrs;
 
 type

--- a/lib/delphi/test/multiplexed/Multiplex.Test.Client.dpr
+++ b/lib/delphi/test/multiplexed/Multiplex.Test.Client.dpr
@@ -34,7 +34,6 @@ uses
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.TypeRegistry in '..\..\src\Thrift.TypeRegistry.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas';
 

--- a/lib/delphi/test/multiplexed/Multiplex.Test.Server.dpr
+++ b/lib/delphi/test/multiplexed/Multiplex.Test.Server.dpr
@@ -24,6 +24,7 @@ program Multiplex.Test.Server;
 uses
   SysUtils,
   Multiplex.Server.Main in 'Multiplex.Server.Main.pas',
+  ConsoleHelper in '..\ConsoleHelper.pas',
   Thrift in '..\..\src\Thrift.pas',
   Thrift.Socket in '..\..\src\Thrift.Socket.pas',
   Thrift.Transport in '..\..\src\Thrift.Transport.pas',
@@ -33,7 +34,6 @@ uses
   Thrift.Processor.Multiplex in '..\..\src\Thrift.Processor.Multiplex.pas',
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas',
   Thrift.TypeRegistry in '..\..\src\Thrift.TypeRegistry.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas';

--- a/lib/delphi/test/serializer/TestSerializer.dpr
+++ b/lib/delphi/test/serializer/TestSerializer.dpr
@@ -30,7 +30,6 @@ uses
   Thrift.Protocol.JSON in '..\..\src\Thrift.Protocol.JSON.pas',
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas',
   Thrift.Serializer in '..\..\src\Thrift.Serializer.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas',

--- a/lib/delphi/test/server.dpr
+++ b/lib/delphi/test/server.dpr
@@ -37,7 +37,6 @@ uses
   Thrift.Processor.Multiplex in '..\src\Thrift.Processor.Multiplex.pas',
   Thrift.Collections in '..\src\Thrift.Collections.pas',
   Thrift.Server in '..\src\Thrift.Server.pas',
-  Thrift.Console in '..\src\Thrift.Console.pas',
   Thrift.TypeRegistry in '..\src\Thrift.TypeRegistry.pas',
   Thrift.Utils in '..\src\Thrift.Utils.pas',
   Thrift.Stream in '..\src\Thrift.Stream.pas';

--- a/lib/delphi/test/skip/skiptest_version1.dpr
+++ b/lib/delphi/test/skip/skiptest_version1.dpr
@@ -31,7 +31,6 @@ uses
   Thrift.Protocol.JSON in '..\..\src\Thrift.Protocol.JSON.pas',
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas',
   Thrift.TypeRegistry in '..\..\src\Thrift.TypeRegistry.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas';

--- a/lib/delphi/test/skip/skiptest_version2.dpr
+++ b/lib/delphi/test/skip/skiptest_version2.dpr
@@ -31,7 +31,6 @@ uses
   Thrift.Protocol.JSON in '..\..\src\Thrift.Protocol.JSON.pas',
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas',
   Thrift.TypeRegistry in '..\..\src\Thrift.TypeRegistry.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas';

--- a/lib/delphi/test/typeregistry/TestTypeRegistry.dpr
+++ b/lib/delphi/test/typeregistry/TestTypeRegistry.dpr
@@ -30,7 +30,6 @@ uses
   Thrift.Protocol.JSON in '..\..\src\Thrift.Protocol.JSON.pas',
   Thrift.Collections in '..\..\src\Thrift.Collections.pas',
   Thrift.Server in '..\..\src\Thrift.Server.pas',
-  Thrift.Console in '..\..\src\Thrift.Console.pas',
   Thrift.Utils in '..\..\src\Thrift.Utils.pas',
   Thrift.Serializer in '..\..\src\Thrift.Serializer.pas',
   Thrift.Stream in '..\..\src\Thrift.Stream.pas',


### PR DESCRIPTION
Client: Delphi
Patch: Jens Geyer