### PR TITLE
THRIFT-4592: [JS] change readI32 to use Array.reverse/Array.pop vs Array.shift

### DIFF
--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -1319,7 +1319,11 @@ Thrift.Protocol.prototype = {
             if (f.length === 0) {
                 r.value = undefined;
             } else {
-                r.value = f.shift();
+                if (!f.isReversed) {
+                    f.reverse();
+                    f.isReversed = true;
+                }
+                r.value = f.pop();
             }
         } else if (f instanceof Object) {
            for (var i in f) {


### PR DESCRIPTION
THRIFT-4592: [JS] change readI32 to use Array.reverse/Array.pop vs Array.shift, which is expensive for big arrays in V8

https://issues.apache.org/jira/browse/THRIFT-4592

`readI32` ( https://github.com/apache/thrift/blob/master/lib/js/src/thrift.js#L1311-L1341 ) performance is extremely poor in Chrome when reading values from large arrays. This is due to the use of Array.shift ( https://github.com/apache/thrift/blob/master/lib/js/src/thrift.js#L1322 ) which seems to have performance issues in V8/Chrome.

As Chrome is a high market share browser I propose either changing this to use reverse/pop or detect the appropriate strategy given array length. I think this is due to how V8 handles large arrays and the heuristics used to determine whether data should be stored in a C-backed array or hash map.