### PR TITLE
Fix build with c++17

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocketPool.cpp
+++ b/lib/cpp/src/thrift/transport/TSocketPool.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <random>
 
 #include <thrift/transport/TSocketPool.h>
 
@@ -188,7 +189,9 @@ void TSocketPool::open() {
   }
 
   if (randomize_ && numServers > 1) {
-    random_shuffle(servers_.begin(), servers_.end());
+    std::random_device rng;
+    std::mt19937 urng(rng());
+    std::shuffle(servers_.begin(), servers_.end(), urng);
   }
 
   for (size_t i = 0; i < numServers; ++i) {

--- a/lib/cpp/src/thrift/transport/TSocketPool.cpp
+++ b/lib/cpp/src/thrift/transport/TSocketPool.cpp
@@ -189,9 +189,13 @@ void TSocketPool::open() {
   }
 
   if (randomize_ && numServers > 1) {
+#if __cplusplus >= 201500L // c++17
     std::random_device rng;
     std::mt19937 urng(rng());
     std::shuffle(servers_.begin(), servers_.end(), urng);
+#else
+    std::random_shuffle(servers_.begin(), servers_.end());
+#endif
   }
 
   for (size_t i = 0; i < numServers; ++i) {

--- a/lib/cpp/src/thrift/transport/TSocketPool.cpp
+++ b/lib/cpp/src/thrift/transport/TSocketPool.cpp
@@ -189,7 +189,7 @@ void TSocketPool::open() {
   }
 
   if (randomize_ && numServers > 1) {
-#if __cplusplus >= 201500L // c++17
+#if __cplusplus >= 201703L
     std::random_device rng;
     std::mt19937 urng(rng());
     std::shuffle(servers_.begin(), servers_.end(), urng);

--- a/lib/cpp/src/thrift/transport/TSocketPool.cpp
+++ b/lib/cpp/src/thrift/transport/TSocketPool.cpp
@@ -21,7 +21,9 @@
 
 #include <algorithm>
 #include <iostream>
+#if __cplusplus >= 201703L
 #include <random>
+#endif
 
 #include <thrift/transport/TSocketPool.h>
 


### PR DESCRIPTION
random_shuffle is deprecated and removed in c++17
https://en.cppreference.com/w/cpp/algorithm/random_shuffle