### PR TITLE
Fix build compiler with cmake

### DIFF
--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -113,7 +113,7 @@ THRIFT_ADD_COMPILER(xml     "Enable compiler for XML" ON)
 # we also add the current binary directory for generated files
 include_directories(${CMAKE_CURRENT_BINARY_DIR} src)
 
-if(NOT ${WITH_PLUGIN})
+if(NOT DEFINED WITH_PLUGIN OR NOT ${WITH_PLUGIN})
     list(APPEND thrift-compiler_SOURCES ${compiler_core})
 endif()
 


### PR DESCRIPTION
This seems an obvious problem, don't know why it works with others. Maybe I do something wrong. 

I follow with the [README](https://github.com/apache/thrift/tree/master/compiler/cpp#build-using-cmake) to build the compiler using cmake, but failed with "Undefined symbols". It is because `compiler_core` sources is not append to `thrift-compiler_SOURCES`.

 * cmake version: 3.12.3
 * OS: mac os Mojave version 10.14