### PR TITLE
THRIFT-4497: Use map() field type for Erlang type for map struct fields

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -717,7 +717,7 @@ string t_erl_generator::render_member_type(t_field* field) {
     return type_name(type) + "()";
   } else if (type->is_map()) {
     if (maps_) {
-      return "#{}";
+      return "map()";
     } else if (otp16_) {
       return "dict()";
     } else {


### PR DESCRIPTION
The Thrift Erlang code generator previously generated fields with the `#{}` Erlang type for maps fields.  In the Erlang type specification languages, however, `#{}` specifically means an empty map.  This commit fixes the code to emit `map()` instead, which means the maps keys and values may be of any type.

It would be possible to emit a field type such as `${keytype() => maptype()}`, but this commit does not do that.