### PR TITLE
[nodejs] Fix issue with connection failures silently failing

### DIFF
--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -198,6 +198,31 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       self.transport.receiver(decodeCallback)(buf);
     });
   };
+
+  function decodeConnectionErrorCallback(transport_with_data) {
+    // grab metadata from initial call
+    // eg. function name (fname) and seqId
+    var proto = new self.protocol(transport_with_data);
+    var header = proto.readMessageBegin();
+    proto.readMessageEnd();
+
+    // set up the output listener
+    var output = new self.protocol(new self.transport(undefined, function(buf) {
+      self.transport.receiver(decodeCallback)(buf);
+    }));
+
+    // write to the output with a TApplicationException
+    var connectionErrorMsg = 'Connection error: ' + this.host + ':' + this.port;
+    var x = new thrift.TApplicationException(thrift.TApplicationExceptionType.PROTOCOL_ERROR, connectionErrorMsg);
+    output.writeMessageBegin(header.fname, thrift.MessageType.EXCEPTION, header.rseqid);
+    x.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  }
+
+  this.respondWithConnectionError = function(data, err) {
+    self.transport.receiver(decodeConnectionErrorCallback.bind(this))(data);
+  };
 };
 util.inherits(HttpConnection, EventEmitter);
 
@@ -215,6 +240,7 @@ HttpConnection.prototype.write = function(data) {
       https.request(self.nodeOptions, self.responseCallback) :
       http.request(self.nodeOptions, self.responseCallback);
   req.on('error', function(err) {
+    self.respondWithConnectionError(data, err);
     self.emit("error", err);
   });
   req.write(data);


### PR DESCRIPTION
In node, when a connection fails, the caller is not signaled the error, it simply hangs. This solution sends a generic `TApplicationException` with details on the unreachable service.

a connection failure is either:
1. Service is unreachable (firewall or the service is just simply not on)
2. During a service call, the service becomes unavailable

------------------

To replicate:
1. Setup a service with a single endpoint (don't start the service)
2. Setup a client that calls the service endpoint
3. Call the service endpoint from the client
4. An `ECONNREFUSED` error occurs
    -  Notice how the error is only emitted to the event loop, the calling process never gets the signal

Another way to replicate: 
1. Setup a service with a single endpoint
    - code the handler to simulate a long-running piece of work (eg. long-running database query)
    - can be accomplished using a `setTimeout(callback, 10000);` to simulate the long-running piece of work
2. Setup a client that calls the service endpoint
3. Call the service endpoint from the client
4. After 2 seconds, before the timeout, kill the service process
5. An `ECONNRESET` error occurs
    -  Notice how the error is only emitted to the event loop, the calling process never gets the signal

------------------

With the proposed fix, the callback receives the proper error, as well as the promise option.
