### PR TITLE
THRIFT-4358: add unix domain socket option to ruby cross tests

### DIFF
--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -369,11 +369,19 @@ module Thrift
         read_list_end
       end
     end
+    
+    def to_s
+      "#{trans.to_s}"
+    end
   end
 
   class BaseProtocolFactory
     def get_protocol(trans)
       raise NotImplementedError
+    end
+    
+    def to_s
+      "base"
     end
   end
 end

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -226,12 +226,19 @@ module Thrift
       size = read_i32
       trans.read_all(size)
     end
-
+    
+    def to_s
+      "binary(#{super.to_s})"
+    end
   end
 
   class BinaryProtocolFactory < BaseProtocolFactory
     def get_protocol(trans)
       return Thrift::BinaryProtocol.new(trans)
+    end
+    
+    def to_s
+      "binary"
     end
   end
 end

--- a/lib/rb/lib/thrift/protocol/binary_protocol_accelerated.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol_accelerated.rb
@@ -35,5 +35,13 @@ module Thrift
         BinaryProtocol.new(trans)
       end
     end
+
+    def to_s
+      if (defined? BinaryProtocolAccelerated)
+        "binary-accel"
+      else
+        "binary"
+      end
+    end
   end
 end

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -345,6 +345,10 @@ module Thrift
       size = read_varint32()
       trans.read_all(size)
     end
+    
+    def to_s
+      "compact(#{super.to_s})"
+    end
 
     private
     
@@ -430,6 +434,10 @@ module Thrift
   class CompactProtocolFactory < BaseProtocolFactory
     def get_protocol(trans)
       CompactProtocol.new(trans)
+    end
+    
+    def to_s
+      "compact"
     end
   end
 end

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -768,11 +768,19 @@ module Thrift
     def read_binary
       read_json_base64
     end
+
+    def to_s
+      "json(#{super.to_s})"
+    end
   end
 
   class JsonProtocolFactory < BaseProtocolFactory
     def get_protocol(trans)
       return Thrift::JsonProtocol.new(trans)
+    end
+
+    def to_s
+      "json"
     end
   end
 end

--- a/lib/rb/lib/thrift/protocol/multiplexed_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/multiplexed_protocol.rb
@@ -36,5 +36,9 @@ module Thrift
         @protocol.write_message_begin(name, type, seqid)
       end 
     end
+    
+    def to_s
+      "multiplexed(#{@service_name=@protocol.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/server/base_server.rb
+++ b/lib/rb/lib/thrift/server/base_server.rb
@@ -26,6 +26,12 @@ module Thrift
       @protocol_factory = protocol_factory ? protocol_factory : Thrift::BinaryProtocolFactory.new
     end
 
-    def serve; nil; end
+    def serve
+      raise NotImplementedError
+    end
+
+    def to_s
+      "server(#{@protocol_factory.to_s}(#{@transport_factory.to_s}(#{@server_transport.to_s})))"
+    end
   end
 end

--- a/lib/rb/lib/thrift/server/simple_server.rb
+++ b/lib/rb/lib/thrift/server/simple_server.rb
@@ -39,5 +39,9 @@ module Thrift
         @server_transport.close
       end
     end
+    
+    def to_s
+      "simple(#{super.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/server/thread_pool_server.rb
+++ b/lib/rb/lib/thrift/server/thread_pool_server.rb
@@ -71,5 +71,9 @@ module Thrift
         @server_transport.close
       end
     end
+    
+    def to_s
+      "threadpool(#{super.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/server/threaded_server.rb
+++ b/lib/rb/lib/thrift/server/threaded_server.rb
@@ -43,5 +43,9 @@ module Thrift
         @server_transport.close
       end
     end
+    
+    def to_s
+      "threaded(#{super.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/base_transport.rb
+++ b/lib/rb/lib/thrift/transport/base_transport.rb
@@ -99,11 +99,19 @@ module Thrift
     alias_method :<<, :write
 
     def flush; end
+
+    def to_s
+      "base"
+    end
   end
   
   class BaseTransportFactory
     def get_transport(trans)
       return trans
+    end
+    
+    def to_s
+      "base"
     end
   end
 end

