### PR TITLE
THRIFT-4527 Upgrade byteorder in rust

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["Makefile*", "test/**"]
 keywords = ["thrift"]
 
 [dependencies]
-byteorder = "~1.1.0"
+byteorder = "~1.2.1"
 integer-encoding = "~1.0.4"
 log = "~0.3.8"
 threadpool = "~1.7.1"


### PR DESCRIPTION
updated byteorder 1.1.0 -> 1.2.1