### PR TITLE
THRIFT-4513: Fixing java thrift compiler to generate constants in stable order.

### DIFF
--- a/compiler/cpp/src/thrift/audit/t_audit.cpp
+++ b/compiler/cpp/src/thrift/audit/t_audit.cpp
@@ -202,8 +202,8 @@ bool compare_defaults(t_const_value* newStructDefault, t_const_value* oldStructD
          }
       case t_const_value::CV_MAP:
          {
-            const std::map<t_const_value*, t_const_value*> newMap = newStructDefault->get_map();
-            const std::map<t_const_value*, t_const_value*> oldMap = oldStructDefault->get_map();
+            const std::map<t_const_value*, t_const_value*, t_const_value::value_compare> newMap = newStructDefault->get_map();
+            const std::map<t_const_value*, t_const_value*, t_const_value::value_compare> oldMap = oldStructDefault->get_map();
 
             bool defaultValuesCompare = (oldMap.size() == newMap.size());
 

--- a/compiler/cpp/src/thrift/generate/t_as3_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_as3_generator.cc
@@ -471,8 +471,8 @@ void t_as3_generator::print_const_value(std::ofstream& out,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     out << name << ":" << type_name(type) << " = new " << type_name(type, false, true) << "();"
         << endl;
     if (!in_static) {
@@ -516,8 +516,8 @@ void t_as3_generator::print_const_value(std::ofstream& out,
     }
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
       string val = render_const_value(out, name, vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -997,8 +997,8 @@ void t_c_glib_generator::generate_const_initializer(string name,
   if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     ostringstream initializers;
 
     // initialize any constants that may be referenced by this initializer
@@ -1171,8 +1171,8 @@ void t_c_glib_generator::generate_const_initializer(string name,
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     ostringstream initializers;
     ostringstream appenders;
 

--- a/compiler/cpp/src/thrift/generate/t_cl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cl_generator.cc
@@ -55,7 +55,7 @@ class t_cl_generator : public t_oop_generator {
     system_prefix = "thrift-gen-";
 
     std::map<std::string, std::string>::const_iterator iter;
-    
+
     for(iter = parsed_options.begin(); iter != parsed_options.end(); ++iter) {
       if(iter->first.compare("no_asd") == 0) {
         no_asd = true;
@@ -65,7 +65,7 @@ class t_cl_generator : public t_oop_generator {
         throw "unknown option cl:" + iter->first;
       }
     }
-    
+
     out_dir_base_ = "gen-cl";
     copy_options_ = option_string;
   }
@@ -112,7 +112,7 @@ class t_cl_generator : public t_oop_generator {
   std::ofstream f_vars_;
 
   std::string copy_options_;
-  
+
   bool no_asd;
   std::string system_prefix;
 };
@@ -310,8 +310,8 @@ string t_cl_generator::render_const_value(t_type* type, t_const_value* value) {
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
@@ -336,8 +336,8 @@ string t_cl_generator::render_const_value(t_type* type, t_const_value* value) {
     t_type* vtype = ((t_map*)type)->get_val_type();
     out << "(thrift:map ";
     indent_up();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       out << endl << indent()
           << "(cl:cons " << render_const_value(ktype, v_iter->first) << " "
@@ -494,7 +494,7 @@ string t_cl_generator::typespec(t_type *t) {
     return type_name(t);
   } else if (t->is_map()) {
     t_map *m = (t_map*) t;
-    return "(thrift:map " + typespec(m->get_key_type()) + " " + 
+    return "(thrift:map " + typespec(m->get_key_type()) + " " +
       typespec(m->get_val_type()) + ")";
   } else if (t->is_struct() || t->is_xception()) {
     return "(struct " + prefix(type_name(t)) + ")";
@@ -530,7 +530,7 @@ string t_cl_generator::argument_list(t_struct* tstruct) {
       typespec((*f_iter)->get_type()) << " " <<
       (*f_iter)->get_key() <<  ")";
 
-    
+
   }
   res << ")";
   return res.str();

--- a/compiler/cpp/src/thrift/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cocoa_generator.cc
@@ -2733,8 +2733,8 @@ void t_cocoa_generator::print_const_value(ostream& out,
     indent(out);
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     if (defval)
       out << type_name(type) << " ";
     out << name << " = [" << type_name(type, true) << " new];"
@@ -2758,8 +2758,8 @@ void t_cocoa_generator::print_const_value(ostream& out,
     indent(mapout);
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     if (defval)
       mapout << type_name(type) << " ";
     mapout << name << " = @{";
@@ -2904,8 +2904,8 @@ string t_cocoa_generator::render_const_value(string name,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     if (val.size() > 0)
       render << "[[" << type_name(type, true) << " alloc] initWith";
     else
@@ -2937,8 +2937,8 @@ string t_cocoa_generator::render_const_value(string name,
     render << "[[NSDictionary alloc] initWithObjectsAndKeys: ";
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     bool first = true;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(name, ktype, v_iter->first, true);

--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -703,8 +703,8 @@ void t_cpp_generator::print_const_value(ofstream& out,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     bool is_nonrequired_field = false;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
@@ -728,8 +728,8 @@ void t_cpp_generator::print_const_value(ofstream& out,
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
       string val = render_const_value(out, name, vtype, v_iter->second);
@@ -1796,7 +1796,7 @@ void t_cpp_generator::generate_service(t_service* tservice) {
     if (!gen_no_skeleton_) {
       generate_service_async_skeleton(tservice);
     }
-   
+
   }
 
   f_header_ << "#ifdef _MSC_VER\n"

--- a/compiler/cpp/src/thrift/generate/t_csharp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_csharp_generator.cc
@@ -511,8 +511,8 @@ void t_csharp_generator::print_const_def_value(std::ofstream& out,
   if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     prepare_member_name_mapping((t_struct*)type);
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_field* field = NULL;
@@ -532,8 +532,8 @@ void t_csharp_generator::print_const_def_value(std::ofstream& out,
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
       string val = render_const_value(out, name, vtype, v_iter->second);
@@ -988,7 +988,7 @@ void t_csharp_generator::generate_csharp_struct_reader(ofstream& out, t_struct* 
       indent_up();
       out << indent()
           << "throw new TProtocolException(TProtocolException.INVALID_DATA, "
-          << "\"required field " << prop_name((*f_iter)) << " not set\");" 
+          << "\"required field " << prop_name((*f_iter)) << " not set\");"
           << endl;
       indent_down();
     }

--- a/compiler/cpp/src/thrift/generate/t_d_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_d_generator.cc
@@ -557,8 +557,8 @@ private:
 
         const vector<t_field*>& fields = ((t_struct*)type)->get_members();
         vector<t_field*>::const_iterator f_iter;
-        const map<t_const_value*, t_const_value*>& val = value->get_map();
-        map<t_const_value*, t_const_value*>::const_iterator v_iter;
+        const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+        map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
         for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
           t_type* field_type = NULL;
           for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -576,8 +576,8 @@ private:
       } else if (type->is_map()) {
         t_type* ktype = ((t_map*)type)->get_key_type();
         t_type* vtype = ((t_map*)type)->get_val_type();
-        const map<t_const_value*, t_const_value*>& val = value->get_map();
-        map<t_const_value*, t_const_value*>::const_iterator v_iter;
+        const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+        map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
         for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
           string key = render_const_value(ktype, v_iter->first);
           string val = render_const_value(vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_dart_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_dart_generator.cc
@@ -594,8 +594,8 @@ void t_dart_generator::print_const_value(std::ofstream& out,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     out << type_name(type) << " " << name << " = new " << type_name(type) << "()";
     indent_up();
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
@@ -623,8 +623,8 @@ void t_dart_generator::print_const_value(std::ofstream& out,
 
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -430,7 +430,7 @@ void t_erl_generator::generate_const_function(t_const* tconst, ostringstream& ex
     exports << const_fun_name << "/1, " << const_fun_name << "/2";
 
     // Emit const function definition.
-    map<t_const_value*, t_const_value*>::const_iterator i, end = value->get_map().end();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator i, end = value->get_map().end();
     // The one-argument form throws an error if the key does not exist in the map.
     for (i = value->get_map().begin(); i != end;) {
       functions << const_fun_name << "(" << render_const_value(ktype, i->first) << ") -> "
@@ -590,8 +590,8 @@ string t_erl_generator::render_const_value(t_type* type, t_const_value* value) {
     out << "#" << type_name(type) << "{";
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     bool first = true;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
@@ -626,7 +626,7 @@ string t_erl_generator::render_const_value(t_type* type, t_const_value* value) {
     } else {
       out << "dict:from_list([";
     }
-    map<t_const_value*, t_const_value*>::const_iterator i, end = value->get_map().end();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator i, end = value->get_map().end();
     for (i = value->get_map().begin(); i != end;) {
       out << "{" << render_const_value(ktype, i->first) << ","
           << render_const_value(vtype, i->second) << "}";

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1097,8 +1097,8 @@ string t_go_generator::render_const_value(t_type* type, t_const_value* value, co
     indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
@@ -1123,10 +1123,10 @@ string t_go_generator::render_const_value(t_type* type, t_const_value* value, co
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
     out << "map[" << type_to_go_type(ktype) << "]" << type_to_go_type(vtype) << "{" << endl;
     indent_up();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       out << indent() << render_const_value(ktype, v_iter->first, name) << ": "

--- a/compiler/cpp/src/thrift/generate/t_gv_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_gv_generator.cc
@@ -249,8 +249,8 @@ void t_gv_generator::print_const_value(t_type* type, t_const_value* tvalue) {
     break;
   case t_const_value::CV_MAP: {
     f_out_ << "\\{ ";
-    map<t_const_value*, t_const_value*> map_elems = tvalue->get_map();
-    map<t_const_value*, t_const_value*>::iterator map_iter;
+    map<t_const_value*, t_const_value*, t_const_value::value_compare> map_elems = tvalue->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::iterator map_iter;
     for (map_iter = map_elems.begin(); map_iter != map_elems.end(); map_iter++) {
       if (!first) {
         f_out_ << ", ";

--- a/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
@@ -503,8 +503,8 @@ void t_haxe_generator::print_const_value(std::ofstream& out,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     out << name << ":" << type_name(type) << " = new " << type_name(type, false, true) << "();"
         << endl;
     if (!in_static) {
@@ -548,8 +548,8 @@ void t_haxe_generator::print_const_value(std::ofstream& out,
     }
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
       string val = render_const_value(out, name, vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_hs_generator.cc
@@ -424,10 +424,10 @@ string t_hs_generator::render_const_value(t_type* type, t_const_value* value) {
     out << "default_" << cname << "{";
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
 
     bool first = true;
-    for (map<t_const_value*, t_const_value*>::const_iterator v_iter = val.begin();
+    for (map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter = val.begin();
          v_iter != val.end();
          ++v_iter) {
       t_field* field = NULL;
@@ -458,8 +458,8 @@ string t_hs_generator::render_const_value(t_type* type, t_const_value* value) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     out << "(Map.fromList [";
 

--- a/compiler/cpp/src/thrift/generate/t_html_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_html_generator.cc
@@ -777,8 +777,8 @@ void t_html_generator::print_const_value(t_type* type, t_const_value* tvalue) {
     f_out_ << "{ ";
     const vector<t_field*>& fields = ((t_struct*)truetype)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = tvalue->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = tvalue->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -800,8 +800,8 @@ void t_html_generator::print_const_value(t_type* type, t_const_value* tvalue) {
     f_out_ << " }";
   } else if (truetype->is_map()) {
     f_out_ << "{ ";
-    map<t_const_value*, t_const_value*> map_elems = tvalue->get_map();
-    map<t_const_value*, t_const_value*>::iterator map_iter;
+    map<t_const_value*, t_const_value*, t_const_value::value_compare> map_elems = tvalue->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::iterator map_iter;
     for (map_iter = map_elems.begin(); map_iter != map_elems.end(); map_iter++) {
       if (!first) {
         f_out_ << ", ";

--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -596,6 +596,7 @@ void t_java_generator::generate_consts(std::vector<t_const*> consts) {
   f_consts.close();
 }
 
+
 /**
  * Prints the value of a constant with the given type. Note that type checking
  * is NOT performed in this function as it is always run beforehand using the
@@ -619,10 +620,12 @@ void t_java_generator::print_const_value(std::ofstream& out,
   } else if (type->is_enum()) {
     out << name << " = " << render_const_value(out, type, value) << ";" << endl << endl;
   } else if (type->is_struct() || type->is_xception()) {
-    const vector<t_field*>& fields = ((t_struct*)type)->get_members();
+    const vector<t_field*>& unsorted_fields = ((t_struct*)type)->get_members();
+    vector<t_field*> fields = unsorted_fields;
+    std::sort(fields.begin(), fields.end(), t_field::key_compare());
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     out << name << " = new " << type_name(type, false, true) << "();" << endl;
     if (!in_static) {
       indent(out) << "static {" << endl;
@@ -660,8 +663,8 @@ void t_java_generator::print_const_value(std::ofstream& out,
     }
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, ktype, v_iter->first);
       string val = render_const_value(out, vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_javame_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_javame_generator.cc
@@ -454,8 +454,8 @@ void t_javame_generator::print_const_value(std::ofstream& out,
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     out << name << " = new " << type_name(type, false, true) << "();" << endl;
     if (!in_static) {
       indent(out) << "static {" << endl;
@@ -489,8 +489,8 @@ void t_javame_generator::print_const_value(std::ofstream& out,
     }
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
       string val = render_const_value(out, name, vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -577,8 +577,8 @@ string t_js_generator::render_const_value(t_type* type, t_const_value* value) {
     indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -604,8 +604,8 @@ string t_js_generator::render_const_value(t_type* type, t_const_value* value) {
     out << "{" << endl;
     indent_up();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       if (v_iter != val.begin())
         out << "," << endl;

--- a/compiler/cpp/src/thrift/generate/t_json_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_json_generator.cc
@@ -510,8 +510,8 @@ void t_json_generator::write_const_value(t_const_value* value, bool should_force
 
   case t_const_value::CV_MAP: {
     start_object(NO_INDENT);
-    std::map<t_const_value*, t_const_value*> map = value->get_map();
-    std::map<t_const_value*, t_const_value*>::iterator mit;
+    std::map<t_const_value*, t_const_value*, t_const_value::value_compare> map = value->get_map();
+    std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::iterator mit;
     for (mit = map.begin(); mit != map.end(); ++mit) {
       write_comma_if_needed();
       f_json_ << indent();

--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -276,8 +276,8 @@ string t_lua_generator::render_const_value(t_type* type, t_const_value* value) {
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end();) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -308,8 +308,8 @@ string t_lua_generator::render_const_value(t_type* type, t_const_value* value) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end();) {
       indent(out) << "[" << render_const_value(ktype, v_iter->first)
                   << "] = " << render_const_value(vtype, v_iter->second);

--- a/compiler/cpp/src/thrift/generate/t_netcore_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netcore_generator.cc
@@ -44,7 +44,7 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
-//TODO: check for indentation 
+//TODO: check for indentation
 //TODO: Do we need seqId_ in generation?
 
 t_netcore_generator::t_netcore_generator(t_program* program, const map<string, string>& parsed_options, const string& option_string)
@@ -328,7 +328,7 @@ void t_netcore_generator::init_keywords()
     netcore_keywords["var"] = 1;
     netcore_keywords["where"] = 1;
     netcore_keywords["yield"] = 1;
-	
+
 	netcore_keywords["when"] = 1;
 }
 
@@ -400,7 +400,7 @@ void t_netcore_generator::generate_enum(t_enum* tenum)
 
     ofstream f_enum;
     f_enum.open(f_enum_name.c_str());
-    
+
 	generate_enum(f_enum, tenum);
 
     f_enum.close();
@@ -428,7 +428,7 @@ void t_netcore_generator::generate_enum(ofstream& out, t_enum* tenum)
 	}
 
 	scope_down(out);
-	end_netcore_namespace(out);	
+	end_netcore_namespace(out);
 }
 
 void t_netcore_generator::generate_consts(vector<t_const*> consts)
@@ -443,7 +443,7 @@ void t_netcore_generator::generate_consts(vector<t_const*> consts)
     f_consts.open(f_consts_name.c_str());
 
     generate_consts(f_consts, consts);
-    
+
     f_consts.close();
 }
 
@@ -487,15 +487,15 @@ void t_netcore_generator::print_const_def_value(ofstream& out, string name, t_ty
     if (type->is_struct() || type->is_xception())
     {
         const vector<t_field*>& fields = static_cast<t_struct*>(type)->get_members();
-        const map<t_const_value*, t_const_value*>& val = value->get_map();
+        const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
         vector<t_field*>::const_iterator f_iter;
-        map<t_const_value*, t_const_value*>::const_iterator v_iter;
+        map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
         prepare_member_name_mapping(static_cast<t_struct*>(type));
 
         for (v_iter = val.begin(); v_iter != val.end(); ++v_iter)
         {
             t_field* field = NULL;
-            
+
             for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter)
             {
                 if ((*f_iter)->get_name() == v_iter->first->get_string())
@@ -510,7 +510,7 @@ void t_netcore_generator::print_const_def_value(ofstream& out, string name, t_ty
             }
 
             t_type* field_type = field->get_type();
-            
+
             string val = render_const_value(out, name, field_type, v_iter->second);
             out << indent() << name << "." << prop_name(field) << " = " << val << ";" << endl;
         }
@@ -521,8 +521,8 @@ void t_netcore_generator::print_const_def_value(ofstream& out, string name, t_ty
     {
         t_type* ktype = static_cast<t_map*>(type)->get_key_type();
         t_type* vtype = static_cast<t_map*>(type)->get_val_type();
-        const map<t_const_value*, t_const_value*>& val = value->get_map();
-        map<t_const_value*, t_const_value*>::const_iterator v_iter;
+        const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+        map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
         for (v_iter = val.begin(); v_iter != val.end(); ++v_iter)
         {
             string key = render_const_value(out, name, ktype, v_iter->first);
@@ -723,7 +723,7 @@ void t_netcore_generator::generate_netcore_struct_definition(ofstream& out, t_st
 
     out << indent() << "public " << (is_final ? "sealed " : "") << "partial class " << sharp_struct_name << " : ";
 
-    if (is_exception) 
+    if (is_exception)
     {
         out << "TException, ";
     }
@@ -786,7 +786,7 @@ void t_netcore_generator::generate_netcore_struct_definition(ofstream& out, t_st
         out << indent() << "public struct Isset" << endl
             << indent() << "{" << endl;
         indent_up();
-        
+
         for (m_iter = members.begin(); m_iter != members.end(); ++m_iter)
         {
             bool is_required = field_is_required((*m_iter));
@@ -912,7 +912,7 @@ void t_netcore_generator::generate_netcore_struct_definition(ofstream& out, t_st
         generate_netcore_struct_hashcode(out, tstruct);
     }
     generate_netcore_struct_tostring(out, tstruct);
-    
+
     indent_down();
     out << indent() << "}" << endl << endl;
 
@@ -968,7 +968,7 @@ void t_netcore_generator::generate_netcore_struct_reader(ofstream& out, t_struct
         << indent() << "try" << endl
         << indent() << "{" << endl;
     indent_up();
-    
+
     const vector<t_field*>& fields = tstruct->get_members();
     vector<t_field*>::const_iterator f_iter;
 
@@ -981,7 +981,7 @@ void t_netcore_generator::generate_netcore_struct_reader(ofstream& out, t_struct
         }
     }
 
-    out << indent() << "TField field;" << endl 
+    out << indent() << "TField field;" << endl
         << indent() << "await iprot.ReadStructBeginAsync(cancellationToken);" << endl
         << indent() << "while (true)" << endl
         << indent() << "{" << endl;
@@ -996,7 +996,7 @@ void t_netcore_generator::generate_netcore_struct_reader(ofstream& out, t_struct
         << indent() << "switch (field.ID)" << endl
         << indent() << "{" << endl;
     indent_up();
-    
+
     for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter)
     {
         bool is_required = field_is_required(*f_iter);
@@ -1050,7 +1050,7 @@ void t_netcore_generator::generate_netcore_struct_reader(ofstream& out, t_struct
             out << indent() << "}" << endl;
         }
     }
-    
+
     indent_down();
     out << indent() << "}" << endl;
     out << indent() << "finally" << endl
@@ -1147,7 +1147,7 @@ void t_netcore_generator::generate_netcore_struct_result_writer(ofstream& out, t
     indent_up();
 
     out << indent() << "oprot.IncrementRecursionDepth();" << endl
-        << indent() << "try" << endl 
+        << indent() << "try" << endl
         << indent() << "{" << endl;
     indent_up();
 
@@ -1333,7 +1333,7 @@ void t_netcore_generator::generate_netcore_union(t_struct* tunion)
     generate_netcore_union_definition(f_union, tunion);
 
     f_union.close();
-    
+
     indent_validate(ic, "generate_netcore_union.");
 }
 
@@ -1720,7 +1720,7 @@ void t_netcore_generator::generate_service_client(ofstream& out, t_service* tser
                 << indent() << "throw x;" << endl;
             indent_down();
 
-            out << indent() << "}" << endl 
+            out << indent() << "}" << endl
                 << endl
                 << indent() << "var result = new " << resultname << "();" << endl
                 << indent() << "await result.ReadAsync(InputProtocol, cancellationToken);" << endl
@@ -1741,7 +1741,7 @@ void t_netcore_generator::generate_service_client(ofstream& out, t_service* tser
                     }
                     else
                     {
-                        out << indent() << "if (result.Success.HasValue)" << endl 
+                        out << indent() << "if (result.Success.HasValue)" << endl
                             << indent() << "{" << endl;
                         indent_up();
                         out << indent() << "return result.Success.Value;" << endl;
@@ -1827,7 +1827,7 @@ void t_netcore_generator::generate_service_server(ofstream& out, t_service* tser
 
     indent_up();
 
-    out << indent() << "private IAsync _iAsync;" << endl 
+    out << indent() << "private IAsync _iAsync;" << endl
         << endl
         << indent() << "public AsyncProcessor(IAsync iAsync)";
 
@@ -1839,7 +1839,7 @@ void t_netcore_generator::generate_service_server(ofstream& out, t_service* tser
     out << endl
         << indent() << "{" << endl;
     indent_up();
-    
+
     out << indent() << "if (iAsync == null) throw new ArgumentNullException(nameof(iAsync));" << endl
         << endl
         << indent() << "_iAsync = iAsync;" << endl;
@@ -1965,7 +1965,7 @@ void t_netcore_generator::generate_function_helpers(ofstream& out, t_function* t
 void t_netcore_generator::generate_process_function_async(ofstream& out, t_service* tservice, t_function* tfunction)
 {
     (void)tservice;
-    out << indent() << "public async Task " << tfunction->get_name() 
+    out << indent() << "public async Task " << tfunction->get_name()
         << "_ProcessAsync(int seqid, TProtocol iprot, TProtocol oprot, CancellationToken cancellationToken)" << endl
         << indent() << "{" << endl;
     indent_up();
@@ -2029,7 +2029,7 @@ void t_netcore_generator::generate_process_function_async(ofstream& out, t_servi
     }
 
     cleanup_member_name_mapping(arg_struct);
-    
+
     if (!first)
     {
         out << ", ";
@@ -2044,7 +2044,7 @@ void t_netcore_generator::generate_process_function_async(ofstream& out, t_servi
     {
         indent_down();
         out << indent() << "}" << endl;
-        
+
         for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter)
         {
             out << indent() << "catch (" << type_name((*x_iter)->get_type(), false, false) << " " << (*x_iter)->get_name() << ")" << endl
@@ -2062,7 +2062,7 @@ void t_netcore_generator::generate_process_function_async(ofstream& out, t_servi
 
     if (!tfunction->is_oneway())
     {
-        out << indent() << "await oprot.WriteMessageBeginAsync(new TMessage(\"" 
+        out << indent() << "await oprot.WriteMessageBeginAsync(new TMessage(\""
                 << correct_function_name_for_async(tfunction->get_name()) << "\", TMessageType.Reply, seqid), cancellationToken); " << endl
             << indent() << "await result.WriteAsync(oprot, cancellationToken);" << endl;
     }
@@ -2274,7 +2274,7 @@ void t_netcore_generator::generate_deserialize_struct(ofstream& out, t_struct* t
     }
     else
     {
-        out << indent() << prefix << " = new " << type_name(tstruct) << "();" << endl 
+        out << indent() << prefix << " = new " << type_name(tstruct) << "();" << endl
             << indent() << "await " << prefix << ".ReadAsync(iprot, cancellationToken);" << endl;
     }
 }
@@ -3074,17 +3074,17 @@ void t_netcore_generator::docstring_comment(ofstream& out, const string& comment
 
     stringstream docs(contents, std::ios_base::in);
 
-    while (!(docs.eof() || docs.fail())) 
+    while (!(docs.eof() || docs.fail()))
     {
         char line[1024];
         docs.getline(line, 1024);
 
         // Just prnt a newline when the line & prefix are empty.
-        if (strlen(line) == 0 && line_prefix == "" && !docs.eof()) 
+        if (strlen(line) == 0 && line_prefix == "" && !docs.eof())
         {
             out << endl;
         }
-        else if (strlen(line) > 0 || !docs.eof()) 
+        else if (strlen(line) > 0 || !docs.eof())
         { // skip the empty last line
             out << indent() << line_prefix << line << endl;
         }

--- a/compiler/cpp/src/thrift/generate/t_ocaml_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_ocaml_generator.cc
@@ -401,8 +401,8 @@ string t_ocaml_generator::render_const_value(t_type* type, t_const_value* value)
     indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -425,8 +425,8 @@ string t_ocaml_generator::render_const_value(t_type* type, t_const_value* value)
   } else if (type->is_map()) {
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     string hm = tmp("_hm");
     out << endl;
     indent_up();

--- a/compiler/cpp/src/thrift/generate/t_perl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_perl_generator.cc
@@ -359,8 +359,8 @@ string t_perl_generator::render_const_value(t_type* type, t_const_value* value) 
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -385,8 +385,8 @@ string t_perl_generator::render_const_value(t_type* type, t_const_value* value) 
     out << "{" << endl;
     indent_up();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       indent(out) << render_const_value(ktype, v_iter->first);
       out << " => ";

--- a/compiler/cpp/src/thrift/generate/t_php_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_php_generator.cc
@@ -642,8 +642,8 @@ string t_php_generator::render_const_value(t_type* type, t_const_value* value) {
     indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -667,8 +667,8 @@ string t_php_generator::render_const_value(t_type* type, t_const_value* value) {
     t_type* vtype = ((t_map*)type)->get_val_type();
     out << "array(" << endl;
     indent_up();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       out << indent();
       out << render_const_value(ktype, v_iter->first);

--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -556,8 +556,8 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
     indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -581,8 +581,8 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
     }
     out << "{" << endl;
     indent_up();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       indent(out) << render_const_value(ktype, v_iter->first) << ": "
           << render_const_value(vtype, v_iter->second) << "," << endl;

--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -455,8 +455,8 @@ t_rb_ofstream& t_rb_generator::render_const_value(t_rb_ofstream& out,
     out.indent_up();
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
       for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -478,8 +478,8 @@ t_rb_ofstream& t_rb_generator::render_const_value(t_rb_ofstream& out,
     t_type* vtype = ((t_map*)type)->get_val_type();
     out << "{" << endl;
     out.indent_up();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       out.indent();
       render_const_value(out, ktype, v_iter->first) << " => ";

--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -781,8 +781,8 @@ void t_rs_generator::render_const_map(t_type* ttype, t_const_value* tvalue) {
     << to_rust_type(key_type) << ", " << to_rust_type(val_type)
     << "> = BTreeMap::new();"
     << endl;
-  const map<t_const_value*, t_const_value*>& elems = tvalue->get_map();
-  map<t_const_value*, t_const_value*>::const_iterator elem_iter;
+  const map<t_const_value*, t_const_value*, t_const_value::value_compare>& elems = tvalue->get_map();
+  map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator elem_iter;
   for (elem_iter = elems.begin(); elem_iter != elems.end(); ++elem_iter) {
     t_const_value* key_value = elem_iter->first;
     t_const_value* val_value = elem_iter->second;

--- a/compiler/cpp/src/thrift/generate/t_st_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_st_generator.cc
@@ -402,8 +402,8 @@ string t_st_generator::render_const_value(t_type* type, t_const_value* value) {
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       t_type* field_type = NULL;
@@ -428,8 +428,8 @@ string t_st_generator::render_const_value(t_type* type, t_const_value* value) {
     out << "(Dictionary new" << endl;
     indent_up();
     indent_up();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       out << indent() << indent();
       out << "at: " << render_const_value(ktype, v_iter->first);

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1900,8 +1900,8 @@ void t_swift_generator::render_const_value(ostream& out,
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (f_iter = fields.begin(); f_iter != fields.end();) {
       t_field* tfield = *f_iter;
@@ -1934,8 +1934,8 @@ void t_swift_generator::render_const_value(ostream& out,
     t_type* ktype = ((t_map*)type)->get_key_type();
     t_type* vtype = ((t_map*)type)->get_val_type();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end();) {
 
@@ -1956,8 +1956,8 @@ void t_swift_generator::render_const_value(ostream& out,
 
     t_type* etype = ((t_list*)type)->get_elem_type();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end();) {
 
@@ -1976,8 +1976,8 @@ void t_swift_generator::render_const_value(ostream& out,
 
     t_type* etype = ((t_set*)type)->get_elem_type();
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
     for (v_iter = val.begin(); v_iter != val.end();) {
 

--- a/compiler/cpp/src/thrift/generate/t_xml_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_xml_generator.cc
@@ -483,8 +483,8 @@ void t_xml_generator::write_const_value(t_const_value* value) {
 
   case t_const_value::CV_MAP: {
     write_element_start("map");
-    std::map<t_const_value*, t_const_value*> map = value->get_map();
-    std::map<t_const_value*, t_const_value*>::iterator mit;
+    std::map<t_const_value*, t_const_value*, t_const_value::value_compare> map = value->get_map();
+    std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::iterator mit;
     for (mit = map.begin(); mit != map.end(); ++mit) {
       write_element_start("entry");
       write_element_start("key");

--- a/compiler/cpp/src/thrift/main.cc
+++ b/compiler/cpp/src/thrift/main.cc
@@ -805,8 +805,8 @@ void validate_const_rec(std::string name, t_type* type, t_const_value* value) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
 
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       if (v_iter->first->get_type() != t_const_value::CV_STRING) {
         throw "type error: " + name + " struct key must be string";
@@ -826,8 +826,8 @@ void validate_const_rec(std::string name, t_type* type, t_const_value* value) {
   } else if (type->is_map()) {
     t_type* k_type = ((t_map*)type)->get_key_type();
     t_type* v_type = ((t_map*)type)->get_val_type();
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
+    const map<t_const_value*, t_const_value*, t_const_value::value_compare>& val = value->get_map();
+    map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       validate_const_rec(name + "<key>", k_type, v_iter->first);
       validate_const_rec(name + "<val>", v_type, v_iter->second);

--- a/compiler/cpp/src/thrift/parse/t_const_value.h
+++ b/compiler/cpp/src/thrift/parse/t_const_value.h
@@ -38,6 +38,17 @@ void convert(From*, To&);
  */
 class t_const_value {
 public:
+  /**
+   * Comparator to sort fields in ascending order by key.
+   * Make this a functor instead of a function to help GCC inline it.
+   */
+  struct value_compare {
+  public:
+    bool operator()(t_const_value const* const& left, t_const_value const* const& right) const {
+      return *left < *right;
+    }
+  };
+
   enum t_const_value_type { CV_INTEGER, CV_DOUBLE, CV_STRING, CV_MAP, CV_LIST, CV_IDENTIFIER, CV_UNKNOWN };
 
   t_const_value() : intVal_(0), doubleVal_(0.0f), enum_((t_enum*)0), valType_(CV_UNKNOWN) {}
@@ -90,7 +101,7 @@ public:
 
   void add_map(t_const_value* key, t_const_value* val) { mapVal_[key] = val; }
 
-  const std::map<t_const_value*, t_const_value*>& get_map() const { return mapVal_; }
+  const std::map<t_const_value*, t_const_value*, t_const_value::value_compare>& get_map() const { return mapVal_; }
 
   void set_list() { valType_ = CV_LIST; }
 
@@ -136,8 +147,55 @@ public:
 
   t_const_value_type get_type() const { if (valType_ == CV_UNKNOWN) { throw std::string("unknown t_const_value"); } return valType_; }
 
+  /**
+   * Comparator to sort map fields in ascending order by key and then value.
+   * This is used for map comparison in lexicographic order.
+   */
+  struct map_entry_compare {
+  private:
+    typedef std::pair<t_const_value*, t_const_value*> ConstPair;
+  public:
+    bool operator()(ConstPair left, ConstPair right) const {
+      if (*(left.first) < *(right.first)) {
+        return true;
+      } else {
+        if (right.first < left.first) {
+          return *(left.second) < *(right.second);
+        } else {
+          return false;
+        }
+      }
+    }
+  };
+
+  bool operator < (const t_const_value& that) const {
+    ::t_const_value::t_const_value_type t1 = get_type();
+    ::t_const_value::t_const_value_type t2 = that.get_type();
+    if (t1 != t2)
+      return t1 < t2;
+    switch (t1) {
+    case ::t_const_value::CV_INTEGER:
+      return intVal_ < that.intVal_;
+    case ::t_const_value::CV_DOUBLE:
+      return doubleVal_ < that.doubleVal_;
+    case ::t_const_value::CV_STRING:
+      return stringVal_ < that.stringVal_;
+    case ::t_const_value::CV_IDENTIFIER:
+      return identifierVal_ < that.identifierVal_;
+    case ::t_const_value::CV_MAP:
+      return std::lexicographical_compare(
+          mapVal_.begin(), mapVal_.end(), that.mapVal_.begin(), that.mapVal_.end(), map_entry_compare());
+    case ::t_const_value::CV_LIST:
+      return std::lexicographical_compare(
+          listVal_.begin(), listVal_.end(), that.listVal_.begin(), that.listVal_.end(), value_compare());
+    case ::t_const_value::CV_UNKNOWN:
+    default:
+      throw "unknown value type";
+    }
+  }
+
 private:
-  std::map<t_const_value*, t_const_value*> mapVal_;
+  std::map<t_const_value*, t_const_value*, value_compare> mapVal_;
   std::vector<t_const_value*> listVal_;
   std::string stringVal_;
   int64_t intVal_;

--- a/compiler/cpp/src/thrift/parse/t_scope.h
+++ b/compiler/cpp/src/thrift/parse/t_scope.h
@@ -76,8 +76,8 @@ public:
 
   void resolve_const_value(t_const_value* const_val, t_type* ttype) {
     if (ttype->is_map()) {
-      const std::map<t_const_value*, t_const_value*>& map = const_val->get_map();
-      std::map<t_const_value*, t_const_value*>::const_iterator v_iter;
+      const std::map<t_const_value*, t_const_value*, t_const_value::value_compare>& map = const_val->get_map();
+      std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
       for (v_iter = map.begin(); v_iter != map.end(); ++v_iter) {
         resolve_const_value(v_iter->first, ((t_map*)ttype)->get_key_type());
         resolve_const_value(v_iter->second, ((t_map*)ttype)->get_val_type());
@@ -96,8 +96,8 @@ public:
       }
     } else if (ttype->is_struct()) {
       t_struct* tstruct = (t_struct*)ttype;
-      const std::map<t_const_value*, t_const_value*>& map = const_val->get_map();
-      std::map<t_const_value*, t_const_value*>::const_iterator v_iter;
+      const std::map<t_const_value*, t_const_value*, t_const_value::value_compare>& map = const_val->get_map();
+      std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
       for (v_iter = map.begin(); v_iter != map.end(); ++v_iter) {
         t_field* field = tstruct->get_field_by_name(v_iter->first->get_string());
         if (field == NULL) {
@@ -137,8 +137,8 @@ public:
             throw "Constants cannot be of type VOID";
           }
         } else if (const_type->is_map()) {
-          const std::map<t_const_value*, t_const_value*>& map = constant->get_value()->get_map();
-          std::map<t_const_value*, t_const_value*>::const_iterator v_iter;
+          const std::map<t_const_value*, t_const_value*, t_const_value::value_compare>& map = constant->get_value()->get_map();
+          std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
 
           const_val->set_map();
           for (v_iter = map.begin(); v_iter != map.end(); ++v_iter) {

--- a/compiler/cpp/test/plugin/conversion_test.cc
+++ b/compiler/cpp/test/plugin/conversion_test.cc
@@ -277,12 +277,12 @@ void test_const_value(t_const_value* sut) {
     BOOST_CHECK_EQUAL(sut->get_map().size(), sut2->get_map().size());
     {
       std::map<t_const_value::t_const_value_type, t_const_value::t_const_value_type> sut_values;
-      for (std::map<t_const_value*, t_const_value*>::const_iterator it = sut->get_map().begin();
+      for (std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator it = sut->get_map().begin();
            it != sut->get_map().end(); it++) {
         sut_values[it->first->get_type()] = it->second->get_type();
       }
       std::map<t_const_value::t_const_value_type, t_const_value::t_const_value_type> sut2_values;
-      for (std::map<t_const_value*, t_const_value*>::const_iterator it = sut2->get_map().begin();
+      for (std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator it = sut2->get_map().begin();
            it != sut2->get_map().end(); it++) {
         sut2_values[it->first->get_type()] = it->second->get_type();
       }


### PR DESCRIPTION
For description of the issue fixed, see: https://issues.apache.org/jira/browse/THRIFT-4513