### PR TITLE
 Fix: do not reconnect if connection.destroyed, prevent connection leak

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -221,6 +221,10 @@ Connection.prototype.connection_gone = function () {
   });
 
   this.retry_timer = setTimeout(function () {
+    if (self.connection.destroyed) {
+        return;
+    }
+
     log.debug("Retrying connection...");
 
     self.retry_totaltime += self.retry_delay;

--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -222,7 +222,7 @@ Connection.prototype.connection_gone = function () {
 
   this.retry_timer = setTimeout(function () {
     if (self.connection.destroyed) {
-        return;
+      return;
     }
 
     log.debug("Retrying connection...");

--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -222,6 +222,7 @@ Connection.prototype.connection_gone = function () {
 
   this.retry_timer = setTimeout(function () {
     if (self.connection.destroyed) {
+      self.retry_timer = null;
       return;
     }
 


### PR DESCRIPTION
I can't destroy the connection while the server is still alive, so do this modify.

When will this happen ?

I use consul to register and discover the servers, and save the clients in an array.
But I found sometimes the server is alive, but it's deregistered from consul, so I splice the  deregistered instance, and hope that the connection destroy auto.
If the server is really down, the connection destroy automatically, but the problem is, the server maybe still alive, so the connection never destroy. So the connection is leak, as it was splice out from the clients array, never accessible.
When server register again, new connection will be create, and put into clients array.

So I want to destroy the connection manually before splice it out. But find out I can't, as it will reconnect.