### PR TITLE
THRIFT-4539 Allow TBufferedTransport to be used as base class

### DIFF
--- a/lib/csharp/src/Transport/TBufferedTransport.cs
+++ b/lib/csharp/src/Transport/TBufferedTransport.cs
@@ -76,19 +76,23 @@ namespace Thrift.Transport
             ValidateBufferArgs(buf, off, len);
             if (!IsOpen)
                 throw new TTransportException(TTransportException.ExceptionType.NotOpen);
+
             if (inputBuffer.Capacity < bufSize)
                 inputBuffer.Capacity = bufSize;
-            int got = inputBuffer.Read(buf, off, len);
-            if (got > 0)
-                return got;
 
-            inputBuffer.Seek(0, SeekOrigin.Begin);
-            inputBuffer.SetLength(inputBuffer.Capacity);
-            int filled = transport.Read(inputBuffer.GetBuffer(), 0, (int)inputBuffer.Length);
-            inputBuffer.SetLength(filled);
-            if (filled == 0)
-                return 0;
-            return Read(buf, off, len);
+            while (true)
+            { 
+                int got = inputBuffer.Read(buf, off, len);
+                if (got > 0)
+                    return got;
+
+                inputBuffer.Seek(0, SeekOrigin.Begin);
+                inputBuffer.SetLength(inputBuffer.Capacity);
+                int filled = transport.Read(inputBuffer.GetBuffer(), 0, (int)inputBuffer.Length);
+                inputBuffer.SetLength(filled);
+                if (filled == 0)
+                    return 0;
+            }
         }
 
         public override void Write(byte[] buf, int off, int len)
@@ -138,14 +142,14 @@ namespace Thrift.Transport
             transport.Flush();
         }
 
-        private void CheckNotDisposed()
+        protected void CheckNotDisposed()
         {
             if (_IsDisposed)
                 throw new ObjectDisposedException("TBufferedTransport");
         }
 
         #region " IDisposable Support "
-        private bool _IsDisposed;
+        protected bool _IsDisposed { get; private set; }
 
         // IDisposable
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Client: C#
Patch: Jens Geyer