--- a/lib/rb/lib/thrift/transport/buffered_transport.rb
+++ b/lib/rb/lib/thrift/transport/buffered_transport.rb
@@ -104,11 +104,19 @@ module Thrift
       
       @transport.flush
     end
+
+    def to_s
+      "buffered(#{@transport.to_s})"
+    end
   end
 
   class BufferedTransportFactory < BaseTransportFactory
     def get_transport(transport)
       return BufferedTransport.new(transport)
+    end
+    
+    def to_s
+      "buffered"
     end
   end
 end

--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -99,6 +99,10 @@ module Thrift
       @wbuf = Bytes.empty_byte_buffer
     end
 
+    def to_s
+      "framed(#{@transport.to_s})"
+    end
+
     private
 
     def read_frame
@@ -112,6 +116,10 @@ module Thrift
   class FramedTransportFactory < BaseTransportFactory
     def get_transport(transport)
       return FramedTransport.new(transport)
+    end
+    
+    def to_s
+      "framed"
     end
   end
 end

--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -53,5 +53,9 @@ module Thrift
     ensure
       @outbuf = Bytes.empty_byte_buffer
     end
+    
+    def to_s
+      "@{self.url}"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/io_stream_transport.rb
+++ b/lib/rb/lib/thrift/transport/io_stream_transport.rb
@@ -35,5 +35,8 @@ module Thrift
     def write(buf); @output.write(Bytes.force_binary_encoding(buf)) end
     def close; @input.close; @output.close end
     def to_io; @input end # we're assuming this is used in a IO.select for reading
+    def to_s
+      "iostream(input=#{@input.to_s},output=#{@output.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -121,5 +121,9 @@ module Thrift
       end
       out.join(" ")
     end
+    
+    def to_s
+      "memory"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/server_socket.rb
+++ b/lib/rb/lib/thrift/transport/server_socket.rb
@@ -59,5 +59,10 @@ module Thrift
     end
 
     alias to_io handle
+
+    def to_s
+      "socket(#{@host}:#{@port})"
+    end
+
   end
 end

--- a/lib/rb/lib/thrift/transport/socket.rb
+++ b/lib/rb/lib/thrift/transport/socket.rb
@@ -134,8 +134,10 @@ module Thrift
       @handle = nil
     end
 
-    def to_io
-      @handle
+    alias to_io handle
+
+    def to_s
+      "socket(#{@host}:#{@port})"
     end
   end
 end

--- a/lib/rb/lib/thrift/transport/ssl_server_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_server_socket.rb
@@ -33,5 +33,9 @@ module Thrift
       socket = TCPServer.new(@host, @port)
       @handle = OpenSSL::SSL::SSLServer.new(socket, @ssl_context)
     end
+    
+    def to_s
+      "ssl(#{super.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/ssl_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_socket.rb
@@ -43,5 +43,9 @@ module Thrift
         raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}: #{e}")
       end
     end
+    
+    def to_s
+      "ssl(#{super.to_s})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/unix_server_socket.rb
+++ b/lib/rb/lib/thrift/transport/unix_server_socket.rb
@@ -56,5 +56,9 @@ module Thrift
     end
 
     alias to_io handle
+
+    def to_s
+      "domain(#{@path})"
+    end
   end
 end

--- a/lib/rb/lib/thrift/transport/unix_socket.rb
+++ b/lib/rb/lib/thrift/transport/unix_socket.rb
@@ -36,5 +36,9 @@ module Thrift
         raise TransportException.new(TransportException::NOT_OPEN, "Could not open UNIX socket at #{@path}")
       end
     end
+    
+    def to_s
+      "domain(#{@path})"
+    end
   end
 end

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -29,6 +29,11 @@ describe 'BaseProtocol' do
   describe Thrift::BaseProtocol do
     # most of the methods are stubs, so we can ignore them
 
+    it "should provide a reasonable to_s" do
+      @trans.should_receive(:to_s).once.and_return("trans")
+      @prot.to_s.should == "trans"
+    end
+
     it "should make trans accessible" do
       @prot.trans.should eql(@trans)
     end
@@ -212,6 +217,10 @@ describe 'BaseProtocol' do
     it "should raise NotImplementedError" do
       # returning nil since Protocol is just an abstract class
       lambda {Thrift::BaseProtocolFactory.new.get_protocol(mock("MockTransport"))}.should raise_error(NotImplementedError)
