### PR TITLE
Swift code generator minor updates

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -299,10 +299,10 @@ void t_swift_generator::init_generator() {
   string module = get_real_swift_module(program_);
   string out_dir = get_out_dir();
   string module_path = out_dir;
-  string name = capitalize(program_name_);
+  string name = program_name_;
   if (namespaced_ && !module.empty()) {
     module_path = module_path + "/" + module;
-    name = capitalize(module);
+    name = module;
   }
   MKDIR(module_path.c_str());
 
@@ -1060,7 +1060,7 @@ void t_swift_generator::generate_swift_union_reader(ostream& out, t_struct* tstr
   const vector<t_field*>& fields = tstruct->get_members();
   vector<t_field*>::const_iterator f_iter;
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    indent(out) << "case (" << (*f_iter)->get_key() << ", " << type_to_enum((*f_iter)->get_type()) << "):";// << endl;
+    indent(out) << "case (" << (*f_iter)->get_key() << ", " << type_to_enum((*f_iter)->get_type()) << "):";
     string padding = "";
 
     t_type* type = get_true_type((*f_iter)->get_type());
@@ -1165,7 +1165,7 @@ void t_swift_generator::generate_swift_struct_reader(ostream& out,
 
     // Generate deserialization code for known cases
     for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-      indent(out) << "case (" << (*f_iter)->get_key() << ", " << type_to_enum((*f_iter)->get_type()) << "):";// << endl;
+      indent(out) << "case (" << (*f_iter)->get_key() << ", " << type_to_enum((*f_iter)->get_type()) << "):";
       string padding = "";
 
       t_type* type = get_true_type((*f_iter)->get_type());
@@ -2414,7 +2414,14 @@ void t_swift_generator::generate_swift_service_server_implementation(ostream& ou
 
       if (!gen_cocoa_) {
         for (x_iter = xfields.begin(); x_iter != xfields.end(); ++x_iter) {
-          indent(out) << "catch let error as " << (*x_iter)->get_type()->get_name();
+          indent(out) << "catch let error as ";
+
+          t_program* program = (*x_iter)->get_type()->get_program();
+          if ((*x_iter)->get_type()->get_name() == "Error" && namespaced_ && program != program_) {
+            out << get_real_swift_module(program) << ".";
+          }
+          out << (*x_iter)->get_type()->get_name();
+
           out << " { result." << (*x_iter)->get_name() << " = error }" << endl;
         }
 

--- a/lib/swift/README.md
+++ b/lib/swift/README.md
@@ -20,8 +20,6 @@ KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 
-Brought to you by [FiscalNote, Inc](http://www.fiscalnote.com/)
-
 
 ## Build
 


### PR DESCRIPTION
Some minor updates to the Swift code generator.
- Source files no longer capitalized (i.e. `index.thrift` now generates `index.swift` and not `Index.swift`, when namespaced it generates `index/index.swift` instead of `index/Index.swift`).  There was an inconsistency with how module names were capitalized which could cause issues when namespacing and using Swift modules.   This change _may_ be breaking for some use cases, but is otherwise resolved by changing the case of the module name where ever it is an issue.  (for most use cases, it shouldn't cause any issues, just a different named file)

- For cases when handling Errors, module name is appropriately prefixed to Error type name if the Error type name happens to be `Error` in order to disambiguate from Swift.Error.  This is a non-breaking change and fixes compiler errors when namespacing _and_ using a type named `Error`
