### PR TITLE
THRIFT-4478 Thrift will not build with dlang 2.078 or later

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -101,7 +101,7 @@ The Language/Library Levels indicate the minimum and maximum versions that are u
 <td align=left><a href="lib/d/README.md">Dlang</a></td>
 <!-- Since -----------------><td>0.9.0</td>
 <!-- Build Systems ---------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>2.073.2</td><td>2.077.1</td>
+<!-- Language Levels -------><td>2.073.2</td><td>2.080.0</td>
 <!-- Low-Level Transports --><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Protocols -------------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -143,7 +143,7 @@ Last updated: October 1, 2017
 | c_glib    | 2.48.2        | 2.54.0        |       |
 | cl (sbcl) |               | 1.4.5         |       |
 | cocoa     |               |               | Not in CI |
-| d         | 2.073.2       | 2.077.1       |       |
+| d         | 2.073.2       | 2.080.0       |       |
 | dart      | 1.22.1        | 1.24.3        |       |
 | delphi    |               |               | Not in CI |
 | dotnet    | 2.1.4         | 2.1.4         | v2.1.4 SDK uses v2.0.5 Runtime |

--- a/build/docker/ubuntu-artful/Dockerfile
+++ b/build/docker/ubuntu-artful/Dockerfile
@@ -18,8 +18,8 @@
 # - dart: does not come with Ubuntu
 # - dotnet: does not come with Ubuntu
 # - haxe: version 3.4.2 that comes with Ubuntu cores in our CI build
-# - go: xenial comes with 1.8, we want the latest (supported)
-# - nodejs: want v8, Ubuntu comes with v6
+# - go: artful comes with 1.9, we want the latest (supported)
+# - nodejs: want v8, artful comes with v6
 #
 
 FROM buildpack-deps:artful-scm
@@ -103,8 +103,8 @@ RUN \
     sbcl --version && \
     rm -rf sbcl*
 
-ENV D_VERSION     2.077.1
-ENV DMD_DEB       dmd_2.077.1-0_amd64.deb
+ENV D_VERSION     2.080.0
+ENV DMD_DEB       dmd_2.080.0-0_amd64.deb
 RUN \
 `# D dependencies` \
     wget -q http://downloads.dlang.org/releases/2.x/${D_VERSION}/${DMD_DEB} && \

--- a/lib/d/src/thrift/async/socket.d
+++ b/lib/d/src/thrift/async/socket.d
@@ -18,6 +18,7 @@
  */
 module thrift.async.socket;
 
+import core.stdc.errno: ECONNRESET;
 import core.thread : Fiber;
 import core.time : dur, Duration;
 import std.array : empty;

