### PR TITLE
THRIFT-4752: Added cmake package configuration for cpp and compiler

### DIFF
--- a/build/cmake/Config.cmake.in
+++ b/build/cmake/Config.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+set(package_deps @package_deps@)
+foreach(dep IN LISTS package_deps)
+    find_package(${dep} REQUIRED)
+endforeach()
+
+check_required_components("@PROJECT_NAME@")
+
+if(@BUILD_COMPILER@)
+    set(THRIFT_COMPILER "@CMAKE_INSTALL_FULL_BINDIR@/thrift@CMAKE_EXECUTABLE_SUFFIX@")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/build/cmake/ThriftMacros.cmake
+++ b/build/cmake/ThriftMacros.cmake
@@ -28,13 +28,8 @@ macro(ADD_LIBRARY_THRIFT name)
     add_library(${name} ${ARGN})
     set_target_properties(${name} PROPERTIES
         OUTPUT_NAME ${name}${THRIFT_RUNTIME_POSTFIX}   # windows link variants (/MT, /MD, /MTd, /MDd) get different names
-        VERSION ${thrift_VERSION} )
-    # set_target_properties(${name} PROPERTIES PUBLIC_HEADER "${thriftcpp_HEADERS}")
-    install(TARGETS ${name}
-        RUNTIME DESTINATION "${BIN_INSTALL_DIR}"
-        LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
-        ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
-        PUBLIC_HEADER DESTINATION "${INCLUDE_INSTALL_DIR}")
+        VERSION ${thrift_VERSION})
+    list(APPEND thrift_lib_targets ${name})
 endmacro()
 
 macro(TARGET_INCLUDE_DIRECTORIES_THRIFT name)

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -105,6 +105,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
     )
     include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
     list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+    list(APPEND package_deps OpenSSL)
 endif()
 
 if(UNIX)
@@ -158,6 +159,7 @@ if(WITH_LIBEVENT)
     LINK_AGAINST_THRIFT_LIBRARY(thriftnb thrift)
     TARGET_LINK_LIBRARIES_THRIFT(thriftnb ${SYSLIBS} ${LIBEVENT_LIBRARIES})
     ADD_PKGCONFIG_THRIFT(thrift-nb)
+    list(APPEND package_deps Libevent)
 endif()
 
 if(WITH_ZLIB)
@@ -168,6 +170,7 @@ if(WITH_ZLIB)
     TARGET_LINK_LIBRARIES_THRIFT(thriftz ${SYSLIBS} ${ZLIB_LIBRARIES})
     TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY(thriftz thrift)
     ADD_PKGCONFIG_THRIFT(thrift-z)
+    list(APPEND package_deps ZLIB)
 endif()
 
 if(WITH_QT5)
@@ -185,6 +188,68 @@ install(DIRECTORY "src/thrift" DESTINATION "${INCLUDE_INSTALL_DIR}"
 # Copy config.h file
 install(DIRECTORY "${CMAKE_BINARY_DIR}/thrift" DESTINATION "${INCLUDE_INSTALL_DIR}"
     FILES_MATCHING PATTERN "*.h")
+
+include(GNUInstallDirs)
+
+# Configuration
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMinorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/build/cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "lib/cmake/"
+)
+
+# Targets:
+#   * <prefix>/lib/libthrift.a
+#   * <prefix>/lib/libthrift.so
+#   * header location after install: <prefix>/include/thrift/Thrift.h
+#   * headers can be included by C++ code `#include <thrift/Thrift.h>`
+install(
+    TARGETS ${thrift_lib_targets}
+    EXPORT "${PROJECT_NAME}Targets"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+# Headers:
+#   * src/thrift/Thrift.h -> <prefix>/include/thrift/Thrift.h
+install(
+    DIRECTORY "src/thrift"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Config
+#   * <prefix>/lib/cmake/thrift/thriftConfig.cmake
+#   * <prefix>/lib/cmake/thrift/thriftConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "lib/cmake/"
+)
+
+install(
+    EXPORT "${PROJECT_NAME}Targets"
+    NAMESPACE "${PROJECT_NAME}::"
+    DESTINATION "lib/cmake/"
+)
 
 if(BUILD_TESTING)
     add_subdirectory(test)


### PR DESCRIPTION
This pull request is loosely inspired by the cmake documentation and by the hunter-package cmake package configuration at https://github.com/hunter-packages/thrift/.

The PR adds support for the cpp library, transitive library dependencies and and the thrift compiler in a cmake package configuration.

With the PR in place, users can
```
find_package(thrift)
```
without the need for a `FindThrift.cmake` script.