### PR TITLE
THRIFT-4577 Outdated cipher string in python unit test

### DIFF
--- a/lib/py/test/test_sslsocket.py
+++ b/lib/py/test/test_sslsocket.py
@@ -42,7 +42,7 @@ CLIENT_CERT = os.path.join(ROOT_DIR, 'test', 'keys', 'client_v3.crt')
 CLIENT_KEY = os.path.join(ROOT_DIR, 'test', 'keys', 'client_v3.key')
 CLIENT_CA = os.path.join(ROOT_DIR, 'test', 'keys', 'CA.pem')
 
-TEST_CIPHERS = 'DES-CBC3-SHA'
+TEST_CIPHERS = 'DES-CBC3-SHA:ECDHE-RSA-AES128-GCM-SHA256'
 
 
 class ServerAcceptor(threading.Thread):
@@ -95,6 +95,11 @@ class ServerAcceptor(threading.Thread):
         self._client_accepted.wait()
         return self._client
 
+    def close(self):
+        if self._client:
+            self._client.close()
+        self._server.close()
+
 
 # Python 2.6 compat
 class AssertRaises(object):
@@ -125,9 +130,7 @@ class TSSLSocketTest(unittest.TestCase):
             client = TSSLSocket(host, port, unix_socket=path, **client_kwargs)
             yield acc, client
         finally:
-            if acc.client:
-                acc.client.close()
-            server.close()
+            acc.close()
 
     def _assert_connection_failure(self, server, path=None, **client_args):
         logging.disable(logging.CRITICAL)


### PR DESCRIPTION
`test_ciphers` fails if system SSL doesn't support "DES-CBC3-SHA" which is quite old.
Adding an additional modern cipher fixes it.

Also fixes a bug where unit test execution hanged forever on SSL initialization failure.