### PR TITLE
THRIFT-4614: Generate missing @Nullable annotations for Java iterator getters

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -2359,6 +2359,7 @@ void t_java_generator::generate_java_bean_boilerplate(ostream& out, t_struct* ts
         if (is_deprecated) {
           indent(out) << "@Deprecated" << endl;
         }
+        indent(out) << java_nullable_annotation() << endl;
         indent(out) << "public java.util.Iterator<" << type_name(element_type, true, false)
                     << "> get" << cap_name;
         out << get_cap_name("iterator() {") << endl;


### PR DESCRIPTION
THRIFT-4614: Generate `@Nullable` annotations for Java iterator getters
Client: Java compiler

This is a straightforward, compile-time-safe, backward-compatible change.