### PR TITLE
THRIFT-3458: add dub support for dlang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tags
 
 .*project
 .classpath
+.dub
 .settings
 .checkstyle
 junit*.properties
@@ -37,8 +38,11 @@ Makefile
 Makefile.in
 aclocal.m4
 acinclude.m4
+apache-thrift-test-library
 autom4te.cache
 cmake-*
+dub.selections.json
+libapache-thrift.a
 node_modules
 compile
 test-driver

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,27 @@
+{
+  "name": "apache-thrift",
+  "description": "Apache Thrift D library",
+  "authors": [
+    "Apache Thrift Developers <dev@thrift.apache.org>"
+  ],
+  "homepage": "http://thrift.apache.org",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "libevent": {
+      "version": "*"
+    },
+    "openssl": {
+      "version": "*"
+    }
+  },
+  "targetType": "library",
+  "sourcePaths": [
+    "lib/d/src" 
+  ],
+  "importPaths": [
+    "lib/d/src"
+  ],
+  "excludedSourceFiles": [
+    "src/thrift/index.d"
+  ]
+}

--- a/dub.json
+++ b/dub.json
@@ -8,12 +8,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "libevent": {
-      "version": "*"
+      "version": "~>2.0.2"
     },
     "openssl": {
-      "version": "*"
+      "version": "~>1.1.6"
     }
   },
+  "systemDependencies": "requires openssl 1.0 until deimos module is updated",
   "targetType": "library",
   "sourcePaths": [
     "lib/d/src" 
@@ -22,6 +23,6 @@
     "lib/d/src"
   ],
   "excludedSourceFiles": [
-    "src/thrift/index.d"
+    "lib/d/src/thrift/index.d"
   ]
 }

--- a/lib/d/src/thrift/server/base.d
+++ b/lib/d/src/thrift/server/base.d
@@ -112,12 +112,44 @@ protected:
     outputProtocolFactory_ = outputProtocolFactory;
   }
 
-  public TProcessorFactory processorFactory_;
-  public TServerTransport serverTransport_;
-  public TTransportFactory inputTransportFactory_;
-  public TTransportFactory outputTransportFactory_;
-  public TProtocolFactory inputProtocolFactory_;
-  public TProtocolFactory outputProtocolFactory_;
+  TProcessorFactory processorFactory_;
+  TServerTransport serverTransport_;
+  TTransportFactory inputTransportFactory_;
+  TTransportFactory outputTransportFactory_;
+  TProtocolFactory inputProtocolFactory_;
+  TProtocolFactory outputProtocolFactory_;
+
+public:
+
+  @property TProcessorFactory processorFactory()
+  {
+    return processorFactory_;
+  }
+
+  @property TServerTransport serverTransport()
+  {
+    return serverTransport_;
+  }
+
+  @property TTransportFactory inputTransportFactory()
+  {
+    return inputTransportFactory_;
+  }
+
+  @property TTransportFactory outputTransportFactory()
+  {
+    return outputTransportFactory_;
+  }
+
+  @property TProtocolFactory inputProtocolFactory()
+  {
+    return inputProtocolFactory_;
+  }
+
+  @property TProtocolFactory outputProtocolFactory()
+  {
+    return outputProtocolFactory_;
+  }
 }
 
 /**

--- a/lib/d/src/thrift/server/nonblocking.d
+++ b/lib/d/src/thrift/server/nonblocking.d
@@ -893,14 +893,14 @@ private {
       callsSinceResize_ = 0;
 
       factoryInputTransport_ =
-        server_.inputTransportFactory_.getTransport(inputTransport_);
+        server_.inputTransportFactory.getTransport(inputTransport_);
       factoryOutputTransport_ =
-        server_.outputTransportFactory_.getTransport(outputTransport_);
+        server_.outputTransportFactory.getTransport(outputTransport_);
 
       inputProtocol_ =
-        server_.inputProtocolFactory_.getProtocol(factoryInputTransport_);
+        server_.inputProtocolFactory.getProtocol(factoryInputTransport_);
       outputProtocol_ =
-        server_.outputProtocolFactory_.getProtocol(factoryOutputTransport_);
+        server_.outputProtocolFactory.getProtocol(factoryOutputTransport_);
 
       if (server_.eventHandler) {
         connectionContext_ =
@@ -908,7 +908,7 @@ private {
       }
 
       auto info = TConnectionInfo(inputProtocol_, outputProtocol_, socket_);
-      processor_ = server_.processorFactory_.getProcessor(info);
+      processor_ = server_.processorFactory.getProcessor(info);
     }
 
     ~this() {


### PR DESCRIPTION
This is in preparation to add thrift to the dub package manager for dlang.  This allows "dub build" and "dub test" to complete successfully when run from the top level directory.

This closes #723 