### PR TITLE
THRIFT-4728: automate the double rendering test

### DIFF
--- a/lib/js/Gruntfile.js
+++ b/lib/js/Gruntfile.js
@@ -270,7 +270,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('installAndGenerate', [
     'shell:InstallThriftJS', 'shell:InstallThriftNodeJSDep', 'shell:ThriftGen',
-    'shell:ThriftGenDeepConstructor',
+    'shell:ThriftGenDeepConstructor', 'shell:ThriftGenDoubleConstants',
     'shell:InstallTestLibs',
   ]);
 
@@ -282,6 +282,7 @@ module.exports = function(grunt) {
     'wait',
     'qunit:ThriftDeepConstructor',
     'qunit:ThriftJS', 'qunit:ThriftJS_TLS',
+    'qunit:ThriftJS_DoubleRendering',
     'qunit:ThriftWS',
     'qunit:ThriftJSJQ', 'qunit:ThriftJSJQ_TLS',
     'qunit:ThriftWSES6',

--- a/lib/js/test/test-double-rendering.html
+++ b/lib/js/test/test-double-rendering.html
@@ -29,11 +29,11 @@
       <script src="gen-js/DoubleConstantsTest_types.js"         type="text/javascript" charset="utf-8"></script>
 
       <!-- jQuery -->
-      <script type="text/javascript" src="../node_modules/jquery/dist/jquery.js" charset="utf-8"></script>
+      <script type="text/javascript" src="build/js/lib/jquery.js" charset="utf-8"></script>
 
       <!-- QUnit Test framework-->
-      <script type="text/javascript" src="../node_modules/qunit/qunit/qunit.js" charset="utf-8"></script>
-      <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" type="text/css" media="screen" />
+      <script type="text/javascript" src="build/js/lib/qunit.js" charset="utf-8"></script>
+      <link rel="stylesheet" href="build/js/lib/qunit.css" type="text/css" media="screen" />
 
       <!-- the Test Suite-->
       <script type="text/javascript" src="test-double-rendering.js" charset="utf-8"></script>

--- a/lib/js/test/test-double-rendering.js
+++ b/lib/js/test/test-double-rendering.js
@@ -20,29 +20,11 @@
 
 /*
  * JavaScript test suite for double constants inside
- * DebugProtoTest.thrift. These tests will run against Normal (-gen js)
+ * DoubleConstantsTest.thrift. These tests will run against Normal (-gen js)
  * Apache Thrift interfaces.
  *
- * Synchronous blocking calls should be identical in both
- * Normal and jQuery interfaces. All synchronous tests belong
- * here.
- *
- * Asynchronous success callbacks passed as the last parameter
- * of an RPC call should be identical in both Normal and jQuery
- * interfaces. Async success tests belong here.
- *
- * Asynchronous exception processing is different in Normal
- * and jQuery interfaces. Such tests belong in the test-nojq.js
- * or test-jq.js files respectively. jQuery specific XHR object
- * tests also belong in test-jq.js. Do not create any jQuery
- * dependencies in this file or in test-nojq.js
- *
  * To compile client code for this test use:
- *      $ thrift -gen js ThriftTest.thrift
- *      $ thrift -gen js DebugProtoTest.thrift
- *
- * See also:
- * ++ test-nojq.js for "-gen js" only tests
+ *      $ thrift -gen js DoubleConstantsTest.thrift
  */
 
 // double assertion threshold


### PR DESCRIPTION
All the changes in this PR are backward compatible. 
See the related issue: https://issues.apache.org/jira/browse/THRIFT-4728
