### PR TITLE
THRIFT-4737: fixed - added beforeSend to add customHeaders to jqXHR in jqRequest

### DIFF
--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -438,7 +438,12 @@ Thrift.TXHRTransport.prototype = {
                 }
             },
             context: client,
-            success: jQuery.makeArray(args).pop()
+            success: jQuery.makeArray(args).pop(),
+            beforeSend: function (xreq) {
+                Object.keys(thriftTransport.customHeaders).forEach(function (prop) {
+                    xreq.setRequestHeader(prop, thriftTransport.customHeaders[prop]);
+                });
+            }
         });
 
         return jqXHR;


### PR DESCRIPTION
THRIFT-4737: [added beforeSend to add customHeaders to jqXHR in jqRequest]
Client: [lib/js]

locally tested - custom headers where missing when using jq. So I added these lines to fix it.
Fix should be compatibel with 0.10.0, 0.11.0, 0.12.0 - but only tested with 0.11.0.