### PR TITLE
THRIFT-4664: Rust cannot create ReadHalf/WriteHalf

### DIFF
--- a/lib/rs/src/transport/mod.rs
+++ b/lib/rs/src/transport/mod.rs
@@ -143,6 +143,26 @@ where
     handle: C,
 }
 
+impl<C> ReadHalf<C>
+where
+    C: Read,
+{
+    /// Create a `ReadHalf` associated with readable `handle`
+    pub fn new(handle: C) -> ReadHalf<C> {
+        ReadHalf { handle }
+    }
+}
+
+impl<C> WriteHalf<C>
+where
+    C: Write,
+{
+    /// Create a `WriteHalf` associated with writable `handle`
+    pub fn new(handle: C) -> WriteHalf<C> {
+        WriteHalf { handle }
+    }
+}
+
 impl<C> Read for ReadHalf<C>
 where
     C: Read,

--- a/lib/rs/src/transport/socket.rs
+++ b/lib/rs/src/transport/socket.rs
@@ -133,8 +133,9 @@ impl TIoChannel for TTcpChannel {
             .and_then(|s| s.try_clone().ok())
             .map(
                 |cloned| {
-                    (ReadHalf { handle: TTcpChannel { stream: s.stream.take() } },
-                     WriteHalf { handle: TTcpChannel { stream: Some(cloned) } })
+                    let read_half = ReadHalf::new( TTcpChannel { stream: s.stream.take() } );
+                    let write_half = WriteHalf::new( TTcpChannel { stream: Some(cloned) } );
+                    (read_half, write_half)
                 },
             )
             .ok_or_else(


### PR DESCRIPTION
Client: rs

Trivial change.  Add a `pub` method for users of the library.