+    end
+
+    it "should provide a reasonable to_s" do
+      Thrift::BaseProtocolFactory.new.to_s.should == "base"
     end
   end
 end

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -48,6 +48,10 @@ describe 'BaseTransport' do
     it "should alias << to write" do
       Thrift::BaseTransport.instance_method(:<<).should == Thrift::BaseTransport.instance_method(:write)
     end
+    
+    it "should provide a reasonable to_s" do
+      Thrift::BaseTransport.new.to_s.should == "base"
+    end
   end
 
   describe Thrift::BaseServerTransport do
@@ -63,9 +67,19 @@ describe 'BaseTransport' do
       transport = mock("Transport")
       Thrift::BaseTransportFactory.new.get_transport(transport).should eql(transport)
     end
+    
+    it "should provide a reasonable to_s" do
+      Thrift::BaseTransportFactory.new.to_s.should == "base"
+    end
   end
 
   describe Thrift::BufferedTransport do
+    it "should provide a to_s that describes the encapsulation" do
+      trans = mock("Transport")
+      trans.should_receive(:to_s).and_return("mock")
+      Thrift::BufferedTransport.new(trans).to_s.should == "buffered(mock)"
+    end
+
     it "should pass through everything but write/flush/read" do
       trans = mock("Transport")
       trans.should_receive(:open?).ordered.and_return("+ open?")
@@ -135,11 +149,21 @@ describe 'BaseTransport' do
       Thrift::BufferedTransport.should_receive(:new).with(trans).and_return(btrans)
       Thrift::BufferedTransportFactory.new.get_transport(trans).should == btrans
     end
+    
+    it "should provide a reasonable to_s" do
+      Thrift::BufferedTransportFactory.new.to_s.should == "buffered"
+    end
   end
 
   describe Thrift::FramedTransport do
     before(:each) do
       @trans = mock("Transport")
+    end
+
+    it "should provide a to_s that describes the encapsulation" do
+      trans = mock("Transport")
+      trans.should_receive(:to_s).and_return("mock")
+      Thrift::FramedTransport.new(trans).to_s.should == "framed(mock)"
     end
 
     it "should pass through open?/open/close" do
@@ -247,11 +271,19 @@ describe 'BaseTransport' do
       Thrift::FramedTransport.should_receive(:new).with(trans)
       Thrift::FramedTransportFactory.new.get_transport(trans)
     end
+    
+    it "should provide a reasonable to_s" do
+      Thrift::FramedTransportFactory.new.to_s.should == "framed"
+    end
   end
 
   describe Thrift::MemoryBufferTransport do
     before(:each) do
       @buffer = Thrift::MemoryBufferTransport.new
+    end
+
+    it "should provide a reasonable to_s" do
+      @buffer.to_s.should == "memory"
     end
 
     it "should accept a buffer on input and use it directly" do
@@ -321,6 +353,12 @@ describe 'BaseTransport' do
       @input = mock("Input", :closed? => false)
       @output = mock("Output", :closed? => false)
       @trans = Thrift::IOStreamTransport.new(@input, @output)
+    end
+
+    it "should provide a reasonable to_s" do
+      @input.should_receive(:to_s).and_return("mock_input")
+      @output.should_receive(:to_s).and_return("mock_output")
+      @trans.to_s.should == "iostream(input=mock_input,output=mock_output)"
     end
 
     it "should be open as long as both input or output are open" do

--- a/lib/rb/spec/binary_protocol_accelerated_spec.rb
+++ b/lib/rb/spec/binary_protocol_accelerated_spec.rb
@@ -35,6 +35,10 @@ if defined? Thrift::BinaryProtocolAccelerated
       it "should create a BinaryProtocolAccelerated" do
         Thrift::BinaryProtocolAcceleratedFactory.new.get_protocol(mock("MockTransport")).should be_instance_of(Thrift::BinaryProtocolAccelerated)
       end
+
+      it "should provide a reasonable to_s" do
+        Thrift::BinaryProtocolAcceleratedFactory.new.to_s.should == "binary-accel"
+      end
     end
   end
 else

--- a/lib/rb/spec/binary_protocol_spec.rb
+++ b/lib/rb/spec/binary_protocol_spec.rb
@@ -56,11 +56,19 @@ describe 'BinaryProtocol' do
         e.type == Thrift::ProtocolException::BAD_VERSION
       end
     end
