### PR TITLE
THRIFT-4548: Supporting TBinaryProtocolAccelerated protocol when using TMultiplexedProcessor in Python

### DIFF
--- a/lib/py/src/TMultiplexedProcessor.py
+++ b/lib/py/src/TMultiplexedProcessor.py
@@ -18,7 +18,7 @@
 #
 
 from thrift.Thrift import TProcessor, TMessageType, TException
-from thrift.protocol import TProtocolDecorator, TMultiplexedProtocol
+from thrift.protocol import TMultiplexedProtocol
 
 
 class TMultiplexedProcessor(TProcessor):
@@ -43,13 +43,5 @@ class TMultiplexedProcessor(TProcessor):
             raise TException("Service name not found: " + serviceName + ". Did you forget to call registerProcessor()?")
 
         standardMessage = (call, type, seqid)
-        return self.services[serviceName].process(StoredMessageProtocol(iprot, standardMessage), oprot)
-
-
-class StoredMessageProtocol(TProtocolDecorator.TProtocolDecorator):
-    def __init__(self, protocol, messageBegin):
-        TProtocolDecorator.TProtocolDecorator.__init__(self, protocol)
-        self.messageBegin = messageBegin
-
-    def readMessageBegin(self):
-        return self.messageBegin
+        iprot.readMessageBegin = lambda: standardMessage
+        return self.services[serviceName].process(iprot, oprot)

--- a/lib/py/src/protocol/TMultiplexedBinaryProtocolAccelerated.py
+++ b/lib/py/src/protocol/TMultiplexedBinaryProtocolAccelerated.py
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from thrift.Thrift import TMessageType
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated
+
+class TMultiplexedBinaryProtocolAccelerated(TBinaryProtocolAccelerated):
+    def __init__(self, serviceName, *args, **kwargs):
+        super(TMultiplexedBinaryProtocolAccelerated, self).__init__(*args, **kwargs)
+        self.serviceName = serviceName
+        self.separator = ":"
+
+    def writeMessageBegin(self, name, type, seqid):
+        if (type == TMessageType.CALL or type == TMessageType.ONEWAY):
+            super(TMultiplexedBinaryProtocolAccelerated, self).writeMessageBegin(self.serviceName + self.separator + name, type, seqid)
+        else:
+            super(TMultiplexedBinaryProtocolAccelerated, self).writeMessageBegin(name, type, seqid)


### PR DESCRIPTION
Updated TMultiplexedProcessor, and new TMultiplexedBinaryProtocolAccelerated to support TBinaryProtocolAccelerated in Python
Client: [lib/py]