### PR TITLE
THRIFT-4694: Upgrade Java to Java 1.8

### DIFF
--- a/contrib/Vagrantfile
+++ b/contrib/Vagrantfile
@@ -43,7 +43,7 @@ sudo apt-get install -qq automake libtool flex bison pkg-config g++ libssl-dev m
 sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libevent-dev 
 
 # Java dependencies
-sudo apt-get install -qq ant openjdk-7-jdk maven
+sudo apt-get install -qq ant openjdk-8-jdk maven
 
 # Python dependencies
 sudo apt-get install -qq python-all python-all-dev python-all-dbg python-setuptools python-support python-six python3-six
@@ -89,8 +89,8 @@ sudo apt-get install -qq xdg-utils dmd-bin
 
 # Customize the system
 # ---
-# Default java to latest 1.7 version
-update-java-alternatives -s java-1.7.0-openjdk-amd64 
+# Default java to latest 1.8 version
+update-java-alternatives -s java-1.8.0-openjdk-amd64 
 
 # PHPUnit package broken in ubuntu. see https://bugs.launchpad.net/ubuntu/+source/phpunit/+bug/701544
 sudo apt-get upgrade pear

--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -34,8 +34,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/contrib/vagrant/centos-6.5/Vagrantfile
+++ b/contrib/vagrant/centos-6.5/Vagrantfile
@@ -87,7 +87,7 @@ sudo ./b2 install
 
 # Java LIB Dependencies
 #####################################
-sudo yum install -y ant junit ant-nodeps ant-junit java-1.7.0-openjdk-devel
+sudo yum install -y ant junit ant-nodeps ant-junit java-1.8.0-openjdk-devel
 
 # Python LIB Dependencies
 #####################################

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -27,7 +27,7 @@ These are only required if you choose to build the libraries for the given langu
     * libevent (optional, to build the nonblocking server)
     * zlib (optional)
 * Java
-    * Java 1.7
+    * Java 1.8
     * Apache Ant
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)

--- a/doc/install/debian.md
+++ b/doc/install/debian.md
@@ -19,7 +19,7 @@ If you would like to build Apache Thrift libraries for other programming languag
 
  * Java
 	* packages: ant  
-	* You will also need Java JDK v1.7 or higher. Type **javac** to see a list of available packages, pick the one you prefer and **apt-get install** it (e.g. default-jdk).
+	* You will also need Java JDK v1.8 or higher. Type **javac** to see a list of available packages, pick the one you prefer and **apt-get install** it (e.g. default-jdk).
  * Ruby
 	* ruby-full ruby-dev ruby-rspec rake rubygems bundler
  * Python

--- a/doc/install/windows.md
+++ b/doc/install/windows.md
@@ -145,7 +145,7 @@ Run bootstrap.sh:
 
 Make sure you have java in your $PATH variable, if not do(adjust path if necessary):
 
-	export PATH=$PATH:"/cygdrive/c/program files/java/jre1.6.0_05/bin"
+	export PATH=$PATH:"/cygdrive/c/program files/java/jre1.8.0_191/bin"
 
 Run configure - using CXXFLAGS to work around an issue with an old pthreads define (untested on MinGW - works on Cygwin):
 

--- a/lib/java/gradle/codeQualityChecks.gradle
+++ b/lib/java/gradle/codeQualityChecks.gradle
@@ -28,7 +28,6 @@ pmd {
     ignoreFailures = true
     toolVersion = '6.0.0'
     sourceSets = [ sourceSets.main ]
-    targetJdk = sourceCompatibility
     ruleSets = [ 'java-basic' ]
 }
 

--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -45,8 +45,8 @@ sourceSets {
 // ----------------------------------------------------------------------------
 // Compiler configuration details
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Some places reference JDK 6, others JDK 7.  Upgrade all to JDK 8