+
+    it "should provide a reasonable to_s" do
+      @prot.to_s.should == "binary(memory)"
+    end
   end
 
   describe Thrift::BinaryProtocolFactory do
     it "should create a BinaryProtocol" do
       Thrift::BinaryProtocolFactory.new.get_protocol(mock("MockTransport")).should be_instance_of(Thrift::BinaryProtocol)
+    end
+
+    it "should provide a reasonable to_s" do
+      Thrift::BinaryProtocolFactory.new.to_s.should == "binary"
     end
   end
 end

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -127,6 +127,11 @@ describe Thrift::CompactProtocol do
     struct.should == struct2
   end
   
+  it "should provide a reasonable to_s" do
+    trans = Thrift::MemoryBufferTransport.new
+    Thrift::CompactProtocol.new(trans).to_s.should == "compact(memory)"
+  end
+  
   class JankyHandler
     def Janky(i32arg)
       i32arg * 2
@@ -139,5 +144,15 @@ describe Thrift::CompactProtocol do
   
   def reader(sym)
     "read_#{sym.to_s}"
+  end
+end
+
+describe Thrift::CompactProtocolFactory do
+  it "should create a CompactProtocol" do
+    Thrift::CompactProtocolFactory.new.get_protocol(mock("MockTransport")).should be_instance_of(Thrift::CompactProtocol)
+  end
+
+  it "should provide a reasonable to_s" do
+    Thrift::CompactProtocolFactory.new.to_s.should == "compact"
   end
 end

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -25,6 +25,10 @@ describe 'Thrift::HTTPClientTransport' do
     before(:each) do
       @client = Thrift::HTTPClientTransport.new("http://my.domain.com/path/to/service?param=value")
     end
+    
+    it "should provide a reasonable to_s" do
+      @client.to_s == "http://my.domain.com/path/to/service?param=value"
+    end
 
     it "should always be open" do
       @client.should be_open

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -534,11 +534,19 @@ describe 'JsonProtocol' do
       @trans.write("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==\"")
       @prot.read_binary.bytes.to_a.should == (0...256).to_a
     end
+  
+    it "should provide a reasonable to_s" do
+      @prot.to_s.should == "json(memory)"
+    end
   end
 
   describe Thrift::JsonProtocolFactory do
     it "should create a JsonProtocol" do
       Thrift::JsonProtocolFactory.new.get_protocol(mock("MockTransport")).should be_instance_of(Thrift::JsonProtocol)
+    end
+
+    it "should provide a reasonable to_s" do
+      Thrift::JsonProtocolFactory.new.to_s.should == "json"
     end
   end
 end

--- a/lib/rb/spec/server_socket_spec.rb
+++ b/lib/rb/spec/server_socket_spec.rb
@@ -35,6 +35,7 @@ describe 'Thrift::ServerSocket' do
     it "should accept an optional host argument" do
       @socket = Thrift::ServerSocket.new('localhost', 1234)
       TCPServer.should_receive(:new).with('localhost', 1234)
+      @socket.to_s == "server(localhost:1234)"
       @socket.listen
     end
 
@@ -74,6 +75,10 @@ describe 'Thrift::ServerSocket' do
       @socket.should_not be_closed
       handle.stub!(:closed?).and_return(true)
       @socket.should be_closed
+    end
+
+    it "should provide a reasonable to_s" do
+      @socket.to_s.should == "socket(:1234)"
     end
   end
 end

--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -21,13 +21,30 @@ require 'spec_helper'
 describe 'Server' do
 
   describe Thrift::BaseServer do
-    it "should default to BaseTransportFactory and BinaryProtocolFactory when not specified" do
-      server = Thrift::BaseServer.new(mock("Processor"), mock("BaseServerTransport"))
-      server.instance_variable_get(:'@transport_factory').should be_an_instance_of(Thrift::BaseTransportFactory)
-      server.instance_variable_get(:'@protocol_factory').should be_an_instance_of(Thrift::BinaryProtocolFactory)
+    before(:each) do
+      @processor = mock("Processor")
+      @serverTrans = mock("ServerTransport")
+      @trans = mock("BaseTransport")
+      @prot = mock("BaseProtocol")
+      @server = described_class.new(@processor, @serverTrans, @trans, @prot)
     end
 