--- a/lib/d/src/thrift/server/transport/base.d
+++ b/lib/d/src/thrift/server/transport/base.d
@@ -95,16 +95,7 @@ class TServerTransportException : TException {
 
   ///
   this(Type type, string file = __FILE__, size_t line = __LINE__, Throwable next = null) {
-    string msg = "TTransportException: ";
-    switch (type) {
-      case Type.UNKNOWN: msg ~= "Unknown server transport exception"; break;
-      case Type.NOT_LISTENING: msg ~= "Server transport not listening"; break;
-      case Type.ALREADY_LISTENING: msg ~= "Server transport already listening"; break;
-      case Type.RESOURCE_FAILED: msg ~= "An underlying resource failed"; break;
-      default: msg ~= "(Invalid exception type)"; break;
-    }
-
-    this(msg, type, file, line, next);
+    this(errorMsg(type), type, file, line, next);
   }
 
   ///
@@ -129,5 +120,18 @@ class TServerTransportException : TException {
 
 protected:
   Type type_;
+
+private:
+  string errorMsg(Type type) {
+    string msg = "TTransportException: ";
+    switch (type) {
+      case Type.UNKNOWN: msg ~= "Unknown server transport exception"; break;
+      case Type.NOT_LISTENING: msg ~= "Server transport not listening"; break;
+      case Type.ALREADY_LISTENING: msg ~= "Server transport already listening"; break;
+      case Type.RESOURCE_FAILED: msg ~= "An underlying resource failed"; break;
+      default: msg ~= "(Invalid exception type)"; break;
+    }
+    return msg;
+  }
 }
 

--- a/lib/d/src/thrift/transport/file.d
+++ b/lib/d/src/thrift/transport/file.d
@@ -37,7 +37,8 @@ import std.array : empty;
 import std.algorithm : min, max;
 import std.concurrency;
 import std.conv : to;
-import std.datetime : AutoStart, dur, Duration, StopWatch;
+import std.datetime : dur, Duration;
+import std.datetime.stopwatch : AutoStart, StopWatch;
 import std.exception;
 import std.stdio : File;
 import thrift.base;
@@ -1076,15 +1077,15 @@ unittest {
 
       // If any attempt takes more than 500ms, treat that as a fatal failure to
       // avoid looping over a potentially very slow operation.
-      enforce(sw.peek().msecs < 1500,
-        text("close() took ", sw.peek().msecs, "ms."));
+      enforce(sw.peek().total!"msecs" < 1500,
+        text("close() took ", sw.peek().total!"msecs", "ms."));
 
       // Normally, it takes less than 5ms on my dev box.
       // However, if the box is heavily loaded, some of the test runs can take
       // longer. Additionally, on a Windows Server 2008 instance running in
       // a VirtualBox VM, it has been observed that about a quarter of the runs
       // takes (217 ± 1) ms, for reasons not yet known.
-      if (sw.peek().msecs > 50) {
+      if (sw.peek().total!"msecs" > 50) {
         ++numOver;
       }
 

--- a/lib/d/src/thrift/transport/socket.d
+++ b/lib/d/src/thrift/transport/socket.d
@@ -18,6 +18,7 @@
  */
 module thrift.transport.socket;
 
+import core.stdc.errno: ECONNRESET;
 import core.thread : Thread;
 import core.time : dur, Duration;
 import std.array : empty;
@@ -256,7 +257,7 @@ class TSocket : TSocketBase {
         new TCompoundOperationException(
           text(
             "All addresses tried failed (",
-            joiner(map!q{text(a._0, `: "`, a._1.msg, `"`)}(zip(addrs, errors)), ", "),
+            joiner(map!q{text(a[0], `: "`, a[1].msg, `"`)}(zip(addrs, errors)), ", "),
             ")."
           ),
           errors

--- a/lib/d/test/client_pool_test.d
+++ b/lib/d/test/client_pool_test.d
@@ -409,8 +409,8 @@ void asyncAggregatorTest(const(ushort)[] ports, ExTestHandler[] handlers) {
     )();
     Thread.sleep(dur!"msecs"(20));
     auto resultTuple = partialResult.finishGet();
-    enforce(resultTuple._0 == ports[0 .. 2]);
-    enforce(equal(map!"a.port"(cast(TestServiceException[])resultTuple._1),
+    enforce(resultTuple[0] == ports[0 .. 2]);
+    enforce(equal(map!"a.port"(cast(TestServiceException[])resultTuple[1]),
       ports[3 .. $ - 1]));
   }
 }

--- a/lib/d/test/serialization_benchmark.d
+++ b/lib/d/test/serialization_benchmark.d
@@ -13,7 +13,7 @@
  */
 module serialization_benchmark;
 
-import std.datetime : AutoStart, StopWatch;
+import std.datetime.stopwatch : AutoStart, StopWatch;
 import std.math : PI;
 import std.stdio;
 import thrift.protocol.binary;
@@ -46,7 +46,7 @@ void main() {
     }
     sw.stop();
 
-    auto msecs = sw.peek().msecs;
+    auto msecs = sw.peek().total!"msecs";
     writefln("Write: %s ms (%s kHz)", msecs, ITERATIONS / msecs);
   }
 
@@ -64,7 +64,7 @@ void main() {
     }
     sw.stop();
 
-    auto msecs = sw.peek().msecs;
+    auto msecs = sw.peek().total!"msecs";
     writefln(" Read: %s ms (%s kHz)", msecs, ITERATIONS / msecs);
   }
 }


### PR DESCRIPTION
This fixes build errors and deprecation warnings on dmd v2.080.0.
