### PR TITLE
THRIFT-4513: fix bug in comparator introduced by e58f75d

### DIFF
--- a/compiler/cpp/src/thrift/parse/t_const_value.h
+++ b/compiler/cpp/src/thrift/parse/t_const_value.h
@@ -159,10 +159,10 @@ public:
       if (*(left.first) < *(right.first)) {
         return true;
       } else {
-        if (right.first < left.first) {
-          return *(left.second) < *(right.second);
-        } else {
+        if (*(right.first) < *(left.first)) {
           return false;
+        } else {
+          return *(left.second) < *(right.second);
         }
       }
     }


### PR DESCRIPTION
Fix ordering bug for the comparator introduced by https://github.com/apache/thrift/pull/1505