### PR TITLE
THRIFT-4657: Include @javax.annotation.Generated annotation for unions

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -827,6 +827,10 @@ void t_java_generator::generate_java_union(t_struct* tstruct) {
   bool is_final = (tstruct->annotations_.find("final") != tstruct->annotations_.end());
   bool is_deprecated = this->is_deprecated(tstruct->annotations_);
 
+  if (!suppress_generated_annotations_) {
+    generate_javax_generated_annotation(f_struct);
+  }
+
   if (is_deprecated) {
     indent(f_struct) << "@Deprecated" << endl;
   }


### PR DESCRIPTION
THRIFT-4657: Include `@javax.annotation.Generated` annotation for generated union classes
Client: Java compiler

This is a straightforward, compile-time-safe, backward-compatible change.
