### PR TITLE
THRIFT-4600: fix-flush-on-THttpClient

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -145,10 +145,6 @@ class THttpClient(TTransportBase):
         return _f
 
     def flush(self):
-        if self.isOpen():
-            self.close()
-        self.open()
-
         # Pull data out of buffer
         data = self.__wbuf.getvalue()
         self.__wbuf = BytesIO()


### PR DESCRIPTION
THRIFT-4600: Don't close the connection on flush.

No close on flush as this makes using keep alive impossible. Flush gets called every time a message is sent. Keep-Alive is essential for performance on high latency connections, and the closing of the connection on flush makes this impossible.
I have this code without the disconnect on flush running in a real production setup.
 Client: python, THttpClient
