### PR TITLE
Fix comparison of integers of different signs

### DIFF
--- a/lib/cocoa/src/transport/TNSStreamTransport.m
+++ b/lib/cocoa/src/transport/TNSStreamTransport.m
@@ -94,7 +94,7 @@
 
 -(BOOL) write:(const UInt8 *)data offset:(UInt32)offset length:(UInt32)length error:(NSError *__autoreleasing *)error
 {
-  int got = 0;
+  UInt32 got = 0;
   NSInteger total = 0;
   while (got < length) {
 


### PR DESCRIPTION
This fixes a warning in Xcode/clang "Comparison of integers of different signs: 'int' and 'UInt32' (aka 'unsigned int')"