### PR TITLE
Fix python build on Vagrant Windows boxes

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -31,7 +31,10 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 # Fix to build sdist under vagrant
 import os
 if 'vagrant' in str(os.environ):
-    del os.link
+    try:
+        del os.link
+    except AttributeError:
+        pass
 
 include_dirs = ['src']
 if sys.platform == 'win32':


### PR DESCRIPTION
Thrift is unable to execute setup.py under Vagrant Windows boxes as Windows version of os library doesn't have attribute link.