### PR TITLE
THRIFT-4564: Reset buffered transport on serialization errors

### DIFF
--- a/lib/nodejs/lib/thrift/buffered_transport.js
+++ b/lib/nodejs/lib/thrift/buffered_transport.js
@@ -33,6 +33,14 @@ function TBufferedTransport(buffer, callback) {
   this.onFlush = callback;
 };
 
+TBufferedTransport.prototype.reset = function() {
+  this.inBuf = new Buffer(this.defaultReadBufferSize);
+  this.readCursor = 0;
+  this.writeCursor = 0;
+  this.outBuffers = [];
+  this.outCount = 0;
+}
+
 TBufferedTransport.receiver = function(callback, seqid) {
   var reader = new TBufferedTransport();
 


### PR DESCRIPTION
Tested locally using the following thrift IDL on thrift v0.10.0
```
struct Foo {
  1: string name
}

service SocketTestService {
  i16 countFoos(1: list<Foo> foos)
}
```

The following client request will fail on the client side, but leave data on the buffer:
```
client.countFoos([new thriftTypes.Foo(), null, new thriftTypes.Foo()]);
```

Using the new code, the client side error will be caught and the buffered transport will be reset, allowing for the socket to be used for a subsequent RPC call without causing a parse error on the server side