### PR TITLE
THRIFT-4751: Missing imports in TProtocol (phpdoc related only)

### DIFF
--- a/lib/php/lib/Protocol/TProtocol.php
+++ b/lib/php/lib/Protocol/TProtocol.php
@@ -22,6 +22,8 @@
 
 namespace Thrift\Protocol;
 
+use Thrift\Exception\TException;
+use Thrift\Transport\TTransport;
 use Thrift\Type\TType;
 use Thrift\Exception\TProtocolException;
 
@@ -38,7 +40,7 @@ abstract class TProtocol
     protected $trans_;
 
     /**
-     * Constructor
+     * @param TTransport $trans
      */
     protected function __construct($trans)
     {


### PR DESCRIPTION
Client: php

TProtocol interface use phpdoc `@return` tags without corresponding imports. This cause some (minor) issues with IDEs and static analysis tools like phpstan.