### PR TITLE
THRIFT-4469: Make isServing volatile

### DIFF
--- a/lib/java/src/org/apache/thrift/server/TServer.java
+++ b/lib/java/src/org/apache/thrift/server/TServer.java
@@ -123,7 +123,7 @@ public abstract class TServer {
    */
   protected TProtocolFactory outputProtocolFactory_;
 
-  private boolean isServing;
+  private volatile boolean isServing;
 
   protected TServerEventHandler eventHandler_;
 


### PR DESCRIPTION
Well, the "stopped" variable is used in a similar context [here](https://github.com/apache/thrift/blob/master/lib/java/src/org/apache/thrift/server/TServer.java#L132)

May as well do it for the "isServing" variable as well.