-    # serve is a noop, so can't test that
+    it "should default to BaseTransportFactory and BinaryProtocolFactory when not specified" do
+      @server = Thrift::BaseServer.new(mock("Processor"), mock("BaseServerTransport"))
+      @server.instance_variable_get(:'@transport_factory').should be_an_instance_of(Thrift::BaseTransportFactory)
+      @server.instance_variable_get(:'@protocol_factory').should be_an_instance_of(Thrift::BinaryProtocolFactory)
+    end
+
+    it "should not serve" do
+      expect { @server.serve()}.to raise_error(NotImplementedError)
+    end
+    
+    it "should provide a reasonable to_s" do
+      @serverTrans.should_receive(:to_s).once.and_return("serverTrans")
+      @trans.should_receive(:to_s).once.and_return("trans")
+      @prot.should_receive(:to_s).once.and_return("prot")
+      @server.to_s.should == "server(prot(trans(serverTrans)))"
+    end
   end
 
   describe Thrift::SimpleServer do
@@ -38,6 +55,13 @@ describe 'Server' do
       @prot = mock("BaseProtocol")
       @client = mock("Client")
       @server = described_class.new(@processor, @serverTrans, @trans, @prot)
+    end
+    
+    it "should provide a reasonable to_s" do
+      @serverTrans.should_receive(:to_s).once.and_return("serverTrans")
+      @trans.should_receive(:to_s).once.and_return("trans")
+      @prot.should_receive(:to_s).once.and_return("prot")
+      @server.to_s.should == "simple(server(prot(trans(serverTrans))))"
     end
     
     it "should serve in the main thread" do
@@ -69,6 +93,13 @@ describe 'Server' do
       @server = described_class.new(@processor, @serverTrans, @trans, @prot)
     end
 
+    it "should provide a reasonable to_s" do
+      @serverTrans.should_receive(:to_s).once.and_return("serverTrans")
+      @trans.should_receive(:to_s).once.and_return("trans")
+      @prot.should_receive(:to_s).once.and_return("prot")
+      @server.to_s.should == "threaded(server(prot(trans(serverTrans))))"
+    end
+    
     it "should serve using threads" do
       @serverTrans.should_receive(:listen).ordered
       @serverTrans.should_receive(:accept).exactly(3).times.and_return(@client)
@@ -97,9 +128,16 @@ describe 'Server' do
       @prot = mock("BaseProtocol")
       @client = mock("Client")
       @server = described_class.new(@processor, @server_trans, @trans, @prot)
-      sleep(0.1)
+      sleep(0.15)
     end
 
+    it "should provide a reasonable to_s" do
+      @server_trans.should_receive(:to_s).once.and_return("server_trans")
+      @trans.should_receive(:to_s).once.and_return("trans")
+      @prot.should_receive(:to_s).once.and_return("prot")
+      @server.to_s.should == "threadpool(server(prot(trans(server_trans))))"
+    end
+    
     it "should serve inside a thread" do
       exception_q = @server.instance_variable_get(:@exception_q)
       described_class.any_instance.should_receive(:serve) do 

--- a/lib/rb/spec/socket_spec.rb
+++ b/lib/rb/spec/socket_spec.rb
@@ -43,6 +43,7 @@ describe 'Socket' do
       ::Socket.should_receive(:new).and_return(mock("Handle", :connect_nonblock => true, :setsockopt => nil))
       ::Socket.should_receive(:getaddrinfo).with("localhost", 9090, nil, ::Socket::SOCK_STREAM).and_return([[]])
       ::Socket.should_receive(:sockaddr_in)
+      @socket.to_s == "socket(localhost:9090)"
       @socket.open
     end
 
@@ -50,12 +51,18 @@ describe 'Socket' do
       ::Socket.should_receive(:new).and_return(mock("Handle", :connect_nonblock => true, :setsockopt => nil))
       ::Socket.should_receive(:getaddrinfo).with("my.domain", 1234, nil, ::Socket::SOCK_STREAM).and_return([[]])
       ::Socket.should_receive(:sockaddr_in)
