### PR TITLE
THRIFT-4646: change dart generation of exception to exception

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_dart_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_dart_generator.cc
@@ -777,10 +777,10 @@ void t_dart_generator::generate_dart_struct_definition(ostream& out,
   }
   indent(out) << "class " << class_name << " ";
 
-  if (is_exception) {
-    out << "extends Error ";
-  }
   out << "implements TBase";
+  if (is_exception) {
+    out << ", Exception ";
+  }
   scope_up(out);
 
   indent(out) << "static final TStruct _STRUCT_DESC = new TStruct(\"" << class_name


### PR DESCRIPTION
Tested locally, and is generating correctly.  The description of the issue being addressed is described in the JIRA ticket.