### PR TITLE
Thrift-4647: Node.js Filesever webroot fixed path

### DIFF
--- a/lib/js/test/server_http.js
+++ b/lib/js/test/server_http.js
@@ -42,7 +42,7 @@ const ThriftTestSvcOpt = {
 };
 
 const ThriftWebServerOptions = {
-	files: '.',
+	files: __dirname,
 	services: {
 		'/service': ThriftTestSvcOpt
 	}

--- a/lib/js/test/server_https.js
+++ b/lib/js/test/server_https.js
@@ -42,7 +42,7 @@ const ThriftTestSvcOpt = {
 };
 
 const ThriftWebServerOptions = {
-  files: '.',
+  files: __dirname,
   tls: {
      key: fs.readFileSync('../../../test/keys/server.key'),
      cert: fs.readFileSync('../../../test/keys/server.crt')

--- a/lib/nodejs/lib/thrift/web_server.js
+++ b/lib/nodejs/lib/thrift/web_server.js
@@ -415,7 +415,15 @@ exports.createWebServer = function(options) {
 
     //Locate the file requested and send it
     var uri = url.parse(request.url).pathname;
-    var filename = path.join(baseDir, uri);
+    var filename = path.resolve(path.join(baseDir, uri));
+
+    //Ensure the basedir path is not able to be escaped
+    if (filename.indexOf(baseDir) != 0) {
+      response.writeHead(400, "Invalid request path", {});
+      response.end();
+      return;
+    }
+
     fs.exists(filename, function(exists) {
       if(!exists) {
         response.writeHead(404);


### PR DESCRIPTION
Updates the node.js fileserver to have a fixed based webroot which can
not be escaped by end users.