### PR TITLE
THRIFT-4741 Missing "inner" argument from one CTOR

### DIFF
--- a/lib/csharp/src/Protocol/TProtocolException.cs
+++ b/lib/csharp/src/Protocol/TProtocolException.cs
@@ -42,8 +42,8 @@ namespace Thrift.Protocol
         {
         }
 
-        public TProtocolException(int type)
-            : base()
+        public TProtocolException(int type, Exception inner = null)
+            : base(inner)
         {
             type_ = type;
         }


### PR DESCRIPTION
Client: C#
Patch: Jens Geyer