-      Thrift::Socket.new('my.domain', 1234).open
+      @socket = Thrift::Socket.new('my.domain', 1234).open
+      @socket.to_s == "socket(my.domain:1234)"
     end
 
     it "should accept an optional timeout" do
       ::Socket.stub!(:new)
       Thrift::Socket.new('localhost', 8080, 5).timeout.should == 5
+    end
+
+    it "should provide a reasonable to_s" do
+      ::Socket.stub!(:new)
+      Thrift::Socket.new('myhost', 8090).to_s.should == "socket(myhost:8090)"
     end
   end
 end

--- a/lib/rb/spec/ssl_server_socket_spec.rb
+++ b/lib/rb/spec/ssl_server_socket_spec.rb
@@ -1,5 +1,4 @@
-# encoding: ascii-8bit
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -7,31 +6,29 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# 
+#
 
-module Thrift
-  class BaseServerTransport
-    def listen
-      raise NotImplementedError
+require 'spec_helper'
+require File.expand_path("#{File.dirname(__FILE__)}/socket_spec_shared")
+
+describe 'SSLServerSocket' do
+
+  describe Thrift::SSLServerSocket do
+    before(:each) do
+      @socket = Thrift::SSLServerSocket.new(1234)
     end
 
-    def accept
-      raise NotImplementedError
-    end
-      
-    def close; nil; end
-
-    def closed?
-      raise NotImplementedError
+    it "should provide a reasonable to_s" do
+      @socket.to_s.should == "ssl(socket(:1234))"
     end
   end
 end

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -70,5 +70,9 @@ describe 'SSLSocket' do
     it "should accept an optional context" do
       Thrift::SSLSocket.new('localhost', 8080, 5, @context).ssl_context.should == @context
     end
+
+    it "should provide a reasonable to_s" do
+      Thrift::SSLSocket.new('myhost', 8090).to_s.should == "ssl(socket(myhost:8090))"
+    end
   end
 end

--- a/lib/rb/spec/unix_socket_spec.rb
+++ b/lib/rb/spec/unix_socket_spec.rb
@@ -42,6 +42,11 @@ describe 'UNIXSocket' do
       ::UNIXSocket.stub!(:new)
       Thrift::UNIXSocket.new(@path, 5).timeout.should == 5
     end
+    
+    it "should provide a reasonable to_s" do
+      ::UNIXSocket.stub!(:new)
+      Thrift::UNIXSocket.new(@path).to_s.should == "domain(#{@path})"
+    end
   end
 
   describe Thrift::UNIXServerSocket do
@@ -102,6 +107,10 @@ describe 'UNIXSocket' do
       @socket.should_not be_closed
       handle.stub!(:closed?).and_return(true)
       @socket.should be_closed
+    end
+
+    it "should provide a reasonable to_s" do
+      @socket.to_s.should == "domain(#{@path})"
     end
   end
 end

--- a/test/crossrunner/report.py
+++ b/test/crossrunner/report.py
@@ -158,6 +158,7 @@ class ExecReporter(TestReporter):
         'client': list(map(re.compile, [
             '[Cc]onnection refused',
             'Could not connect to',
+            'Could not open UNIX ',       # domain socket (rb)
             'ECONNREFUSED',
             'econnrefused',               # erl
             'CONNECTION-REFUSED-ERROR',   # cl

--- a/test/tests.json
+++ b/test/tests.json
@@ -373,13 +373,14 @@
       "framed"
     ],
     "sockets": [
+      "domain",
       "ip"
     ],
     "protocols": [
-      "compact",
       "binary",
-      "json",
-      "binary:accel"
+      "binary:accel",
+      "compact",
+      "json"
     ],
     "workdir": "rb/gen-rb"
   },


### PR DESCRIPTION
This is the first time I've tried to use ruby with any seriousness.  I like the unit test framework (rspec) -
 very descriptive and the mocking is so damn easy compared to C++.  

In addition to adding domain socket support to the test harness for client and server (there was already an implementation in the library), the ruby test server has a new line of code that's neat:

    puts "Starting TestServer #{@server.to_s}"

which turns into, for example:

    Starting TestServer threaded(server(binary(buffered(domain(/tmp/ThriftTest.thrift.57621)))))

or for a socket test:

    Starting TestServer threaded(server(compact(framed(socket(:36653)))))
