### PR TITLE
THRIFT-4661: Rust enum name wrong case in generated structs

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -3022,7 +3022,7 @@ string t_rs_generator::to_rust_type(t_type* ttype, bool ordered_float) {
     rust_type =  ttypedef->is_forward_typedef() ? "Box<" + rust_type + ">" : rust_type;
     return rust_type;
   } else if (ttype->is_enum()) {
-    return rust_namespace(ttype) + ttype->get_name();
+    return rust_namespace(ttype) + rust_camel_case(ttype->get_name());
   } else if (ttype->is_struct() || ttype->is_xception()) {
     return rust_namespace(ttype) + rust_camel_case(ttype->get_name());
   } else if (ttype->is_map()) {

--- a/lib/rs/test/src/bin/kitchen_sink_server.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_server.rs
@@ -22,7 +22,7 @@ extern crate kitchen_sink;
 extern crate thrift;
 
 use kitchen_sink::base_one::Noodle;
-use kitchen_sink::base_two::{Napkin, NapkinServiceSyncHandler, Ramen, RamenServiceSyncHandler};
+use kitchen_sink::base_two::{BrothType, Napkin, NapkinServiceSyncHandler, Ramen, RamenServiceSyncHandler};
 use kitchen_sink::midlayer::{Dessert, Meal, MealServiceSyncHandler, MealServiceSyncProcessor};
 use kitchen_sink::recursive;
 use kitchen_sink::ultimate::{Drink, FullMeal, FullMealAndDrinks,
@@ -252,7 +252,7 @@ fn noodle() -> Noodle {
 }
 
 fn ramen() -> Ramen {
-    Ramen::new("Mr Ramen".to_owned(), 72)
+    Ramen::new("Mr Ramen".to_owned(), 72, BrothType::MISO)
 }
 
 fn napkin() -> Napkin {

--- a/lib/rs/test/thrifts/Base_Two.thrift
+++ b/lib/rs/test/thrifts/Base_Two.thrift
@@ -23,9 +23,15 @@
 
 const i32 WaterWeight = 200
 
+enum brothType {
+  Miso,
+  shouyu,
+}
+
 struct Ramen {
   1: optional string ramenType
   2: required i32 noodleCount
+  3: brothType broth
 }
 
 struct Napkin {


### PR DESCRIPTION
Client: rs

Small fix with test.