### PR TITLE
THRIFT-4561: Remove python socket timeout

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -19,7 +19,6 @@
 
 from io import BytesIO
 import os
-import socket
 import ssl
 import sys
 import warnings
@@ -128,9 +127,6 @@ class THttpClient(TTransportBase):
         return self.__http is not None
 
     def setTimeout(self, ms):
-        if not hasattr(socket, 'getdefaulttimeout'):
-            raise NotImplementedError
-
         if ms is None:
             self.__timeout = None
         else:
@@ -144,17 +140,6 @@ class THttpClient(TTransportBase):
 
     def write(self, buf):
         self.__wbuf.write(buf)
-
-    def __withTimeout(f):
-        def _f(*args, **kwargs):
-            orig_timeout = socket.getdefaulttimeout()
-            socket.setdefaulttimeout(args[0].__timeout)
-            try:
-                result = f(*args, **kwargs)
-            finally:
-                socket.setdefaulttimeout(orig_timeout)
-            return result
-        return _f
 
     def flush(self):
         if self.isOpen():
@@ -200,7 +185,3 @@ class THttpClient(TTransportBase):
         self.code = self.__http_response.status
         self.message = self.__http_response.reason
         self.headers = self.__http_response.msg
-
-    # Decorate if we know how to timeout
-    if hasattr(socket, 'getdefaulttimeout'):
-        flush = __withTimeout(flush)


### PR DESCRIPTION
Client: py

Timeout is already set in HttpClient. The reason for removal is issue
with gunicorn and gevent as described here
https://github.com/benoitc/gunicorn/pull/1616

Tested locally, works as expected