### PR TITLE
THRIFT-4382: Replace the use of Indirect Object Syntax calls to new()

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_perl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_perl_generator.cc
@@ -354,7 +354,7 @@ string t_perl_generator::render_const_value(t_type* type, t_const_value* value) 
   } else if (type->is_enum()) {
     out << value->get_integer();
   } else if (type->is_struct() || type->is_xception()) {
-    out << "new " << perl_namespace(type->get_program()) << type->get_name() << "({" << endl;
+    out << perl_namespace(type->get_program()) << type->get_name() << "->new({" << endl;
     indent_up();
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
@@ -546,7 +546,7 @@ void t_perl_generator::generate_perl_struct_reader(ostream& out, t_struct* tstru
   indent(out) << "$xfer += $input->readStructBegin(\\$fname);" << endl;
 
   // Loop over reading in fields
-  indent(out) << "while (1) " << endl;
+  indent(out) << "while (1)" << endl;
 
   scope_up(out);
 
@@ -758,7 +758,7 @@ void t_perl_generator::generate_service_processor(t_service* tservice) {
 
   f_service_ << indent() << "$input->skip(Thrift::TType::STRUCT);" << endl << indent()
              << "$input->readMessageEnd();" << endl << indent()
-             << "my $x = new Thrift::TApplicationException('Function '.$fname.' not implemented.', "
+             << "my $x = Thrift::TApplicationException->new('Function '.$fname.' not implemented.', "
                 "Thrift::TApplicationException::UNKNOWN_METHOD);" << endl << indent()
              << "$output->writeMessageBegin($fname, Thrift::TMessageType::EXCEPTION, $rseqid);" << endl
              << indent() << "$x->write($output);" << endl << indent()
@@ -798,7 +798,7 @@ void t_perl_generator::generate_process_function(t_service* tservice, t_function
   string resultname = perl_namespace(tservice->get_program()) + service_name_ + "_"
                       + tfunction->get_name() + "_result";
 
-  f_service_ << indent() << "my $args = new " << argsname << "();" << endl << indent()
+  f_service_ << indent() << "my $args = " << argsname << "->new();" << endl << indent()
              << "$args->read($input);" << endl;
 
   f_service_ << indent() << "$input->readMessageEnd();" << endl;
@@ -809,7 +809,7 @@ void t_perl_generator::generate_process_function(t_service* tservice, t_function
 
   // Declare result for non oneway function
   if (!tfunction->is_oneway()) {
-    f_service_ << indent() << "my $result = new " << resultname << "();" << endl;
+    f_service_ << indent() << "my $result = " << resultname << "->new();" << endl;
   }
 
   // Try block for a function with exceptions
@@ -858,7 +858,7 @@ void t_perl_generator::generate_process_function(t_service* tservice, t_function
     f_service_ << indent() << "if ($@) {" << endl;
     indent_up();
     f_service_ << indent() << "$@ =~ s/^\\s+|\\s+$//g;" << endl
-               << indent() << "my $err = new Thrift::TApplicationException(\"Unexpected Exception: \" . $@, Thrift::TApplicationException::INTERNAL_ERROR);" << endl
+               << indent() << "my $err = Thrift::TApplicationException->new(\"Unexpected Exception: \" . $@, Thrift::TApplicationException::INTERNAL_ERROR);" << endl
                << indent() << "$output->writeMessageBegin('" << tfunction->get_name() << "', Thrift::TMessageType::EXCEPTION, $seqid);" << endl
                << indent() << "$err->write($output);" << endl
                << indent() << "$output->writeMessageEnd();" << endl
@@ -1106,7 +1106,7 @@ void t_perl_generator::generate_service_client(t_service* tservice) {
                << "', " << ((*f_iter)->is_oneway() ? "Thrift::TMessageType::ONEWAY" : "Thrift::TMessageType::CALL")
                << ", $self->{seqid});" << endl;
 
-    f_service_ << indent() << "my $args = new " << argsname << "();" << endl;
+    f_service_ << indent() << "my $args = " << argsname << "->new();" << endl;
 
     for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
       f_service_ << indent() << "$args->{" << (*fld_iter)->get_name() << "} = $"
@@ -1140,12 +1140,12 @@ void t_perl_generator::generate_service_client(t_service* tservice) {
 
       f_service_ << indent() << "$self->{input}->readMessageBegin(\\$fname, \\$mtype, \\$rseqid);"
                  << endl << indent() << "if ($mtype == Thrift::TMessageType::EXCEPTION) {" << endl
-                 << indent() << "  my $x = new Thrift::TApplicationException();" << endl << indent()
+                 << indent() << "  my $x = Thrift::TApplicationException->new();" << endl << indent()
                  << "  $x->read($self->{input});" << endl << indent()
                  << "  $self->{input}->readMessageEnd();" << endl << indent() << "  die $x;" << endl
                  << indent() << "}" << endl;
 
-      f_service_ << indent() << "my $result = new " << resultname << "();" << endl << indent()
+      f_service_ << indent() << "my $result = " << resultname << "->new();" << endl << indent()
                  << "$result->read($self->{input});" << endl;
 
       f_service_ << indent() << "$self->{input}->readMessageEnd();" << endl << endl;
@@ -1586,7 +1586,7 @@ string t_perl_generator::declare_field(t_field* tfield, bool init, bool obj) {
       result += " = []";
     } else if (type->is_struct() || type->is_xception()) {
       if (obj) {
-        result += " = new " + perl_namespace(type->get_program()) + type->get_name() + "()";
+        result += " = " + perl_namespace(type->get_program()) + type->get_name() + "->new()";
       } else {
         result += " = undef";
       }

--- a/lib/perl/lib/Thrift/BinaryProtocol.pm
+++ b/lib/perl/lib/Thrift/BinaryProtocol.pm
@@ -39,7 +39,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 use constant VERSION_MASK   => 0xffff0000;
 use constant VERSION_1      => 0x80010000;
-use constant IS_BIG_ENDIAN  => unpack("h*", pack("s", 1)) =~ /01/;
+use constant IS_BIG_ENDIAN  => unpack('h*', pack('s', 1)) =~ m/01/;
 
 sub new
 {
@@ -67,7 +67,8 @@ sub writeMessageEnd
     return 0;
 }
 
-sub writeStructBegin{
+sub writeStructBegin
+{
     my $self = shift;
     my $name = shift;
     return 0;
@@ -253,7 +254,7 @@ sub readMessageBegin
     my $result = $self->readI32(\$version);
     if (($version & VERSION_MASK) > 0) {
       if (($version & VERSION_MASK) != VERSION_1) {
-        die new Thrift::TProtocolException('Missing version identifier',
+        die Thrift::TProtocolException->new('Missing version identifier',
                                            Thrift::TProtocolException::BAD_VERSION);
       }
       $$type = $version & 0x000000ff;
@@ -261,7 +262,8 @@ sub readMessageBegin
           $result +
           $self->readString($name) +
           $self->readI32($seqid);
-    } else { # old client support code
+    }
+    else { # old client support code
       return
         $result +
         $self->readStringBody($name, $version) + # version here holds the size of the string
@@ -427,7 +429,7 @@ sub readI64
 
     my ($hi,$lo)=unpack('NN',$data);
 
-    my $vec = new Bit::Vector(64);
+    my $vec = Bit::Vector->new(64);
 
     $vec->Chunk_Store(32,32,$hi);
     $vec->Chunk_Store(32,0,$lo);
@@ -467,7 +469,8 @@ sub readString
 
     if ($len) {
       $$value = $self->{trans}->readAll($len);
-    } else {
+    }
+    else {
       $$value = '';
     }
 
@@ -482,7 +485,8 @@ sub readStringBody
 
     if ($len) {
       $$value = $self->{trans}->readAll($len);
-    } else {
+    }
+    else {
       $$value = '';
     }
 
@@ -508,7 +512,7 @@ sub getProtocol{
     my $self  = shift;
     my $trans = shift;
 
-    return new Thrift::BinaryProtocol($trans);
+    return Thrift::BinaryProtocol->new($trans);
 }
 
 1;

--- a/lib/perl/lib/Thrift/Exception.pm
+++ b/lib/perl/lib/Thrift/Exception.pm
@@ -29,11 +29,10 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 use overload '""' => sub {
     return
-          ref( $_[0] )
-        . " error: "
-        . ( $_[0]->{message} || 'empty message' )
-        . " (code "
-        . ( defined $_[0]->{code} ? $_[0]->{code} : 'undefined' ) . ")";
+        sprintf '%s error: %s (code %s)',
+          ref( $_[0] ),
+          ( $_[0]->{message} || 'empty message' ),
+          ( defined $_[0]->{code} ? $_[0]->{code} : 'undefined' );
     };
 
 sub new {
@@ -91,7 +90,8 @@ sub read {
 
               if ($ftype == Thrift::TType::STRING) {
                   $xfer += $input->readString(\$self->{message});
-              } else {
+              }
+              else {
                   $xfer += $input->skip($ftype);
               }
 
@@ -101,7 +101,8 @@ sub read {
           /2/ && do{
               if ($ftype == Thrift::TType::I32) {
                   $xfer += $input->readI32(\$self->{code});
-              } else {
+              }
+              else {
                   $xfer += $input->skip($ftype);
               }
               last;

--- a/lib/perl/lib/Thrift/FramedTransport.pm
+++ b/lib/perl/lib/Thrift/FramedTransport.pm
@@ -70,7 +70,7 @@ sub close
     my $self = shift;
 
     if (defined $self->{transport}) {
-      $self->{transport}->close();
+        $self->{transport}->close();
     }
 }
 

--- a/lib/perl/lib/Thrift/HttpClient.pm
+++ b/lib/perl/lib/Thrift/HttpClient.pm
@@ -61,7 +61,7 @@ sub setTimeout
 
 sub setRecvTimeout
 {
-    warn "setRecvTimeout is deprecated - use setTimeout instead";
+    warn 'setRecvTimeout is deprecated - use setTimeout instead';
     # note: recvTimeout was never used so we do not need to do anything here
 }
 
@@ -70,7 +70,7 @@ sub setSendTimeout
     my $self    = shift;
     my $timeout = shift;
 
-    warn "setSendTimeout is deprecated - use setTimeout instead";
+    warn 'setSendTimeout is deprecated - use setTimeout instead';
 
     $self->setTimeout($timeout);
 }
@@ -102,8 +102,8 @@ sub close
 {
     my $self = shift;
     if (defined($self->{io})) {
-      close($self->{io});
-      $self->{io} = undef;
+        close($self->{io});
+        $self->{io} = undef;
     }
 }
 
@@ -121,7 +121,7 @@ sub readAll
     my $buf = $self->read($len);
 
     if (!defined($buf)) {
-      die new Thrift::TTransportException("TSocket: Could not read $len bytes from input buffer",
+        die Thrift::TTransportException->new("TSocket: Could not read $len bytes from input buffer",
                                           Thrift::TTransportException::END_OF_FILE);
     }
     return $buf;
@@ -140,17 +140,18 @@ sub read
     my $in = $self->{in};
 
     if (!defined($in)) {
-      die new Thrift::TTransportException("Response buffer is empty, no request.",
+        die Thrift::TTransportException->new('Response buffer is empty, no request.',
                                           Thrift::TTransportException::END_OF_FILE);
     }
     eval {
-      my $ret = sysread($in, $buf, $len);
-      if (! defined($ret)) {
-        die new Thrift::TTransportException("No more data available.",
+        my $ret = sysread($in, $buf, $len);
+        if (! defined($ret)) {
+            die Thrift::TTransportException->new('No more data available.',
                                             Thrift::TTransportException::TIMED_OUT);
-      }
-    }; if($@){
-      die new Thrift::TTransportException("$@", Thrift::TTransportException::UNKNOWN);
+        }
+    };
+    if($@){
+        die Thrift::TTransportException->new("$@", Thrift::TTransportException::UNKNOWN);
     }
 
     return $buf;
@@ -173,8 +174,9 @@ sub flush
 {
     my $self = shift;
 
-    my $ua = LWP::UserAgent->new('timeout' => ($self->{timeout} / 1000),
-      'agent' => 'Perl/THttpClient'
+    my $ua = LWP::UserAgent->new(
+        'timeout' => ($self->{timeout} / 1000),
+        'agent'   => 'Perl/THttpClient'
      );
     $ua->default_header('Accept' => 'application/x-thrift');
     $ua->default_header('Content-Type' => 'application/x-thrift');
@@ -184,8 +186,7 @@ sub flush
     $out->setpos(0); # rewind
     my $buf = join('', <$out>);
 
-    my $request = new HTTP::Request(POST => $self->{url}, undef, $buf);
-    map { $request->header($_ => $self->{headers}->{$_}) } keys %{$self->{headers}};
+    my $request = HTTP::Request->new(POST => $self->{url}, ($self->{headers} || undef), $buf);
     my $response = $ua->request($request);
     my $content_ref = $response->content_ref;
 

--- a/lib/perl/lib/Thrift/MemoryBuffer.pm
+++ b/lib/perl/lib/Thrift/MemoryBuffer.pm
@@ -35,10 +35,10 @@ sub new
     my $bufferSize= shift || 1024;
 
     my $self = {
-        buffer    => '',
-        bufferSize=> $bufferSize,
-        wPos      => 0,
-        rPos      => 0,
+        buffer     => '',
+        bufferSize => $bufferSize,
+        wPos       => 0,
+        rPos       => 0,
     };
 
     return bless($self,$classname);
@@ -117,7 +117,7 @@ sub readAll
 
     my $avail = ($self->{wPos} - $self->{rPos});
     if ($avail < $len) {
-        die new TTransportException("Attempt to readAll($len) found only $avail available",
+        die TTransportException->new("Attempt to readAll($len) found only $avail available",
                                     Thrift::TTransportException::END_OF_FILE);
     }
 

--- a/lib/perl/lib/Thrift/MultiplexedProcessor.pm
+++ b/lib/perl/lib/Thrift/MultiplexedProcessor.pm
@@ -101,32 +101,32 @@ sub process {
     $input->readMessageBegin(\$fname, \$mtype, \$rseqid);
 
     if ($mtype ne Thrift::TMessageType::CALL && $mtype ne Thrift::TMessageType::ONEWAY) {
-        die new Thrift::TException("This should not have happened!?");
+        die Thrift::TException->new('This should not have happened!?');
     }
 
     # Extract the service name and the new Message name.
     if (index($fname, Thrift::MultiplexedProtocol::SEPARATOR) == -1) {
         if (defined $self->{defaultProcessor}) {
             return $self->{defaultProcessor}->process(
-                new Thrift::StoredMessageProtocol($input, $fname, $mtype, $rseqid), $output
+                Thrift::StoredMessageProtocol->new($input, $fname, $mtype, $rseqid), $output
             );
         } else {
-            die new Thrift::TException("Service name not found in message name: {$fname} and no default processor defined. Did you " .
-                "forget to use a MultiplexProtocol in your client?");
+            die Thrift::TException->new("Service name not found in message name: {$fname} and no default processor defined. Did you " .
+                'forget to use a MultiplexProtocol in your client?');
         }
     }
 
     (my $serviceName, my $messageName) = split(':', $fname, 2);
 
     if (!exists($self->{serviceProcessorMap}->{$serviceName})) {
-        die new Thrift::TException("Service name not found: {$serviceName}.  Did you forget " .
-            "to call registerProcessor()?");
+        die Thrift::TException->new("Service name not found: {$serviceName}.  Did you forget " .
+            'to call registerProcessor()?');
     }
 
     # Dispatch processing to the stored processor
     my $processor = $self->{serviceProcessorMap}->{$serviceName};
     return $processor->process(
-        new Thrift::StoredMessageProtocol($input, $messageName, $mtype, $rseqid), $output
+        Thrift::StoredMessageProtocol->new($input, $messageName, $mtype, $rseqid), $output
     );
 }
 

--- a/lib/perl/lib/Thrift/MultiplexedProtocol.pm
+++ b/lib/perl/lib/Thrift/MultiplexedProtocol.pm
@@ -53,7 +53,7 @@ sub new {
 #
 sub writeMessageBegin
 {
-  my $self = shift;
+    my $self = shift;
     my ($name, $type, $seqid) = @_;
 
     if ($type == Thrift::TMessageType::CALL || $type == Thrift::TMessageType::ONEWAY) {

--- a/lib/perl/lib/Thrift/Protocol.pm
+++ b/lib/perl/lib/Thrift/Protocol.pm
@@ -81,14 +81,14 @@ sub getTransport
 sub writeMessageBegin
 {
     my ($name, $type, $seqid);
-    die "abstract";
+    die 'abstract';
 }
 
 #
 # Close the message
 #
 sub writeMessageEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -101,7 +101,7 @@ sub writeMessageEnd {
 sub writeStructBegin {
     my ($name);
 
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -111,7 +111,7 @@ sub writeStructBegin {
 # @return int How many bytes written
 #
 sub writeStructEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -126,79 +126,79 @@ sub writeStructEnd {
 sub writeFieldBegin {
     my ($fieldName, $fieldType, $fieldId);
 
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeFieldEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeFieldStop {
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeMapBegin {
     my ($keyType, $valType, $size);
 
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeMapEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeListBegin {
     my ($elemType, $size);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeListEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeSetBegin {
     my ($elemType, $size);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeSetEnd {
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeBool {
     my ($bool);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeByte {
     my ($byte);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeI16 {
     my ($i16);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeI32 {
     my ($i32);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeI64 {
     my ($i64);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeDouble {
     my ($dub);
-    die "abstract";
+    die 'abstract';
 }
 
 sub writeString
 {
     my ($str);
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -211,7 +211,7 @@ sub writeString
 sub readMessageBegin
 {
     my ($name, $type, $seqid);
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -219,105 +219,105 @@ sub readMessageBegin
 #
 sub readMessageEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readStructBegin
 {
     my($name);
 
-    die "abstract";
+    die 'abstract';
 }
 
 sub readStructEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readFieldBegin
 {
     my ($name, $fieldType, $fieldId);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readFieldEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readMapBegin
 {
     my ($keyType, $valType, $size);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readMapEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readListBegin
 {
     my ($elemType, $size);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readListEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readSetBegin
 {
     my ($elemType, $size);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readSetEnd
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub readBool
 {
     my ($bool);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readByte
 {
     my ($byte);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readI16
 {
     my ($i16);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readI32
 {
     my ($i32);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readI64
 {
     my ($i64);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readDouble
 {
     my ($dub);
-    die "abstract";
+    die 'abstract';
 }
 
 sub readString
 {
     my ($str);
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -405,7 +405,7 @@ sub skip
         return $result;
     }
 
-    die new Thrift::TProtocolException("Type $type not recognized --- corrupt data?",
+    die Thrift::TProtocolException->new("Type $type not recognized --- corrupt data?",
                                        Thrift::TProtocolException::INVALID_DATA);
 
   }
@@ -424,7 +424,7 @@ sub skipBinary
 
     if($type == Thrift::TType::BOOL)
     {
-      return $itrans->readAll(1);
+        return $itrans->readAll(1);
     }
     elsif($type == Thrift::TType::BYTE)
     {
@@ -459,17 +459,17 @@ sub skipBinary
     {
         my $result = 0;
         while (1) {
-          my $ftype = 0;
-          my $fid = 0;
-          my $data = $itrans->readAll(1);
-          my @arr = unpack('c', $data);
-          $ftype = $arr[0];
-          if ($ftype == Thrift::TType::STOP) {
-            last;
-          }
-          # I16 field id
-          $result += $itrans->readAll(2);
-          $result += $self->skipBinary($itrans, $ftype);
+            my $ftype = 0;
+            my $fid = 0;
+            my $data = $itrans->readAll(1);
+            my @arr = unpack('c', $data);
+            $ftype = $arr[0];
+            if ($ftype == Thrift::TType::STOP) {
+                last;
+            }
+            # I16 field id
+            $result += $itrans->readAll(2);
+            $result += $self->skipBinary($itrans, $ftype);
         }
         return $result;
     }
@@ -517,7 +517,7 @@ sub skipBinary
         return $result;
     }
 
-    die new Thrift::TProtocolException("Type $type not recognized --- corrupt data?",
+    die Thrift::TProtocolException->new("Type $type not recognized --- corrupt data?",
                                        Thrift::TProtocolException::INVALID_DATA);
 }
 
@@ -542,7 +542,7 @@ sub new {
 sub getProtocol
 {
     my ($trans);
-    die "interface";
+    die 'interface';
 }
 
 

--- a/lib/perl/lib/Thrift/SSLServerSocket.pm
+++ b/lib/perl/lib/Thrift/SSLServerSocket.pm
@@ -48,7 +48,7 @@ sub new
 
 sub __client
 {
-  return new Thrift::SSLSocket();
+  return Thrift::SSLSocket->new();
 }
 
 sub __listen

--- a/lib/perl/lib/Thrift/SSLSocket.pm
+++ b/lib/perl/lib/Thrift/SSLSocket.pm
@@ -34,7 +34,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 # Construction and usage
 #
 # my $opts = {}
-# my $socket = new Thrift::SSLSocket(\%opts);
+# my $socket = Thrift::SSLSocket->new(\%opts);
 #
 # options:
 #

--- a/lib/perl/lib/Thrift/Server.pm
+++ b/lib/perl/lib/Thrift/Server.pm
@@ -51,7 +51,7 @@ sub new
 
     if (scalar @args == 2)
     {
-      $self = _init($args[0], $args[1],
+        $self = _init($args[0], $args[1],
                     Thrift::BufferedTransportFactory->new(),
                     Thrift::BufferedTransportFactory->new(),
                     Thrift::BinaryProtocolFactory->new(),
@@ -67,7 +67,7 @@ sub new
     }
     else
     {
-      die new Thrift::TException("Thrift::Server expects exactly 2, 4, or 6 args");
+      die Thrift::TException->new('Thrift::Server expects exactly 2, 4, or 6 args');
     }
 
     return bless($self,$classname);
@@ -94,7 +94,7 @@ sub _init
 
 sub serve
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub _clientBegin
@@ -115,7 +115,7 @@ sub _handleException
     my $self = shift;
     my $e    = shift;
 
-    if ($e->isa("Thrift::TException") and exists $e->{message}) {
+    if ($e->isa('Thrift::TException') and exists $e->{message}) {
         my $message = $e->{message};
         my $code    = $e->{code};
         my $out     = $code . ':' . $message;
@@ -123,10 +123,12 @@ sub _handleException
         $message =~ m/TTransportException/ and die $out;
         if ($message =~ m/Socket/) {
             # suppress Socket messages
-        } else {
+        }
+        else {
             warn $out;
         }
-    } else {
+    }
+    else {
         warn $e;
     }
 }
@@ -151,7 +153,7 @@ sub serve
 {
     my $self = shift;
     my $stop = 0;
-    
+
     $self->{serverTransport}->listen();
     while (!$stop) {
         my $client = $self->{serverTransport}->accept();
@@ -166,10 +168,10 @@ sub serve
                 {
                     $self->{processor}->process($iprot, $oprot);
                 }
-            }; if($@) {
+            };
+            if($@) {
                 $self->_handleException($@);
             }
-
             $itrans->close();
             $otrans->close();
         } else {
@@ -184,7 +186,7 @@ sub serve
 #
 package Thrift::ForkingServer;
 use parent -norequire, 'Thrift::Server';
-use POSIX ":sys_wait_h";
+use POSIX ':sys_wait_h';
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 sub new
@@ -231,10 +233,12 @@ sub _client
         if ($pid)
         {
             $self->_parent($pid, $itrans, $otrans);
-        } else {
+        }
+        else {
             $self->_child($itrans, $otrans, $iprot, $oprot);
         }
-    }; if($@) {
+    };
+    if($@) {
         $self->_handleException($@);
     }
 }
@@ -267,7 +271,8 @@ sub _child
         {
             $self->{processor}->process($iprot, $oprot);
         }
-    }; if($@) {
+    };
+    if($@) {
         $ecode = 1;
         $self->_handleException($@);
     }
@@ -288,14 +293,16 @@ sub tryClose
         {
           $file->close();
         }
-    }; if($@) {
-        if ($@->isa("Thrift::TException") and exists $@->{message}) {
+    };
+    if($@) {
+        if ($@->isa('Thrift::TException') and exists $@->{message}) {
             my $message = $@->{message};
             my $code    = $@->{code};
             my $out     = $code . ':' . $message;
 
             warn $out;
-        } else {
+        }
+        else {
             warn $@;
         }
     }

--- a/lib/perl/lib/Thrift/ServerSocket.pm
+++ b/lib/perl/lib/Thrift/ServerSocket.pm
@@ -38,7 +38,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 # @param[in]  host   host interface to listen on (undef = all interfaces)
 # @param[in]  port   port number to listen on (required)
 # @param[in]  queue  the listen queue size (default if not specified is 128)
-# @example    my $serversock = new Thrift::ServerSocket(host => undef, port => port)
+# @example    my $serversock = Thrift::ServerSocket->new(host => undef, port => port)
 #
 sub new
 {
@@ -49,7 +49,8 @@ sub new
     # Support both old-style "port number" construction and newer...
     if (ref($args) eq 'HASH') {
         $self = $args;
-    } else {
+    }
+    else {
         $self = { port => $args };
     }
 
@@ -71,7 +72,7 @@ sub listen
             $self->{debugHandler}->($error);
         }
 
-        die new Thrift::TTransportException($error, Thrift::TTransportException::NOT_OPEN);
+        die Thrift::TTransportException->new($error, Thrift::TTransportException::NOT_OPEN);
     };
 
     $self->{handle} = $sock;
@@ -84,7 +85,7 @@ sub accept
     if ( exists $self->{handle} and defined $self->{handle} ) {
         my $client        = $self->{handle}->accept();
         my $result        = $self->__client();
-        $result->{handle} = new IO::Select($client);
+        $result->{handle} = IO::Select->new($client);
         return $result;
     }
 
@@ -93,12 +94,12 @@ sub accept
 
 sub close
 {
-	my $self = shift;
-	
+    my $self = shift;
+
     if ( exists $self->{handle} and defined $self->{handle} )
     {
         $self->{handle}->close();
-	}
+    }
 }
 
 ###
@@ -107,7 +108,7 @@ sub close
 
 sub __client
 {
-  return new Thrift::Socket();
+  return Thrift::Socket->new();
 }
 
 sub __listen

--- a/lib/perl/lib/Thrift/Socket.pm
+++ b/lib/perl/lib/Thrift/Socket.pm
@@ -36,7 +36,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 # Construction and usage
 #
 # my $opts = {}
-# my $socket = new Thrift::Socket(\%opts);
+# my $socket = Thrift::Socket->new(\%opts);
 #
 # options:
 #
@@ -120,10 +120,10 @@ sub open
 
     my $sock = $self->__open() || do {
         my $error = ref($self).': Could not connect to '.$self->{host}.':'.$self->{port}.' ('.$!.')';
-        die new Thrift::TTransportException($error, Thrift::TTransportException::NOT_OPEN);
+        die Thrift::TTransportException->new($error, Thrift::TTransportException::NOT_OPEN);
     };
 
-    $self->{handle} = new IO::Select( $sock );
+    $self->{handle} = IO::Select->new( $sock );
 }
 
 #
@@ -159,15 +159,17 @@ sub readAll
 
         if (!defined $buf || $buf eq '') {
 
-            die new Thrift::TTransportException(ref($self).': Could not read '.$len.' bytes from '.
+            die Thrift::TTransportException->new(ref($self).': Could not read '.$len.' bytes from '.
                                $self->{host}.':'.$self->{port}, Thrift::TTransportException::END_OF_FILE);
 
-        } elsif ((my $sz = length($buf)) < $len) {
+        }
+        elsif ((my $sz = length($buf)) < $len) {
 
             $pre .= $buf;
             $len -= $sz;
 
-        } else {
+        }
+        else {
             return $pre.$buf;
         }
     }
@@ -191,7 +193,7 @@ sub read
 
     if (!defined $buf || $buf eq '') {
 
-        die new Thrift::TTransportException(ref($self).': Could not read '.$len.' bytes from '.
+        die Thrift::TTransportException->new(ref($self).': Could not read '.$len.' bytes from '.
                            $self->{host}.':'.$self->{port}, Thrift::TTransportException::END_OF_FILE);
 
     }
@@ -217,7 +219,7 @@ sub write
         my @sockets = $self->{handle}->can_write( $self->{sendTimeout} / 1000 );
 
         if(@sockets == 0){
-            die new Thrift::TTransportException(ref($self).': timed out writing to bytes from '.
+            die Thrift::TTransportException->new(ref($self).': timed out writing to bytes from '.
                                        $self->{host}.':'.$self->{port}, Thrift::TTransportException::TIMED_OUT);
         }
 
@@ -225,7 +227,7 @@ sub write
 
         if (!defined $sent || $sent == 0 ) {
 
-            die new Thrift::TTransportException(ref($self).': Could not write '.length($buf).' bytes '.
+            die Thrift::TTransportException->new(ref($self).': Could not write '.length($buf).' bytes '.
                                  $self->{host}.':'.$self->{host}, Thrift::TTransportException::END_OF_FILE);
 
         }
@@ -314,7 +316,7 @@ sub __wait
     my @sockets = $self->{handle}->can_read( $self->{recvTimeout} / 1000 );
 
     if (@sockets == 0) {
-        die new Thrift::TTransportException(ref($self).': timed out reading from '.
+        die Thrift::TTransportException->new(ref($self).': timed out reading from '.
                                    $self->{host}.':'.$self->{port}, Thrift::TTransportException::TIMED_OUT);
     }
 

--- a/lib/perl/lib/Thrift/Transport.pm
+++ b/lib/perl/lib/Thrift/Transport.pm
@@ -54,7 +54,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 #
 sub isOpen
 {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -64,7 +64,7 @@ sub isOpen
 #
 sub open
 {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -72,7 +72,7 @@ sub open
 #
 sub close
 {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -84,7 +84,7 @@ sub close
 #
 sub read
 {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -116,7 +116,7 @@ sub readAll
 #
 sub write
 {
-    die "abstract";
+    die 'abstract';
 }
 
 #
@@ -162,17 +162,17 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 sub listen
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub accept
 {
-    die "abstract";
+    die 'abstract';
 }
 
 sub close
 {
-    die "abstract";
+    die 'abstract';
 }
 
 

--- a/lib/perl/lib/Thrift/UnixServerSocket.pm
+++ b/lib/perl/lib/Thrift/UnixServerSocket.pm
@@ -37,8 +37,8 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 # If a single argument is given that is a hash:
 # @param[in]  path   unix domain socket file name
 # @param[in]  queue  the listen queue size (default is not specified is supplied by ServerSocket)
-# @example    my $serversock = new Thrift::UnixServerSocket($path);
-# @example    my $serversock = new Thrift::UnixServerSocket(path => "somepath", queue => 64);
+# @example    my $serversock = Thrift::UnixServerSocket->new($path);
+# @example    my $serversock = Thrift::UnixServerSocket->new(path => "somepath", queue => 64);
 #
 sub new
 {
@@ -58,7 +58,7 @@ sub new
 
 sub __client
 {
-  return new Thrift::UnixSocket();
+  return Thrift::UnixSocket->new();
 }
 
 sub __listen
@@ -75,7 +75,7 @@ sub __listen
         if ($self->{debug}) {
             $self->{debugHandler}->($error);
         }
-        die new Thrift::TTransportException($error, Thrift::TTransportException::NOT_OPEN);
+        die Thrift::TTransportException->new($error, Thrift::TTransportException::NOT_OPEN);
     };
 
     return $sock;

--- a/lib/perl/lib/Thrift/UnixSocket.pm
+++ b/lib/perl/lib/Thrift/UnixSocket.pm
@@ -35,7 +35,7 @@ use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 # Takes a unix domain socket filename.
 # See Thrift::Socket for base class parameters.
 # @param[in]  path   path to unix socket file
-# @example    my $sock = new Thrift::UnixSocket($path);
+# @example    my $sock = Thrift::UnixSocket->new($path);
 #
 sub new
 {
@@ -58,7 +58,7 @@ sub __open
         if ($self->{debug}) {
             $self->{debugHandler}->($error);
         }
-        die new Thrift::TTransportException($error, Thrift::TTransportException::NOT_OPEN);
+        die Thrift::TTransportException->new($error, Thrift::TTransportException::NOT_OPEN);
     };
 
     return $sock;

--- a/tutorial/perl/PerlClient.pl
+++ b/tutorial/perl/PerlClient.pl
@@ -37,10 +37,10 @@ use tutorial::Types;
 
 use Data::Dumper;
 
-my $socket    = new Thrift::Socket('localhost',9090);
-my $transport = new Thrift::BufferedTransport($socket,1024,1024);
-my $protocol  = new Thrift::BinaryProtocol($transport);
-my $client    = new tutorial::CalculatorClient($protocol);
+my $socket    = Thrift::Socket->new('localhost',9090);
+my $transport = Thrift::BufferedTransport->new($socket,1024,1024);
+my $protocol  = Thrift::BinaryProtocol->new($transport);
+my $client    = tutorial::CalculatorClient->new($protocol);
 
 
 eval{
@@ -53,7 +53,7 @@ eval{
     my $sum = $client->add(1,1);
     print "1+1=$sum\n";
 
-    my $work = new tutorial::Work();
+    my $work = tutorial::Work->new();
 
     $work->op(tutorial::Operation::DIVIDE);
     $work->num1(1);
@@ -63,7 +63,7 @@ eval{
         $client->calculate(1, $work);
         print "Whoa! We can divide by zero?\n";
     }; if($@) {
-        warn "InvalidOperation: ".Dumper($@);
+        warn 'InvalidOperation: '.Dumper($@);
     }
 
     $work->op(tutorial::Operation::SUBTRACT);

--- a/tutorial/perl/PerlServer.pl
+++ b/tutorial/perl/PerlServer.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -67,20 +67,20 @@ sub calculate
   } elsif ($op == tutorial::Operation::DIVIDE) {
     if ($num2 == 0)
     {
-      my $x = new tutorial::InvalidOperation;
+      my $x = tutorial::InvalidOperation->new();
       $x->whatOp($op);
       $x->why('Cannot divide by 0');
       die $x;
     }
     $val = $num1 / $num2;
   } else {
-    my $x = new tutorial::InvalidOperation;
+    my $x = tutorial::InvalidOperation->new();
     $x->whatOp($op);
     $x->why('Invalid operation');
     die $x;
   }
 
-  my $log = new shared::SharedStruct;
+  my $log = shared::SharedStruct->new();
   $log->key($logid);
   $log->value(int($val));
   $self->{log}->{$logid} = $log;
@@ -104,10 +104,10 @@ sub zip
 
 
 eval {
-  my $handler       = new CalculatorHandler;
-  my $processor     = new tutorial::CalculatorProcessor($handler);
-  my $serversocket  = new Thrift::ServerSocket(9090);
-  my $forkingserver = new Thrift::ForkingServer($processor, $serversocket);
+  my $handler       = CalculatorHandler->new();
+  my $processor     = tutorial::CalculatorProcessor->new($handler);
+  my $serversocket  = Thrift::ServerSocket->new(9090);
+  my $forkingserver = Thrift::ForkingServer->new($processor, $serversocket);
   print "Starting the server...\n";
   $forkingserver->serve();
   print "done.\n";


### PR DESCRIPTION
Using Indirect Object Syntax to instantiate objects is not recommended as per https://perldoc.perl.org/perlobj.html#Invoking-Class-Methods I have update the output to follow the recommended Class->new() syntax

See also https://github.com/apache/thrift/pull/1261