### PR TITLE
THRIFT-4604: NodeJS: adds Int64 to exports for browserify

### DIFF
--- a/lib/nodejs/lib/thrift/browser.js
+++ b/lib/nodejs/lib/thrift/browser.js
@@ -32,3 +32,5 @@ exports.TFramedTransport = require('./framed_transport');
 exports.Protocol = exports.TJSONProtocol = require('./json_protocol');
 exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
+
+exports.Int64 = require('node-int64');


### PR DESCRIPTION
When using the Node.js libs in the browser (via browser.js) Int64 isn't exposed the same way as it is in a Node environment. This just adds Int64 to the exports in browser.js to make consuming the libs more consistent with how we do in an actual Node environment.