### PR TITLE
THRIFT-4660: Include @javax.annotation.Generated and Nullable as needed for enums

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -498,6 +498,11 @@ void t_java_generator::generate_enum(t_enum* tenum) {
   f_enum << autogen_comment() << java_package() << endl;
 
   generate_java_doc(f_enum, tenum);
+
+  if (!suppress_generated_annotations_) {
+    generate_javax_generated_annotation(f_enum);
+  }
+
   if (is_deprecated) {
     indent(f_enum) << "@Deprecated" << endl;
   }
@@ -544,6 +549,7 @@ void t_java_generator::generate_enum(t_enum* tenum) {
                  << endl;
   indent(f_enum) << " * @return null if the value is not found." << endl;
   indent(f_enum) << " */" << endl;
+  indent(f_enum) << java_nullable_annotation() << endl;
   indent(f_enum) << "public static " + tenum->get_name() + " findByValue(int value) { " << endl;
 
   indent_up();


### PR DESCRIPTION
Follow up to THRIFT-4530 and THRIFT-4614.

In that patch, we neglected to add Nullable and Generated annotations to enums, in addition to classes. This PR fixes that.

Client: Java compiler

This is a straightforward, compile-time-safe, backward-compatible change.
