### PR TITLE
THRIFT-4678:add noexcept cpp generator option

### DIFF
--- a/lib/cpp/src/thrift/TApplicationException.h
+++ b/lib/cpp/src/thrift/TApplicationException.h
@@ -57,7 +57,7 @@ public:
   TApplicationException(TApplicationExceptionType type, const std::string& message)
     : TException(message), type_(type) {}
 
-  virtual ~TApplicationException() throw() {}
+  virtual ~TApplicationException() BOOST_NOEXCEPT_OR_NOTHROW {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -67,7 +67,7 @@ public:
    */
   TApplicationExceptionType getType() const { return type_; }
 
-  virtual const char* what() const throw() {
+  virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW {
     if (message_.empty()) {
       switch (type_) {
       case UNKNOWN:

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -82,9 +82,9 @@ public:
 
   TException(const std::string& message) : message_(message) {}
 
-  virtual ~TException() throw() {}
+  virtual ~TException() BOOST_NOEXCEPT_OR_NOTHROW {}
 
-  virtual const char* what() const throw() {
+  virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW {
     if (message_.empty()) {
       return "Default TException.";
     } else {

--- a/lib/cpp/src/thrift/protocol/TProtocolException.h
+++ b/lib/cpp/src/thrift/protocol/TProtocolException.h
@@ -59,7 +59,7 @@ public:
   TProtocolException(TProtocolExceptionType type, const std::string& message)
     : apache::thrift::TException(message), type_(type) {}
 
-  virtual ~TProtocolException() throw() {}
+  virtual ~TProtocolException() BOOST_NOEXCEPT_OR_NOTHROW {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -69,7 +69,7 @@ public:
    */
   TProtocolExceptionType getType() const { return type_; }
 
-  virtual const char* what() const throw() {
+  virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW {
     if (message_.empty()) {
       switch (type_) {
       case UNKNOWN:

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -1046,14 +1046,14 @@ void buildErrors(string& errors, int errno_copy, int sslerrno) {
 /**
  * Default implementation of AccessManager
  */
-Decision DefaultClientAccessManager::verify(const sockaddr_storage& sa) throw() {
+Decision DefaultClientAccessManager::verify(const sockaddr_storage& sa) BOOST_NOEXCEPT_OR_NOTHROW {
   (void)sa;
   return SKIP;
 }
 
 Decision DefaultClientAccessManager::verify(const string& host,
                                             const char* name,
-                                            int size) throw() {
+                                            int size) BOOST_NOEXCEPT_OR_NOTHROW {
   if (host.empty() || name == NULL || size <= 0) {
     return SKIP;
   }
@@ -1062,7 +1062,7 @@ Decision DefaultClientAccessManager::verify(const string& host,
 
 Decision DefaultClientAccessManager::verify(const sockaddr_storage& sa,
                                             const char* data,
-                                            int size) throw() {
+                                            int size) BOOST_NOEXCEPT_OR_NOTHROW {
   bool match = false;
   if (sa.ss_family == AF_INET && size == sizeof(in_addr)) {
     match = (memcmp(&((sockaddr_in*)&sa)->sin_addr, data, size) == 0);

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -335,7 +335,7 @@ public:
   TSSLException(const std::string& message)
     : TTransportException(TTransportException::INTERNAL_ERROR, message) {}
 
-  virtual const char* what() const throw() {
+  virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW {
     if (message_.empty()) {
       return "TSSLException";
     } else {
@@ -386,7 +386,7 @@ public:
    * @param  sa Peer IP address
    * @return True if the peer is trusted, false otherwise
    */
-  virtual Decision verify(const sockaddr_storage& /* sa */) throw() { return DENY; }
+  virtual Decision verify(const sockaddr_storage& /* sa */) BOOST_NOEXCEPT_OR_NOTHROW { return DENY; }
   /**
    * Determine whether the peer should be granted access or not. It's called
    * every time a DNS subjectAltName/common name is extracted from peer's
@@ -402,7 +402,7 @@ public:
    */
   virtual Decision verify(const std::string& /* host */,
                           const char* /* name */,
-                          int /* size */) throw() {
+                          int /* size */) BOOST_NOEXCEPT_OR_NOTHROW {
     return DENY;
   }
   /**
@@ -416,7 +416,7 @@ public:
    */
   virtual Decision verify(const sockaddr_storage& /* sa */,
                           const char* /* data */,
-                          int /* size */) throw() {
+                          int /* size */) BOOST_NOEXCEPT_OR_NOTHROW {
     return DENY;
   }
 };
@@ -426,9 +426,9 @@ typedef AccessManager::Decision Decision;
 class DefaultClientAccessManager : public AccessManager {
 public:
   // AccessManager interface
-  Decision verify(const sockaddr_storage& sa) throw();
-  Decision verify(const std::string& host, const char* name, int size) throw();
-  Decision verify(const sockaddr_storage& sa, const char* data, int size) throw();
+  Decision verify(const sockaddr_storage& sa) BOOST_NOEXCEPT_OR_NOTHROW;
+  Decision verify(const std::string& host, const char* name, int size) BOOST_NOEXCEPT_OR_NOTHROW;
+  Decision verify(const sockaddr_storage& sa, const char* data, int size) BOOST_NOEXCEPT_OR_NOTHROW;
 };
 }
 }

--- a/lib/cpp/src/thrift/transport/TTransportException.cpp
+++ b/lib/cpp/src/thrift/transport/TTransportException.cpp
@@ -28,7 +28,7 @@ namespace apache {
 namespace thrift {
 namespace transport {
 
-const char* TTransportException::what() const throw() {
+const char* TTransportException::what() const BOOST_NOEXCEPT_OR_NOTHROW {
   if (message_.empty()) {
     switch (type_) {
     case UNKNOWN:

--- a/lib/cpp/src/thrift/transport/TTransportException.h
+++ b/lib/cpp/src/thrift/transport/TTransportException.h
@@ -65,7 +65,7 @@ public:
   TTransportException(TTransportExceptionType type, const std::string& message, int errno_copy)
     : apache::thrift::TException(message + ": " + TOutput::strerror_s(errno_copy)), type_(type) {}
 
-  virtual ~TTransportException() throw() {}
+  virtual ~TTransportException() BOOST_NOEXCEPT_OR_NOTHROW {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -73,9 +73,9 @@ public:
    *
    * @return Error code
    */
-  TTransportExceptionType getType() const throw() { return type_; }
+  TTransportExceptionType getType() const BOOST_NOEXCEPT_OR_NOTHROW { return type_; }
 
-  virtual const char* what() const throw();
+  virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW;
 
 protected:
   /** Just like strerror_r but returns a C++ string object. */

--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -38,7 +38,7 @@ public:
       zlib_status_(status),
       zlib_msg_(msg == NULL ? "(null)" : msg) {}
 
-  virtual ~TZlibTransportException() throw() {}
+  virtual ~TZlibTransportException() BOOST_NOEXCEPT_OR_NOTHROW {}
 
   int getZlibStatus() { return zlib_status_; }
   std::string getZlibMessage() { return zlib_msg_; }


### PR DESCRIPTION
Because throw() is deprecated in C++11,to avoid compiler warnings.