### PR TITLE
THRIFT-4684: Fix WCF related C# code generation

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_csharp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_csharp_generator.cc
@@ -422,7 +422,7 @@ string t_csharp_generator::csharp_type_usings() {
          + ((async_) ? "using System.Threading.Tasks;\n" : "") + "using Thrift;\n"
          + "using Thrift.Collections;\n" + ((serialize_ || wcf_) ? "#if !SILVERLIGHT\n" : "")
          + ((serialize_ || wcf_) ? "using System.Xml.Serialization;\n" : "")
-         + ((serialize_ || wcf_) ? "#endif\n" : "") + (wcf_ ? "//using System.ServiceModel;\n" : "")
+         + ((serialize_ || wcf_) ? "#endif\n" : "")
          + "using System.Runtime.Serialization;\n";
 }
 
@@ -903,7 +903,10 @@ void t_csharp_generator::generate_csharp_wcffault(ostream& out, t_struct* tstruc
 
   // make private members with public Properties
   for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-    indent(out) << "private " << declare_field(*m_iter, false, "_") << endl;
+    // if the field is requied, then we use auto-properties
+    if (!field_is_required((*m_iter)) && (!nullable_ || field_has_default((*m_iter)))) {
+      indent(out) << "private " << declare_field(*m_iter, false, "_") << endl;
+    }
   }
   out << endl;
 
@@ -1475,7 +1478,7 @@ void t_csharp_generator::generate_sync_service_interface(t_service* tservice) {
   generate_csharp_doc(f_service_, tservice);
 
   if (wcf_) {
-    indent(f_service_) << "[ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
+    indent(f_service_) << "[System.ServiceModel.ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
   }
   indent(f_service_) << "public interface ISync" << extends_iface << " {" << endl;
 
@@ -1487,12 +1490,12 @@ void t_csharp_generator::generate_sync_service_interface(t_service* tservice) {
 
     // if we're using WCF, add the corresponding attributes
     if (wcf_) {
-      indent(f_service_) << "[OperationContract]" << endl;
+      indent(f_service_) << "[System.ServiceModel.OperationContract]" << endl;
 
       const std::vector<t_field*>& xceptions = (*f_iter)->get_xceptions()->get_members();
       vector<t_field*>::const_iterator x_iter;
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
-        indent(f_service_) << "[FaultContract(typeof("
+        indent(f_service_) << "[System.ServiceModel.FaultContract(typeof("
           + type_name((*x_iter)->get_type(), false, false) + "Fault))]" << endl;
       }
     }
@@ -1514,7 +1517,7 @@ void t_csharp_generator::generate_async_service_interface(t_service* tservice) {
   generate_csharp_doc(f_service_, tservice);
 
   if (wcf_) {
-    indent(f_service_) << "[ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
+    indent(f_service_) << "[System.ServiceModel.ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
   }
   indent(f_service_) << "public interface IAsync" << extends_iface << " {" << endl;
 
@@ -1526,12 +1529,12 @@ void t_csharp_generator::generate_async_service_interface(t_service* tservice) {
 
     // if we're using WCF, add the corresponding attributes
     if (wcf_) {
-      indent(f_service_) << "[OperationContract]" << endl;
+      indent(f_service_) << "[System.ServiceModel.OperationContract]" << endl;
 
       const std::vector<t_field*>& xceptions = (*f_iter)->get_xceptions()->get_members();
       vector<t_field*>::const_iterator x_iter;
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
-        indent(f_service_) << "[FaultContract(typeof("
+        indent(f_service_) << "[System.ServiceModel.FaultContract(typeof("
           + type_name((*x_iter)->get_type(), false, false) + "Fault))]" << endl;
       }
     }
@@ -1552,7 +1555,7 @@ void t_csharp_generator::generate_combined_service_interface(t_service* tservice
   generate_csharp_doc(f_service_, tservice);
 
   if (wcf_) {
-    indent(f_service_) << "[ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
+    indent(f_service_) << "[System.ServiceModel.ServiceContract(Namespace=\"" << wcf_namespace_ << "\")]" << endl;
   }
 
   indent(f_service_) << "public interface Iface" << extends_iface << " {" << endl;


### PR DESCRIPTION
THRIFT-4684: Fix WCF related C# code generation

Client: C#
Complete the namespace in System.ServiceModel in WCF related code.
Also when generating fields in fault classes, we follow the same behavior in normal struct,
to avoid generating unused private fields, when auto properties are also generated.

