### PR TITLE
[Erlang]: processor: allow for user controlled request/response cycle

### DIFF
--- a/lib/erl/src/thrift_processor.erl
+++ b/lib/erl/src/thrift_processor.erl
@@ -28,7 +28,7 @@
 
 % Instead of a loop, do a single-shot processing of a packet
 % allows user to control how the bytes are sent and received
-% see: [https://github.com/apache/thrift/blob/master/lib/rb/lib/thrift/server/mongrel_http_server.rb]
+% see: [https://github.com/apache/thrift/blob/88591e32e710a0524327153c8b629d5b461e35e0/lib/rb/lib/thrift/server/mongrel_http_server.rb]
 process({_Server, Proto, Service, Handler}) ->
     State0 = #thrift_processor{ protocol = Proto,
                                 service = Service,

--- a/lib/erl/src/thrift_processor.erl
+++ b/lib/erl/src/thrift_processor.erl
@@ -44,6 +44,7 @@ process({_Server, Proto, Service, Handler}) ->
                  			thrift_protocol:close_transport(Proto1),
                  			ok
     			end
+    end.
 
 init({_Server, ProtoGen, Service, Handler}) when is_function(ProtoGen, 0) ->
     {ok, Proto} = ProtoGen(),

--- a/lib/erl/src/thrift_processor.erl
+++ b/lib/erl/src/thrift_processor.erl
@@ -27,6 +27,8 @@
 -record(thrift_processor, {handler, protocol, service}).
 
 % Instead of a loop, do a single-shot processing of a packet
+% allows user to control how the bytes are sent and received
+% see: [https://github.com/apache/thrift/blob/master/lib/rb/lib/thrift/server/mongrel_http_server.rb]
 process({_Server, Proto, Service, Handler}) ->
     State0 = #thrift_processor{ protocol = Proto,
                                 service = Service,


### PR DESCRIPTION
While attempting to create a simple HTTP endpoint in Elixir using Plug I noticed that the Erlang library does not have a way to manually process a payload.  
I have done it before in other languages, and the simplest example of that kind of action is done by Ruby http servers @[https://github.com/apache/thrift/blob/master/lib/rb/lib/thrift/server/mongrel_http_server.rb]
As you can see, you can process the thrift message 'manually' regardless of how it was received or how the response is to be sent back.

Assuming this patch is in place, here is an example of usage in Elixir using Plug for handling HTTP thrift requests:
```elixir
  # -----------------------------------------------
  # Low level raw binary handler for thrift packets, raw_data is basically just the POST body
  # returns raw thrift response
  def handle_post(raw_data) do
    # Construct a protocol
    {:ok, mem_transport} = :thrift_membuffer_transport.new(raw_data)
    {:ok, cb_protocol} = :thrift_compact_protocol.new(mem_transport)

    # Have thrift core library process the service request
    # reply is written back into the mem_transport inside the State
    {:ok, state} =
      :thrift_processor.process(
        {"ServiceHandler", cb_protocol, :query_service_thrift, ServiceHandler}
      )

    # Extract data buffer from the State object
    {:thrift_processor, _handler, protocol, _service} = state
    {:protocol, :thrift_compact_protocol, {:t_compact, transport, _, _, _, _}} = protocol
    {:t_transport, :thrift_membuffer_transport, {:t_membuffer, data}} = transport

    case data do
      [_ | _] = reply ->
        {:ok, :erlang.iolist_to_binary(reply)}
      _ ->
        {:error, "No reply was detected!"}
    end
  end
```

This was tested with Ruby client using standard Thrift::HTTPClientTransport.
