### PR TITLE
THRIFT-4645: TCurlClient: include failure reason in exception

### DIFF
--- a/lib/php/lib/Transport/TCurlClient.php
+++ b/lib/php/lib/Transport/TCurlClient.php
@@ -219,15 +219,19 @@ class TCurlClient extends TTransport
 
         curl_setopt(self::$curlHandle, CURLOPT_URL, $fullUrl);
         $this->response_ = curl_exec(self::$curlHandle);
+        $responseError = curl_error(self::$curlHandle);
 
         $code = curl_getinfo(self::$curlHandle, CURLINFO_HTTP_CODE);
 
         // Handle non 200 status code / connect failure
-        if (!$this->response_ || $code !== 200) {
+        if ($this->response_ === false || $code !== 200) {
             curl_close(self::$curlHandle);
             self::$curlHandle = null;
             $this->response_ = null;
             $error = 'TCurlClient: Could not connect to ' . $fullUrl;
+            if ($responseError) {
+                $error .= ', ' . $responseError;
+            }
             if ($code) {
                 $error .= ', HTTP status code: ' . $code;
             }


### PR DESCRIPTION
When curl_exec fails, more detailed failure information is available by calling curl_error.  Include this error information in the message in the thrown TTransportException.

Also change the comparison of the return value of curl_exec to explicitly check for boolean false, so as to distinguish from an empty response body (per the PHP documentation on this subject).

Changes have been tested and running in production at Thumbtack for the past several days, and it's working as expected.  TCurlClient doesn't seem to have any existing test suite to update.