### PR TITLE
THRIFT-4591:cannot read call result via lua lib

### DIFF
--- a/lib/lua/TFramedTransport.lua
+++ b/lib/lua/TFramedTransport.lua
@@ -100,7 +100,7 @@ function TFramedTransport:flush()
   local tmp = self.wBuf
   self.wBuf = ''
   local frame_len_buf = libluabpack.bpack("i", string.len(tmp))
-  self.trans:write(frame_len_buf)
+  tmp = frame_len_buf .. tmp
   self.trans:write(tmp)
   self.trans:flush()
 end


### PR DESCRIPTION
THRIFT-4591: [cannot read call result via lua lib]
Client: [lua,  lib/lua]