### PR TITLE
Replace git.apache.org imports with github.com

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -61,7 +61,7 @@ static const string endl = "\n"; // avoid ostream << std::endl flushes
  */
 bool format_go_output(const string& file_path);
 
-const string DEFAULT_THRIFT_IMPORT = "git.apache.org/thrift.git/lib/go/thrift";
+const string DEFAULT_THRIFT_IMPORT = "github.com/apache/thrift/lib/go/thrift";
 static std::string package_flag;
 
 /**

--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -29,7 +29,7 @@ Thrift supports Go 1.7+
 In following Go conventions, we recommend you use the 'go' tool to install
 Thrift for go.
 
-    $ go get git.apache.org/thrift.git/lib/go/thrift/...
+    $ go get github.com/apache/thrift/lib/go/thrift/...
 
 Will retrieve and install the most recent version of the package.
 

--- a/tutorial/go/Makefile.am
+++ b/tutorial/go/Makefile.am
@@ -22,15 +22,15 @@ gen-go/tutorial/calculator.go gen-go/shared/shared_service.go: $(top_srcdir)/tut
 
 all-local: gen-go/tutorial/calculator.go
 
-check: src/git.apache.org/thrift.git/lib/go/thrift thirdparty-dep
+check: src/github.com/apache/thrift/lib/go/thrift thirdparty-dep
 	$(THRIFT) -r --gen go$(COMPILER_EXTRAFLAG) $(top_srcdir)/tutorial/tutorial.thrift
 	cp -r gen-go/* src/
 	GOPATH=`pwd` $(GO) build -o go-tutorial ./src
 	GOPATH=`pwd` $(GO) build -o calculator-remote src/tutorial/calculator-remote/calculator-remote.go
 
-src/git.apache.org/thrift.git/lib/go/thrift:
-	mkdir -p src/git.apache.org/thrift.git/lib/go
-	ln -sf $(realpath $(top_srcdir)/lib/go/thrift) src/git.apache.org/thrift.git/lib/go/thrift
+src/github.com/apache/thrift/lib/go/thrift:
+	mkdir -p src/github.com/apache/thrift/lib/go
+	ln -sf $(realpath $(top_srcdir)/lib/go/thrift) src/github.com/apache/thrift/lib/go/thrift
 
 thirdparty-dep:
 

--- a/tutorial/go/src/client.go
+++ b/tutorial/go/src/client.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"tutorial"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 var defaultCtx = context.Background()

--- a/tutorial/go/src/main.go
+++ b/tutorial/go/src/main.go
@@ -22,7 +22,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"os"
 )
 

--- a/tutorial/go/src/server.go
+++ b/tutorial/go/src/server.go
@@ -22,7 +22,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"tutorial"
 )
 


### PR DESCRIPTION
Github has been the canonical repo for a while now and I plan to merge this before 0.12 is tagged. I'm opening a PR to see if anyone has any feedback.

If you think this should be reverted or delayed, please say so.