### PR TITLE
Updated ZeroMQ examples to ZeroMQ version >= 3.0.

### DIFF
--- a/contrib/zeromq/Makefile
+++ b/contrib/zeromq/Makefile
@@ -26,7 +26,7 @@ test-client.o test-server.o test-sender.o test-receiver.o: $(GENSRCS)
 
 storage/__init__.py: storage.thrift
 	$(RM) $(dir $@)
-	$(THRIFT) --gen py:newstyle $<
+	$(THRIFT) --gen py $<
 	mv gen-py/$(dir $@) .
 
 $(GENSRCS): storage.thrift

--- a/contrib/zeromq/TZmqServer.cpp
+++ b/contrib/zeromq/TZmqServer.cpp
@@ -21,7 +21,7 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <boost/scoped_ptr.hpp>
 
-using boost::shared_ptr;
+using apache::thrift::stdcxx::shared_ptr;
 using apache::thrift::transport::TMemoryBuffer;
 using apache::thrift::protocol::TProtocol;
 

--- a/contrib/zeromq/TZmqServer.h
+++ b/contrib/zeromq/TZmqServer.h
@@ -28,7 +28,7 @@ namespace apache { namespace thrift { namespace server {
 class TZmqServer : public TServer {
  public:
   TZmqServer(
-      boost::shared_ptr<TProcessor> processor,
+      apache::thrift::stdcxx::shared_ptr<TProcessor> processor,
       zmq::context_t& ctx, const std::string& endpoint, int type)
     : TServer(processor)
     , processor_(processor)
@@ -56,7 +56,7 @@ class TZmqServer : public TServer {
   }
 
  private:
-  boost::shared_ptr<TProcessor> processor_;
+  apache::thrift::stdcxx::shared_ptr<TProcessor> processor_;
   int zmq_type_;
   zmq::socket_t sock_;
 };

--- a/contrib/zeromq/test-client.cpp
+++ b/contrib/zeromq/test-client.cpp
@@ -6,7 +6,7 @@
 #include "TZmqClient.h"
 #include "Storage.h"
 
-using boost::shared_ptr;
+using apache::thrift::stdcxx::shared_ptr;
 using apache::thrift::transport::TZmqClient;
 using apache::thrift::protocol::TBinaryProtocol;
 

--- a/contrib/zeromq/test-client.cpp
+++ b/contrib/zeromq/test-client.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv) {
   if (argc > 1) {
     incr = atoi(argv[1]);
     if (incr) {
-      socktype = ZMQ_DOWNSTREAM;
+      socktype = ZMQ_PUSH;
       endpoint = "tcp://127.0.0.1:9091";
     }
   }

--- a/contrib/zeromq/test-client.py
+++ b/contrib/zeromq/test-client.py
@@ -15,7 +15,7 @@ def main(args):
     if len(args) > 1:
         incr = int(args[1])
         if incr:
-            socktype = zmq.DOWNSTREAM
+            socktype = zmq.PUSH
             endpoint = "tcp://127.0.0.1:9091"
 
     ctx = zmq.Context()

--- a/contrib/zeromq/test-receiver.cpp
+++ b/contrib/zeromq/test-receiver.cpp
@@ -2,7 +2,7 @@
 #include "TZmqServer.h"
 #include "Storage.h"
 
-using boost::shared_ptr;
+using apache::thrift::stdcxx::shared_ptr;
 using apache::thrift::TProcessor;
 using apache::thrift::server::TZmqServer;
 using apache::thrift::server::TZmqMultiServer;

--- a/contrib/zeromq/test-sender.cpp
+++ b/contrib/zeromq/test-sender.cpp
@@ -6,7 +6,7 @@
 #include "TZmqClient.h"
 #include "Storage.h"
 
-using boost::shared_ptr;
+using apache::thrift::stdcxx::shared_ptr;
 using apache::thrift::transport::TZmqClient;
 using apache::thrift::protocol::TBinaryProtocol;
 

--- a/contrib/zeromq/test-server.cpp
+++ b/contrib/zeromq/test-server.cpp
@@ -2,7 +2,7 @@
 #include "TZmqServer.h"
 #include "Storage.h"
 
-using boost::shared_ptr;
+using apache::thrift::stdcxx::shared_ptr;
 using apache::thrift::TProcessor;
 using apache::thrift::server::TZmqServer;
 using apache::thrift::server::TZmqMultiServer;

--- a/contrib/zeromq/test-server.cpp
+++ b/contrib/zeromq/test-server.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
 
   zmq::context_t ctx(1);
   TZmqServer reqrep_server(processor, ctx, "tcp://0.0.0.0:9090", ZMQ_REP);
-  TZmqServer oneway_server(processor, ctx, "tcp://0.0.0.0:9091", ZMQ_UPSTREAM);
+  TZmqServer oneway_server(processor, ctx, "tcp://0.0.0.0:9091", ZMQ_PULL);
   TZmqMultiServer multiserver;
   multiserver.servers().push_back(&reqrep_server);
   multiserver.servers().push_back(&oneway_server);

--- a/contrib/zeromq/test-server.py
+++ b/contrib/zeromq/test-server.py
@@ -22,7 +22,7 @@ def main():
 
     ctx = zmq.Context()
     reqrep_server = TZmqServer.TZmqServer(processor, ctx, "tcp://0.0.0.0:9090", zmq.REP)
-    oneway_server = TZmqServer.TZmqServer(processor, ctx, "tcp://0.0.0.0:9091", zmq.UPSTREAM)
+    oneway_server = TZmqServer.TZmqServer(processor, ctx, "tcp://0.0.0.0:9091", zmq.PULL)
     multiserver = TZmqServer.TZmqMultiServer()
     multiserver.servers.append(reqrep_server)
     multiserver.servers.append(oneway_server)


### PR DESCRIPTION
Some ZeroMQ symbols have changes in version 3.0 of ZeroMQ (before 2014). Current stable branch is 4.2. Additionally, the Python code used `newstyle` language option, which isn't supported in the Thrift compiler anymore. This style is the default now.