### PR TITLE
THRIFT-4552: remove unneccessary lock

### DIFF
--- a/lib/go/thrift/simple_server_test.go
+++ b/lib/go/thrift/simple_server_test.go
@@ -20,9 +20,9 @@
 package thrift
 
 import (
-	"testing"
 	"errors"
 	"runtime"
+	"testing"
 )
 
 type mockServerTransport struct {

--- a/tutorial/go/src/server.go
+++ b/tutorial/go/src/server.go
@@ -40,7 +40,7 @@ func runServer(transportFactory thrift.TTransportFactory, protocolFactory thrift
 	} else {
 		transport, err = thrift.NewTServerSocket(addr)
 	}
-	
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. use CAS operation instead of lock
2. remove defer to reduce unneccessary performance consume
3. go fmt those code
