### PR TITLE
THRIFT-4495: Allow `undefined` for non-required Erlang records fields.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -810,6 +810,8 @@ void t_erl_generator::generate_erl_struct_member(ostream& out, t_field* tmember)
   if (has_default_value(tmember))
     out << " = " << render_member_value(tmember);
   out << " :: " << render_member_type(tmember);
+  if (tmember->get_req() != t_field::T_REQUIRED)
+    out << " | 'undefined'";
 }
 
 bool t_erl_generator::has_default_value(t_field* field) {


### PR DESCRIPTION
As of Erlang 19, the dialyzer static type-analysis tool no longer implicitly adds `undefined` to the allowed types for a field.  This means that dialyzer will now complain about any non-required fields that are not explicitly initialed when creating a new record.