### PR TITLE
THRIFT-4622: Resolve typedef'd list elements (C (GLib))

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -579,7 +579,7 @@ string t_c_glib_generator::type_name(t_type* ttype, bool in_typedef, bool is_con
       // TODO: discuss whether or not to implement TSet, THashSet or GHashSet
       cname = "GHashTable";
     } else if (ttype->is_list()) {
-      t_type* etype = ((t_list*)ttype)->get_elem_type();
+      t_type* etype = get_true_type(((t_list*)ttype)->get_elem_type());
       if (etype->is_void()) {
         throw std::runtime_error("compiler error: list element type cannot be void");
       }


### PR DESCRIPTION
With this change the C (GLib) compiler fully resolves the type of a list's elements before generating the C type for the list.

This fixes an issue where the compiler would output broken code for a list containing elements of a typedef'd type.