### PR TITLE
THRIFT-4762: Applied some C++11 refactorings to the runtime library and compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - [THRIFT-4712](https://issues.apache.org/jira/browse/THRIFT-4712) - java: class org.apache.thrift.ShortStack is no longer public
 - [THRIFT-4725](https://issues.apache.org/jira/browse/THRIFT-4725) - java: change return type signature of 'process' methods
 - [THRIFT-4675](https://issues.apache.org/jira/browse/THRIFT-4675) - js: now uses node-int64 for 64 bit integer constants
+- [THRIFT-4672](https://issues.apache.org/jira/browse/THRIFT-4672) - C++: TTransport::getOrigin() is now const
 
 ### Known Issues (Blocker or Critical)
 

--- a/compiler/cpp/src/thrift/audit/t_audit.cpp
+++ b/compiler/cpp/src/thrift/audit/t_audit.cpp
@@ -79,7 +79,7 @@ void compare_enum_values(t_enum* newEnum,t_enum* oldEnum)
    {
       int enumValue = (*oldEnumValuesIt)->get_value();
       t_enum_value* newEnumValue = newEnum->get_constant_by_value(enumValue);
-      if(newEnumValue != NULL)
+      if(newEnumValue != nullptr)
       {
          std::string enumName = (*oldEnumValuesIt)->get_name();
          if(enumName != newEnumValue->get_name())
@@ -175,9 +175,9 @@ bool compare_pair(std::pair<t_const_value*, t_const_value*> newMapPair, std::pai
 // This function returns 'true' if the default values are same. Returns false if they are different.
 bool compare_defaults(t_const_value* newStructDefault, t_const_value* oldStructDefault)
 {
-   if(newStructDefault == NULL && oldStructDefault == NULL) return true;
-   else if(newStructDefault == NULL && oldStructDefault != NULL) return false;
-   else if (newStructDefault != NULL && oldStructDefault == NULL) return false;
+   if(newStructDefault == nullptr && oldStructDefault == nullptr) return true;
+   else if(newStructDefault == nullptr && oldStructDefault != nullptr) return false;
+   else if (newStructDefault != nullptr && oldStructDefault == nullptr) return false;
 
    if(newStructDefault->get_type() != oldStructDefault->get_type())
    {
@@ -405,12 +405,12 @@ void compare_services(const std::vector<t_service*>& newServices, const std::vec
          t_service* oldServiceExtends = (*oldServiceIt)->get_extends();
          t_service* newServiceExtends = (newServiceMapIt->second)->get_extends();
 
-         if(oldServiceExtends == NULL)
+         if(oldServiceExtends == nullptr)
          {
             // It is fine to add extends. So if service in older thrift did not have any extends, we are fine.
             // DO Nothing
          }
-         else if(oldServiceExtends != NULL && newServiceExtends == NULL)
+         else if(oldServiceExtends != nullptr && newServiceExtends == nullptr)
          {
             thrift_audit_failure("Change in Service inheritance for %s\n", oldServiceName.c_str());
          }

--- a/compiler/cpp/src/thrift/audit/t_audit.cpp
+++ b/compiler/cpp/src/thrift/audit/t_audit.cpp
@@ -54,11 +54,11 @@ void compare_namespace(t_program* newProgram, t_program* oldProgram)
    const std::map<std::string, std::string>& newNamespaceMap = newProgram->get_all_namespaces();
    const std::map<std::string, std::string>& oldNamespaceMap = oldProgram->get_all_namespaces();
 
-   for(std::map<std::string, std::string>::const_iterator oldNamespaceMapIt = oldNamespaceMap.begin();
+   for(auto oldNamespaceMapIt = oldNamespaceMap.begin();
          oldNamespaceMapIt != oldNamespaceMap.end();
          oldNamespaceMapIt++)
    {
-      std::map<std::string, std::string>::const_iterator newNamespaceMapIt = newNamespaceMap.find(oldNamespaceMapIt->first);
+      auto newNamespaceMapIt = newNamespaceMap.find(oldNamespaceMapIt->first);
       if(newNamespaceMapIt == newNamespaceMap.end())
       {
          thrift_audit_warning(1, "Language %s not found in new thrift file\n", (oldNamespaceMapIt->first).c_str());
@@ -73,7 +73,7 @@ void compare_namespace(t_program* newProgram, t_program* oldProgram)
 void compare_enum_values(t_enum* newEnum,t_enum* oldEnum)
 {
    const std::vector<t_enum_value*>& oldEnumValues = oldEnum->get_constants();
-   for(std::vector<t_enum_value*>::const_iterator oldEnumValuesIt = oldEnumValues.begin();
+   for(auto oldEnumValuesIt = oldEnumValues.begin();
          oldEnumValuesIt != oldEnumValues.end();
          oldEnumValuesIt++)
    {
@@ -255,8 +255,8 @@ void compare_single_struct(t_struct* newStruct, t_struct* oldStruct, const std::
    std::string structName = oldStructName.empty() ? oldStruct->get_name() : oldStructName;
    const std::vector<t_field*>& oldStructMembersInIdOrder = oldStruct->get_sorted_members();
    const std::vector<t_field*>& newStructMembersInIdOrder = newStruct->get_sorted_members();
-   std::vector<t_field*>::const_iterator oldStructMemberIt = oldStructMembersInIdOrder.begin();
-   std::vector<t_field*>::const_iterator newStructMemberIt = newStructMembersInIdOrder.begin();
+   auto oldStructMemberIt = oldStructMembersInIdOrder.begin();
+   auto newStructMemberIt = newStructMembersInIdOrder.begin();
 
    // Since we have the struct members in their ID order, comparing their IDs can be done by traversing the two member
    // lists together.
@@ -352,14 +352,14 @@ void compare_functions(const std::vector<t_function*>& newFunctionList, const st
 {
    std::map<std::string, t_function*> newFunctionMap;
    std::map<std::string, t_function*>::iterator newFunctionMapIt;
-   for(std::vector<t_function*>::const_iterator newFunctionIt = newFunctionList.begin();
+   for(auto newFunctionIt = newFunctionList.begin();
          newFunctionIt != newFunctionList.end();
          newFunctionIt++)
    {
       newFunctionMap[(*newFunctionIt)->get_name()] = *newFunctionIt;
    }
 
-   for(std::vector<t_function*>::const_iterator oldFunctionIt = oldFunctionList.begin();
+   for(auto oldFunctionIt = oldFunctionList.begin();
          oldFunctionIt != oldFunctionList.end();
          oldFunctionIt++)
    {
@@ -383,7 +383,7 @@ void compare_services(const std::vector<t_service*>& newServices, const std::vec
    std::vector<t_service*>::const_iterator oldServiceIt;
 
    std::map<std::string, t_service*> newServiceMap;
-   for(std::vector<t_service*>::const_iterator newServiceIt = newServices.begin();
+   for(auto newServiceIt = newServices.begin();
          newServiceIt != newServices.end();
          newServiceIt++)
    {
@@ -394,7 +394,7 @@ void compare_services(const std::vector<t_service*>& newServices, const std::vec
    for(oldServiceIt = oldServices.begin(); oldServiceIt != oldServices.end(); oldServiceIt++)
    {
       const std::string oldServiceName = (*oldServiceIt)->get_name();
-      std::map<std::string, t_service*>::iterator newServiceMapIt = newServiceMap.find(oldServiceName);
+      auto newServiceMapIt = newServiceMap.find(oldServiceName);
 
       if(newServiceMapIt == newServiceMap.end())
       {

--- a/compiler/cpp/src/thrift/generate/t_generator_registry.h
+++ b/compiler/cpp/src/thrift/generate/t_generator_registry.h
@@ -35,7 +35,7 @@ public:
                       const std::string& long_name,
                       const std::string& documentation);
 
-  virtual ~t_generator_factory() {}
+  virtual ~t_generator_factory() = default;
 
   virtual t_generator* get_generator(
       // The program to generate.

--- a/compiler/cpp/src/thrift/generate/t_generator_registry.h
+++ b/compiler/cpp/src/thrift/generate/t_generator_registry.h
@@ -65,13 +65,13 @@ public:
                            const std::string& documentation)
     : t_generator_factory(short_name, long_name, documentation) {}
 
-  virtual t_generator* get_generator(t_program* program,
+  t_generator* get_generator(t_program* program,
                                      const std::map<std::string, std::string>& parsed_options,
-                                     const std::string& option_string) {
+                                     const std::string& option_string) override {
     return new generator(program, parsed_options, option_string);
   }
 
-  virtual bool is_valid_namespace(const std::string& sub_namespace) {
+  bool is_valid_namespace(const std::string& sub_namespace) override {
     return generator::is_valid_namespace(sub_namespace);
   }
 };

--- a/compiler/cpp/src/thrift/main.h
+++ b/compiler/cpp/src/thrift/main.h
@@ -106,7 +106,7 @@ void emit_byte_type_warning();
  * If new_form is NULL, old_form is assumed to be a language identifier, such as "cpp"
  * If new_form is not NULL, both arguments are used exactly as given
  */
-void error_unsupported_namespace_decl(const char* old_form, const char* new_form = NULL);
+void error_unsupported_namespace_decl(const char* old_form, const char* new_form = nullptr);
 
 /**
  * Flex utilities

--- a/compiler/cpp/src/thrift/parse/parse.cc
+++ b/compiler/cpp/src/thrift/parse/parse.cc
@@ -23,11 +23,7 @@
 #include "thrift/main.h"
 
 t_type* t_type::get_true_type() {
-  t_type* type = this;
-  while (type->is_typedef()) {
-    type = ((t_typedef*)type)->get_type();
-  }
-  return type;
+  return const_cast<t_type*>(const_cast<const t_type*>(this)->get_true_type());
 }
 
 const t_type* t_type::get_true_type() const {

--- a/compiler/cpp/src/thrift/parse/t_base_type.h
+++ b/compiler/cpp/src/thrift/parse/t_base_type.h
@@ -49,11 +49,11 @@ public:
 
   t_base get_base() const { return base_; }
 
-  bool is_void() const { return base_ == TYPE_VOID; }
+  bool is_void() const override { return base_ == TYPE_VOID; }
 
-  bool is_string() const { return base_ == TYPE_STRING; }
+  bool is_string() const override { return base_ == TYPE_STRING; }
 
-  bool is_bool() const { return base_ == TYPE_BOOL; }
+  bool is_bool() const override { return base_ == TYPE_BOOL; }
 
   void set_string_list(bool val) { string_list_ = val; }
 
@@ -61,7 +61,7 @@ public:
 
   void set_binary(bool val) { binary_ = val; }
 
-  bool is_binary() const { return binary_ && (base_ == TYPE_STRING); }
+  bool is_binary() const override { return binary_ && (base_ == TYPE_STRING); }
 
   void set_string_enum(bool val) { string_enum_ = val; }
 
@@ -71,7 +71,7 @@ public:
 
   const std::vector<std::string>& get_string_enum_vals() const { return string_enum_vals_; }
 
-  bool is_base_type() const { return true; }
+  bool is_base_type() const override { return true; }
 
   static std::string t_base_name(t_base tbase) {
     switch (tbase) {

--- a/compiler/cpp/src/thrift/parse/t_const_value.h
+++ b/compiler/cpp/src/thrift/parse/t_const_value.h
@@ -46,11 +46,11 @@ public:
 
   enum t_const_value_type { CV_INTEGER, CV_DOUBLE, CV_STRING, CV_MAP, CV_LIST, CV_IDENTIFIER, CV_UNKNOWN };
 
-  t_const_value() : intVal_(0), doubleVal_(0.0f), enum_((t_enum*)0), valType_(CV_UNKNOWN) {}
+  t_const_value() : intVal_(0), doubleVal_(0.0f), enum_((t_enum*)nullptr), valType_(CV_UNKNOWN) {}
 
-  t_const_value(int64_t val) : doubleVal_(0.0f), enum_((t_enum*)0), valType_(CV_UNKNOWN) { set_integer(val); }
+  t_const_value(int64_t val) : doubleVal_(0.0f), enum_((t_enum*)nullptr), valType_(CV_UNKNOWN) { set_integer(val); }
 
-  t_const_value(std::string val) : intVal_(0), doubleVal_(0.0f), enum_((t_enum*)0), valType_(CV_UNKNOWN) { set_string(val); }
+  t_const_value(std::string val) : intVal_(0), doubleVal_(0.0f), enum_((t_enum*)nullptr), valType_(CV_UNKNOWN) { set_string(val); }
 
   void set_string(std::string val) {
     valType_ = CV_STRING;
@@ -66,7 +66,7 @@ public:
 
   int64_t get_integer() const {
     if (valType_ == CV_IDENTIFIER) {
-      if (enum_ == NULL) {
+      if (enum_ == nullptr) {
         throw "have identifier \"" + get_identifier() + "\", but unset enum on line!";
       }
       std::string identifier = get_identifier();
@@ -75,7 +75,7 @@ public:
         identifier = identifier.substr(dot + 1);
       }
       t_enum_value* val = enum_->get_constant_by_name(identifier);
-      if (val == NULL) {
+      if (val == nullptr) {
         throw "Unable to find enum value \"" + identifier + "\" in enum \"" + enum_->get_name()
             + "\"";
       }

--- a/compiler/cpp/src/thrift/parse/t_container.h
+++ b/compiler/cpp/src/thrift/parse/t_container.h
@@ -26,7 +26,7 @@ class t_container : public t_type {
 public:
   t_container() : cpp_name_(), has_cpp_name_(false) {}
 
-  ~t_container() override {}
+  ~t_container() override = default;
 
   void set_cpp_name(std::string cpp_name) {
     cpp_name_ = cpp_name;

--- a/compiler/cpp/src/thrift/parse/t_container.h
+++ b/compiler/cpp/src/thrift/parse/t_container.h
@@ -26,7 +26,7 @@ class t_container : public t_type {
 public:
   t_container() : cpp_name_(), has_cpp_name_(false) {}
 
-  virtual ~t_container() {}
+  ~t_container() override {}
 
   void set_cpp_name(std::string cpp_name) {
     cpp_name_ = cpp_name;
@@ -37,7 +37,7 @@ public:
 
   std::string get_cpp_name() const { return cpp_name_; }
 
-  bool is_container() const { return true; }
+  bool is_container() const override { return true; }
 
 private:
   std::string cpp_name_;

--- a/compiler/cpp/src/thrift/parse/t_doc.h
+++ b/compiler/cpp/src/thrift/parse/t_doc.h
@@ -31,7 +31,7 @@ class t_doc {
 
 public:
   t_doc() : has_doc_(false) {}
-  virtual ~t_doc() {}
+  virtual ~t_doc() = default;
 
   void set_doc(const std::string& doc) {
     doc_ = doc;

--- a/compiler/cpp/src/thrift/parse/t_enum.h
+++ b/compiler/cpp/src/thrift/parse/t_enum.h
@@ -39,7 +39,7 @@ public:
 
   const std::vector<t_enum_value*>& get_constants() const { return constants_; }
 
-  t_enum_value* get_constant_by_name(const std::string& name) {
+  t_enum_value* get_constant_by_name(const std::string& name) const {
     const std::vector<t_enum_value*>& enum_values = get_constants();
     std::vector<t_enum_value*>::const_iterator c_iter;
     for (c_iter = enum_values.begin(); c_iter != enum_values.end(); ++c_iter) {
@@ -50,7 +50,7 @@ public:
     return NULL;
   }
 
-  t_enum_value* get_constant_by_value(int64_t value) {
+  t_enum_value* get_constant_by_value(int64_t value) const {
     const std::vector<t_enum_value*>& enum_values = get_constants();
     std::vector<t_enum_value*>::const_iterator c_iter;
     for (c_iter = enum_values.begin(); c_iter != enum_values.end(); ++c_iter) {
@@ -61,7 +61,7 @@ public:
     return NULL;
   }
 
-  t_enum_value* get_min_value() {
+  t_enum_value* get_min_value() const {
     const std::vector<t_enum_value*>& enum_values = get_constants();
     std::vector<t_enum_value*>::const_iterator c_iter;
     t_enum_value* min_value;
@@ -81,7 +81,7 @@ public:
     return min_value;
   }
 
-  t_enum_value* get_max_value() {
+  t_enum_value* get_max_value() const {
     const std::vector<t_enum_value*>& enum_values = get_constants();
     std::vector<t_enum_value*>::const_iterator c_iter;
     t_enum_value* max_value;

--- a/compiler/cpp/src/thrift/parse/t_enum.h
+++ b/compiler/cpp/src/thrift/parse/t_enum.h
@@ -33,7 +33,7 @@ class t_enum : public t_type {
 public:
   t_enum(t_program* program) : t_type(program) {}
 
-  void set_name(const std::string& name) { name_ = name; }
+  void set_name(const std::string& name) override { name_ = name; }
 
   void append(t_enum_value* constant) { constants_.push_back(constant); }
 
@@ -101,7 +101,7 @@ public:
     return max_value;
   }
 
-  bool is_enum() const { return true; }
+  bool is_enum() const override { return true; }
 
 private:
   std::vector<t_enum_value*> constants_;

--- a/compiler/cpp/src/thrift/parse/t_enum.h
+++ b/compiler/cpp/src/thrift/parse/t_enum.h
@@ -47,7 +47,7 @@ public:
         return *c_iter;
       }
     }
-    return NULL;
+    return nullptr;
   }
 
   t_enum_value* get_constant_by_value(int64_t value) const {
@@ -58,7 +58,7 @@ public:
         return *c_iter;
       }
     }
-    return NULL;
+    return nullptr;
   }
 
   t_enum_value* get_min_value() const {
@@ -66,7 +66,7 @@ public:
     std::vector<t_enum_value*>::const_iterator c_iter;
     t_enum_value* min_value;
     if (enum_values.size() == 0) {
-      min_value = NULL;
+      min_value = nullptr;
     } else {
       int min_value_value;
       min_value = enum_values.front();
@@ -86,7 +86,7 @@ public:
     std::vector<t_enum_value*>::const_iterator c_iter;
     t_enum_value* max_value;
     if (enum_values.size() == 0) {
-      max_value = NULL;
+      max_value = nullptr;
     } else {
       int max_value_value;
       max_value = enum_values.back();

--- a/compiler/cpp/src/thrift/parse/t_enum_value.h
+++ b/compiler/cpp/src/thrift/parse/t_enum_value.h
@@ -34,7 +34,7 @@ class t_enum_value : public t_doc {
 public:
   t_enum_value(std::string name, int value) : name_(name), value_(value) {}
 
-  ~t_enum_value() override {}
+  ~t_enum_value() override = default;
 
   const std::string& get_name() const { return name_; }
 

--- a/compiler/cpp/src/thrift/parse/t_enum_value.h
+++ b/compiler/cpp/src/thrift/parse/t_enum_value.h
@@ -34,7 +34,7 @@ class t_enum_value : public t_doc {
 public:
   t_enum_value(std::string name, int value) : name_(name), value_(value) {}
 
-  ~t_enum_value() {}
+  ~t_enum_value() override {}
 
   const std::string& get_name() const { return name_; }
 

--- a/compiler/cpp/src/thrift/parse/t_field.h
+++ b/compiler/cpp/src/thrift/parse/t_field.h
@@ -58,7 +58,7 @@ public:
       xsd_attrs_(nullptr),
       reference_(false) {}
 
-  ~t_field() override {}
+  ~t_field() override = default;
 
   t_type* get_type() { return type_; }
 

--- a/compiler/cpp/src/thrift/parse/t_field.h
+++ b/compiler/cpp/src/thrift/parse/t_field.h
@@ -58,7 +58,7 @@ public:
       xsd_attrs_(NULL),
       reference_(false) {}
 
-  ~t_field() {}
+  ~t_field() override {}
 
   t_type* get_type() { return type_; }
 

--- a/compiler/cpp/src/thrift/parse/t_field.h
+++ b/compiler/cpp/src/thrift/parse/t_field.h
@@ -41,10 +41,10 @@ public:
     : type_(type),
       name_(name),
       key_(0),
-      value_(NULL),
+      value_(nullptr),
       xsd_optional_(false),
       xsd_nillable_(false),
-      xsd_attrs_(NULL),
+      xsd_attrs_(nullptr),
       reference_(false) {}
 
   t_field(t_type* type, std::string name, int32_t key)
@@ -52,10 +52,10 @@ public:
       name_(name),
       key_(key),
       req_(T_OPT_IN_REQ_OUT),
-      value_(NULL),
+      value_(nullptr),
       xsd_optional_(false),
       xsd_nillable_(false),
-      xsd_attrs_(NULL),
+      xsd_attrs_(nullptr),
       reference_(false) {}
 
   ~t_field() override {}

--- a/compiler/cpp/src/thrift/parse/t_field.h
+++ b/compiler/cpp/src/thrift/parse/t_field.h
@@ -92,6 +92,8 @@ public:
 
   t_struct* get_xsd_attrs() { return xsd_attrs_; }
 
+  const t_struct* get_xsd_attrs() const { return xsd_attrs_; }
+
   /**
    * Comparator to sort fields in ascending order by key.
    * Make this a functor instead of a function to help GCC inline it.
@@ -105,7 +107,7 @@ public:
 
   std::map<std::string, std::string> annotations_;
 
-  bool get_reference() { return reference_; }
+  bool get_reference() const { return reference_; }
 
   void set_reference(bool reference) { reference_ = reference; }
 

--- a/compiler/cpp/src/thrift/parse/t_function.h
+++ b/compiler/cpp/src/thrift/parse/t_function.h
@@ -64,7 +64,7 @@ public:
     }
   }
 
-  ~t_function() {
+  ~t_function() override {
     if (own_xceptions_)
       delete xceptions_;
   }

--- a/compiler/cpp/src/thrift/parse/t_function.h
+++ b/compiler/cpp/src/thrift/parse/t_function.h
@@ -37,7 +37,7 @@ public:
     : returntype_(returntype),
       name_(name),
       arglist_(arglist),
-      xceptions_(new t_struct(NULL)),
+      xceptions_(new t_struct(nullptr)),
       own_xceptions_(true),
       oneway_(oneway) {
     if (oneway_ && (!returntype_->is_void())) {

--- a/compiler/cpp/src/thrift/parse/t_list.h
+++ b/compiler/cpp/src/thrift/parse/t_list.h
@@ -32,7 +32,7 @@ public:
 
   t_type* get_elem_type() const { return elem_type_; }
 
-  bool is_list() const { return true; }
+  bool is_list() const override { return true; }
 
 private:
   t_type* elem_type_;

--- a/compiler/cpp/src/thrift/parse/t_map.h
+++ b/compiler/cpp/src/thrift/parse/t_map.h
@@ -35,7 +35,7 @@ public:
 
   t_type* get_val_type() const { return val_type_; }
 
-  bool is_map() const { return true; }
+  bool is_map() const override { return true; }
 
 private:
   t_type* key_type_;

--- a/compiler/cpp/src/thrift/parse/t_program.h
+++ b/compiler/cpp/src/thrift/parse/t_program.h
@@ -65,7 +65,7 @@ public:
     scope_ = new t_scope();
   }
 
-  ~t_program() {
+  ~t_program() override {
     if (scope_) {
       delete scope_;
       scope_ = NULL;

--- a/compiler/cpp/src/thrift/parse/t_program.h
+++ b/compiler/cpp/src/thrift/parse/t_program.h
@@ -68,7 +68,7 @@ public:
   ~t_program() override {
     if (scope_) {
       delete scope_;
-      scope_ = NULL;
+      scope_ = nullptr;
     }
   }
 

--- a/compiler/cpp/src/thrift/parse/t_program.h
+++ b/compiler/cpp/src/thrift/parse/t_program.h
@@ -115,6 +115,8 @@ public:
   void add_service(t_service* ts) { services_.push_back(ts); }
 
   // Programs to include
+  std::vector<t_program*>& get_includes() { return includes_; }
+
   const std::vector<t_program*>& get_includes() const { return includes_; }
 
   void set_out_path(std::string out_path, bool out_path_is_absolute) {
@@ -133,9 +135,9 @@ public:
    * @param t    the type to test for collisions
    * @return     true if a certain collision was found, otherwise false
    */
-  bool is_unique_typename(t_type* t) {
+  bool is_unique_typename(const t_type* t) const {
     int occurrences = program_typename_count(this, t);
-    for (std::vector<t_program*>::iterator it = includes_.begin(); it != includes_.end(); ++it) {
+    for (std::vector<t_program*>::const_iterator it = includes_.cbegin(); it != includes_.cend(); ++it) {
       occurrences += program_typename_count(*it, t);
     }
     return 0 == occurrences;
@@ -147,7 +149,7 @@ public:
    * @param t    the type to test for collisions
    * @return     the number of certain typename collisions
    */
-  int program_typename_count(t_program* prog, t_type* t) {
+  int program_typename_count(const t_program* prog, const t_type* t) const {
     int occurrences = 0;
     occurrences += collection_typename_count(prog, prog->typedefs_, t);
     occurrences += collection_typename_count(prog, prog->enums_, t);
@@ -164,9 +166,9 @@ public:
    * @return                the number of certain typename collisions
    */
   template <class T>
-  int collection_typename_count(t_program* prog, T type_collection, t_type* t) {
+  int collection_typename_count(const t_program* prog, const T type_collection, const t_type* t) const {
     int occurrences = 0;
-    for (typename T::iterator it = type_collection.begin(); it != type_collection.end(); ++it)
+    for (typename T::const_iterator it = type_collection.cbegin(); it != type_collection.cend(); ++it)
       if (t != *it && 0 == t->get_name().compare((*it)->get_name()) && is_common_namespace(prog, t))
         ++occurrences;
     return occurrences;
@@ -184,7 +186,7 @@ public:
    * @param t    the type containing the typename match
    * @return     true if a collision within namespaces is found, otherwise false
    */
-  bool is_common_namespace(t_program* prog, t_type* t) {
+  bool is_common_namespace(const t_program* prog, const t_type* t) const {
     // Case 1: Typenames are in the same program [collision]
     if (prog == t->get_program()) {
       pwarning(1,
@@ -196,8 +198,8 @@ public:
 
     // Case 2: Both programs have identical namespace scope/name declarations [collision]
     bool match = true;
-    for (std::map<std::string, std::string>::iterator it = prog->namespaces_.begin();
-         it != prog->namespaces_.end();
+    for (auto it = prog->namespaces_.cbegin();
+         it != prog->namespaces_.cend();
          ++it) {
       if (0 == it->second.compare(t->get_program()->get_namespace(it->first))) {
         pwarning(1,
@@ -213,8 +215,8 @@ public:
         match = false;
       }
     }
-    for (std::map<std::string, std::string>::iterator it = t->get_program()->namespaces_.begin();
-         it != t->get_program()->namespaces_.end();
+    for (auto it = t->get_program()->namespaces_.cbegin();
+         it != t->get_program()->namespaces_.cend();
          ++it) {
       if (0 == it->second.compare(prog->get_namespace(it->first))) {
         pwarning(1,
@@ -244,7 +246,9 @@ public:
   void set_namespace(std::string name) { namespace_ = name; }
 
   // Scope accessor
-  t_scope* scope() const { return scope_; }
+  t_scope* scope() { return scope_; }
+
+  const t_scope* scope() const { return scope_; }
 
   // Includes
 
@@ -266,8 +270,6 @@ public:
     program->set_include_prefix(include_prefix);
     includes_.push_back(program);
   }
-
-  std::vector<t_program*>& get_includes() { return includes_; }
 
   void set_include_prefix(std::string include_prefix) {
     include_prefix_ = include_prefix;
@@ -323,7 +325,7 @@ public:
     return std::string();
   }
 
-  const std::map<std::string, std::string>& get_all_namespaces(){
+  const std::map<std::string, std::string>& get_all_namespaces() const {
      return namespaces_;
   }
 
@@ -331,7 +333,16 @@ public:
     namespace_annotations_[language] = annotations;
   }
 
-  const std::map<std::string, std::string>& get_namespace_annotations(std::string language) {
+  const std::map<std::string, std::string>& get_namespace_annotations(const std::string& language) const {
+    auto it = namespace_annotations_.find(language);
+    if (namespace_annotations_.end() != it) {
+      return it->second;
+    }
+    static const std::map<std::string, std::string> emptyMap;
+    return emptyMap;
+  }
+
+  std::map<std::string, std::string>& get_namespace_annotations(const std::string& language) {
     return namespace_annotations_[language];
   }
 
@@ -339,11 +350,11 @@ public:
 
   void add_cpp_include(std::string path) { cpp_includes_.push_back(path); }
 
-  const std::vector<std::string>& get_cpp_includes() { return cpp_includes_; }
+  const std::vector<std::string>& get_cpp_includes() const { return cpp_includes_; }
 
   void add_c_include(std::string path) { c_includes_.push_back(path); }
 
-  const std::vector<std::string>& get_c_includes() { return c_includes_; }
+  const std::vector<std::string>& get_c_includes() const { return c_includes_; }
 
 private:
   // File path

--- a/compiler/cpp/src/thrift/parse/t_program.h
+++ b/compiler/cpp/src/thrift/parse/t_program.h
@@ -137,7 +137,7 @@ public:
    */
   bool is_unique_typename(const t_type* t) const {
     int occurrences = program_typename_count(this, t);
-    for (std::vector<t_program*>::const_iterator it = includes_.cbegin(); it != includes_.cend(); ++it) {
+    for (auto it = includes_.cbegin(); it != includes_.cend(); ++it) {
       occurrences += program_typename_count(*it, t);
     }
     return 0 == occurrences;
@@ -168,7 +168,7 @@ public:
   template <class T>
   int collection_typename_count(const t_program* prog, const T type_collection, const t_type* t) const {
     int occurrences = 0;
-    for (typename T::const_iterator it = type_collection.cbegin(); it != type_collection.cend(); ++it)
+    for (auto it = type_collection.cbegin(); it != type_collection.cend(); ++it)
       if (t != *it && 0 == t->get_name().compare((*it)->get_name()) && is_common_namespace(prog, t))
         ++occurrences;
     return occurrences;

--- a/compiler/cpp/src/thrift/parse/t_scope.h
+++ b/compiler/cpp/src/thrift/parse/t_scope.h
@@ -48,9 +48,27 @@ public:
 
   t_type* get_type(std::string name) { return types_[name]; }
 
+  const t_type* get_type(std::string name) const {
+    const auto it = types_.find(name);
+    if (types_.end() != it)
+    {
+       return it->second;
+    }
+    return nullptr;
+  }
+
   void add_service(std::string name, t_service* service) { services_[name] = service; }
 
   t_service* get_service(std::string name) { return services_[name]; }
+
+  const t_service* get_service(std::string name) const { 
+    const auto it = services_.find(name);
+    if (services_.end() != it)
+    {
+       return it->second;
+    }
+    return nullptr;
+  }
 
   void add_constant(std::string name, t_const* constant) {
     if (constants_.find(name) != constants_.end()) {
@@ -61,6 +79,15 @@ public:
   }
 
   t_const* get_constant(std::string name) { return constants_[name]; }
+
+  const t_const* get_constant(std::string name) const { 
+    const auto it = constants_.find(name);
+    if (constants_.end() != it)
+    {
+       return it->second;
+    }
+    return nullptr;
+  }
 
   void print() {
     std::map<std::string, t_type*>::iterator iter;

--- a/compiler/cpp/src/thrift/parse/t_scope.h
+++ b/compiler/cpp/src/thrift/parse/t_scope.h
@@ -122,7 +122,7 @@ public:
       std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
       for (v_iter = map.begin(); v_iter != map.end(); ++v_iter) {
         t_field* field = tstruct->get_field_by_name(v_iter->first->get_string());
-        if (field == NULL) {
+        if (field == nullptr) {
           throw "No field named \"" + v_iter->first->get_string()
               + "\" was found in struct of type \"" + tstruct->get_name() + "\"";
         }
@@ -133,7 +133,7 @@ public:
         const_val->set_enum((t_enum*)ttype);
       } else {
         t_const* constant = get_constant(const_val->get_identifier());
-        if (constant == NULL) {
+        if (constant == nullptr) {
           throw "No enum value or constant found named \"" + const_val->get_identifier() + "\"!";
         }
 
@@ -181,7 +181,7 @@ public:
       // value's name.
       auto* tenum = (t_enum*)ttype;
       t_enum_value* enum_value = tenum->get_constant_by_value(const_val->get_integer());
-      if (enum_value == NULL) {
+      if (enum_value == nullptr) {
         std::ostringstream valstm;
         valstm << const_val->get_integer();
         throw "Couldn't find a named value in enum " + tenum->get_name() + " for value "

--- a/compiler/cpp/src/thrift/parse/t_scope.h
+++ b/compiler/cpp/src/thrift/parse/t_scope.h
@@ -42,7 +42,7 @@
  */
 class t_scope {
 public:
-  t_scope() {}
+  t_scope() = default;
 
   void add_type(std::string name, t_type* type) { types_[name] = type; }
 

--- a/compiler/cpp/src/thrift/parse/t_scope.h
+++ b/compiler/cpp/src/thrift/parse/t_scope.h
@@ -117,7 +117,7 @@ public:
         resolve_const_value((*v_iter), ((t_set*)ttype)->get_elem_type());
       }
     } else if (ttype->is_struct()) {
-      t_struct* tstruct = (t_struct*)ttype;
+      auto* tstruct = (t_struct*)ttype;
       const std::map<t_const_value*, t_const_value*, t_const_value::value_compare>& map = const_val->get_map();
       std::map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
       for (v_iter = map.begin(); v_iter != map.end(); ++v_iter) {
@@ -179,7 +179,7 @@ public:
     } else if (ttype->is_enum()) {
       // enum constant with non-identifier value. set the enum and find the
       // value's name.
-      t_enum* tenum = (t_enum*)ttype;
+      auto* tenum = (t_enum*)ttype;
       t_enum_value* enum_value = tenum->get_constant_by_value(const_val->get_integer());
       if (enum_value == NULL) {
         std::ostringstream valstm;

--- a/compiler/cpp/src/thrift/parse/t_service.h
+++ b/compiler/cpp/src/thrift/parse/t_service.h
@@ -31,7 +31,7 @@ class t_program;
  */
 class t_service : public t_type {
 public:
-  t_service(t_program* program) : t_type(program), extends_(NULL) {}
+  t_service(t_program* program) : t_type(program), extends_(nullptr) {}
 
   bool is_service() const override { return true; }
 

--- a/compiler/cpp/src/thrift/parse/t_service.h
+++ b/compiler/cpp/src/thrift/parse/t_service.h
@@ -33,7 +33,7 @@ class t_service : public t_type {
 public:
   t_service(t_program* program) : t_type(program), extends_(NULL) {}
 
-  bool is_service() const { return true; }
+  bool is_service() const override { return true; }
 
   void set_extends(t_service* extends) { extends_ = extends; }
 

--- a/compiler/cpp/src/thrift/parse/t_set.h
+++ b/compiler/cpp/src/thrift/parse/t_set.h
@@ -30,7 +30,9 @@ class t_set : public t_container {
 public:
   t_set(t_type* elem_type) : elem_type_(elem_type) {}
 
-  t_type* get_elem_type() const { return elem_type_; }
+  const t_type* get_elem_type() const { return elem_type_; }
+
+  t_type* get_elem_type() { return elem_type_; }
 
   bool is_set() const override { return true; }
 

--- a/compiler/cpp/src/thrift/parse/t_set.h
+++ b/compiler/cpp/src/thrift/parse/t_set.h
@@ -32,7 +32,7 @@ public:
 
   t_type* get_elem_type() const { return elem_type_; }
 
-  bool is_set() const { return true; }
+  bool is_set() const override { return true; }
 
 private:
   t_type* elem_type_;

--- a/compiler/cpp/src/thrift/parse/t_struct.h
+++ b/compiler/cpp/src/thrift/parse/t_struct.h
@@ -56,7 +56,7 @@ public:
       members_with_value(0),
       xsd_all_(false) {}
 
-  void set_name(const std::string& name) {
+  void set_name(const std::string& name) override {
     name_ = name;
     validate_union_members();
   }
@@ -131,9 +131,9 @@ public:
 
   const members_type& get_sorted_members() { return members_in_id_order_; }
 
-  bool is_struct() const { return !is_xception_; }
+  bool is_struct() const override { return !is_xception_; }
 
-  bool is_xception() const { return is_xception_; }
+  bool is_xception() const override { return is_xception_; }
 
   bool is_union() const { return is_union_; }
 

--- a/compiler/cpp/src/thrift/parse/t_struct.h
+++ b/compiler/cpp/src/thrift/parse/t_struct.h
@@ -80,7 +80,7 @@ public:
       }
 
       // unions may have up to one member defaulted, but not more
-      if (field->get_value() != NULL) {
+      if (field->get_value() != nullptr) {
         if (1 < ++members_with_value) {
           throw "Error: Field " + field->get_name() + " provides another default value for union "
               + name_;
@@ -118,7 +118,7 @@ public:
       return false;
     }
     // returns false when there is a conflict of field names
-    if (get_field_by_name(elem->get_name()) != NULL) {
+    if (get_field_by_name(elem->get_name()) != nullptr) {
       return false;
     }
     members_.push_back(elem);
@@ -148,7 +148,7 @@ public:
         return *m_iter;
       }
     }
-    return NULL;
+    return nullptr;
   }
 
 private:

--- a/compiler/cpp/src/thrift/parse/t_struct.h
+++ b/compiler/cpp/src/thrift/parse/t_struct.h
@@ -129,7 +129,7 @@ public:
 
   const members_type& get_members() const { return members_; }
 
-  const members_type& get_sorted_members() { return members_in_id_order_; }
+  const members_type& get_sorted_members() const { return members_in_id_order_; }
 
   bool is_struct() const override { return !is_xception_; }
 
@@ -138,13 +138,7 @@ public:
   bool is_union() const { return is_union_; }
 
   t_field* get_field_by_name(std::string field_name) {
-    members_type::const_iterator m_iter;
-    for (m_iter = members_in_id_order_.begin(); m_iter != members_in_id_order_.end(); ++m_iter) {
-      if ((*m_iter)->get_name() == field_name) {
-        return *m_iter;
-      }
-    }
-    return NULL;
+    return const_cast<t_field*>(const_cast<const t_struct&>(*this).get_field_by_name(field_name));
   }
 
   const t_field* get_field_by_name(std::string field_name) const {

--- a/compiler/cpp/src/thrift/parse/t_type.h
+++ b/compiler/cpp/src/thrift/parse/t_type.h
@@ -85,13 +85,13 @@ public:
   std::map<std::string, std::string> annotations_;
 
 protected:
-  t_type() : program_(NULL) { ; }
+  t_type() : program_(nullptr) { ; }
 
   t_type(t_program* program) : program_(program) { ; }
 
   t_type(t_program* program, std::string name) : program_(program), name_(name) { ; }
 
-  t_type(std::string name) : program_(NULL), name_(name) { ; }
+  t_type(std::string name) : program_(nullptr), name_(name) { ; }
 
   t_program* program_;
   std::string name_;

--- a/compiler/cpp/src/thrift/parse/t_type.h
+++ b/compiler/cpp/src/thrift/parse/t_type.h
@@ -38,7 +38,7 @@ class t_program;
  */
 class t_type : public t_doc {
 public:
-  ~t_type() override {}
+  ~t_type() override = default;
 
   virtual void set_name(const std::string& name) { name_ = name; }
 

--- a/compiler/cpp/src/thrift/parse/t_type.h
+++ b/compiler/cpp/src/thrift/parse/t_type.h
@@ -38,7 +38,7 @@ class t_program;
  */
 class t_type : public t_doc {
 public:
-  virtual ~t_type() {}
+  ~t_type() override {}
 
   virtual void set_name(const std::string& name) { name_ = name; }
 

--- a/compiler/cpp/src/thrift/parse/t_typedef.cc
+++ b/compiler/cpp/src/thrift/parse/t_typedef.cc
@@ -21,9 +21,13 @@
 #include "thrift/parse/t_typedef.h"
 #include "thrift/parse/t_program.h"
 
-t_type* t_typedef::get_type() const {
+t_type* t_typedef::get_type() {
+  return const_cast<t_type*>(const_cast<const t_typedef*>(this)->get_type());
+}
+
+const t_type* t_typedef::get_type() const {
   if (type_ == NULL) {
-    t_type* type = get_program()->scope()->get_type(symbolic_);
+    const t_type* type = get_program()->scope()->get_type(symbolic_);
     if (type == NULL) {
       printf("Type \"%s\" not defined\n", symbolic_.c_str());
       exit(1);

--- a/compiler/cpp/src/thrift/parse/t_typedef.h
+++ b/compiler/cpp/src/thrift/parse/t_typedef.h
@@ -42,7 +42,7 @@ public:
    */
   t_typedef(t_program* program, const std::string& symbolic, bool forward)
     : t_type(program, symbolic),
-      type_(NULL),
+      type_(nullptr),
       symbolic_(symbolic),
       forward_(forward)
   {}

--- a/compiler/cpp/src/thrift/parse/t_typedef.h
+++ b/compiler/cpp/src/thrift/parse/t_typedef.h
@@ -47,7 +47,7 @@ public:
       forward_(forward)
   {}
 
-  ~t_typedef() override {}
+  ~t_typedef() override = default;
 
   t_type* get_type();
 

--- a/compiler/cpp/src/thrift/parse/t_typedef.h
+++ b/compiler/cpp/src/thrift/parse/t_typedef.h
@@ -49,7 +49,9 @@ public:
 
   ~t_typedef() override {}
 
-  t_type* get_type() const;
+  t_type* get_type();
+
+  const t_type* get_type() const;
 
   const std::string& get_symbolic() const { return symbolic_; }
 

--- a/compiler/cpp/src/thrift/parse/t_typedef.h
+++ b/compiler/cpp/src/thrift/parse/t_typedef.h
@@ -47,7 +47,7 @@ public:
       forward_(forward)
   {}
 
-  ~t_typedef() {}
+  ~t_typedef() override {}
 
   t_type* get_type() const;
 
@@ -55,7 +55,7 @@ public:
 
   bool is_forward_typedef() const { return forward_; }
 
-  bool is_typedef() const { return true; }
+  bool is_typedef() const override { return true; }
 
 private:
   t_type* type_;

--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -350,12 +350,12 @@ extern "C" {
 static void
 test_thrift_client (void)
 {
-  ThriftSocket *tsocket = NULL;
-  ThriftBinaryProtocol *protocol = NULL;
-  TTestThriftTestClient *client = NULL;
-  TTestThriftTestIf *iface = NULL;
-  GError *error = NULL;
-  gchar *string = NULL;
+  ThriftSocket *tsocket = nullptr;
+  ThriftBinaryProtocol *protocol = nullptr;
+  TTestThriftTestClient *client = nullptr;
+  TTestThriftTestIf *iface = nullptr;
+  GError *error = nullptr;
+  gchar *string = nullptr;
   gint8 byte = 0;
   gint16 i16 = 0;
   gint32 i32 = 0, another_i32 = 56789;
@@ -363,18 +363,18 @@ test_thrift_client (void)
   double dbl = 0.0;
   TTestXtruct *xtruct_in, *xtruct_out;
   TTestXtruct2 *xtruct2_in, *xtruct2_out;
-  GHashTable *map_in = NULL, *map_out = NULL;
-  GHashTable *set_in = NULL, *set_out = NULL;
-  GArray *list_in = NULL, *list_out = NULL;
+  GHashTable *map_in = nullptr, *map_out = nullptr;
+  GHashTable *set_in = nullptr, *set_out = nullptr;
+  GArray *list_in = nullptr, *list_out = nullptr;
   TTestNumberz enum_in, enum_out;
   TTestUserId user_id_in, user_id_out;
-  GHashTable *insanity_in = NULL;
+  GHashTable *insanity_in = nullptr;
   TTestXtruct *xtruct1, *xtruct2;
-  TTestInsanity *insanity_out = NULL;
-  TTestXtruct *multi_in = NULL;
-  GHashTable *multi_map_out = NULL;
-  TTestXception *xception = NULL;
-  TTestXception2 *xception2 = NULL;
+  TTestInsanity *insanity_out = nullptr;
+  TTestXtruct *multi_in = nullptr;
+  GHashTable *multi_map_out = nullptr;
+  TTestXception *xception = nullptr;
+  TTestXception2 *xception2 = nullptr;
 
 #if (!GLIB_CHECK_VERSION (2, 36, 0))
   // initialize gobject
@@ -392,33 +392,33 @@ test_thrift_client (void)
   iface = T_TEST_THRIFT_TEST_IF (client);
 
   // open and send
-  thrift_transport_open (THRIFT_TRANSPORT(tsocket), NULL);
+  thrift_transport_open (THRIFT_TRANSPORT(tsocket), nullptr);
 
   assert (t_test_thrift_test_client_test_void (iface, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   assert (t_test_thrift_test_client_test_string (iface, &string, "test123", &error) == TRUE);
   assert (strcmp (string, "test123") == 0);
   g_free (string);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   assert (t_test_thrift_test_client_test_byte (iface, &byte, (gint8) 5, &error) == TRUE);
   assert (byte == 5);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   assert (t_test_thrift_test_client_test_i32 (iface, &i32, 123, &error) == TRUE);
   assert (i32 == 123);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   assert (t_test_thrift_test_client_test_i64 (iface, &i64, 12345, &error) == TRUE);
   assert (i64 == 12345);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   assert (t_test_thrift_test_client_test_double (iface, &dbl, 5.6, &error) == TRUE);
   assert (dbl == 5.6);
-  assert (error == NULL);
+  assert (error == nullptr);
 
-  xtruct_out = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
+  xtruct_out = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
   xtruct_out->byte_thing = 1;
   xtruct_out->__isset_byte_thing = TRUE;
   xtruct_out->i32_thing = 15;
@@ -427,50 +427,50 @@ test_thrift_client (void)
   xtruct_out->__isset_i64_thing = TRUE;
   xtruct_out->string_thing = g_strdup ("abc123");
   xtruct_out->__isset_string_thing = TRUE;
-  xtruct_in = (TTestXtruct *) g_object_new(T_TEST_TYPE_XTRUCT, NULL);
+  xtruct_in = (TTestXtruct *) g_object_new(T_TEST_TYPE_XTRUCT, nullptr);
   assert (t_test_thrift_test_client_test_struct (iface, &xtruct_in, xtruct_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
 
-  xtruct2_out = (TTestXtruct2 *) g_object_new (T_TEST_TYPE_XTRUCT2, NULL);
+  xtruct2_out = (TTestXtruct2 *) g_object_new (T_TEST_TYPE_XTRUCT2, nullptr);
   xtruct2_out->byte_thing = 1;
   xtruct2_out->__isset_byte_thing = TRUE;
-  if (xtruct2_out->struct_thing != NULL)
+  if (xtruct2_out->struct_thing != nullptr)
     g_object_unref(xtruct2_out->struct_thing);
   xtruct2_out->struct_thing = xtruct_out;
   xtruct2_out->__isset_struct_thing = TRUE;
   xtruct2_out->i32_thing = 123;
   xtruct2_out->__isset_i32_thing = TRUE;
-  xtruct2_in = (TTestXtruct2 *) g_object_new (T_TEST_TYPE_XTRUCT2, NULL);
+  xtruct2_in = (TTestXtruct2 *) g_object_new (T_TEST_TYPE_XTRUCT2, nullptr);
   assert (t_test_thrift_test_client_test_nest (iface, &xtruct2_in, xtruct2_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   g_object_unref (xtruct2_out);
   g_object_unref (xtruct2_in);
   g_object_unref (xtruct_in);
 
-  map_out = g_hash_table_new (NULL, NULL);
-  map_in = g_hash_table_new (NULL, NULL);  g_hash_table_insert (map_out, &i32, &i32);
+  map_out = g_hash_table_new (nullptr, nullptr);
+  map_in = g_hash_table_new (nullptr, nullptr);  g_hash_table_insert (map_out, &i32, &i32);
   assert (t_test_thrift_test_client_test_map (iface, &map_in, map_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
   g_hash_table_destroy (map_out);
   g_hash_table_destroy (map_in);
 
-  map_out = g_hash_table_new (NULL, NULL);
-  map_in = g_hash_table_new (NULL, NULL);
+  map_out = g_hash_table_new (nullptr, nullptr);
+  map_in = g_hash_table_new (nullptr, nullptr);
   g_hash_table_insert (map_out, g_strdup ("a"), g_strdup ("123"));
   g_hash_table_insert (map_out, g_strdup ("a b"), g_strdup ("with spaces "));
   g_hash_table_insert (map_out, g_strdup ("same"), g_strdup ("same"));
   g_hash_table_insert (map_out, g_strdup ("0"), g_strdup ("numeric key"));
   assert (t_test_thrift_test_client_test_string_map (iface, &map_in, map_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
   g_hash_table_destroy (map_out);
   g_hash_table_destroy (map_in);
 
-  set_out = g_hash_table_new (NULL, NULL);
-  set_in = g_hash_table_new (NULL, NULL);
+  set_out = g_hash_table_new (nullptr, nullptr);
+  set_in = g_hash_table_new (nullptr, nullptr);
   g_hash_table_insert (set_out, &i32, &i32);
   assert (t_test_thrift_test_client_test_set (iface, &set_in, set_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
   g_hash_table_destroy (set_out);
   g_hash_table_destroy (set_in);
 
@@ -480,31 +480,31 @@ test_thrift_client (void)
   g_array_append_val (list_out, i32);
   g_array_append_val (list_out, another_i32);
   assert (t_test_thrift_test_client_test_list (iface, &list_in, list_out, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
   g_array_free (list_out, TRUE);
   g_array_free (list_in, TRUE);
 
   enum_out = T_TEST_NUMBERZ_ONE;
   assert (t_test_thrift_test_client_test_enum (iface, &enum_in, enum_out, &error) == TRUE);
   assert (enum_in == enum_out);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   user_id_out = 12345;
   assert (t_test_thrift_test_client_test_typedef (iface, &user_id_in, user_id_out, &error) == TRUE);
   assert (user_id_in == user_id_out);
-  assert (error == NULL);
+  assert (error == nullptr);
 
-  map_in = g_hash_table_new (NULL, NULL);
+  map_in = g_hash_table_new (nullptr, nullptr);
   assert (t_test_thrift_test_client_test_map_map (iface, &map_in, i32, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
   g_hash_table_destroy (map_in);
 
   // insanity
-  insanity_out = (TTestInsanity *) g_object_new (T_TEST_TYPE_INSANITY, NULL);
-  insanity_out->userMap = g_hash_table_new (NULL, NULL);
+  insanity_out = (TTestInsanity *) g_object_new (T_TEST_TYPE_INSANITY, nullptr);
+  insanity_out->userMap = g_hash_table_new (nullptr, nullptr);
   g_hash_table_insert (insanity_out->userMap, GINT_TO_POINTER (enum_out), &user_id_out);
 
-  xtruct1 = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
+  xtruct1 = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
   xtruct1->byte_thing = 1;
   xtruct1->__isset_byte_thing = TRUE;
   xtruct1->i32_thing = 15;
@@ -513,7 +513,7 @@ test_thrift_client (void)
   xtruct1->__isset_i64_thing = TRUE;
   xtruct1->string_thing = g_strdup ("abc123");
   xtruct1->__isset_string_thing = TRUE;
-  xtruct2 = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
+  xtruct2 = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
   xtruct2->byte_thing = 1;
   xtruct2->__isset_byte_thing = TRUE;
   xtruct2->i32_thing = 15;
@@ -523,7 +523,7 @@ test_thrift_client (void)
   xtruct2->string_thing = g_strdup ("abc123");
   xtruct2->__isset_string_thing = TRUE;
 
-  insanity_in = g_hash_table_new (NULL, NULL);
+  insanity_in = g_hash_table_new (nullptr, nullptr);
   g_ptr_array_add (insanity_out->xtructs, xtruct1);
   g_ptr_array_add (insanity_out->xtructs, xtruct2);
   assert (t_test_thrift_test_client_test_insanity (iface, &insanity_in, insanity_out, &error) == TRUE);
@@ -531,10 +531,10 @@ test_thrift_client (void)
   g_hash_table_unref (insanity_in);
   g_ptr_array_free (insanity_out->xtructs, TRUE);
 
-  multi_map_out = g_hash_table_new (NULL, NULL);
+  multi_map_out = g_hash_table_new (nullptr, nullptr);
   string = g_strdup ("abc123");
   g_hash_table_insert (multi_map_out, &i16, string);
-  multi_in = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
+  multi_in = (TTestXtruct *) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
   assert (t_test_thrift_test_client_test_multi (iface, &multi_in, byte, i32, i64, multi_map_out, enum_out, user_id_out, &error) == TRUE);
   assert (multi_in->i32_thing == i32);
   assert (multi_in->i64_thing == i64);
@@ -545,53 +545,53 @@ test_thrift_client (void)
   assert (t_test_thrift_test_client_test_exception (iface, "Xception", &xception, &error) == FALSE);
   assert (xception->errorCode == 1001);
   g_error_free (error);
-  error = NULL;
+  error = nullptr;
   g_object_unref (xception);
-  xception = NULL;
+  xception = nullptr;
 
   assert (t_test_thrift_test_client_test_exception (iface, "ApplicationException", &xception, &error) == FALSE);
   g_error_free (error);
-  error = NULL;
-  assert (xception == NULL);
+  error = nullptr;
+  assert (xception == nullptr);
 
   assert (t_test_thrift_test_client_test_exception (iface, "Test", &xception, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
 
-  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
-  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, "Xception", NULL, &xception, &xception2, &error) == FALSE);
+  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
+  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, "Xception", nullptr, &xception, &xception2, &error) == FALSE);
   assert (xception->errorCode == 1001);
-  assert (xception2 == NULL);
+  assert (xception2 == nullptr);
   g_error_free (error);
-  error = NULL;
+  error = nullptr;
   g_object_unref (xception);
   g_object_unref (multi_in);
-  xception = NULL;
-  multi_in = NULL;
+  xception = nullptr;
+  multi_in = nullptr;
 
-  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
-  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, "Xception2", NULL, &xception, &xception2, &error) == FALSE);
+  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
+  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, "Xception2", nullptr, &xception, &xception2, &error) == FALSE);
   assert (xception2->errorCode == 2002);
-  assert (xception == NULL);
+  assert (xception == nullptr);
   g_error_free (error);
-  error = NULL;
+  error = nullptr;
   g_object_unref (xception2);
   g_object_unref (multi_in);
-  xception2 = NULL;
-  multi_in = NULL;
+  xception2 = nullptr;
+  multi_in = nullptr;
 
-  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, NULL);
-  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, NULL , NULL, &xception, &xception2, &error) == TRUE);
-  assert (error == NULL);
+  multi_in = (TTestXtruct*) g_object_new (T_TEST_TYPE_XTRUCT, nullptr);
+  assert (t_test_thrift_test_client_test_multi_exception (iface, &multi_in, nullptr , nullptr, &xception, &xception2, &error) == TRUE);
+  assert (error == nullptr);
   g_object_unref(multi_in);
-  multi_in = NULL;
+  multi_in = nullptr;
 
   assert (t_test_thrift_test_client_test_oneway (iface, 1, &error) == TRUE);
-  assert (error == NULL);
+  assert (error == nullptr);
 
   /* sleep to let the oneway call go through */
   sleep (5);
 
-  thrift_transport_close (THRIFT_TRANSPORT(tsocket), NULL);
+  thrift_transport_close (THRIFT_TRANSPORT(tsocket), nullptr);
   g_object_unref (client);
   g_object_unref (protocol);
   g_object_unref (tsocket);

--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -69,56 +69,56 @@ class TestHandler : public ThriftTestIf {
   public:
   TestHandler() {}
 
-  void testVoid() {
+  void testVoid() override {
     cout << "[C -> C++] testVoid()" << endl;
   }
 
-  void testString(string& out, const string &thing) {
+  void testString(string& out, const string &thing) override {
     cout << "[C -> C++] testString(\"" << thing << "\")" << endl;
     out = thing;
   }
 
-  bool testBool(const bool thing) {
+  bool testBool(const bool thing) override {
     cout << "[C -> C++] testBool(" << (thing ? "true" : "false") << ")" << endl;
     return thing;
   }
-  int8_t testByte(const int8_t thing) {
+  int8_t testByte(const int8_t thing) override {
     cout << "[C -> C++] testByte(" << (int)thing << ")" << endl;
     return thing;
   }
-  int32_t testI32(const int32_t thing) {
+  int32_t testI32(const int32_t thing) override {
     cout << "[C -> C++] testI32(" << thing << ")" << endl;
     return thing;
   }
 
-  int64_t testI64(const int64_t thing) {
+  int64_t testI64(const int64_t thing) override {
     cout << "[C -> C++] testI64(" << thing << ")" << endl;
     return thing;
   }
 
-  double testDouble(const double thing) {
+  double testDouble(const double thing) override {
     cout.precision(6);
     cout << "[C -> C++] testDouble(" << fixed << thing << ")" << endl;
     return thing;
   }
 
-  void testBinary(string& out, const string &thing) {
+  void testBinary(string& out, const string &thing) override {
     cout << "[C -> C++] testBinary(\"" << thing << "\")" << endl;
     out = thing;
   }
 
-  void testStruct(Xtruct& out, const Xtruct &thing) {
+  void testStruct(Xtruct& out, const Xtruct &thing) override {
     cout << "[C -> C++] testStruct({\"" << thing.string_thing << "\", " << (int)thing.byte_thing << ", " << thing.i32_thing << ", " << thing.i64_thing << "})" << endl;
     out = thing;
   }
 
-  void testNest(Xtruct2& out, const Xtruct2& nest) {
+  void testNest(Xtruct2& out, const Xtruct2& nest) override {
     const Xtruct &thing = nest.struct_thing;
     cout << "[C -> C++] testNest({" << (int)nest.byte_thing << ", {\"" << thing.string_thing << "\", " << (int)thing.byte_thing << ", " << thing.i32_thing << ", " << thing.i64_thing << "}, " << nest.i32_thing << "})" << endl;
     out = nest;
   }
 
-  void testMap(map<int32_t, int32_t> &out, const map<int32_t, int32_t> &thing) {
+  void testMap(map<int32_t, int32_t> &out, const map<int32_t, int32_t> &thing) override {
     cout << "[C -> C++] testMap({";
     map<int32_t, int32_t>::const_iterator m_iter;
     bool first = true;
@@ -134,7 +134,7 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  void testStringMap(map<std::string, std::string> &out, const map<std::string, std::string> &thing) {
+  void testStringMap(map<std::string, std::string> &out, const map<std::string, std::string> &thing) override {
     cout << "[C -> C++] testStringMap({";
     map<std::string, std::string>::const_iterator m_iter;
     bool first = true;
@@ -151,7 +151,7 @@ class TestHandler : public ThriftTestIf {
   }
 
 
-  void testSet(set<int32_t> &out, const set<int32_t> &thing) {
+  void testSet(set<int32_t> &out, const set<int32_t> &thing) override {
     cout << "[C -> C++] testSet({";
     set<int32_t>::const_iterator s_iter;
     bool first = true;
@@ -167,7 +167,7 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  void testList(vector<int32_t> &out, const vector<int32_t> &thing) {
+  void testList(vector<int32_t> &out, const vector<int32_t> &thing) override {
     cout << "[C -> C++] testList({";
     vector<int32_t>::const_iterator l_iter;
     bool first = true;
@@ -183,16 +183,16 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  Numberz::type testEnum(const Numberz::type thing) {
+  Numberz::type testEnum(const Numberz::type thing) override {
     cout << "[C -> C++] testEnum(" << thing << ")" << endl;
     return thing;
   }
 
-  UserId testTypedef(const UserId thing) {
+  UserId testTypedef(const UserId thing) override {
     cout << "[C -> C++] testTypedef(" << thing << ")" << endl;
     return thing;  }
 
-  void testMapMap(map<int32_t, map<int32_t,int32_t> > &mapmap, const int32_t hello) {
+  void testMapMap(map<int32_t, map<int32_t,int32_t> > &mapmap, const int32_t hello) override {
     cout << "[C -> C++] testMapMap(" << hello << ")" << endl;
 
     map<int32_t,int32_t> pos;
@@ -207,7 +207,7 @@ class TestHandler : public ThriftTestIf {
 
   }
 
-  void testInsanity(map<UserId, map<Numberz::type,Insanity> > &insane, const Insanity &argument) {
+  void testInsanity(map<UserId, map<Numberz::type,Insanity> > &insane, const Insanity &argument) override {
     THRIFT_UNUSED_VARIABLE (argument);
 
     cout << "[C -> C++] testInsanity()" << endl;
@@ -277,7 +277,7 @@ class TestHandler : public ThriftTestIf {
 
   }
 
-  void testMulti(Xtruct &hello, const int8_t arg0, const int32_t arg1, const int64_t arg2, const std::map<int16_t, std::string>  &arg3, const Numberz::type arg4, const UserId arg5) {
+  void testMulti(Xtruct &hello, const int8_t arg0, const int32_t arg1, const int64_t arg2, const std::map<int16_t, std::string>  &arg3, const Numberz::type arg4, const UserId arg5) override {
     THRIFT_UNUSED_VARIABLE (arg3);
     THRIFT_UNUSED_VARIABLE (arg4);
     THRIFT_UNUSED_VARIABLE (arg5);
@@ -291,7 +291,7 @@ class TestHandler : public ThriftTestIf {
   }
 
   void testException(const std::string &arg)
-    throw(Xception, apache::thrift::TException)
+    throw(Xception, apache::thrift::TException) override
   {
     cout << "[C -> C++] testException(" << arg << ")" << endl;
     if (arg.compare("Xception") == 0) {
@@ -309,7 +309,7 @@ class TestHandler : public ThriftTestIf {
     }
   }
 
-  void testMultiException(Xtruct &result, const std::string &arg0, const std::string &arg1) throw(Xception, Xception2) {
+  void testMultiException(Xtruct &result, const std::string &arg0, const std::string &arg1) throw(Xception, Xception2) override {
 
     cout << "[C -> C++] testMultiException(" << arg0 << ", " << arg1 << ")" << endl;
 
@@ -329,7 +329,7 @@ class TestHandler : public ThriftTestIf {
     }
   }
 
-  void testOneway(int sleepFor) {
+  void testOneway(int sleepFor) override {
     cout << "testOneway(" << sleepFor << "): Sleeping..." << endl;
     sleep(sleepFor);
     cout << "testOneway(" << sleepFor << "): done sleeping!" << endl;

--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -67,7 +67,7 @@ bool Insanity::operator<(thrift::test::Insanity const& other) const {
 
 class TestHandler : public ThriftTestIf {
   public:
-  TestHandler() {}
+  TestHandler() = default;
 
   void testVoid() override {
     cout << "[C -> C++] testVoid()" << endl;

--- a/lib/cpp/README.md
+++ b/lib/cpp/README.md
@@ -252,6 +252,10 @@ libraries now.  This is CMake standard behavior.
 THRIFT-4735:
 Qt4 support was removed.
 
+THRIFT-4762:
+Added `const` specifier to `TTransport::getOrigin()`. This changes its function signature.
+It's recommended to add the `override` specifier in implementations derived from `TTransport`.
+
 ## 0.11.0
 
 Older versions of thrift depended on the <boost/smart_ptr.hpp> classes which

--- a/lib/cpp/src/thrift/TApplicationException.h
+++ b/lib/cpp/src/thrift/TApplicationException.h
@@ -57,7 +57,7 @@ public:
   TApplicationException(TApplicationExceptionType type, const std::string& message)
     : TException(message), type_(type) {}
 
-  ~TApplicationException() noexcept override {}
+  ~TApplicationException() noexcept override = default;
 
   /**
    * Returns an error code that provides information about the type of error

--- a/lib/cpp/src/thrift/TApplicationException.h
+++ b/lib/cpp/src/thrift/TApplicationException.h
@@ -57,7 +57,7 @@ public:
   TApplicationException(TApplicationExceptionType type, const std::string& message)
     : TException(message), type_(type) {}
 
-  virtual ~TApplicationException() noexcept {}
+  ~TApplicationException() noexcept override {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -67,7 +67,7 @@ public:
    */
   TApplicationExceptionType getType() const { return type_; }
 
-  virtual const char* what() const noexcept {
+  const char* what() const noexcept override {
     if (message_.empty()) {
       switch (type_) {
       case UNKNOWN:

--- a/lib/cpp/src/thrift/TBase.h
+++ b/lib/cpp/src/thrift/TBase.h
@@ -28,7 +28,7 @@ namespace thrift {
 
 class TBase {
 public:
-  virtual ~TBase(){};
+  virtual ~TBase()= default;;
   virtual uint32_t read(protocol::TProtocol* iprot) = 0;
   virtual uint32_t write(protocol::TProtocol* oprot) const = 0;
 };

--- a/lib/cpp/src/thrift/TDispatchProcessor.h
+++ b/lib/cpp/src/thrift/TDispatchProcessor.h
@@ -40,8 +40,8 @@ public:
     protocol::TProtocol* outRaw = out.get();
 
     // Try to dynamic cast to the template protocol type
-    Protocol_* specificIn = dynamic_cast<Protocol_*>(inRaw);
-    Protocol_* specificOut = dynamic_cast<Protocol_*>(outRaw);
+    auto* specificIn = dynamic_cast<Protocol_*>(inRaw);
+    auto* specificOut = dynamic_cast<Protocol_*>(outRaw);
     if (specificIn && specificOut) {
       return processFast(specificIn, specificOut, connectionContext);
     }

--- a/lib/cpp/src/thrift/TDispatchProcessor.h
+++ b/lib/cpp/src/thrift/TDispatchProcessor.h
@@ -33,9 +33,9 @@ namespace thrift {
 template <class Protocol_>
 class TDispatchProcessorT : public TProcessor {
 public:
-  virtual bool process(std::shared_ptr<protocol::TProtocol> in,
+  bool process(std::shared_ptr<protocol::TProtocol> in,
                        std::shared_ptr<protocol::TProtocol> out,
-                       void* connectionContext) {
+                       void* connectionContext) override {
     protocol::TProtocol* inRaw = in.get();
     protocol::TProtocol* outRaw = out.get();
 
@@ -105,9 +105,9 @@ protected:
  */
 class TDispatchProcessor : public TProcessor {
 public:
-  virtual bool process(std::shared_ptr<protocol::TProtocol> in,
+  bool process(std::shared_ptr<protocol::TProtocol> in,
                        std::shared_ptr<protocol::TProtocol> out,
-                       void* connectionContext) {
+                       void* connectionContext) override {
     std::string fname;
     protocol::TMessageType mtype;
     int32_t seqid;

--- a/lib/cpp/src/thrift/TOutput.cpp
+++ b/lib/cpp/src/thrift/TOutput.cpp
@@ -62,7 +62,7 @@ void TOutput::printf(const char* message, ...) {
 #endif
 
   char* heap_buf = (char*)malloc((need + 1) * sizeof(char));
-  if (heap_buf == NULL) {
+  if (heap_buf == nullptr) {
 #ifdef _MSC_VER
     va_start(ap, message);
     vsnprintf_s(stack_buf, STACK_BUF_SIZE, _TRUNCATE, message, ap);

--- a/lib/cpp/src/thrift/TProcessor.h
+++ b/lib/cpp/src/thrift/TProcessor.h
@@ -46,7 +46,7 @@ public:
   virtual void* getContext(const char* fn_name, void* serverContext) {
     (void)fn_name;
     (void)serverContext;
-    return NULL;
+    return nullptr;
   }
 
   /**
@@ -119,10 +119,10 @@ public:
   TProcessorContextFreer(TProcessorEventHandler* handler, void* context, const char* method)
     : handler_(handler), context_(context), method_(method) {}
   ~TProcessorContextFreer() {
-    if (handler_ != NULL)
+    if (handler_ != nullptr)
       handler_->freeContext(context_, method_);
   }
-  void unregister() { handler_ = NULL; }
+  void unregister() { handler_ = nullptr; }
 
 private:
   apache::thrift::TProcessorEventHandler* handler_;

--- a/lib/cpp/src/thrift/TProcessor.h
+++ b/lib/cpp/src/thrift/TProcessor.h
@@ -218,7 +218,7 @@ class TSingletonProcessorFactory : public TProcessorFactory {
 public:
   TSingletonProcessorFactory(std::shared_ptr<TProcessor> processor) : processor_(processor) {}
 
-  std::shared_ptr<TProcessor> getProcessor(const TConnectionInfo&) { return processor_; }
+  std::shared_ptr<TProcessor> getProcessor(const TConnectionInfo&) override { return processor_; }
 
 private:
   std::shared_ptr<TProcessor> processor_;

--- a/lib/cpp/src/thrift/TProcessor.h
+++ b/lib/cpp/src/thrift/TProcessor.h
@@ -35,7 +35,7 @@ namespace thrift {
  */
 class TProcessorEventHandler {
 public:
-  virtual ~TProcessorEventHandler() {}
+  virtual ~TProcessorEventHandler() = default;
 
   /**
    * Called before calling other callback methods.
@@ -108,7 +108,7 @@ public:
   }
 
 protected:
-  TProcessorEventHandler() {}
+  TProcessorEventHandler() = default;
 };
 
 /**
@@ -139,7 +139,7 @@ private:
  */
 class TProcessor {
 public:
-  virtual ~TProcessor() {}
+  virtual ~TProcessor() = default;
 
   virtual bool process(std::shared_ptr<protocol::TProtocol> in,
                        std::shared_ptr<protocol::TProtocol> out,
@@ -156,7 +156,7 @@ public:
   }
 
 protected:
-  TProcessor() {}
+  TProcessor() = default;
 
   std::shared_ptr<TProcessorEventHandler> eventHandler_;
 };
@@ -202,7 +202,7 @@ struct TConnectionInfo {
 
 class TProcessorFactory {
 public:
-  virtual ~TProcessorFactory() {}
+  virtual ~TProcessorFactory() = default;
 
   /**
    * Get the TProcessor to use for a particular connection.

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -79,9 +79,9 @@ public:
 
   TException(const std::string& message) : message_(message) {}
 
-  virtual ~TException() noexcept {}
+  ~TException() noexcept override {}
 
-  virtual const char* what() const noexcept {
+  const char* what() const noexcept override {
     if (message_.empty()) {
       return "Default TException.";
     } else {
@@ -105,7 +105,7 @@ template <class E>
 class TExceptionWrapper : public TDelayedException {
 public:
   TExceptionWrapper(const E& e) : e_(e) {}
-  virtual void throw_it() {
+  void throw_it() override {
     E temp(e_);
     delete this;
     throw temp;

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -79,7 +79,7 @@ public:
 
   TException(const std::string& message) : message_(message) {}
 
-  ~TException() noexcept override {}
+  ~TException() noexcept override = default;
 
   const char* what() const noexcept override {
     if (message_.empty()) {
@@ -98,7 +98,7 @@ public:
   template <class E>
   static TDelayedException* delayException(const E& e);
   virtual void throw_it() = 0;
-  virtual ~TDelayedException(){};
+  virtual ~TDelayedException()= default;;
 };
 
 template <class E>

--- a/lib/cpp/src/thrift/async/TAsyncBufferProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncBufferProcessor.h
@@ -37,7 +37,7 @@ public:
   virtual void process(std::function<void(bool healthy)> _return,
                        std::shared_ptr<transport::TBufferBase> ibuf,
                        std::shared_ptr<transport::TBufferBase> obuf) = 0;
-  virtual ~TAsyncBufferProcessor() {}
+  virtual ~TAsyncBufferProcessor() = default;
 };
 }
 }

--- a/lib/cpp/src/thrift/async/TAsyncChannel.h
+++ b/lib/cpp/src/thrift/async/TAsyncChannel.h
@@ -41,7 +41,7 @@ class TAsyncChannel {
 public:
   typedef std::function<void()> VoidCallback;
 
-  virtual ~TAsyncChannel() {}
+  virtual ~TAsyncChannel() = default;
 
   // is the channel in a good state?
   virtual bool good() const = 0;

--- a/lib/cpp/src/thrift/async/TAsyncDispatchProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncDispatchProcessor.h
@@ -41,8 +41,8 @@ public:
     protocol::TProtocol* outRaw = out.get();
 
     // Try to dynamic cast to the template protocol type
-    Protocol_* specificIn = dynamic_cast<Protocol_*>(inRaw);
-    Protocol_* specificOut = dynamic_cast<Protocol_*>(outRaw);
+    auto* specificIn = dynamic_cast<Protocol_*>(inRaw);
+    auto* specificOut = dynamic_cast<Protocol_*>(outRaw);
     if (specificIn && specificOut) {
       return processFast(_return, specificIn, specificOut);
     }

--- a/lib/cpp/src/thrift/async/TAsyncDispatchProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncDispatchProcessor.h
@@ -34,9 +34,9 @@ namespace async {
 template <class Protocol_>
 class TAsyncDispatchProcessorT : public TAsyncProcessor {
 public:
-  virtual void process(std::function<void(bool success)> _return,
+  void process(std::function<void(bool success)> _return,
                        std::shared_ptr<protocol::TProtocol> in,
-                       std::shared_ptr<protocol::TProtocol> out) {
+                       std::shared_ptr<protocol::TProtocol> out) override {
     protocol::TProtocol* inRaw = in.get();
     protocol::TProtocol* outRaw = out.get();
 
@@ -106,9 +106,9 @@ public:
  */
 class TAsyncDispatchProcessor : public TAsyncProcessor {
 public:
-  virtual void process(std::function<void(bool success)> _return,
+  void process(std::function<void(bool success)> _return,
                        std::shared_ptr<protocol::TProtocol> in,
-                       std::shared_ptr<protocol::TProtocol> out) {
+                       std::shared_ptr<protocol::TProtocol> out) override {
     protocol::TProtocol* inRaw = in.get();
     protocol::TProtocol* outRaw = out.get();
 

--- a/lib/cpp/src/thrift/async/TAsyncProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncProcessor.h
@@ -35,7 +35,7 @@ namespace async {
 
 class TAsyncProcessor {
 public:
-  virtual ~TAsyncProcessor() {}
+  virtual ~TAsyncProcessor() = default;
 
   virtual void process(std::function<void(bool success)> _return,
                        std::shared_ptr<protocol::TProtocol> in,
@@ -53,14 +53,14 @@ public:
   }
 
 protected:
-  TAsyncProcessor() {}
+  TAsyncProcessor() = default;
 
   std::shared_ptr<TProcessorEventHandler> eventHandler_;
 };
 
 class TAsyncProcessorFactory {
 public:
-  virtual ~TAsyncProcessorFactory() {}
+  virtual ~TAsyncProcessorFactory() = default;
 
   /**
    * Get the TAsyncProcessor to use for a particular connection.

--- a/lib/cpp/src/thrift/async/TAsyncProtocolProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncProtocolProcessor.h
@@ -34,11 +34,11 @@ public:
                           std::shared_ptr<apache::thrift::protocol::TProtocolFactory> pfact)
     : underlying_(underlying), pfact_(pfact) {}
 
-  virtual void process(std::function<void(bool healthy)> _return,
+  void process(std::function<void(bool healthy)> _return,
                        std::shared_ptr<apache::thrift::transport::TBufferBase> ibuf,
-                       std::shared_ptr<apache::thrift::transport::TBufferBase> obuf);
+                       std::shared_ptr<apache::thrift::transport::TBufferBase> obuf) override;
 
-  virtual ~TAsyncProtocolProcessor() {}
+  ~TAsyncProtocolProcessor() override {}
 
 private:
   static void finish(std::function<void(bool healthy)> _return,

--- a/lib/cpp/src/thrift/async/TAsyncProtocolProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncProtocolProcessor.h
@@ -38,7 +38,7 @@ public:
                        std::shared_ptr<apache::thrift::transport::TBufferBase> ibuf,
                        std::shared_ptr<apache::thrift::transport::TBufferBase> obuf) override;
 
-  ~TAsyncProtocolProcessor() override {}
+  ~TAsyncProtocolProcessor() override = default;
 
 private:
   static void finish(std::function<void(bool healthy)> _return,

--- a/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.cpp
+++ b/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.cpp
@@ -75,7 +75,7 @@ void TConcurrentClientSyncInfo::updatePending(
   MonitorPtr monitor;
   {
     Guard seqidGuard(seqidMutex_);
-    MonitorMap::iterator i = seqidToMonitorMap_.find(rseqid);
+    auto i = seqidToMonitorMap_.find(rseqid);
     if(i == seqidToMonitorMap_.end())
       throwBadSeqId_();
     monitor = i->second;
@@ -140,7 +140,7 @@ void TConcurrentClientSyncInfo::markBad_(const Guard &)
 {
   wakeupSomeone_ = true;
   stop_ = true;
-  for(MonitorMap::iterator i = seqidToMonitorMap_.begin(); i != seqidToMonitorMap_.end(); ++i)
+  for(auto i = seqidToMonitorMap_.begin(); i != seqidToMonitorMap_.end(); ++i)
     i->second->notify();
 }
 

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
@@ -142,7 +142,7 @@ void TEvhttpClientChannel::finish(struct evhttp_request* req) {
 }
 
 /* static */ void TEvhttpClientChannel::response(struct evhttp_request* req, void* arg) {
-  TEvhttpClientChannel* self = (TEvhttpClientChannel*)arg;
+  auto* self = (TEvhttpClientChannel*)arg;
   try {
     self->finish(req);
   } catch (std::exception& e) {

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.cpp
@@ -41,15 +41,15 @@ TEvhttpClientChannel::TEvhttpClientChannel(const std::string& host,
                                            struct event_base* eb,
                                            struct evdns_base* dnsbase)
 
-  : host_(host), path_(path), conn_(NULL) {
+  : host_(host), path_(path), conn_(nullptr) {
   conn_ = evhttp_connection_base_new(eb, dnsbase, address, port);
-  if (conn_ == NULL) {
+  if (conn_ == nullptr) {
     throw TException("evhttp_connection_new failed");
   }
 }
 
 TEvhttpClientChannel::~TEvhttpClientChannel() {
-  if (conn_ != NULL) {
+  if (conn_ != nullptr) {
     evhttp_connection_free(conn_);
   }
 }
@@ -58,7 +58,7 @@ void TEvhttpClientChannel::sendAndRecvMessage(const VoidCallback& cob,
                                               apache::thrift::transport::TMemoryBuffer* sendBuf,
                                               apache::thrift::transport::TMemoryBuffer* recvBuf) {
   struct evhttp_request* req = evhttp_request_new(response, this);
-  if (req == NULL) {
+  if (req == nullptr) {
     throw TException("evhttp_request_new failed");
   }
 
@@ -110,7 +110,7 @@ void TEvhttpClientChannel::finish(struct evhttp_request* req) {
   assert(!completionQueue_.empty());
   Completion completion = completionQueue_.front();
   completionQueue_.pop();
-  if (req == NULL) {
+  if (req == nullptr) {
     try {
       completion.first();
     } catch (const TTransportException& e) {

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
@@ -53,23 +53,23 @@ public:
                        int port,
                        struct event_base* eb,
                        struct evdns_base *dnsbase = 0);
-  ~TEvhttpClientChannel();
+  ~TEvhttpClientChannel() override;
 
-  virtual void sendAndRecvMessage(const VoidCallback& cob,
+  void sendAndRecvMessage(const VoidCallback& cob,
                                   apache::thrift::transport::TMemoryBuffer* sendBuf,
-                                  apache::thrift::transport::TMemoryBuffer* recvBuf);
+                                  apache::thrift::transport::TMemoryBuffer* recvBuf) override;
 
-  virtual void sendMessage(const VoidCallback& cob,
-                           apache::thrift::transport::TMemoryBuffer* message);
-  virtual void recvMessage(const VoidCallback& cob,
-                           apache::thrift::transport::TMemoryBuffer* message);
+  void sendMessage(const VoidCallback& cob,
+                           apache::thrift::transport::TMemoryBuffer* message) override;
+  void recvMessage(const VoidCallback& cob,
+                           apache::thrift::transport::TMemoryBuffer* message) override;
 
   void finish(struct evhttp_request* req);
 
   // XXX
-  virtual bool good() const { return true; }
-  virtual bool error() const { return false; }
-  virtual bool timedOut() const { return false; }
+  bool good() const override { return true; }
+  bool error() const override { return false; }
+  bool timedOut() const override { return false; }
 
 private:
   static void response(struct evhttp_request* req, void* arg);

--- a/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
+++ b/lib/cpp/src/thrift/async/TEvhttpClientChannel.h
@@ -52,7 +52,7 @@ public:
                        const char* address,
                        int port,
                        struct event_base* eb,
-                       struct evdns_base *dnsbase = 0);
+                       struct evdns_base *dnsbase = nullptr);
   ~TEvhttpClientChannel() override;
 
   void sendAndRecvMessage(const VoidCallback& cob,

--- a/lib/cpp/src/thrift/async/TEvhttpServer.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpServer.cpp
@@ -46,24 +46,24 @@ struct TEvhttpServer::RequestContext {
 };
 
 TEvhttpServer::TEvhttpServer(std::shared_ptr<TAsyncBufferProcessor> processor)
-  : processor_(processor), eb_(NULL), eh_(NULL) {
+  : processor_(processor), eb_(nullptr), eh_(nullptr) {
 }
 
 TEvhttpServer::TEvhttpServer(std::shared_ptr<TAsyncBufferProcessor> processor, int port)
-  : processor_(processor), eb_(NULL), eh_(NULL) {
+  : processor_(processor), eb_(nullptr), eh_(nullptr) {
   // Create event_base and evhttp.
   eb_ = event_base_new();
-  if (eb_ == NULL) {
+  if (eb_ == nullptr) {
     throw TException("event_base_new failed");
   }
   eh_ = evhttp_new(eb_);
-  if (eh_ == NULL) {
+  if (eh_ == nullptr) {
     event_base_free(eb_);
     throw TException("evhttp_new failed");
   }
 
   // Bind to port.
-  int ret = evhttp_bind_socket(eh_, NULL, port);
+  int ret = evhttp_bind_socket(eh_, nullptr, port);
   if (ret < 0) {
     evhttp_free(eh_);
     event_base_free(eb_);
@@ -77,16 +77,16 @@ TEvhttpServer::TEvhttpServer(std::shared_ptr<TAsyncBufferProcessor> processor, i
 }
 
 TEvhttpServer::~TEvhttpServer() {
-  if (eh_ != NULL) {
+  if (eh_ != nullptr) {
     evhttp_free(eh_);
   }
-  if (eb_ != NULL) {
+  if (eb_ != nullptr) {
     event_base_free(eb_);
   }
 }
 
 int TEvhttpServer::serve() {
-  if (eb_ == NULL) {
+  if (eb_ == nullptr) {
     throw TException("Unexpected call to TEvhttpServer::serve");
   }
   return event_base_dispatch(eb_);
@@ -103,7 +103,7 @@ void TEvhttpServer::request(struct evhttp_request* req, void* self) {
   try {
     static_cast<TEvhttpServer*>(self)->process(req);
   } catch (std::exception& e) {
-    evhttp_send_reply(req, HTTP_INTERNAL, e.what(), 0);
+    evhttp_send_reply(req, HTTP_INTERNAL, e.what(), nullptr);
   }
 }
 
@@ -131,7 +131,7 @@ void TEvhttpServer::complete(RequestContext* ctx, bool success) {
   }
 
   struct evbuffer* buf = evbuffer_new();
-  if (buf == NULL) {
+  if (buf == nullptr) {
     // TODO: Log an error.
     std::cerr << "evbuffer_new failed " << __FILE__ << ":" << __LINE__ << std::endl;
   } else {
@@ -147,7 +147,7 @@ void TEvhttpServer::complete(RequestContext* ctx, bool success) {
   }
 
   evhttp_send_reply(ctx->req, code, reason, buf);
-  if (buf != NULL) {
+  if (buf != nullptr) {
     evbuffer_free(buf);
   }
 }

--- a/lib/cpp/src/thrift/async/TEvhttpServer.cpp
+++ b/lib/cpp/src/thrift/async/TEvhttpServer.cpp
@@ -108,7 +108,7 @@ void TEvhttpServer::request(struct evhttp_request* req, void* self) {
 }
 
 void TEvhttpServer::process(struct evhttp_request* req) {
-  RequestContext* ctx = new RequestContext(req);
+  auto* ctx = new RequestContext(req);
   return processor_->process(std::bind(&TEvhttpServer::complete,
                                                           this,
                                                           ctx,

--- a/lib/cpp/src/thrift/concurrency/Exception.h
+++ b/lib/cpp/src/thrift/concurrency/Exception.h
@@ -35,7 +35,7 @@ class InvalidArgumentException : public apache::thrift::TException {};
 
 class IllegalStateException : public apache::thrift::TException {
 public:
-  IllegalStateException() {}
+  IllegalStateException() = default;
   IllegalStateException(const std::string& message) : TException(message) {}
 };
 
@@ -53,7 +53,7 @@ public:
 
 class SystemResourceException : public apache::thrift::TException {
 public:
-  SystemResourceException() {}
+  SystemResourceException() = default;
 
   SystemResourceException(const std::string& message) : TException(message) {}
 };

--- a/lib/cpp/src/thrift/concurrency/FunctionRunner.h
+++ b/lib/cpp/src/thrift/concurrency/FunctionRunner.h
@@ -96,7 +96,7 @@ public:
    */
   FunctionRunner(const BoolFunc& cob, int intervalMs) : repFunc_(cob), intervalMs_(intervalMs) {}
 
-  void run() {
+  void run() override {
     if (repFunc_) {
       while (repFunc_()) {
         THRIFT_SLEEP_USEC(intervalMs_ * 1000);

--- a/lib/cpp/src/thrift/concurrency/Monitor.cpp
+++ b/lib/cpp/src/thrift/concurrency/Monitor.cpp
@@ -81,7 +81,7 @@ public:
     }
 
     assert(mutex_);
-    std::timed_mutex* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
+    auto* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
     assert(mutexImpl);
 
     std::unique_lock<std::timed_mutex> lock(*mutexImpl, std::adopt_lock);
@@ -97,7 +97,7 @@ public:
    */
   int waitForTime(const std::chrono::time_point<std::chrono::steady_clock>& abstime) {
     assert(mutex_);
-    std::timed_mutex* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
+    auto* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
     assert(mutexImpl);
 
     std::unique_lock<std::timed_mutex> lock(*mutexImpl, std::adopt_lock);
@@ -113,7 +113,7 @@ public:
    */
   int waitForever() {
     assert(mutex_);
-    std::timed_mutex* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
+    auto* mutexImpl = static_cast<std::timed_mutex*>(mutex_->getUnderlyingImpl());
     assert(mutexImpl);
 
     std::unique_lock<std::timed_mutex> lock(*mutexImpl, std::adopt_lock);

--- a/lib/cpp/src/thrift/concurrency/Monitor.cpp
+++ b/lib/cpp/src/thrift/concurrency/Monitor.cpp
@@ -41,11 +41,11 @@ namespace concurrency {
 class Monitor::Impl {
 
 public:
-  Impl() : ownedMutex_(new Mutex()), conditionVariable_(), mutex_(NULL) { init(ownedMutex_.get()); }
+  Impl() : ownedMutex_(new Mutex()), conditionVariable_(), mutex_(nullptr) { init(ownedMutex_.get()); }
 
-  Impl(Mutex* mutex) : ownedMutex_(), conditionVariable_(), mutex_(NULL) { init(mutex); }
+  Impl(Mutex* mutex) : ownedMutex_(), conditionVariable_(), mutex_(nullptr) { init(mutex); }
 
-  Impl(Monitor* monitor) : ownedMutex_(), conditionVariable_(), mutex_(NULL) {
+  Impl(Monitor* monitor) : ownedMutex_(), conditionVariable_(), mutex_(nullptr) {
     init(&(monitor->mutex()));
   }
 

--- a/lib/cpp/src/thrift/concurrency/Mutex.h
+++ b/lib/cpp/src/thrift/concurrency/Mutex.h
@@ -62,11 +62,11 @@ public:
       value.lock();
     } else if (timeout < 0) {
       if (!value.trylock()) {
-        mutex_ = NULL;
+        mutex_ = nullptr;
       }
     } else {
       if (!value.timedlock(timeout)) {
-        mutex_ = NULL;
+        mutex_ = nullptr;
       }
     }
   }
@@ -76,7 +76,7 @@ public:
     }
   }
 
-  operator bool() const { return (mutex_ != NULL); }
+  operator bool() const { return (mutex_ != nullptr); }
 
 private:
   const Mutex* mutex_;

--- a/lib/cpp/src/thrift/concurrency/Mutex.h
+++ b/lib/cpp/src/thrift/concurrency/Mutex.h
@@ -40,7 +40,7 @@ namespace concurrency {
 class Mutex {
 public:
   Mutex();
-  virtual ~Mutex() {}
+  virtual ~Mutex() = default;
 
   virtual void lock() const;
   virtual bool trylock() const;

--- a/lib/cpp/src/thrift/concurrency/Thread.h
+++ b/lib/cpp/src/thrift/concurrency/Thread.h
@@ -39,7 +39,7 @@ class Thread;
 class Runnable {
 
 public:
-  virtual ~Runnable(){};
+  virtual ~Runnable()= default;;
   virtual void run() = 0;
 
   /**

--- a/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
@@ -64,19 +64,19 @@ public:
       maxMonitor_(&mutex_),
       workerMonitor_(&mutex_) {}
 
-  ~Impl() { stop(); }
+  ~Impl() override { stop(); }
 
-  void start();
-  void stop();
+  void start() override;
+  void stop() override;
 
-  ThreadManager::STATE state() const { return state_; }
+  ThreadManager::STATE state() const override { return state_; }
 
-  shared_ptr<ThreadFactory> threadFactory() const {
+  shared_ptr<ThreadFactory> threadFactory() const override {
     Guard g(mutex_);
     return threadFactory_;
   }
 
-  void threadFactory(shared_ptr<ThreadFactory> value) {
+  void threadFactory(shared_ptr<ThreadFactory> value) override {
     Guard g(mutex_);
     if (threadFactory_ && threadFactory_->isDetached() != value->isDetached()) {
       throw InvalidArgumentException();
@@ -84,33 +84,33 @@ public:
     threadFactory_ = value;
   }
 
-  void addWorker(size_t value);
+  void addWorker(size_t value) override;
 
-  void removeWorker(size_t value);
+  void removeWorker(size_t value) override;
 
-  size_t idleWorkerCount() const { return idleCount_; }
+  size_t idleWorkerCount() const override { return idleCount_; }
 
-  size_t workerCount() const {
+  size_t workerCount() const override {
     Guard g(mutex_);
     return workerCount_;
   }
 
-  size_t pendingTaskCount() const {
+  size_t pendingTaskCount() const override {
     Guard g(mutex_);
     return tasks_.size();
   }
 
-  size_t totalTaskCount() const {
+  size_t totalTaskCount() const override {
     Guard g(mutex_);
     return tasks_.size() + workerCount_ - idleCount_;
   }
 
-  size_t pendingTaskCountMax() const {
+  size_t pendingTaskCountMax() const override {
     Guard g(mutex_);
     return pendingTaskCountMax_;
   }
 
-  size_t expiredTaskCount() const {
+  size_t expiredTaskCount() const override {
     Guard g(mutex_);
     return expiredCount_;
   }
@@ -120,17 +120,17 @@ public:
     pendingTaskCountMax_ = value;
   }
 
-  void add(shared_ptr<Runnable> value, int64_t timeout, int64_t expiration);
+  void add(shared_ptr<Runnable> value, int64_t timeout, int64_t expiration) override;
 
-  void remove(shared_ptr<Runnable> task);
+  void remove(shared_ptr<Runnable> task) override;
 
-  shared_ptr<Runnable> removeNextPending();
+  shared_ptr<Runnable> removeNextPending() override;
 
-  void removeExpiredTasks() {
+  void removeExpiredTasks() override {
     removeExpired(false);
   }
 
-  void setExpireCallback(ExpireCallback expireCallback);
+  void setExpireCallback(ExpireCallback expireCallback) override;
 
 private:
   /**
@@ -188,9 +188,9 @@ public:
         }
     }
 
-  ~Task() {}
+  ~Task() override {}
 
-  void run() {
+  void run() override {
     if (state_ == EXECUTING) {
       runnable_->run();
       state_ = COMPLETE;
@@ -214,7 +214,7 @@ class ThreadManager::Worker : public Runnable {
 public:
   Worker(ThreadManager::Impl* manager) : manager_(manager), state_(UNINITIALIZED) {}
 
-  ~Worker() {}
+  ~Worker() override {}
 
 private:
   bool isActive() const {
@@ -229,7 +229,7 @@ public:
    * As long as worker thread is running, pull tasks off the task queue and
    * execute.
    */
-  void run() {
+  void run() override {
     Guard g(manager_->mutex_);
 
     /**
@@ -562,7 +562,7 @@ public:
   SimpleThreadManager(size_t workerCount = 4, size_t pendingTaskCountMax = 0)
     : workerCount_(workerCount), pendingTaskCountMax_(pendingTaskCountMax) {}
 
-  void start() {
+  void start() override {
     ThreadManager::Impl::pendingTaskCountMax(pendingTaskCountMax_);
     ThreadManager::Impl::start();
     addWorker(workerCount_);

--- a/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
@@ -188,7 +188,7 @@ public:
         }
     }
 
-  ~Task() override {}
+  ~Task() override = default;
 
   void run() override {
     if (state_ == EXECUTING) {
@@ -214,7 +214,7 @@ class ThreadManager::Worker : public Runnable {
 public:
   Worker(ThreadManager::Impl* manager) : manager_(manager), state_(UNINITIALIZED) {}
 
-  ~Worker() override {}
+  ~Worker() override = default;
 
 private:
   bool isActive() const {

--- a/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
@@ -352,7 +352,7 @@ void ThreadManager::Impl::addWorker(size_t value) {
   workerMaxCount_ += value;
   workers_.insert(newThreads.begin(), newThreads.end());
 
-  for (std::set<shared_ptr<Thread> >::iterator ix = newThreads.begin(); ix != newThreads.end();
+  for (auto ix = newThreads.begin(); ix != newThreads.end();
        ++ix) {
     shared_ptr<ThreadManager::Worker> worker
         = dynamic_pointer_cast<ThreadManager::Worker, Runnable>((*ix)->runnable());
@@ -430,7 +430,7 @@ void ThreadManager::Impl::removeWorkersUnderLock(size_t value) {
     workerMonitor_.wait();
   }
 
-  for (std::set<shared_ptr<Thread> >::iterator ix = deadWorkers_.begin();
+  for (auto ix = deadWorkers_.begin();
        ix != deadWorkers_.end();
        ++ix) {
 
@@ -497,7 +497,7 @@ void ThreadManager::Impl::remove(shared_ptr<Runnable> task) {
         "started");
   }
 
-  for (TaskQueue::iterator it = tasks_.begin(); it != tasks_.end(); ++it)
+  for (auto it = tasks_.begin(); it != tasks_.end(); ++it)
   {
     if ((*it)->getRunnable() == task)
     {
@@ -532,7 +532,7 @@ void ThreadManager::Impl::removeExpired(bool justOne) {
   }
   auto now = std::chrono::steady_clock::now();
 
-  for (TaskQueue::iterator it = tasks_.begin(); it != tasks_.end(); )
+  for (auto it = tasks_.begin(); it != tasks_.end(); )
   {
     if ((*it)->getExpireTime() && *((*it)->getExpireTime()) < now) {
       if (expireCallback_) {

--- a/lib/cpp/src/thrift/concurrency/ThreadManager.h
+++ b/lib/cpp/src/thrift/concurrency/ThreadManager.h
@@ -55,12 +55,12 @@ class ThreadManager;
 class ThreadManager {
 
 protected:
-  ThreadManager() {}
+  ThreadManager() = default;
 
 public:
   typedef std::function<void(std::shared_ptr<Runnable>)> ExpireCallback;
 
-  virtual ~ThreadManager() {}
+  virtual ~ThreadManager() = default;
 
   /**
    * Starts the thread manager. Verifies all attributes have been properly

--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -221,7 +221,7 @@ void TimerManager::stop() {
     taskMap_.clear();
 
     // Remove dispatcher's reference to us.
-    dispatcher_->manager_ = NULL;
+    dispatcher_->manager_ = nullptr;
   }
 }
 

--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -43,9 +43,9 @@ public:
 
   Task(shared_ptr<Runnable> runnable) : runnable_(runnable), state_(WAITING) {}
 
-  ~Task() {}
+  ~Task() override {}
 
-  void run() {
+  void run() override {
     if (state_ == EXECUTING) {
       runnable_->run();
       state_ = COMPLETE;
@@ -67,7 +67,7 @@ class TimerManager::Dispatcher : public Runnable {
 public:
   Dispatcher(TimerManager* manager) : manager_(manager) {}
 
-  ~Dispatcher() {}
+  ~Dispatcher() override {}
 
   /**
    * Dispatcher entry point
@@ -75,7 +75,7 @@ public:
    * As long as dispatcher thread is running, pull tasks off the task taskMap_
    * and execute.
    */
-  void run() {
+  void run() override {
     {
       Synchronized s(manager_->monitor_);
       if (manager_->state_ == TimerManager::STARTING) {

--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -108,7 +108,7 @@ public:
         }
 
         if (manager_->state_ == TimerManager::STARTED) {
-          for (task_iterator ix = manager_->taskMap_.begin(); ix != expiredTaskEnd; ix++) {
+          for (auto ix = manager_->taskMap_.begin(); ix != expiredTaskEnd; ix++) {
             shared_ptr<TimerManager::Task> task = ix->second;
             expiredTasks.insert(task);
             task->it_ = manager_->taskMap_.end();
@@ -121,7 +121,7 @@ public:
         }
       }
 
-      for (std::set<shared_ptr<Task> >::iterator ix = expiredTasks.begin();
+      for (auto ix = expiredTasks.begin();
            ix != expiredTasks.end();
            ++ix) {
         (*ix)->run();
@@ -280,7 +280,7 @@ void TimerManager::remove(shared_ptr<Runnable> task) {
     throw IllegalStateException();
   }
   bool found = false;
-  for (task_iterator ix = taskMap_.begin(); ix != taskMap_.end();) {
+  for (auto ix = taskMap_.begin(); ix != taskMap_.end();) {
     if (*ix->second == task) {
       found = true;
       taskCount_--;

--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -43,7 +43,7 @@ public:
 
   Task(shared_ptr<Runnable> runnable) : runnable_(runnable), state_(WAITING) {}
 
-  ~Task() override {}
+  ~Task() override = default;
 
   void run() override {
     if (state_ == EXECUTING) {
@@ -67,7 +67,7 @@ class TimerManager::Dispatcher : public Runnable {
 public:
   Dispatcher(TimerManager* manager) : manager_(manager) {}
 
-  ~Dispatcher() override {}
+  ~Dispatcher() override = default;
 
   /**
    * Dispatcher entry point

--- a/lib/cpp/src/thrift/processor/PeekProcessor.cpp
+++ b/lib/cpp/src/thrift/processor/PeekProcessor.cpp
@@ -31,8 +31,7 @@ PeekProcessor::PeekProcessor() {
   memoryBuffer_.reset(new TMemoryBuffer());
   targetTransport_ = memoryBuffer_;
 }
-PeekProcessor::~PeekProcessor() {
-}
+PeekProcessor::~PeekProcessor() = default;
 
 void PeekProcessor::initialize(std::shared_ptr<TProcessor> actualProcessor,
                                std::shared_ptr<TProtocolFactory> protocolFactory,

--- a/lib/cpp/src/thrift/processor/PeekProcessor.h
+++ b/lib/cpp/src/thrift/processor/PeekProcessor.h
@@ -40,7 +40,7 @@ class PeekProcessor : public apache::thrift::TProcessor {
 
 public:
   PeekProcessor();
-  virtual ~PeekProcessor();
+  ~PeekProcessor() override;
 
   // Input here: actualProcessor  - the underlying processor
   //             protocolFactory  - the protocol factory used to wrap the memory buffer
@@ -56,9 +56,9 @@ public:
 
   void setTargetTransport(std::shared_ptr<apache::thrift::transport::TTransport> targetTransport);
 
-  virtual bool process(std::shared_ptr<apache::thrift::protocol::TProtocol> in,
+  bool process(std::shared_ptr<apache::thrift::protocol::TProtocol> in,
                        std::shared_ptr<apache::thrift::protocol::TProtocol> out,
-                       void* connectionContext);
+                       void* connectionContext) override;
 
   // The following three functions can be overloaded by child classes to
   // achieve desired peeking behavior

--- a/lib/cpp/src/thrift/processor/TMultiplexedProcessor.h
+++ b/lib/cpp/src/thrift/processor/TMultiplexedProcessor.h
@@ -42,7 +42,7 @@ public:
                         const int32_t _seqid)
     : TProtocolDecorator(_protocol), name(_name), type(_type), seqid(_seqid) {}
 
-  uint32_t readMessageBegin_virt(std::string& _name, TMessageType& _type, int32_t& _seqid) {
+  uint32_t readMessageBegin_virt(std::string& _name, TMessageType& _type, int32_t& _seqid) override {
 
     _name = name;
     _type = type;
@@ -149,7 +149,7 @@ public:
    */
   bool process(std::shared_ptr<protocol::TProtocol> in,
                std::shared_ptr<protocol::TProtocol> out,
-               void* connectionContext) {
+               void* connectionContext) override {
     std::string name;
     protocol::TMessageType type;
     int32_t seqid;

--- a/lib/cpp/src/thrift/processor/TMultiplexedProcessor.h
+++ b/lib/cpp/src/thrift/processor/TMultiplexedProcessor.h
@@ -174,7 +174,7 @@ public:
     // name and the name of the method to call.
     if (tokens.size() == 2) {
       // Search for a processor associated with this service name.
-      services_t::iterator it = services.find(tokens[0]);
+      auto it = services.find(tokens[0]);
 
       if (it != services.end()) {
         std::shared_ptr<TProcessor> processor = it->second;

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
@@ -201,7 +201,7 @@ public:
       strict_read_(strict_read),
       strict_write_(strict_write) {}
 
-  ~TBinaryProtocolFactoryT() override {}
+  ~TBinaryProtocolFactoryT() override = default;
 
   void setStringSizeLimit(int32_t string_limit) { string_limit_ = string_limit; }
 

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
@@ -201,7 +201,7 @@ public:
       strict_read_(strict_read),
       strict_write_(strict_write) {}
 
-  virtual ~TBinaryProtocolFactoryT() {}
+  ~TBinaryProtocolFactoryT() override {}
 
   void setStringSizeLimit(int32_t string_limit) { string_limit_ = string_limit; }
 
@@ -212,7 +212,7 @@ public:
     strict_write_ = strict_write;
   }
 
-  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) {
+  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     std::shared_ptr<Transport_> specific_trans = std::dynamic_pointer_cast<Transport_>(trans);
     TProtocol* prot;
     if (specific_trans) {

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
@@ -144,21 +144,21 @@ uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeByte(const int8_t byte) 
 
 template <class Transport_, class ByteOrder_>
 uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeI16(const int16_t i16) {
-  int16_t net = (int16_t)ByteOrder_::toWire16(i16);
+  auto net = (int16_t)ByteOrder_::toWire16(i16);
   this->trans_->write((uint8_t*)&net, 2);
   return 2;
 }
 
 template <class Transport_, class ByteOrder_>
 uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeI32(const int32_t i32) {
-  int32_t net = (int32_t)ByteOrder_::toWire32(i32);
+  auto net = (int32_t)ByteOrder_::toWire32(i32);
   this->trans_->write((uint8_t*)&net, 4);
   return 4;
 }
 
 template <class Transport_, class ByteOrder_>
 uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeI64(const int64_t i64) {
-  int64_t net = (int64_t)ByteOrder_::toWire64(i64);
+  auto net = (int64_t)ByteOrder_::toWire64(i64);
   this->trans_->write((uint8_t*)&net, 8);
   return 8;
 }
@@ -168,7 +168,7 @@ uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeDouble(const double dub)
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) == sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "std::numeric_limits<double>::is_iec559");
 
-  uint64_t bits = bitwise_cast<uint64_t>(dub);
+  auto bits = bitwise_cast<uint64_t>(dub);
   bits = ByteOrder_::toWire64(bits);
   this->trans_->write((uint8_t*)&bits, 8);
   return 8;
@@ -179,7 +179,7 @@ template <typename StrType>
 uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::writeString(const StrType& str) {
   if (str.size() > static_cast<size_t>((std::numeric_limits<int32_t>::max)()))
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
-  uint32_t size = static_cast<uint32_t>(str.size());
+  auto size = static_cast<uint32_t>(str.size());
   uint32_t result = writeI32((int32_t)size);
   if (size > 0) {
     this->trans_->write((uint8_t*)str.data(), size);

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
@@ -437,7 +437,7 @@ uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::readStringBody(StrType& str, 
   // Try to borrow first
   const uint8_t* borrow_buf;
   uint32_t got = size;
-  if ((borrow_buf = this->trans_->borrow(NULL, &got))) {
+  if ((borrow_buf = this->trans_->borrow(nullptr, &got))) {
     str.assign((const char*)borrow_buf, size);
     this->trans_->consume(size);
     return size;

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -79,10 +79,10 @@ public:
       trans_(trans.get()),
       lastFieldId_(0),
       string_limit_(0),
-      string_buf_(NULL),
+      string_buf_(nullptr),
       string_buf_size_(0),
       container_limit_(0) {
-    booleanField_.name = NULL;
+    booleanField_.name = nullptr;
     boolValue_.hasBoolValue = false;
   }
 
@@ -93,10 +93,10 @@ public:
       trans_(trans.get()),
       lastFieldId_(0),
       string_limit_(string_limit),
-      string_buf_(NULL),
+      string_buf_(nullptr),
       string_buf_size_(0),
       container_limit_(container_limit) {
-    booleanField_.name = NULL;
+    booleanField_.name = nullptr;
     boolValue_.hasBoolValue = false;
   }
 

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -233,7 +233,7 @@ public:
   TCompactProtocolFactoryT(int32_t string_limit, int32_t container_limit)
     : string_limit_(string_limit), container_limit_(container_limit) {}
 
-  ~TCompactProtocolFactoryT() override {}
+  ~TCompactProtocolFactoryT() override = default;
 
   void setStringSizeLimit(int32_t string_limit) { string_limit_ = string_limit; }
 

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -100,7 +100,7 @@ public:
     boolValue_.hasBoolValue = false;
   }
 
-  ~TCompactProtocolT() { free(string_buf_); }
+  ~TCompactProtocolT() override { free(string_buf_); }
 
   /**
    * Writing functions
@@ -233,13 +233,13 @@ public:
   TCompactProtocolFactoryT(int32_t string_limit, int32_t container_limit)
     : string_limit_(string_limit), container_limit_(container_limit) {}
 
-  virtual ~TCompactProtocolFactoryT() {}
+  ~TCompactProtocolFactoryT() override {}
 
   void setStringSizeLimit(int32_t string_limit) { string_limit_ = string_limit; }
 
   void setContainerSizeLimit(int32_t container_limit) { container_limit_ = container_limit; }
 
-  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) {
+  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     std::shared_ptr<Transport_> specific_trans = std::dynamic_pointer_cast<Transport_>(trans);
     TProtocol* prot;
     if (specific_trans) {

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
@@ -256,7 +256,7 @@ uint32_t TCompactProtocolT<Transport_>::writeDouble(const double dub) {
   static_assert(sizeof(double) == sizeof(uint64_t), "sizeof(double) == sizeof(uint64_t)");
   static_assert(std::numeric_limits<double>::is_iec559, "std::numeric_limits<double>::is_iec559");
 
-  uint64_t bits = bitwise_cast<uint64_t>(dub);
+  auto bits = bitwise_cast<uint64_t>(dub);
   bits = THRIFT_htolell(bits);
   trans_->write((uint8_t*)&bits, 8);
   return 8;
@@ -274,7 +274,7 @@ template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::writeBinary(const std::string& str) {
   if(str.size() > (std::numeric_limits<uint32_t>::max)())
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
-  uint32_t ssize = static_cast<uint32_t>(str.size());
+  auto ssize = static_cast<uint32_t>(str.size());
   uint32_t wsize = writeVarint32(ssize) ;
   // checking ssize + wsize > uint_max, but we don't want to overflow while checking for overflows.
   // transforming the check to ssize > uint_max - wsize
@@ -488,7 +488,7 @@ uint32_t TCompactProtocolT<Transport_>::readFieldBegin(std::string& name,
   }
 
   // mask off the 4 MSB of the type header. it could contain a field id delta.
-  int16_t modifier = (int16_t)(((uint8_t)byte & 0xf0) >> 4);
+  auto modifier = (int16_t)(((uint8_t)byte & 0xf0) >> 4);
   if (modifier == 0) {
     // not a delta, look ahead for the zigzag varint field id.
     rsize += readI16(fieldId);

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
@@ -198,7 +198,7 @@ template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::writeBool(const bool value) {
   uint32_t wsize = 0;
 
-  if (booleanField_.name != NULL) {
+  if (booleanField_.name != nullptr) {
     // we haven't written the field header yet
     wsize
       += writeFieldBeginInternal(booleanField_.name,
@@ -207,7 +207,7 @@ uint32_t TCompactProtocolT<Transport_>::writeBool(const bool value) {
                                  static_cast<int8_t>(value
                                                      ? detail::compact::CT_BOOLEAN_TRUE
                                                      : detail::compact::CT_BOOLEAN_FALSE));
-    booleanField_.name = NULL;
+    booleanField_.name = nullptr;
   } else {
     // we're not part of a field, so just write the value
     wsize
@@ -695,9 +695,9 @@ uint32_t TCompactProtocolT<Transport_>::readBinary(std::string& str) {
   }
 
   // Use the heap here to prevent stack overflow for v. large strings
-  if (size > string_buf_size_ || string_buf_ == NULL) {
+  if (size > string_buf_size_ || string_buf_ == nullptr) {
     void* new_string_buf = std::realloc(string_buf_, (uint32_t)size);
-    if (new_string_buf == NULL) {
+    if (new_string_buf == nullptr) {
       throw std::bad_alloc();
     }
     string_buf_ = (uint8_t*)new_string_buf;
@@ -735,7 +735,7 @@ uint32_t TCompactProtocolT<Transport_>::readVarint64(int64_t& i64) {
   const uint8_t* borrowed = trans_->borrow(buf, &buf_size);
 
   // Fast path.
-  if (borrowed != NULL) {
+  if (borrowed != nullptr) {
     while (true) {
       uint8_t byte = borrowed[rsize];
       rsize++;

--- a/lib/cpp/src/thrift/protocol/TDebugProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TDebugProtocol.h
@@ -139,9 +139,9 @@ private:
 class TDebugProtocolFactory : public TProtocolFactory {
 public:
   TDebugProtocolFactory() {}
-  virtual ~TDebugProtocolFactory() {}
+  ~TDebugProtocolFactory() override {}
 
-  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) {
+  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TProtocol>(new TDebugProtocol(trans));
   }
 };

--- a/lib/cpp/src/thrift/protocol/TDebugProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TDebugProtocol.h
@@ -159,7 +159,7 @@ template <typename ThriftStruct>
 std::string ThriftDebugString(const ThriftStruct& ts) {
   using namespace apache::thrift::transport;
   using namespace apache::thrift::protocol;
-  TMemoryBuffer* buffer = new TMemoryBuffer;
+  auto* buffer = new TMemoryBuffer;
   std::shared_ptr<TTransport> trans(buffer);
   TDebugProtocol protocol(trans);
 

--- a/lib/cpp/src/thrift/protocol/TDebugProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TDebugProtocol.h
@@ -138,8 +138,8 @@ private:
  */
 class TDebugProtocolFactory : public TProtocolFactory {
 public:
-  TDebugProtocolFactory() {}
-  ~TDebugProtocolFactory() override {}
+  TDebugProtocolFactory() = default;
+  ~TDebugProtocolFactory() override = default;
 
   std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TProtocol>(new TDebugProtocol(trans));

--- a/lib/cpp/src/thrift/protocol/THeaderProtocol.h
+++ b/lib/cpp/src/thrift/protocol/THeaderProtocol.h
@@ -63,7 +63,7 @@ public:
     resetProtocol();
   }
 
-  ~THeaderProtocol() override {}
+  ~THeaderProtocol() override = default;
 
   /**
    * Functions to work with headers by calling into THeaderTransport

--- a/lib/cpp/src/thrift/protocol/THeaderProtocol.h
+++ b/lib/cpp/src/thrift/protocol/THeaderProtocol.h
@@ -63,7 +63,7 @@ public:
     resetProtocol();
   }
 
-  ~THeaderProtocol() {}
+  ~THeaderProtocol() override {}
 
   /**
    * Functions to work with headers by calling into THeaderTransport
@@ -190,15 +190,15 @@ protected:
 
 class THeaderProtocolFactory : public TProtocolFactory {
 public:
-  virtual std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<transport::TTransport> trans) {
+  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<transport::TTransport> trans) override {
     THeaderProtocol* headerProtocol
         = new THeaderProtocol(trans, trans, T_BINARY_PROTOCOL);
     return std::shared_ptr<TProtocol>(headerProtocol);
   }
 
-  virtual std::shared_ptr<TProtocol> getProtocol(
+  std::shared_ptr<TProtocol> getProtocol(
       std::shared_ptr<transport::TTransport> inTrans,
-      std::shared_ptr<transport::TTransport> outTrans) {
+      std::shared_ptr<transport::TTransport> outTrans) override {
     THeaderProtocol* headerProtocol = new THeaderProtocol(inTrans, outTrans, T_BINARY_PROTOCOL);
     return std::shared_ptr<TProtocol>(headerProtocol);
   }

--- a/lib/cpp/src/thrift/protocol/THeaderProtocol.h
+++ b/lib/cpp/src/thrift/protocol/THeaderProtocol.h
@@ -191,7 +191,7 @@ protected:
 class THeaderProtocolFactory : public TProtocolFactory {
 public:
   std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<transport::TTransport> trans) override {
-    THeaderProtocol* headerProtocol
+    auto* headerProtocol
         = new THeaderProtocol(trans, trans, T_BINARY_PROTOCOL);
     return std::shared_ptr<TProtocol>(headerProtocol);
   }
@@ -199,7 +199,7 @@ public:
   std::shared_ptr<TProtocol> getProtocol(
       std::shared_ptr<transport::TTransport> inTrans,
       std::shared_ptr<transport::TTransport> outTrans) override {
-    THeaderProtocol* headerProtocol = new THeaderProtocol(inTrans, outTrans, T_BINARY_PROTOCOL);
+    auto* headerProtocol = new THeaderProtocol(inTrans, outTrans, T_BINARY_PROTOCOL);
     return std::shared_ptr<TProtocol>(headerProtocol);
   }
 };

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -336,7 +336,7 @@ class JSONPairContext : public TJSONContext {
 public:
   JSONPairContext() : first_(true), colon_(true) {}
 
-  uint32_t write(TTransport& trans) {
+  uint32_t write(TTransport& trans) override {
     if (first_) {
       first_ = false;
       colon_ = true;
@@ -348,7 +348,7 @@ public:
     }
   }
 
-  uint32_t read(TJSONProtocol::LookaheadReader& reader) {
+  uint32_t read(TJSONProtocol::LookaheadReader& reader) override {
     if (first_) {
       first_ = false;
       colon_ = true;
@@ -361,7 +361,7 @@ public:
   }
 
   // Numbers must be turned into strings if they are the key part of a pair
-  virtual bool escapeNum() { return colon_; }
+  bool escapeNum() override { return colon_; }
 
 private:
   bool first_;
@@ -374,7 +374,7 @@ class JSONListContext : public TJSONContext {
 public:
   JSONListContext() : first_(true) {}
 
-  uint32_t write(TTransport& trans) {
+  uint32_t write(TTransport& trans) override {
     if (first_) {
       first_ = false;
       return 0;
@@ -384,7 +384,7 @@ public:
     }
   }
 
-  uint32_t read(TJSONProtocol::LookaheadReader& reader) {
+  uint32_t read(TJSONProtocol::LookaheadReader& reader) override {
     if (first_) {
       first_ = false;
       return 0;

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -303,9 +303,9 @@ static bool isLowSurrogate(uint16_t val) {
 class TJSONContext {
 
 public:
-  TJSONContext(){};
+  TJSONContext()= default;;
 
-  virtual ~TJSONContext(){};
+  virtual ~TJSONContext()= default;;
 
   /**
    * Write context data to the transport. Default is to do nothing.
@@ -404,8 +404,7 @@ TJSONProtocol::TJSONProtocol(std::shared_ptr<TTransport> ptrans)
     reader_(*ptrans) {
 }
 
-TJSONProtocol::~TJSONProtocol() {
-}
+TJSONProtocol::~TJSONProtocol() = default;
 
 void TJSONProtocol::pushContext(std::shared_ptr<TJSONContext> c) {
   contexts_.push(context_);

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -477,10 +477,10 @@ uint32_t TJSONProtocol::writeJSONBase64(const std::string& str) {
   result += 2; // For quotes
   trans_->write(&kJSONStringDelimiter, 1);
   uint8_t b[4];
-  const uint8_t* bytes = (const uint8_t*)str.c_str();
+  const auto* bytes = (const uint8_t*)str.c_str();
   if (str.length() > (std::numeric_limits<uint32_t>::max)())
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
-  uint32_t len = static_cast<uint32_t>(str.length());
+  auto len = static_cast<uint32_t>(str.length());
   while (len >= 3) {
     // Encode 3 bytes at a time
     base64_encode(bytes, 3, b);
@@ -798,10 +798,10 @@ uint32_t TJSONProtocol::readJSONString(std::string& str, bool skipContext) {
 uint32_t TJSONProtocol::readJSONBase64(std::string& str) {
   std::string tmp;
   uint32_t result = readJSONString(tmp);
-  uint8_t* b = (uint8_t*)tmp.c_str();
+  auto* b = (uint8_t*)tmp.c_str();
   if (tmp.length() > (std::numeric_limits<uint32_t>::max)())
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
-  uint32_t len = static_cast<uint32_t>(tmp.length());
+  auto len = static_cast<uint32_t>(tmp.length());
   str.clear();
   // Ignore padding
   if (len >= 2)  {
@@ -1065,7 +1065,7 @@ uint32_t TJSONProtocol::readBool(bool& value) {
 // readByte() must be handled properly because boost::lexical cast sees int8_t
 // as a text type instead of an integer type
 uint32_t TJSONProtocol::readByte(int8_t& byte) {
-  int16_t tmp = (int16_t)byte;
+  auto tmp = (int16_t)byte;
   uint32_t result = readJSONInteger(tmp);
   assert(tmp < 256);
   byte = (int8_t)tmp;

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.h
@@ -308,7 +308,7 @@ template <typename ThriftStruct>
 std::string ThriftJSONString(const ThriftStruct& ts) {
   using namespace apache::thrift::transport;
   using namespace apache::thrift::protocol;
-  TMemoryBuffer* buffer = new TMemoryBuffer;
+  auto* buffer = new TMemoryBuffer;
   std::shared_ptr<TTransport> trans(buffer);
   TJSONProtocol protocol(trans);
 

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.h
@@ -286,9 +286,9 @@ private:
  */
 class TJSONProtocolFactory : public TProtocolFactory {
 public:
-  TJSONProtocolFactory() {}
+  TJSONProtocolFactory() = default;
 
-  ~TJSONProtocolFactory() override {}
+  ~TJSONProtocolFactory() override = default;
 
   std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TProtocol>(new TJSONProtocol(trans));

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.h
@@ -98,7 +98,7 @@ class TJSONProtocol : public TVirtualProtocol<TJSONProtocol> {
 public:
   TJSONProtocol(std::shared_ptr<TTransport> ptrans);
 
-  ~TJSONProtocol();
+  ~TJSONProtocol() override;
 
 private:
   void pushContext(std::shared_ptr<TJSONContext> c);
@@ -288,9 +288,9 @@ class TJSONProtocolFactory : public TProtocolFactory {
 public:
   TJSONProtocolFactory() {}
 
-  virtual ~TJSONProtocolFactory() {}
+  ~TJSONProtocolFactory() override {}
 
-  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) {
+  std::shared_ptr<TProtocol> getProtocol(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TProtocol>(new TJSONProtocol(trans));
   }
 };

--- a/lib/cpp/src/thrift/protocol/TMultiplexedProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TMultiplexedProtocol.h
@@ -69,7 +69,7 @@ public:
    */
   TMultiplexedProtocol(shared_ptr<TProtocol> _protocol, const std::string& _serviceName)
     : TProtocolDecorator(_protocol), serviceName(_serviceName), separator(":") {}
-  ~TMultiplexedProtocol() override {}
+  ~TMultiplexedProtocol() override = default;
 
   /**
    * Prepends the service name to the function name, separated by TMultiplexedProtocol::SEPARATOR.

--- a/lib/cpp/src/thrift/protocol/TMultiplexedProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TMultiplexedProtocol.h
@@ -69,7 +69,7 @@ public:
    */
   TMultiplexedProtocol(shared_ptr<TProtocol> _protocol, const std::string& _serviceName)
     : TProtocolDecorator(_protocol), serviceName(_serviceName), separator(":") {}
-  virtual ~TMultiplexedProtocol() {}
+  ~TMultiplexedProtocol() override {}
 
   /**
    * Prepends the service name to the function name, separated by TMultiplexedProtocol::SEPARATOR.
@@ -82,7 +82,7 @@ public:
    */
   uint32_t writeMessageBegin_virt(const std::string& _name,
                                   const TMessageType _type,
-                                  const int32_t _seqid);
+                                  const int32_t _seqid) override;
 
 private:
   const std::string serviceName;

--- a/lib/cpp/src/thrift/protocol/TProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TProtocol.cpp
@@ -23,11 +23,11 @@ namespace apache {
 namespace thrift {
 namespace protocol {
 
-TProtocol::~TProtocol() {}
+TProtocol::~TProtocol() = default;
 uint32_t TProtocol::skip_virt(TType type) {
   return ::apache::thrift::protocol::skip(*this, type);
 }
 
-TProtocolFactory::~TProtocolFactory() {}
+TProtocolFactory::~TProtocolFactory() = default;
 
 }}} // apache::thrift::protocol

--- a/lib/cpp/src/thrift/protocol/TProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TProtocol.h
@@ -583,7 +583,7 @@ protected:
   std::shared_ptr<TTransport> ptrans_;
 
 private:
-  TProtocol() {}
+  TProtocol() = default;
   uint32_t input_recursion_depth_;
   uint32_t output_recursion_depth_;
   uint32_t recursion_limit_;
@@ -594,7 +594,7 @@ private:
  */
 class TProtocolFactory {
 public:
-  TProtocolFactory() {}
+  TProtocolFactory() = default;
 
   virtual ~TProtocolFactory();
 

--- a/lib/cpp/src/thrift/protocol/TProtocolDecorator.h
+++ b/lib/cpp/src/thrift/protocol/TProtocolDecorator.h
@@ -39,107 +39,107 @@ using std::shared_ptr;
  */
 class TProtocolDecorator : public TProtocol {
 public:
-  virtual ~TProtocolDecorator() {}
+  ~TProtocolDecorator() override {}
 
   // Desc: Initializes the protocol decorator object.
   TProtocolDecorator(shared_ptr<TProtocol> proto)
     : TProtocol(proto->getTransport()), protocol(proto) {}
 
-  virtual uint32_t writeMessageBegin_virt(const std::string& name,
+  uint32_t writeMessageBegin_virt(const std::string& name,
                                           const TMessageType messageType,
-                                          const int32_t seqid) {
+                                          const int32_t seqid) override {
     return protocol->writeMessageBegin(name, messageType, seqid);
   }
-  virtual uint32_t writeMessageEnd_virt() { return protocol->writeMessageEnd(); }
-  virtual uint32_t writeStructBegin_virt(const char* name) {
+  uint32_t writeMessageEnd_virt() override { return protocol->writeMessageEnd(); }
+  uint32_t writeStructBegin_virt(const char* name) override {
     return protocol->writeStructBegin(name);
   }
-  virtual uint32_t writeStructEnd_virt() { return protocol->writeStructEnd(); }
+  uint32_t writeStructEnd_virt() override { return protocol->writeStructEnd(); }
 
-  virtual uint32_t writeFieldBegin_virt(const char* name,
+  uint32_t writeFieldBegin_virt(const char* name,
                                         const TType fieldType,
-                                        const int16_t fieldId) {
+                                        const int16_t fieldId) override {
     return protocol->writeFieldBegin(name, fieldType, fieldId);
   }
 
-  virtual uint32_t writeFieldEnd_virt() { return protocol->writeFieldEnd(); }
-  virtual uint32_t writeFieldStop_virt() { return protocol->writeFieldStop(); }
+  uint32_t writeFieldEnd_virt() override { return protocol->writeFieldEnd(); }
+  uint32_t writeFieldStop_virt() override { return protocol->writeFieldStop(); }
 
-  virtual uint32_t writeMapBegin_virt(const TType keyType,
+  uint32_t writeMapBegin_virt(const TType keyType,
                                       const TType valType,
-                                      const uint32_t size) {
+                                      const uint32_t size) override {
     return protocol->writeMapBegin(keyType, valType, size);
   }
 
-  virtual uint32_t writeMapEnd_virt() { return protocol->writeMapEnd(); }
+  uint32_t writeMapEnd_virt() override { return protocol->writeMapEnd(); }
 
-  virtual uint32_t writeListBegin_virt(const TType elemType, const uint32_t size) {
+  uint32_t writeListBegin_virt(const TType elemType, const uint32_t size) override {
     return protocol->writeListBegin(elemType, size);
   }
-  virtual uint32_t writeListEnd_virt() { return protocol->writeListEnd(); }
+  uint32_t writeListEnd_virt() override { return protocol->writeListEnd(); }
 
-  virtual uint32_t writeSetBegin_virt(const TType elemType, const uint32_t size) {
+  uint32_t writeSetBegin_virt(const TType elemType, const uint32_t size) override {
     return protocol->writeSetBegin(elemType, size);
   }
-  virtual uint32_t writeSetEnd_virt() { return protocol->writeSetEnd(); }
+  uint32_t writeSetEnd_virt() override { return protocol->writeSetEnd(); }
 
-  virtual uint32_t writeBool_virt(const bool value) { return protocol->writeBool(value); }
-  virtual uint32_t writeByte_virt(const int8_t byte) { return protocol->writeByte(byte); }
-  virtual uint32_t writeI16_virt(const int16_t i16) { return protocol->writeI16(i16); }
-  virtual uint32_t writeI32_virt(const int32_t i32) { return protocol->writeI32(i32); }
-  virtual uint32_t writeI64_virt(const int64_t i64) { return protocol->writeI64(i64); }
+  uint32_t writeBool_virt(const bool value) override { return protocol->writeBool(value); }
+  uint32_t writeByte_virt(const int8_t byte) override { return protocol->writeByte(byte); }
+  uint32_t writeI16_virt(const int16_t i16) override { return protocol->writeI16(i16); }
+  uint32_t writeI32_virt(const int32_t i32) override { return protocol->writeI32(i32); }
+  uint32_t writeI64_virt(const int64_t i64) override { return protocol->writeI64(i64); }
 
-  virtual uint32_t writeDouble_virt(const double dub) { return protocol->writeDouble(dub); }
-  virtual uint32_t writeString_virt(const std::string& str) { return protocol->writeString(str); }
-  virtual uint32_t writeBinary_virt(const std::string& str) { return protocol->writeBinary(str); }
+  uint32_t writeDouble_virt(const double dub) override { return protocol->writeDouble(dub); }
+  uint32_t writeString_virt(const std::string& str) override { return protocol->writeString(str); }
+  uint32_t writeBinary_virt(const std::string& str) override { return protocol->writeBinary(str); }
 
-  virtual uint32_t readMessageBegin_virt(std::string& name,
+  uint32_t readMessageBegin_virt(std::string& name,
                                          TMessageType& messageType,
-                                         int32_t& seqid) {
+                                         int32_t& seqid) override {
     return protocol->readMessageBegin(name, messageType, seqid);
   }
-  virtual uint32_t readMessageEnd_virt() { return protocol->readMessageEnd(); }
+  uint32_t readMessageEnd_virt() override { return protocol->readMessageEnd(); }
 
-  virtual uint32_t readStructBegin_virt(std::string& name) {
+  uint32_t readStructBegin_virt(std::string& name) override {
     return protocol->readStructBegin(name);
   }
-  virtual uint32_t readStructEnd_virt() { return protocol->readStructEnd(); }
+  uint32_t readStructEnd_virt() override { return protocol->readStructEnd(); }
 
-  virtual uint32_t readFieldBegin_virt(std::string& name, TType& fieldType, int16_t& fieldId) {
+  uint32_t readFieldBegin_virt(std::string& name, TType& fieldType, int16_t& fieldId) override {
     return protocol->readFieldBegin(name, fieldType, fieldId);
   }
-  virtual uint32_t readFieldEnd_virt() { return protocol->readFieldEnd(); }
+  uint32_t readFieldEnd_virt() override { return protocol->readFieldEnd(); }
 
-  virtual uint32_t readMapBegin_virt(TType& keyType, TType& valType, uint32_t& size) {
+  uint32_t readMapBegin_virt(TType& keyType, TType& valType, uint32_t& size) override {
     return protocol->readMapBegin(keyType, valType, size);
   }
-  virtual uint32_t readMapEnd_virt() { return protocol->readMapEnd(); }
+  uint32_t readMapEnd_virt() override { return protocol->readMapEnd(); }
 
-  virtual uint32_t readListBegin_virt(TType& elemType, uint32_t& size) {
+  uint32_t readListBegin_virt(TType& elemType, uint32_t& size) override {
     return protocol->readListBegin(elemType, size);
   }
-  virtual uint32_t readListEnd_virt() { return protocol->readListEnd(); }
+  uint32_t readListEnd_virt() override { return protocol->readListEnd(); }
 
-  virtual uint32_t readSetBegin_virt(TType& elemType, uint32_t& size) {
+  uint32_t readSetBegin_virt(TType& elemType, uint32_t& size) override {
     return protocol->readSetBegin(elemType, size);
   }
-  virtual uint32_t readSetEnd_virt() { return protocol->readSetEnd(); }
+  uint32_t readSetEnd_virt() override { return protocol->readSetEnd(); }
 
-  virtual uint32_t readBool_virt(bool& value) { return protocol->readBool(value); }
-  virtual uint32_t readBool_virt(std::vector<bool>::reference value) {
+  uint32_t readBool_virt(bool& value) override { return protocol->readBool(value); }
+  uint32_t readBool_virt(std::vector<bool>::reference value) override {
     return protocol->readBool(value);
   }
 
-  virtual uint32_t readByte_virt(int8_t& byte) { return protocol->readByte(byte); }
+  uint32_t readByte_virt(int8_t& byte) override { return protocol->readByte(byte); }
 
-  virtual uint32_t readI16_virt(int16_t& i16) { return protocol->readI16(i16); }
-  virtual uint32_t readI32_virt(int32_t& i32) { return protocol->readI32(i32); }
-  virtual uint32_t readI64_virt(int64_t& i64) { return protocol->readI64(i64); }
+  uint32_t readI16_virt(int16_t& i16) override { return protocol->readI16(i16); }
+  uint32_t readI32_virt(int32_t& i32) override { return protocol->readI32(i32); }
+  uint32_t readI64_virt(int64_t& i64) override { return protocol->readI64(i64); }
 
-  virtual uint32_t readDouble_virt(double& dub) { return protocol->readDouble(dub); }
+  uint32_t readDouble_virt(double& dub) override { return protocol->readDouble(dub); }
 
-  virtual uint32_t readString_virt(std::string& str) { return protocol->readString(str); }
-  virtual uint32_t readBinary_virt(std::string& str) { return protocol->readBinary(str); }
+  uint32_t readString_virt(std::string& str) override { return protocol->readString(str); }
+  uint32_t readBinary_virt(std::string& str) override { return protocol->readBinary(str); }
 
 private:
   shared_ptr<TProtocol> protocol;

--- a/lib/cpp/src/thrift/protocol/TProtocolDecorator.h
+++ b/lib/cpp/src/thrift/protocol/TProtocolDecorator.h
@@ -39,7 +39,7 @@ using std::shared_ptr;
  */
 class TProtocolDecorator : public TProtocol {
 public:
-  ~TProtocolDecorator() override {}
+  ~TProtocolDecorator() override = default;
 
   // Desc: Initializes the protocol decorator object.
   TProtocolDecorator(shared_ptr<TProtocol> proto)

--- a/lib/cpp/src/thrift/protocol/TProtocolException.h
+++ b/lib/cpp/src/thrift/protocol/TProtocolException.h
@@ -59,7 +59,7 @@ public:
   TProtocolException(TProtocolExceptionType type, const std::string& message)
     : apache::thrift::TException(message), type_(type) {}
 
-  virtual ~TProtocolException() noexcept {}
+  ~TProtocolException() noexcept override {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -69,7 +69,7 @@ public:
    */
   TProtocolExceptionType getType() const { return type_; }
 
-  virtual const char* what() const noexcept {
+  const char* what() const noexcept override {
     if (message_.empty()) {
       switch (type_) {
       case UNKNOWN:

--- a/lib/cpp/src/thrift/protocol/TProtocolException.h
+++ b/lib/cpp/src/thrift/protocol/TProtocolException.h
@@ -59,7 +59,7 @@ public:
   TProtocolException(TProtocolExceptionType type, const std::string& message)
     : apache::thrift::TException(message), type_(type) {}
 
-  ~TProtocolException() noexcept override {}
+  ~TProtocolException() noexcept override = default;
 
   /**
    * Returns an error code that provides information about the type of error

--- a/lib/cpp/src/thrift/protocol/TVirtualProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TVirtualProtocol.h
@@ -484,7 +484,7 @@ public:
    * correct parent implementation, if desired.
    */
   uint32_t skip(TType type) {
-    Protocol_* const prot = static_cast<Protocol_*>(this);
+    auto* const prot = static_cast<Protocol_*>(this);
     return ::apache::thrift::protocol::skip(*prot, type);
   }
 

--- a/lib/cpp/src/thrift/protocol/TVirtualProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TVirtualProtocol.h
@@ -315,81 +315,81 @@ public:
    * Writing functions.
    */
 
-  virtual uint32_t writeMessageBegin_virt(const std::string& name,
+  uint32_t writeMessageBegin_virt(const std::string& name,
                                           const TMessageType messageType,
-                                          const int32_t seqid) {
+                                          const int32_t seqid) override {
     return static_cast<Protocol_*>(this)->writeMessageBegin(name, messageType, seqid);
   }
 
-  virtual uint32_t writeMessageEnd_virt() {
+  uint32_t writeMessageEnd_virt() override {
     return static_cast<Protocol_*>(this)->writeMessageEnd();
   }
 
-  virtual uint32_t writeStructBegin_virt(const char* name) {
+  uint32_t writeStructBegin_virt(const char* name) override {
     return static_cast<Protocol_*>(this)->writeStructBegin(name);
   }
 
-  virtual uint32_t writeStructEnd_virt() { return static_cast<Protocol_*>(this)->writeStructEnd(); }
+  uint32_t writeStructEnd_virt() override { return static_cast<Protocol_*>(this)->writeStructEnd(); }
 
-  virtual uint32_t writeFieldBegin_virt(const char* name,
+  uint32_t writeFieldBegin_virt(const char* name,
                                         const TType fieldType,
-                                        const int16_t fieldId) {
+                                        const int16_t fieldId) override {
     return static_cast<Protocol_*>(this)->writeFieldBegin(name, fieldType, fieldId);
   }
 
-  virtual uint32_t writeFieldEnd_virt() { return static_cast<Protocol_*>(this)->writeFieldEnd(); }
+  uint32_t writeFieldEnd_virt() override { return static_cast<Protocol_*>(this)->writeFieldEnd(); }
 
-  virtual uint32_t writeFieldStop_virt() { return static_cast<Protocol_*>(this)->writeFieldStop(); }
+  uint32_t writeFieldStop_virt() override { return static_cast<Protocol_*>(this)->writeFieldStop(); }
 
-  virtual uint32_t writeMapBegin_virt(const TType keyType,
+  uint32_t writeMapBegin_virt(const TType keyType,
                                       const TType valType,
-                                      const uint32_t size) {
+                                      const uint32_t size) override {
     return static_cast<Protocol_*>(this)->writeMapBegin(keyType, valType, size);
   }
 
-  virtual uint32_t writeMapEnd_virt() { return static_cast<Protocol_*>(this)->writeMapEnd(); }
+  uint32_t writeMapEnd_virt() override { return static_cast<Protocol_*>(this)->writeMapEnd(); }
 
-  virtual uint32_t writeListBegin_virt(const TType elemType, const uint32_t size) {
+  uint32_t writeListBegin_virt(const TType elemType, const uint32_t size) override {
     return static_cast<Protocol_*>(this)->writeListBegin(elemType, size);
   }
 
-  virtual uint32_t writeListEnd_virt() { return static_cast<Protocol_*>(this)->writeListEnd(); }
+  uint32_t writeListEnd_virt() override { return static_cast<Protocol_*>(this)->writeListEnd(); }
 
-  virtual uint32_t writeSetBegin_virt(const TType elemType, const uint32_t size) {
+  uint32_t writeSetBegin_virt(const TType elemType, const uint32_t size) override {
     return static_cast<Protocol_*>(this)->writeSetBegin(elemType, size);
   }
 
-  virtual uint32_t writeSetEnd_virt() { return static_cast<Protocol_*>(this)->writeSetEnd(); }
+  uint32_t writeSetEnd_virt() override { return static_cast<Protocol_*>(this)->writeSetEnd(); }
 
-  virtual uint32_t writeBool_virt(const bool value) {
+  uint32_t writeBool_virt(const bool value) override {
     return static_cast<Protocol_*>(this)->writeBool(value);
   }
 
-  virtual uint32_t writeByte_virt(const int8_t byte) {
+  uint32_t writeByte_virt(const int8_t byte) override {
     return static_cast<Protocol_*>(this)->writeByte(byte);
   }
 
-  virtual uint32_t writeI16_virt(const int16_t i16) {
+  uint32_t writeI16_virt(const int16_t i16) override {
     return static_cast<Protocol_*>(this)->writeI16(i16);
   }
 
-  virtual uint32_t writeI32_virt(const int32_t i32) {
+  uint32_t writeI32_virt(const int32_t i32) override {
     return static_cast<Protocol_*>(this)->writeI32(i32);
   }
 
-  virtual uint32_t writeI64_virt(const int64_t i64) {
+  uint32_t writeI64_virt(const int64_t i64) override {
     return static_cast<Protocol_*>(this)->writeI64(i64);
   }
 
-  virtual uint32_t writeDouble_virt(const double dub) {
+  uint32_t writeDouble_virt(const double dub) override {
     return static_cast<Protocol_*>(this)->writeDouble(dub);
   }
 
-  virtual uint32_t writeString_virt(const std::string& str) {
+  uint32_t writeString_virt(const std::string& str) override {
     return static_cast<Protocol_*>(this)->writeString(str);
   }
 
-  virtual uint32_t writeBinary_virt(const std::string& str) {
+  uint32_t writeBinary_virt(const std::string& str) override {
     return static_cast<Protocol_*>(this)->writeBinary(str);
   }
 
@@ -397,81 +397,81 @@ public:
    * Reading functions
    */
 
-  virtual uint32_t readMessageBegin_virt(std::string& name,
+  uint32_t readMessageBegin_virt(std::string& name,
                                          TMessageType& messageType,
-                                         int32_t& seqid) {
+                                         int32_t& seqid) override {
     return static_cast<Protocol_*>(this)->readMessageBegin(name, messageType, seqid);
   }
 
-  virtual uint32_t readMessageEnd_virt() { return static_cast<Protocol_*>(this)->readMessageEnd(); }
+  uint32_t readMessageEnd_virt() override { return static_cast<Protocol_*>(this)->readMessageEnd(); }
 
-  virtual uint32_t readStructBegin_virt(std::string& name) {
+  uint32_t readStructBegin_virt(std::string& name) override {
     return static_cast<Protocol_*>(this)->readStructBegin(name);
   }
 
-  virtual uint32_t readStructEnd_virt() { return static_cast<Protocol_*>(this)->readStructEnd(); }
+  uint32_t readStructEnd_virt() override { return static_cast<Protocol_*>(this)->readStructEnd(); }
 
-  virtual uint32_t readFieldBegin_virt(std::string& name, TType& fieldType, int16_t& fieldId) {
+  uint32_t readFieldBegin_virt(std::string& name, TType& fieldType, int16_t& fieldId) override {
     return static_cast<Protocol_*>(this)->readFieldBegin(name, fieldType, fieldId);
   }
 
-  virtual uint32_t readFieldEnd_virt() { return static_cast<Protocol_*>(this)->readFieldEnd(); }
+  uint32_t readFieldEnd_virt() override { return static_cast<Protocol_*>(this)->readFieldEnd(); }
 
-  virtual uint32_t readMapBegin_virt(TType& keyType, TType& valType, uint32_t& size) {
+  uint32_t readMapBegin_virt(TType& keyType, TType& valType, uint32_t& size) override {
     return static_cast<Protocol_*>(this)->readMapBegin(keyType, valType, size);
   }
 
-  virtual uint32_t readMapEnd_virt() { return static_cast<Protocol_*>(this)->readMapEnd(); }
+  uint32_t readMapEnd_virt() override { return static_cast<Protocol_*>(this)->readMapEnd(); }
 
-  virtual uint32_t readListBegin_virt(TType& elemType, uint32_t& size) {
+  uint32_t readListBegin_virt(TType& elemType, uint32_t& size) override {
     return static_cast<Protocol_*>(this)->readListBegin(elemType, size);
   }
 
-  virtual uint32_t readListEnd_virt() { return static_cast<Protocol_*>(this)->readListEnd(); }
+  uint32_t readListEnd_virt() override { return static_cast<Protocol_*>(this)->readListEnd(); }
 
-  virtual uint32_t readSetBegin_virt(TType& elemType, uint32_t& size) {
+  uint32_t readSetBegin_virt(TType& elemType, uint32_t& size) override {
     return static_cast<Protocol_*>(this)->readSetBegin(elemType, size);
   }
 
-  virtual uint32_t readSetEnd_virt() { return static_cast<Protocol_*>(this)->readSetEnd(); }
+  uint32_t readSetEnd_virt() override { return static_cast<Protocol_*>(this)->readSetEnd(); }
 
-  virtual uint32_t readBool_virt(bool& value) {
+  uint32_t readBool_virt(bool& value) override {
     return static_cast<Protocol_*>(this)->readBool(value);
   }
 
-  virtual uint32_t readBool_virt(std::vector<bool>::reference value) {
+  uint32_t readBool_virt(std::vector<bool>::reference value) override {
     return static_cast<Protocol_*>(this)->readBool(value);
   }
 
-  virtual uint32_t readByte_virt(int8_t& byte) {
+  uint32_t readByte_virt(int8_t& byte) override {
     return static_cast<Protocol_*>(this)->readByte(byte);
   }
 
-  virtual uint32_t readI16_virt(int16_t& i16) {
+  uint32_t readI16_virt(int16_t& i16) override {
     return static_cast<Protocol_*>(this)->readI16(i16);
   }
 
-  virtual uint32_t readI32_virt(int32_t& i32) {
+  uint32_t readI32_virt(int32_t& i32) override {
     return static_cast<Protocol_*>(this)->readI32(i32);
   }
 
-  virtual uint32_t readI64_virt(int64_t& i64) {
+  uint32_t readI64_virt(int64_t& i64) override {
     return static_cast<Protocol_*>(this)->readI64(i64);
   }
 
-  virtual uint32_t readDouble_virt(double& dub) {
+  uint32_t readDouble_virt(double& dub) override {
     return static_cast<Protocol_*>(this)->readDouble(dub);
   }
 
-  virtual uint32_t readString_virt(std::string& str) {
+  uint32_t readString_virt(std::string& str) override {
     return static_cast<Protocol_*>(this)->readString(str);
   }
 
-  virtual uint32_t readBinary_virt(std::string& str) {
+  uint32_t readBinary_virt(std::string& str) override {
     return static_cast<Protocol_*>(this)->readBinary(str);
   }
 
-  virtual uint32_t skip_virt(TType type) { return static_cast<Protocol_*>(this)->skip(type); }
+  uint32_t skip_virt(TType type) override { return static_cast<Protocol_*>(this)->skip(type); }
 
   /*
    * Provide a default skip() implementation that uses non-virtual read

--- a/lib/cpp/src/thrift/qt/TQIODeviceTransport.cpp
+++ b/lib/cpp/src/thrift/qt/TQIODeviceTransport.cpp
@@ -157,7 +157,7 @@ void TQIODeviceTransport::flush() {
 uint8_t* TQIODeviceTransport::borrow(uint8_t* buf, uint32_t* len) {
   (void)buf;
   (void)len;
-  return NULL;
+  return nullptr;
 }
 
 void TQIODeviceTransport::consume(uint32_t len) {

--- a/lib/cpp/src/thrift/qt/TQIODeviceTransport.h
+++ b/lib/cpp/src/thrift/qt/TQIODeviceTransport.h
@@ -37,12 +37,12 @@ class TQIODeviceTransport
     : public apache::thrift::transport::TVirtualTransport<TQIODeviceTransport> {
 public:
   explicit TQIODeviceTransport(std::shared_ptr<QIODevice> dev);
-  virtual ~TQIODeviceTransport();
+  ~TQIODeviceTransport() override;
 
-  void open();
+  void open() override;
   bool isOpen();
-  bool peek();
-  void close();
+  bool peek() override;
+  void close() override;
 
   uint32_t readAll(uint8_t* buf, uint32_t len);
   uint32_t read(uint8_t* buf, uint32_t len);
@@ -50,7 +50,7 @@ public:
   void write(const uint8_t* buf, uint32_t len);
   uint32_t write_partial(const uint8_t* buf, uint32_t len);
 
-  void flush();
+  void flush() override;
 
   uint8_t* borrow(uint8_t* buf, uint32_t* len);
   void consume(uint32_t len);

--- a/lib/cpp/src/thrift/qt/TQTcpServer.cpp
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.cpp
@@ -67,8 +67,7 @@ TQTcpServer::TQTcpServer(shared_ptr<QTcpServer> server,
   connect(server.get(), SIGNAL(newConnection()), SLOT(processIncoming()));
 }
 
-TQTcpServer::~TQTcpServer() {
-}
+TQTcpServer::~TQTcpServer() = default;
 
 void TQTcpServer::processIncoming() {
   while (server_->hasPendingConnections()) {

--- a/lib/cpp/src/thrift/qt/TQTcpServer.cpp
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.cpp
@@ -100,7 +100,7 @@ void TQTcpServer::processIncoming() {
 }
 
 void TQTcpServer::beginDecode() {
-  QTcpSocket* connection(qobject_cast<QTcpSocket*>(sender()));
+  auto* connection(qobject_cast<QTcpSocket*>(sender()));
   Q_ASSERT(connection);
 
   if (ctxMap_.find(connection) == ctxMap_.end()) {
@@ -125,7 +125,7 @@ void TQTcpServer::beginDecode() {
 }
 
 void TQTcpServer::socketClosed() {
-  QTcpSocket* connection(qobject_cast<QTcpSocket*>(sender()));
+  auto* connection(qobject_cast<QTcpSocket*>(sender()));
   Q_ASSERT(connection);
   scheduleDeleteConnectionContext(connection);
 }

--- a/lib/cpp/src/thrift/qt/TQTcpServer.h
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.h
@@ -50,7 +50,7 @@ public:
   TQTcpServer(std::shared_ptr<QTcpServer> server,
               std::shared_ptr<TAsyncProcessor> processor,
               std::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocolFactory,
-              QObject* parent = NULL);
+              QObject* parent = nullptr);
   ~TQTcpServer() override;
 
 private Q_SLOTS:

--- a/lib/cpp/src/thrift/qt/TQTcpServer.h
+++ b/lib/cpp/src/thrift/qt/TQTcpServer.h
@@ -51,7 +51,7 @@ public:
               std::shared_ptr<TAsyncProcessor> processor,
               std::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocolFactory,
               QObject* parent = NULL);
-  virtual ~TQTcpServer();
+  ~TQTcpServer() override;
 
 private Q_SLOTS:
   void processIncoming();

--- a/lib/cpp/src/thrift/server/TConnectedClient.cpp
+++ b/lib/cpp/src/thrift/server/TConnectedClient.cpp
@@ -42,7 +42,7 @@ TConnectedClient::TConnectedClient(const shared_ptr<TProcessor>& processor,
     outputProtocol_(outputProtocol),
     eventHandler_(eventHandler),
     client_(client),
-    opaqueContext_(0) {
+    opaqueContext_(nullptr) {
 }
 
 TConnectedClient::~TConnectedClient() {

--- a/lib/cpp/src/thrift/server/TConnectedClient.cpp
+++ b/lib/cpp/src/thrift/server/TConnectedClient.cpp
@@ -45,8 +45,7 @@ TConnectedClient::TConnectedClient(const shared_ptr<TProcessor>& processor,
     opaqueContext_(nullptr) {
 }
 
-TConnectedClient::~TConnectedClient() {
-}
+TConnectedClient::~TConnectedClient() = default;
 
 void TConnectedClient::run() {
   if (eventHandler_) {

--- a/lib/cpp/src/thrift/server/TConnectedClient.h
+++ b/lib/cpp/src/thrift/server/TConnectedClient.h
@@ -58,7 +58,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~TConnectedClient();
+  ~TConnectedClient() override;
 
   /**
    * Drive the client until it is done.
@@ -76,7 +76,7 @@ public:
    *              handle unexpected exceptions by logging
    *            cleanup()
    */
-  virtual void run() /* override */;
+  void run() override /* override */;
 
 protected:
   /**

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -327,7 +327,7 @@ public:
       serverEventHandler_(connection_->getServerEventHandler()),
       connectionContext_(connection_->getConnectionContext()) {}
 
-  void run() {
+  void run() override {
     try {
       for (;;) {
         if (serverEventHandler_) {

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -687,7 +687,7 @@ void TNonblockingServer::TConnection::transition() {
       socketState_ = SOCKET_SEND;
 
       // Put the frame size into the write buffer
-      int32_t frameSize = (int32_t)htonl(writeBufferSize_ - 4);
+      auto frameSize = (int32_t)htonl(writeBufferSize_ - 4);
       memcpy(writeBuffer_, &frameSize, 4);
 
       // Socket into write mode
@@ -749,7 +749,7 @@ void TNonblockingServer::TConnection::transition() {
         newSize *= 2;
       }
 
-      uint8_t* newBuffer = (uint8_t*)std::realloc(readBuffer_, newSize);
+      auto* newBuffer = (uint8_t*)std::realloc(readBuffer_, newSize);
       if (newBuffer == NULL) {
         // nothing else to be done...
         throw std::bad_alloc();
@@ -1368,7 +1368,7 @@ bool TNonblockingIOThread::notify(TNonblockingServer::TConnection* conn) {
 
 /* static */
 void TNonblockingIOThread::notifyHandler(evutil_socket_t fd, short which, void* v) {
-  TNonblockingIOThread* ioThread = (TNonblockingIOThread*)v;
+  auto* ioThread = (TNonblockingIOThread*)v;
   assert(ioThread);
   (void)which;
 

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -215,7 +215,7 @@ public:
   /// Constructor
   TConnection(std::shared_ptr<TSocket> socket,
               TNonblockingIOThread* ioThread) {
-    readBuffer_ = NULL;
+    readBuffer_ = nullptr;
     readBufferSize_ = 0;
 
     ioThread_ = ioThread;
@@ -380,7 +380,7 @@ void TNonblockingServer::TConnection::init(TNonblockingIOThread* ioThread) {
   readBufferPos_ = 0;
   readWant_ = 0;
 
-  writeBuffer_ = NULL;
+  writeBuffer_ = nullptr;
   writeBufferSize_ = 0;
   writeBufferPos_ = 0;
   largestWriteBufferSize_ = 0;
@@ -407,7 +407,7 @@ void TNonblockingServer::TConnection::init(TNonblockingIOThread* ioThread) {
   if (serverEventHandler_) {
     connectionContext_ = serverEventHandler_->createContext(inputProtocol_, outputProtocol_);
   } else {
-    connectionContext_ = NULL;
+    connectionContext_ = nullptr;
   }
 
   // Get the processor
@@ -570,7 +570,7 @@ bool TNonblockingServer::getHeaderTransport() {
   // Currently if there is no output protocol factory,
   // we assume header transport (without having to create
   // a new transport and check)
-  return getOutputProtocolFactory() == NULL;
+  return getOutputProtocolFactory() == nullptr;
 }
 
 /**
@@ -720,7 +720,7 @@ void TNonblockingServer::TConnection::transition() {
   case APP_INIT:
 
     // Clear write buffer variables
-    writeBuffer_ = NULL;
+    writeBuffer_ = nullptr;
     writeBufferPos_ = 0;
     writeBufferSize_ = 0;
 
@@ -750,7 +750,7 @@ void TNonblockingServer::TConnection::transition() {
       }
 
       auto* newBuffer = (uint8_t*)std::realloc(readBuffer_, newSize);
-      if (newBuffer == NULL) {
+      if (newBuffer == nullptr) {
         // nothing else to be done...
         throw std::bad_alloc();
       }
@@ -829,7 +829,7 @@ void TNonblockingServer::TConnection::setFlags(short eventFlags) {
   event_base_set(ioThread_->getEventBase(), &event_);
 
   // Add the event
-  if (event_add(&event_, 0) == -1) {
+  if (event_add(&event_, nullptr) == -1) {
     GlobalOutput.perror("TConnection::setFlags(): could not event_add", THRIFT_GET_SOCKET_ERROR);
   }
 }
@@ -843,7 +843,7 @@ void TNonblockingServer::TConnection::close() {
   if (serverEventHandler_) {
     serverEventHandler_->deleteContext(connectionContext_, inputProtocol_, outputProtocol_);
   }
-  ioThread_ = NULL;
+  ioThread_ = nullptr;
 
   // Close the socket
   tSocket_->close();
@@ -862,7 +862,7 @@ void TNonblockingServer::TConnection::close() {
 void TNonblockingServer::TConnection::checkIdleBufferMemLimit(size_t readLimit, size_t writeLimit) {
   if (readLimit > 0 && readBufferSize_ > readLimit) {
     free(readBuffer_);
-    readBuffer_ = NULL;
+    readBuffer_ = nullptr;
     readBufferSize_ = 0;
   }
 
@@ -910,7 +910,7 @@ TNonblockingServer::TConnection* TNonblockingServer::createConnection(std::share
   TNonblockingIOThread* ioThread = ioThreads_[selectedThreadIdx].get();
 
   // Check the connection stack to see if we can re-use
-  TConnection* result = NULL;
+  TConnection* result = nullptr;
   if (connectionStack_.empty()) {
     result = new TConnection(socket, ioThread);
     ++numTConnections_;
@@ -979,7 +979,7 @@ void TNonblockingServer::handleEvent(THRIFT_SOCKET fd, short which) {
     TConnection* clientConnection = createConnection(clientSocket);
 
     // Fail fast if we could not create a TConnection object
-    if (clientConnection == NULL) {
+    if (clientConnection == nullptr) {
       GlobalOutput.printf("thriftServerEventHandler: failed TConnection factory");
       clientSocket->close();
       return;
@@ -1143,7 +1143,7 @@ void TNonblockingServer::registerEvents(event_base* user_event_base) {
 void TNonblockingServer::serve() {
 
   if (ioThreads_.empty())
-    registerEvents(NULL);
+    registerEvents(nullptr);
 
   // Run the primary (listener) IO thread loop in our main thread; this will
   // only return when the server is shutting down.
@@ -1164,7 +1164,7 @@ TNonblockingIOThread::TNonblockingIOThread(TNonblockingServer* server,
     number_(number),
     listenSocket_(listenSocket),
     useHighPriority_(useHighPriority),
-    eventBase_(NULL),
+    eventBase_(nullptr),
     ownEventBase_(false) {
   notificationPipeFDs_[0] = -1;
   notificationPipeFDs_[1] = -1;
@@ -1231,9 +1231,9 @@ void TNonblockingIOThread::createNotificationPipe() {
 void TNonblockingIOThread::registerEvents() {
   threadId_ = Thread::get_current();
 
-  assert(eventBase_ == 0);
+  assert(eventBase_ == nullptr);
   eventBase_ = getServer()->getUserEventBase();
-  if (eventBase_ == NULL) {
+  if (eventBase_ == nullptr) {
     eventBase_ = event_base_new();
     ownEventBase_ = true;
   }
@@ -1255,7 +1255,7 @@ void TNonblockingIOThread::registerEvents() {
     event_base_set(eventBase_, &serverEvent_);
 
     // Add the event and start up the server
-    if (-1 == event_add(&serverEvent_, 0)) {
+    if (-1 == event_add(&serverEvent_, nullptr)) {
       throw TException(
           "TNonblockingServer::serve(): "
           "event_add() failed on server listen event");
@@ -1276,7 +1276,7 @@ void TNonblockingIOThread::registerEvents() {
   event_base_set(eventBase_, &notificationEvent_);
 
   // Add the event and start up the server
-  if (-1 == event_add(&notificationEvent_, 0)) {
+  if (-1 == event_add(&notificationEvent_, nullptr)) {
     throw TException(
         "TNonblockingServer::serve(): "
         "event_add() failed on task-done notification event");
@@ -1373,11 +1373,11 @@ void TNonblockingIOThread::notifyHandler(evutil_socket_t fd, short which, void* 
   (void)which;
 
   while (true) {
-    TNonblockingServer::TConnection* connection = 0;
+    TNonblockingServer::TConnection* connection = nullptr;
     const int kSize = sizeof(connection);
     long nBytes = recv(fd, cast_sockopt(&connection), kSize, 0);
     if (nBytes == kSize) {
-      if (connection == NULL) {
+      if (connection == nullptr) {
         // this is the command to stop our thread, exit the handler!
         ioThread->breakLoop(false);
         return;
@@ -1420,7 +1420,7 @@ void TNonblockingIOThread::breakLoop(bool error) {
   // same thread, this means the thread can't be blocking in the event
   // loop either.
   if (!Thread::is_current(threadId_)) {
-    notify(NULL);
+    notify(nullptr);
   } else {
     // cause the loop to stop ASAP - even if it has things to do in it
     event_base_loopbreak(eventBase_);
@@ -1457,14 +1457,14 @@ void TNonblockingIOThread::setCurrentThreadHighPriority(bool value) {
 }
 
 void TNonblockingIOThread::run() {
-  if (eventBase_ == NULL) {
+  if (eventBase_ == nullptr) {
     registerEvents();
   }
   if (useHighPriority_) {
     setCurrentThreadHighPriority(true);
   }
 
-  if (eventBase_ != NULL)
+  if (eventBase_ != nullptr)
   {
     GlobalOutput.printf("TNonblockingServer: IO thread #%d entering loop...", number_);
     // Run libevent engine, never returns, invokes calls to eventHandler

--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -376,7 +376,7 @@ public:
     setThreadManager(threadManager);
   }
 
-  ~TNonblockingServer();
+  ~TNonblockingServer() override;
 
   void setThreadManager(std::shared_ptr<ThreadManager> threadManager);
 
@@ -669,12 +669,12 @@ public:
    * Main workhorse function, starts up the server listening on a port and
    * loops over the libevent handler.
    */
-  void serve();
+  void serve() override;
 
   /**
    * Causes the server to terminate gracefully (can be called from any thread).
    */
-  void stop();
+  void stop() override;
 
   /// Creates a socket to listen on and binds it to the local port.
   void createAndListenOnSocket();
@@ -741,7 +741,7 @@ public:
                        THRIFT_SOCKET listenSocket,
                        bool useHighPriority);
 
-  ~TNonblockingIOThread();
+  ~TNonblockingIOThread() override;
 
   // Returns the event-base for this thread.
   event_base* getEventBase() const { return eventBase_; }
@@ -772,7 +772,7 @@ public:
   bool notify(TNonblockingServer::TConnection* conn);
 
   // Enters the event loop and does not return until a call to stop().
-  virtual void run();
+  void run() override;
 
   // Exits the event loop as soon as possible.
   void stop();

--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -280,7 +280,7 @@ private:
     numIOThreads_ = DEFAULT_IO_THREADS;
     nextIOThread_ = 0;
     useHighPriorityIOThreads_ = false;
-    userEventBase_ = NULL;
+    userEventBase_ = nullptr;
     threadPoolProcessing_ = false;
     numTConnections_ = 0;
     numActiveProcessors_ = 0;

--- a/lib/cpp/src/thrift/server/TServer.h
+++ b/lib/cpp/src/thrift/server/TServer.h
@@ -48,7 +48,7 @@ using apache::thrift::transport::TTransportFactory;
  */
 class TServerEventHandler {
 public:
-  virtual ~TServerEventHandler() {}
+  virtual ~TServerEventHandler() = default;
 
   /**
    * Called before the server begins.
@@ -89,7 +89,7 @@ protected:
   /**
    * Prevent direct instantiation.
    */
-  TServerEventHandler() {}
+  TServerEventHandler() = default;
 };
 
 /**
@@ -98,7 +98,7 @@ protected:
  */
 class TServer : public concurrency::Runnable {
 public:
-  ~TServer() override {}
+  ~TServer() override = default;
 
   virtual void serve() = 0;
 

--- a/lib/cpp/src/thrift/server/TServer.h
+++ b/lib/cpp/src/thrift/server/TServer.h
@@ -62,7 +62,7 @@ public:
                               std::shared_ptr<TProtocol> output) {
     (void)input;
     (void)output;
-    return NULL;
+    return nullptr;
   }
 
   /**

--- a/lib/cpp/src/thrift/server/TServer.h
+++ b/lib/cpp/src/thrift/server/TServer.h
@@ -98,14 +98,14 @@ protected:
  */
 class TServer : public concurrency::Runnable {
 public:
-  virtual ~TServer() {}
+  ~TServer() override {}
 
   virtual void serve() = 0;
 
   virtual void stop() {}
 
   // Allows running the server as a Runnable thread
-  virtual void run() { serve(); }
+  void run() override { serve(); }
 
   std::shared_ptr<TProcessorFactory> getProcessorFactory() { return processorFactory_; }
 

--- a/lib/cpp/src/thrift/server/TServerFramework.cpp
+++ b/lib/cpp/src/thrift/server/TServerFramework.cpp
@@ -91,8 +91,7 @@ TServerFramework::TServerFramework(const shared_ptr<TProcessor>& processor,
     limit_(INT64_MAX) {
 }
 
-TServerFramework::~TServerFramework() {
-}
+TServerFramework::~TServerFramework() = default;
 
 template <typename T>
 static void releaseOneDescriptor(const string& name, T& pTransport) {

--- a/lib/cpp/src/thrift/server/TServerFramework.h
+++ b/lib/cpp/src/thrift/server/TServerFramework.h
@@ -75,7 +75,7 @@ public:
       const std::shared_ptr<apache::thrift::protocol::TProtocolFactory>& inputProtocolFactory,
       const std::shared_ptr<apache::thrift::protocol::TProtocolFactory>& outputProtocolFactory);
 
-  virtual ~TServerFramework();
+  ~TServerFramework() override;
 
   /**
    * Accept clients from the TServerTransport and add them for processing.
@@ -84,12 +84,12 @@ public:
    * Post-conditions (return guarantees):
    *   The serverTransport will be closed.
    */
-  virtual void serve();
+  void serve() override;
 
   /**
    * Interrupt serve() so that it meets post-conditions and returns.
    */
-  virtual void stop();
+  void stop() override;
 
   /**
    * Get the concurrent client limit.

--- a/lib/cpp/src/thrift/server/TSimpleServer.cpp
+++ b/lib/cpp/src/thrift/server/TSimpleServer.cpp
@@ -78,8 +78,7 @@ TSimpleServer::TSimpleServer(const shared_ptr<TProcessor>& processor,
   TServerFramework::setConcurrentClientLimit(1);
 }
 
-TSimpleServer::~TSimpleServer() {
-}
+TSimpleServer::~TSimpleServer() = default;
 
 /**
  * The main body of customized implementation for TSimpleServer is quite simple:

--- a/lib/cpp/src/thrift/server/TSimpleServer.h
+++ b/lib/cpp/src/thrift/server/TSimpleServer.h
@@ -61,14 +61,14 @@ public:
       const std::shared_ptr<apache::thrift::protocol::TProtocolFactory>& inputProtocolFactory,
       const std::shared_ptr<apache::thrift::protocol::TProtocolFactory>& outputProtocolFactory);
 
-  virtual ~TSimpleServer();
+  ~TSimpleServer() override;
 
 protected:
-  virtual void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) /* override */;
-  virtual void onClientDisconnected(TConnectedClient* pClient) /* override */;
+  void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) override /* override */;
+  void onClientDisconnected(TConnectedClient* pClient) override /* override */;
 
 private:
-  void setConcurrentClientLimit(int64_t newLimit); // hide
+  void setConcurrentClientLimit(int64_t newLimit) override; // hide
 };
 }
 }

--- a/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.cpp
@@ -91,8 +91,7 @@ TThreadPoolServer::TThreadPoolServer(const shared_ptr<TProcessor>& processor,
     taskExpiration_(0) {
 }
 
-TThreadPoolServer::~TThreadPoolServer() {
-}
+TThreadPoolServer::~TThreadPoolServer() = default;
 
 void TThreadPoolServer::serve() {
   TServerFramework::serve();

--- a/lib/cpp/src/thrift/server/TThreadPoolServer.h
+++ b/lib/cpp/src/thrift/server/TThreadPoolServer.h
@@ -69,13 +69,13 @@ public:
       const std::shared_ptr<apache::thrift::concurrency::ThreadManager>& threadManager
       = apache::thrift::concurrency::ThreadManager::newSimpleThreadManager());
 
-  virtual ~TThreadPoolServer();
+  ~TThreadPoolServer() override;
 
   /**
    * Post-conditions (return guarantees):
    *   There will be no clients connected.
    */
-  virtual void serve();
+  void serve() override;
 
   virtual int64_t getTimeout() const;
   virtual void setTimeout(int64_t value);
@@ -86,8 +86,8 @@ public:
   virtual std::shared_ptr<apache::thrift::concurrency::ThreadManager> getThreadManager() const;
 
 protected:
-  virtual void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) /* override */;
-  virtual void onClientDisconnected(TConnectedClient* pClient) /* override */;
+  void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) override /* override */;
+  void onClientDisconnected(TConnectedClient* pClient) override /* override */;
 
   std::shared_ptr<apache::thrift::concurrency::ThreadManager> threadManager_;
   std::atomic<int64_t> timeout_;

--- a/lib/cpp/src/thrift/server/TThreadedServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadedServer.cpp
@@ -107,7 +107,7 @@ void TThreadedServer::serve() {
 void TThreadedServer::drainDeadClients() {
   // we're in a monitor here
   while (!deadClientMap_.empty()) {
-    ClientMap::iterator it = deadClientMap_.begin();
+    auto it = deadClientMap_.begin();
     it->second->join();
     deadClientMap_.erase(it);
   }
@@ -125,9 +125,9 @@ void TThreadedServer::onClientConnected(const shared_ptr<TConnectedClient>& pCli
 void TThreadedServer::onClientDisconnected(TConnectedClient* pClient) {
   Synchronized sync(clientMonitor_);
   drainDeadClients(); // use the outgoing thread to do some maintenance on our dead client backlog
-  ClientMap::iterator it = activeClientMap_.find(pClient);
+  auto it = activeClientMap_.find(pClient);
   if (it != activeClientMap_.end()) {
-    ClientMap::iterator end = it;
+    auto end = it;
     deadClientMap_.insert(it, ++end);
     activeClientMap_.erase(it);
   }

--- a/lib/cpp/src/thrift/server/TThreadedServer.cpp
+++ b/lib/cpp/src/thrift/server/TThreadedServer.cpp
@@ -89,8 +89,7 @@ TThreadedServer::TThreadedServer(const shared_ptr<TProcessor>& processor,
     threadFactory_(threadFactory) {
 }
 
-TThreadedServer::~TThreadedServer() {
-}
+TThreadedServer::~TThreadedServer() = default;
 
 void TThreadedServer::serve() {
   TServerFramework::serve();
@@ -140,8 +139,7 @@ TThreadedServer::TConnectedClientRunner::TConnectedClientRunner(const shared_ptr
   : pClient_(pClient) {
 }
 
-TThreadedServer::TConnectedClientRunner::~TConnectedClientRunner() {
-}
+TThreadedServer::TConnectedClientRunner::~TConnectedClientRunner() = default;
 
 void TThreadedServer::TConnectedClientRunner::run() /* override */ {
   pClient_->run();  // Run the client

--- a/lib/cpp/src/thrift/server/TThreadedServer.h
+++ b/lib/cpp/src/thrift/server/TThreadedServer.h
@@ -77,13 +77,13 @@ public:
       = std::shared_ptr<apache::thrift::concurrency::ThreadFactory>(
           new apache::thrift::concurrency::ThreadFactory(false)));
 
-  virtual ~TThreadedServer();
+  ~TThreadedServer() override;
 
   /**
    * Post-conditions (return guarantees):
    *   There will be no clients connected.
    */
-  virtual void serve();
+  void serve() override;
 
 protected:
   /**
@@ -95,12 +95,12 @@ protected:
   /**
    * Implementation of TServerFramework::onClientConnected
    */
-  virtual void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) /* override */;
+  void onClientConnected(const std::shared_ptr<TConnectedClient>& pClient) override /* override */;
 
   /**
    * Implementation of TServerFramework::onClientDisconnected
    */
-  virtual void onClientDisconnected(TConnectedClient *pClient) /* override */;
+  void onClientDisconnected(TConnectedClient *pClient) override /* override */;
 
   std::shared_ptr<apache::thrift::concurrency::ThreadFactory> threadFactory_;
 
@@ -115,8 +115,8 @@ protected:
   {
   public:
     TConnectedClientRunner(const std::shared_ptr<TConnectedClient>& pClient);
-    virtual ~TConnectedClientRunner();
-    void run() /* override */;
+    ~TConnectedClientRunner() override;
+    void run() override /* override */;
   private:
     std::shared_ptr<TConnectedClient> pClient_;
   };

--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -29,7 +29,7 @@ namespace thrift {
 namespace transport {
 
 uint32_t TBufferedTransport::readSlow(uint8_t* buf, uint32_t len) {
-  uint32_t have = static_cast<uint32_t>(rBound_ - rBase_);
+  auto have = static_cast<uint32_t>(rBound_ - rBase_);
 
   // We should only take the slow path if we can't satisfy the read
   // with the data already in the buffer.
@@ -61,8 +61,8 @@ uint32_t TBufferedTransport::readSlow(uint8_t* buf, uint32_t len) {
 }
 
 void TBufferedTransport::writeSlow(const uint8_t* buf, uint32_t len) {
-  uint32_t have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
-  uint32_t space = static_cast<uint32_t>(wBound_ - wBase_);
+  auto have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
+  auto space = static_cast<uint32_t>(wBound_ - wBase_);
   // We should only take the slow path if we can't accommodate the write
   // with the free space already in the buffer.
   assert(wBound_ - wBase_ < static_cast<ptrdiff_t>(len));
@@ -119,7 +119,7 @@ const uint8_t* TBufferedTransport::borrowSlow(uint8_t* buf, uint32_t* len) {
 
 void TBufferedTransport::flush() {
   // Write out any data waiting in the write buffer.
-  uint32_t have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
+  auto have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
   if (have_bytes > 0) {
     // Note that we reset wBase_ prior to the underlying write
     // to ensure we're in a sane state (i.e. internal buffer cleaned)
@@ -134,7 +134,7 @@ void TBufferedTransport::flush() {
 
 uint32_t TFramedTransport::readSlow(uint8_t* buf, uint32_t len) {
   uint32_t want = len;
-  uint32_t have = static_cast<uint32_t>(rBound_ - rBase_);
+  auto have = static_cast<uint32_t>(rBound_ - rBase_);
 
   // We should only take the slow path if we can't satisfy the read
   // with the data already in the buffer.
@@ -217,7 +217,7 @@ bool TFramedTransport::readFrame() {
 
 void TFramedTransport::writeSlow(const uint8_t* buf, uint32_t len) {
   // Double buffer size until sufficient.
-  uint32_t have = static_cast<uint32_t>(wBase_ - wBuf_.get());
+  auto have = static_cast<uint32_t>(wBase_ - wBuf_.get());
   uint32_t new_size = wBufSize_;
   if (len + have < have /* overflow */ || len + have > 0x7fffffff) {
     throw TTransportException(TTransportException::BAD_ARGS,
@@ -231,7 +231,7 @@ void TFramedTransport::writeSlow(const uint8_t* buf, uint32_t len) {
   // so we can use realloc here.
 
   // Allocate new buffer.
-  uint8_t* new_buf = new uint8_t[new_size];
+  auto* new_buf = new uint8_t[new_size];
 
   // Copy the old buffer to the new one.
   memcpy(new_buf, wBuf_.get(), have);
@@ -297,7 +297,7 @@ const uint8_t* TFramedTransport::borrowSlow(uint8_t* buf, uint32_t* len) {
 
 uint32_t TFramedTransport::readEnd() {
   // include framing bytes
-  uint32_t bytes_read = static_cast<uint32_t>(rBound_ - rBuf_.get() + sizeof(uint32_t));
+  auto bytes_read = static_cast<uint32_t>(rBound_ - rBuf_.get() + sizeof(uint32_t));
 
   if (rBufSize_ > bufReclaimThresh_) {
     rBufSize_ = 0;
@@ -372,7 +372,7 @@ void TMemoryBuffer::ensureCanWrite(uint32_t len) {
   }
 
   // Allocate into a new pointer so we don't bork ours if it fails.
-  uint8_t* new_buffer = static_cast<uint8_t*>(std::realloc(buffer_, new_size));
+  auto* new_buffer = static_cast<uint8_t*>(std::realloc(buffer_, new_size));
   if (new_buffer == NULL) {
     throw std::bad_alloc();
   }

--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -114,7 +114,7 @@ const uint8_t* TBufferedTransport::borrowSlow(uint8_t* buf, uint32_t* len) {
   (void)len;
   // Simply return NULL.  We don't know if there is actually data available on
   // the underlying transport, so calling read() might block.
-  return NULL;
+  return nullptr;
 }
 
 void TBufferedTransport::flush() {
@@ -292,7 +292,7 @@ const uint8_t* TFramedTransport::borrowSlow(uint8_t* buf, uint32_t* len) {
   // Don't try to be clever with shifting buffers.
   // If the fast path failed let the protocol use its slow path.
   // Besides, who is going to try to borrow across messages?
-  return NULL;
+  return nullptr;
 }
 
 uint32_t TFramedTransport::readEnd() {
@@ -335,7 +335,7 @@ uint32_t TMemoryBuffer::readSlow(uint8_t* buf, uint32_t len) {
 
 uint32_t TMemoryBuffer::readAppendToString(std::string& str, uint32_t len) {
   // Don't get some stupid assertion failure.
-  if (buffer_ == NULL) {
+  if (buffer_ == nullptr) {
     return 0;
   }
 
@@ -373,7 +373,7 @@ void TMemoryBuffer::ensureCanWrite(uint32_t len) {
 
   // Allocate into a new pointer so we don't bork ours if it fails.
   auto* new_buffer = static_cast<uint8_t*>(std::realloc(buffer_, new_size));
-  if (new_buffer == NULL) {
+  if (new_buffer == nullptr) {
     throw std::bad_alloc();
   }
 
@@ -408,7 +408,7 @@ const uint8_t* TMemoryBuffer::borrowSlow(uint8_t* buf, uint32_t* len) {
     *len = available_read();
     return rBase_;
   }
-  return NULL;
+  return nullptr;
 }
 }
 }

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -240,7 +240,7 @@ public:
   /**
    * Returns the origin of the underlying transport
    */
-  const std::string getOrigin() override { return transport_->getOrigin(); }
+  const std::string getOrigin() const override { return transport_->getOrigin(); }
 
   /**
    * The following behavior is currently implemented by TBufferedTransport,
@@ -377,7 +377,7 @@ public:
   /**
    * Returns the origin of the underlying transport
    */
-  const std::string getOrigin() override { return transport_->getOrigin(); }
+  const std::string getOrigin() const override { return transport_->getOrigin(); }
 
   /**
    * Set the maximum size of the frame at read

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -636,7 +636,7 @@ public:
   // return number of bytes read
   uint32_t readEnd() override {
     // This cast should be safe, because buffer_'s size is a uint32_t
-    uint32_t bytes = static_cast<uint32_t>(rBase_ - buffer_);
+    auto bytes = static_cast<uint32_t>(rBase_ - buffer_);
     if (rBase_ == wBase_) {
       resetBuffer();
     }

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -162,7 +162,7 @@ protected:
     wBound_ = buf + len;
   }
 
-  ~TBufferBase() override {}
+  ~TBufferBase() override = default;
 
   /// Reads begin here.
   uint8_t* rBase_;
@@ -284,9 +284,9 @@ protected:
  */
 class TBufferedTransportFactory : public TTransportFactory {
 public:
-  TBufferedTransportFactory() {}
+  TBufferedTransportFactory() = default;
 
-  ~TBufferedTransportFactory() override {}
+  ~TBufferedTransportFactory() override = default;
 
   /**
    * Wraps the transport into a buffered one.
@@ -423,9 +423,9 @@ protected:
  */
 class TFramedTransportFactory : public TTransportFactory {
 public:
-  TFramedTransportFactory() {}
+  TFramedTransportFactory() = default;
 
-  ~TFramedTransportFactory() override {}
+  ~TFramedTransportFactory() override = default;
 
   /**
    * Wraps the transport into a framed one.

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -148,7 +148,7 @@ protected:
    * performance-sensitive operation, so it is okay to just leave it to
    * the concrete class to set up pointers correctly.
    */
-  TBufferBase() : rBase_(NULL), rBound_(NULL), wBase_(NULL), wBound_(NULL) {}
+  TBufferBase() : rBase_(nullptr), rBound_(nullptr), wBase_(nullptr), wBound_(nullptr) {}
 
   /// Convenience mutator for setting the read buffer.
   void setReadBuffer(uint8_t* buf, uint32_t len) {
@@ -399,7 +399,7 @@ protected:
   virtual bool readFrame();
 
   void initPointers() {
-    setReadBuffer(NULL, 0);
+    setReadBuffer(nullptr, 0);
     setWriteBuffer(wBuf_.get(), wBufSize_);
 
     // Pad the buffer so we can insert the size later.
@@ -451,10 +451,10 @@ private:
 
     maxBufferSize_ = (std::numeric_limits<uint32_t>::max)();
 
-    if (buf == NULL && size != 0) {
+    if (buf == nullptr && size != 0) {
       assert(owner);
       buf = (uint8_t*)std::malloc(size);
-      if (buf == NULL) {
+      if (buf == nullptr) {
 	throw std::bad_alloc();
       }
     }
@@ -503,7 +503,7 @@ public:
    * Construct a TMemoryBuffer with a default-sized buffer,
    * owned by the TMemoryBuffer object.
    */
-  TMemoryBuffer() { initCommon(NULL, defaultSize, true, 0); }
+  TMemoryBuffer() { initCommon(nullptr, defaultSize, true, 0); }
 
   /**
    * Construct a TMemoryBuffer with a buffer of a specified size,
@@ -511,7 +511,7 @@ public:
    *
    * @param sz  The initial size of the buffer.
    */
-  TMemoryBuffer(uint32_t sz) { initCommon(NULL, sz, true, 0); }
+  TMemoryBuffer(uint32_t sz) { initCommon(nullptr, sz, true, 0); }
 
   /**
    * Construct a TMemoryBuffer with buf as its initial contents.
@@ -524,7 +524,7 @@ public:
    * @param policy See @link MemoryPolicy @endlink .
    */
   TMemoryBuffer(uint8_t* buf, uint32_t sz, MemoryPolicy policy = OBSERVE) {
-    if (buf == NULL && sz != 0) {
+    if (buf == nullptr && sz != 0) {
       throw TTransportException(TTransportException::BAD_ARGS,
                                 "TMemoryBuffer given null buffer with non-zero size.");
     }
@@ -535,7 +535,7 @@ public:
       initCommon(buf, sz, policy == TAKE_OWNERSHIP, sz);
       break;
     case COPY:
-      initCommon(NULL, sz, true, 0);
+      initCommon(nullptr, sz, true, 0);
       this->write(buf, sz);
       break;
     default:
@@ -565,7 +565,7 @@ public:
   }
 
   std::string getBufferAsString() {
-    if (buffer_ == NULL) {
+    if (buffer_ == nullptr) {
       return "";
     }
     uint8_t* buf;
@@ -575,7 +575,7 @@ public:
   }
 
   void appendBufferToString(std::string& str) {
-    if (buffer_ == NULL) {
+    if (buffer_ == nullptr) {
       return;
     }
     uint8_t* buf;

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -162,7 +162,7 @@ protected:
     wBound_ = buf + len;
   }
 
-  virtual ~TBufferBase() {}
+  ~TBufferBase() override {}
 
   /// Reads begin here.
   uint8_t* rBase_;
@@ -215,32 +215,32 @@ public:
     initPointers();
   }
 
-  void open() { transport_->open(); }
+  void open() override { transport_->open(); }
 
   bool isOpen() { return transport_->isOpen(); }
 
-  bool peek() {
+  bool peek() override {
     if (rBase_ == rBound_) {
       setReadBuffer(rBuf_.get(), transport_->read(rBuf_.get(), rBufSize_));
     }
     return (rBound_ > rBase_);
   }
 
-  void close() {
+  void close() override {
     flush();
     transport_->close();
   }
 
-  virtual uint32_t readSlow(uint8_t* buf, uint32_t len);
+  uint32_t readSlow(uint8_t* buf, uint32_t len) override;
 
-  virtual void writeSlow(const uint8_t* buf, uint32_t len);
+  void writeSlow(const uint8_t* buf, uint32_t len) override;
 
   void flush() override;
 
   /**
    * Returns the origin of the underlying transport
    */
-  virtual const std::string getOrigin() { return transport_->getOrigin(); }
+  const std::string getOrigin() override { return transport_->getOrigin(); }
 
   /**
    * The following behavior is currently implemented by TBufferedTransport,
@@ -253,7 +253,7 @@ public:
    *    will ever have to be copied again.  For optimial performance,
    *    stay under this limit.
    */
-  virtual const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len);
+  const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len) override;
 
   std::shared_ptr<TTransport> getUnderlyingTransport() { return transport_; }
 
@@ -286,7 +286,7 @@ class TBufferedTransportFactory : public TTransportFactory {
 public:
   TBufferedTransportFactory() {}
 
-  virtual ~TBufferedTransportFactory() {}
+  ~TBufferedTransportFactory() override {}
 
   /**
    * Wraps the transport into a buffered one.
@@ -343,13 +343,13 @@ public:
     initPointers();
   }
 
-  void open() { transport_->open(); }
+  void open() override { transport_->open(); }
 
   bool isOpen() { return transport_->isOpen(); }
 
-  bool peek() { return (rBase_ < rBound_) || transport_->peek(); }
+  bool peek() override { return (rBase_ < rBound_) || transport_->peek(); }
 
-  void close() {
+  void close() override {
     flush();
     transport_->close();
   }
@@ -360,11 +360,11 @@ public:
 
   void flush() override;
 
-  uint32_t readEnd();
+  uint32_t readEnd() override;
 
-  uint32_t writeEnd();
+  uint32_t writeEnd() override;
 
-  const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len);
+  const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len) override;
 
   std::shared_ptr<TTransport> getUnderlyingTransport() { return transport_; }
 
@@ -377,7 +377,7 @@ public:
   /**
    * Returns the origin of the underlying transport
    */
-  virtual const std::string getOrigin() { return transport_->getOrigin(); }
+  const std::string getOrigin() override { return transport_->getOrigin(); }
 
   /**
    * Set the maximum size of the frame at read
@@ -425,7 +425,7 @@ class TFramedTransportFactory : public TTransportFactory {
 public:
   TFramedTransportFactory() {}
 
-  virtual ~TFramedTransportFactory() {}
+  ~TFramedTransportFactory() override {}
 
   /**
    * Wraps the transport into a framed one.
@@ -544,7 +544,7 @@ public:
     }
   }
 
-  ~TMemoryBuffer() {
+  ~TMemoryBuffer() override {
     if (owner_) {
       std::free(buffer_);
     }
@@ -552,11 +552,11 @@ public:
 
   bool isOpen() { return true; }
 
-  bool peek() { return (rBase_ < wBase_); }
+  bool peek() override { return (rBase_ < wBase_); }
 
-  void open() {}
+  void open() override {}
 
-  void close() {}
+  void close() override {}
 
   // TODO(dreiss): Make bufPtr const.
   void getBuffer(uint8_t** bufPtr, uint32_t* sz) {
@@ -634,7 +634,7 @@ public:
   uint32_t readAppendToString(std::string& str, uint32_t len);
 
   // return number of bytes read
-  uint32_t readEnd() {
+  uint32_t readEnd() override {
     // This cast should be safe, because buffer_'s size is a uint32_t
     uint32_t bytes = static_cast<uint32_t>(rBase_ - buffer_);
     if (rBase_ == wBase_) {
@@ -644,7 +644,7 @@ public:
   }
 
   // Return number of bytes written
-  uint32_t writeEnd() {
+  uint32_t writeEnd() override {
     // This cast should be safe, because buffer_'s size is a uint32_t
     return static_cast<uint32_t>(wBase_ - buffer_);
   }
@@ -719,11 +719,11 @@ protected:
   // Compute the position and available data for reading.
   void computeRead(uint32_t len, uint8_t** out_start, uint32_t* out_give);
 
-  uint32_t readSlow(uint8_t* buf, uint32_t len);
+  uint32_t readSlow(uint8_t* buf, uint32_t len) override;
 
-  void writeSlow(const uint8_t* buf, uint32_t len);
+  void writeSlow(const uint8_t* buf, uint32_t len) override;
 
-  const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len);
+  const uint8_t* borrowSlow(uint8_t* buf, uint32_t* len) override;
 
   // Data buffer
   uint8_t* buffer_;

--- a/lib/cpp/src/thrift/transport/TFDTransport.h
+++ b/lib/cpp/src/thrift/transport/TFDTransport.h
@@ -43,7 +43,7 @@ public:
   TFDTransport(int fd, ClosePolicy close_policy = NO_CLOSE_ON_DESTROY)
     : fd_(fd), close_policy_(close_policy) {}
 
-  ~TFDTransport() {
+  ~TFDTransport() override {
     if (close_policy_ == CLOSE_ON_DESTROY) {
       try {
         close();
@@ -55,9 +55,9 @@ public:
 
   bool isOpen() { return fd_ >= 0; }
 
-  void open() {}
+  void open() override {}
 
-  void close();
+  void close() override;
 
   uint32_t read(uint8_t* buf, uint32_t len);
 

--- a/lib/cpp/src/thrift/transport/TFileTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TFileTransport.cpp
@@ -422,9 +422,9 @@ void TFileTransport::writerThread() {
           if (chunk1 != chunk2) {
             // refetch the offset to keep in sync
             offset_ = THRIFT_LSEEK(fd_, 0, SEEK_CUR);
-            int32_t padding = (int32_t)((offset_ / chunkSize_ + 1) * chunkSize_ - offset_);
+            auto padding = (int32_t)((offset_ / chunkSize_ + 1) * chunkSize_ - offset_);
 
-            uint8_t* zeros = new uint8_t[padding];
+            auto* zeros = new uint8_t[padding];
             memset(zeros, '\0', padding);
             boost::scoped_array<uint8_t> array(zeros);
             if (-1 == ::write(fd_, zeros, padding)) {

--- a/lib/cpp/src/thrift/transport/TFileTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TFileTransport.cpp
@@ -65,8 +65,8 @@ using namespace apache::thrift::concurrency;
 
 TFileTransport::TFileTransport(string path, bool readOnly)
   : readState_(),
-    readBuff_(NULL),
-    currentEvent_(NULL),
+    readBuff_(nullptr),
+    currentEvent_(nullptr),
     readBuffSize_(DEFAULT_READ_BUFF_SIZE),
     readTimeout_(NO_TAIL_READ_TIMEOUT),
     chunkSize_(DEFAULT_CHUNK_SIZE),
@@ -78,8 +78,8 @@ TFileTransport::TFileTransport(string path, bool readOnly)
     eofSleepTime_(DEFAULT_EOF_SLEEP_TIME_US),
     corruptedEventSleepTime_(DEFAULT_CORRUPTED_SLEEP_TIME_US),
     writerThreadIOErrorSleepTime_(DEFAULT_WRITER_THREAD_SLEEP_TIME_US),
-    dequeueBuffer_(NULL),
-    enqueueBuffer_(NULL),
+    dequeueBuffer_(nullptr),
+    enqueueBuffer_(nullptr),
     notFull_(&mutex_),
     notEmpty_(&mutex_),
     closing_(false),
@@ -141,22 +141,22 @@ TFileTransport::~TFileTransport() {
 
   if (dequeueBuffer_) {
     delete dequeueBuffer_;
-    dequeueBuffer_ = NULL;
+    dequeueBuffer_ = nullptr;
   }
 
   if (enqueueBuffer_) {
     delete enqueueBuffer_;
-    enqueueBuffer_ = NULL;
+    enqueueBuffer_ = nullptr;
   }
 
   if (readBuff_) {
     delete[] readBuff_;
-    readBuff_ = NULL;
+    readBuff_ = nullptr;
   }
 
   if (currentEvent_) {
     delete currentEvent_;
-    currentEvent_ = NULL;
+    currentEvent_ = nullptr;
   }
 
   // close logfile
@@ -275,7 +275,7 @@ bool TFileTransport::swapEventBuffers(const std::chrono::time_point<std::chrono:
     // return immediately if the transport is closing
     swap = false;
   } else {
-    if (deadline != NULL) {
+    if (deadline != nullptr) {
       // if we were handed a deadline time struct, do a timed wait
       notEmpty_.waitForTime(*deadline);
     } else {
@@ -362,7 +362,7 @@ void TFileTransport::writerThread() {
 
     if (swapEventBuffers(&ts_next_flush)) {
       eventInfo* outEvent;
-      while (NULL != (outEvent = dequeueBuffer_->getNext())) {
+      while (nullptr != (outEvent = dequeueBuffer_->getNext())) {
         // Remove an event from the buffer and write it out to disk. If there is any IO error, for
         // instance,
         // the output file is unmounted or deleted, then this event is dropped. However, the writer
@@ -587,7 +587,7 @@ uint32_t TFileTransport::read(uint8_t* buf, uint32_t len) {
       memcpy(buf, currentEvent_->eventBuff_ + currentEvent_->eventBuffPos_, remaining);
     }
     delete (currentEvent_);
-    currentEvent_ = NULL;
+    currentEvent_ = nullptr;
     return remaining;
   }
 
@@ -630,12 +630,12 @@ eventInfo* TFileTransport::readEvent() {
         } else if (readTimeout_ == NO_TAIL_READ_TIMEOUT) {
           // reset state
           readState_.resetState(0);
-          return NULL;
+          return nullptr;
         } else if (readTimeout_ > 0) {
           // timeout already expired once
           if (readTries > 0) {
             readState_.resetState(0);
-            return NULL;
+            return nullptr;
           } else {
             THRIFT_SLEEP_USEC(readTimeout_ * 1000);
             readTries++;
@@ -709,7 +709,7 @@ eventInfo* TFileTransport::readEvent() {
           eventInfo* completeEvent = readState_.event_;
           completeEvent->eventBuffPos_ = 0;
 
-          readState_.event_ = NULL;
+          readState_.event_ = nullptr;
           readState_.resetState(readState_.bufferPtr_);
 
           // exit criteria
@@ -778,7 +778,7 @@ void TFileTransport::performRecovery() {
       // pretty hosed at this stage, rewind the file back to the last successful
       // point and punt on the error
       readState_.resetState(readState_.lastDispatchPtr_);
-      currentEvent_ = NULL;
+      currentEvent_ = nullptr;
       char errorMsg[1024];
       sprintf(errorMsg,
               "TFileTransport: log file corrupted at offset: %lu",
@@ -827,7 +827,7 @@ void TFileTransport::seekToChunk(int32_t chunk) {
   off_t newOffset = off_t(chunk) * chunkSize_;
   offset_ = ::THRIFT_LSEEK(fd_, newOffset, SEEK_SET);
   readState_.resetAllValues();
-  currentEvent_ = NULL;
+  currentEvent_ = nullptr;
   if (offset_ == -1) {
     GlobalOutput("TFileTransport: lseek error in seekToChunk");
     throw TTransportException("TFileTransport: lseek error in seekToChunk");
@@ -841,7 +841,7 @@ void TFileTransport::seekToChunk(int32_t chunk) {
     shared_ptr<eventInfo> event;
     while ((offset_ + readState_.bufferPtr_) < minEndOffset) {
       event.reset(readEvent());
-      if (event.get() == NULL) {
+      if (event.get() == nullptr) {
         break;
       }
     }
@@ -918,7 +918,7 @@ TFileTransportBuffer::~TFileTransportBuffer() {
       delete buffer_[i];
     }
     delete[] buffer_;
-    buffer_ = NULL;
+    buffer_ = nullptr;
   }
 }
 
@@ -943,7 +943,7 @@ eventInfo* TFileTransportBuffer::getNext() {
     return buffer_[readPoint_++];
   } else {
     // no more entries
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -1020,7 +1020,7 @@ void TFileProcessor::process(uint32_t numEvents, bool tail) {
     // bad form to use exceptions for flow control but there is really
     // no other way around it
     try {
-      processor_->process(inputProtocol, outputProtocol, NULL);
+      processor_->process(inputProtocol, outputProtocol, nullptr);
       numProcessed++;
       if ((numEvents > 0) && (numProcessed == numEvents)) {
         return;
@@ -1051,7 +1051,7 @@ void TFileProcessor::processChunk() {
     // bad form to use exceptions for flow control but there is really
     // no other way around it
     try {
-      processor_->process(inputProtocol, outputProtocol, NULL);
+      processor_->process(inputProtocol, outputProtocol, nullptr);
       if (curChunk != inputTransport_->getCurChunk()) {
         break;
       }

--- a/lib/cpp/src/thrift/transport/TFileTransport.h
+++ b/lib/cpp/src/thrift/transport/TFileTransport.h
@@ -174,24 +174,24 @@ public:
 class TFileTransport : public TFileReaderTransport, public TFileWriterTransport {
 public:
   TFileTransport(std::string path, bool readOnly = false);
-  ~TFileTransport();
+  ~TFileTransport() override;
 
   // TODO: what is the correct behaviour for this?
   // the log file is generally always open
   bool isOpen() const override { return true; }
 
   void write(const uint8_t* buf, uint32_t len);
-  void flush();
+  void flush() override;
 
   uint32_t readAll(uint8_t* buf, uint32_t len);
   uint32_t read(uint8_t* buf, uint32_t len);
   bool peek() override;
 
   // log-file specific functions
-  void seekToChunk(int32_t chunk);
-  void seekToEnd();
-  uint32_t getNumChunks();
-  uint32_t getCurChunk();
+  void seekToChunk(int32_t chunk) override;
+  void seekToEnd() override;
+  uint32_t getNumChunks() override;
+  uint32_t getCurChunk() override;
 
   // for changing the output file
   void resetOutputFile(int fd, std::string filename, off_t offset);
@@ -206,15 +206,15 @@ public:
 
   static const int32_t TAIL_READ_TIMEOUT = -1;
   static const int32_t NO_TAIL_READ_TIMEOUT = 0;
-  void setReadTimeout(int32_t readTimeout) { readTimeout_ = readTimeout; }
-  int32_t getReadTimeout() { return readTimeout_; }
+  void setReadTimeout(int32_t readTimeout) override { readTimeout_ = readTimeout; }
+  int32_t getReadTimeout() override { return readTimeout_; }
 
-  void setChunkSize(uint32_t chunkSize) {
+  void setChunkSize(uint32_t chunkSize) override {
     if (chunkSize) {
       chunkSize_ = chunkSize;
     }
   }
-  uint32_t getChunkSize() { return chunkSize_; }
+  uint32_t getChunkSize() override { return chunkSize_; }
 
   void setEventBufferSize(uint32_t bufferSize) {
     if (bufferAndThreadInitialized_) {

--- a/lib/cpp/src/thrift/transport/TFileTransport.h
+++ b/lib/cpp/src/thrift/transport/TFileTransport.h
@@ -48,7 +48,7 @@ typedef struct eventInfo {
   uint32_t eventSize_;
   uint32_t eventBuffPos_;
 
-  eventInfo() : eventBuff_(NULL), eventSize_(0), eventBuffPos_(0){};
+  eventInfo() : eventBuff_(nullptr), eventSize_(0), eventBuffPos_(0){};
   ~eventInfo() {
     if (eventBuff_) {
       delete[] eventBuff_;
@@ -85,7 +85,7 @@ typedef struct readState {
     if (event_) {
       delete (event_);
     }
-    event_ = 0;
+    event_ = nullptr;
   }
 
   inline uint32_t getEventSize() {
@@ -94,7 +94,7 @@ typedef struct readState {
   }
 
   readState() {
-    event_ = 0;
+    event_ = nullptr;
     resetAllValues();
   }
 
@@ -273,7 +273,7 @@ private:
   // control for writer thread
   static void* startWriterThread(void* ptr) {
     static_cast<TFileTransport*>(ptr)->writerThread();
-    return NULL;
+    return nullptr;
   }
   void writerThread();
 

--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
@@ -197,7 +197,7 @@ void THeaderTransport::readHeaderFormat(uint16_t headerSize, uint32_t sz) {
   readHeaders_.clear(); // Clear out any previous headers.
 
   // skip over already processed magic(4), seqId(4), headerSize(2)
-  uint8_t* ptr = reinterpret_cast<uint8_t*>(rBuf_.get() + 10);
+  auto* ptr = reinterpret_cast<uint8_t*>(rBuf_.get() + 10);
 
   // Catch integer overflow, check for reasonable header size
   if (headerSize >= 16384) {
@@ -317,7 +317,7 @@ void THeaderTransport::untransform(uint8_t* ptr, uint32_t sz) {
 void THeaderTransport::resizeTransformBuffer(uint32_t additionalSize) {
   if (tBufSize_ < wBufSize_ + DEFAULT_BUFFER_SIZE) {
     uint32_t new_size = wBufSize_ + DEFAULT_BUFFER_SIZE + additionalSize;
-    uint8_t* new_buf = new uint8_t[new_size];
+    auto* new_buf = new uint8_t[new_size];
     tBuf_.reset(new_buf);
     tBufSize_ = new_size;
   }
@@ -389,7 +389,7 @@ uint32_t THeaderTransport::getWriteBytes() {
  * Automatically advances ptr to after the written portion
  */
 void THeaderTransport::writeString(uint8_t*& ptr, const string& str) {
-  int32_t strLen = safe_numeric_cast<int32_t>(str.length());
+  auto strLen = safe_numeric_cast<int32_t>(str.length());
   ptr += writeVarint32(strLen, ptr);
   memcpy(ptr, str.c_str(), strLen); // no need to write \0
   ptr += strLen;
@@ -484,7 +484,7 @@ void THeaderTransport::flush() {
     // write info headers
 
     // for now only write kv-headers
-    int32_t headerCount = safe_numeric_cast<int32_t>(writeHeaders_.size());
+    auto headerCount = safe_numeric_cast<int32_t>(writeHeaders_.size());
     if (headerCount > 0) {
       pkt += writeVarint32(infoIdType::KEYVALUE, pkt);
       // Write key-value headers count
@@ -526,7 +526,7 @@ void THeaderTransport::flush() {
     outTransport_->write(pktStart, szHbo - haveBytes + 4);
     outTransport_->write(wBuf_.get(), haveBytes);
   } else if (clientType == THRIFT_FRAMED_BINARY || clientType == THRIFT_FRAMED_COMPACT) {
-    uint32_t szHbo = (uint32_t)haveBytes;
+    auto szHbo = (uint32_t)haveBytes;
     uint32_t szNbo = htonl(szHbo);
 
     outTransport_->write(reinterpret_cast<uint8_t*>(&szNbo), 4);

--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
@@ -275,9 +275,9 @@ void THeaderTransport::untransform(uint8_t* ptr, uint32_t sz) {
       stream.avail_in = sz;
 
       // Setting these to 0 means use the default free/alloc functions
-      stream.zalloc = (alloc_func)0;
-      stream.zfree = (free_func)0;
-      stream.opaque = (voidpf)0;
+      stream.zalloc = (alloc_func)nullptr;
+      stream.zfree = (free_func)nullptr;
+      stream.opaque = (voidpf)nullptr;
       err = inflateInit(&stream);
       if (err != Z_OK) {
         throw TApplicationException(TApplicationException::MISSING_RESULT,
@@ -337,9 +337,9 @@ void THeaderTransport::transform(uint8_t* ptr, uint32_t sz) {
       stream.next_in = ptr;
       stream.avail_in = sz;
 
-      stream.zalloc = (alloc_func)0;
-      stream.zfree = (free_func)0;
-      stream.opaque = (voidpf)0;
+      stream.zalloc = (alloc_func)nullptr;
+      stream.zfree = (free_func)nullptr;
+      stream.opaque = (voidpf)nullptr;
       err = deflateInit(&stream, Z_DEFAULT_COMPRESSION);
       if (err != Z_OK) {
         throw TTransportException(TTransportException::CORRUPTED_DATA,

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -82,7 +82,7 @@ public:
       seqId(0),
       flags(0),
       tBufSize_(0),
-      tBuf_(NULL) {
+      tBuf_(nullptr) {
     if (!transport_) throw std::invalid_argument("transport is empty");
     initBuffers();
   }
@@ -96,7 +96,7 @@ public:
       seqId(0),
       flags(0),
       tBufSize_(0),
-      tBuf_(NULL) {
+      tBuf_(nullptr) {
     if (!transport_) throw std::invalid_argument("inTransport is empty");
     if (!outTransport_) throw std::invalid_argument("outTransport is empty");
     initBuffers();
@@ -181,7 +181,7 @@ protected:
   uint32_t getWriteBytes();
 
   void initBuffers() {
-    setReadBuffer(NULL, 0);
+    setReadBuffer(nullptr, 0);
     setWriteBuffer(wBuf_.get(), wBufSize_);
   }
 

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -102,7 +102,7 @@ public:
     initBuffers();
   }
 
-  virtual uint32_t readSlow(uint8_t* buf, uint32_t len);
+  uint32_t readSlow(uint8_t* buf, uint32_t len) override;
   void flush() override;
 
   void resizeTransformBuffer(uint32_t additionalSize = 0);
@@ -175,7 +175,7 @@ protected:
    * Returns true if a frame was read successfully, or false on EOF.
    * (Raises a TTransportException if EOF occurs after a partial frame.)
    */
-  virtual bool readFrame();
+  bool readFrame() override;
 
   void ensureReadBuffer(uint32_t sz);
   uint32_t getWriteBytes();
@@ -259,7 +259,7 @@ class THeaderTransportFactory : public TTransportFactory {
 public:
   THeaderTransportFactory() {}
 
-  virtual ~THeaderTransportFactory() {}
+  ~THeaderTransportFactory() override {}
 
   /**
    * Wraps the transport into a header one.

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -257,9 +257,9 @@ protected:
  */
 class THeaderTransportFactory : public TTransportFactory {
 public:
-  THeaderTransportFactory() {}
+  THeaderTransportFactory() = default;
 
-  ~THeaderTransportFactory() override {}
+  ~THeaderTransportFactory() override = default;
 
   /**
    * Wraps the transport into a header one.

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -44,8 +44,7 @@ THttpClient::THttpClient(string host, int port, string path)
     path_(path) {
 }
 
-THttpClient::~THttpClient() {
-}
+THttpClient::~THttpClient() = default;
 
 void THttpClient::parseHeader(char* header) {
   char* colon = strchr(header, ':');

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -49,7 +49,7 @@ THttpClient::~THttpClient() {
 
 void THttpClient::parseHeader(char* header) {
   char* colon = strchr(header, ':');
-  if (colon == NULL) {
+  if (colon == nullptr) {
     return;
   }
   char* value = colon + 1;
@@ -68,7 +68,7 @@ bool THttpClient::parseStatusLine(char* status) {
   char* http = status;
 
   char* code = strchr(http, ' ');
-  if (code == NULL) {
+  if (code == nullptr) {
     throw TTransportException(string("Bad Status: ") + status);
   }
 
@@ -77,7 +77,7 @@ bool THttpClient::parseStatusLine(char* status) {
   };
 
   char* msg = strchr(code, ' ');
-  if (msg == NULL) {
+  if (msg == nullptr) {
     throw TTransportException(string("Bad Status: ") + status);
   }
   *msg = '\0';

--- a/lib/cpp/src/thrift/transport/THttpClient.h
+++ b/lib/cpp/src/thrift/transport/THttpClient.h
@@ -32,7 +32,7 @@ public:
 
   THttpClient(std::string host, int port, std::string path = "");
 
-  virtual ~THttpClient();
+  ~THttpClient() override;
 
   void flush() override;
 
@@ -40,8 +40,8 @@ protected:
   std::string host_;
   std::string path_;
 
-  virtual void parseHeader(char* header);
-  virtual bool parseStatusLine(char* status);
+  void parseHeader(char* header) override;
+  bool parseStatusLine(char* status) override;
 };
 }
 }

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -52,14 +52,14 @@ THttpServer::~THttpServer() {
 
 void THttpServer::parseHeader(char* header) {
   char* colon = strchr(header, ':');
-  if (colon == NULL) {
+  if (colon == nullptr) {
     return;
   }
   size_t sz = colon - header;
   char* value = colon + 1;
 
   if (THRIFT_strncasecmp(header, "Transfer-Encoding", sz) == 0) {
-    if (THRIFT_strcasestr(value, "chunked") != NULL) {
+    if (THRIFT_strcasestr(value, "chunked") != nullptr) {
       chunked_ = true;
     }
   } else if (THRIFT_strncasecmp(header, "Content-length", sz) == 0) {
@@ -74,7 +74,7 @@ bool THttpServer::parseStatusLine(char* status) {
   char* method = status;
 
   char* path = strchr(method, ' ');
-  if (path == NULL) {
+  if (path == nullptr) {
     throw TTransportException(string("Bad Status: ") + status);
   }
 
@@ -83,7 +83,7 @@ bool THttpServer::parseStatusLine(char* status) {
   };
 
   char* http = strchr(path, ' ');
-  if (http == NULL) {
+  if (http == nullptr) {
     throw TTransportException(string("Bad Status: ") + status);
   }
   *http = '\0';
@@ -149,7 +149,7 @@ std::string THttpServer::getTimeRFC1123() {
       = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
   char buff[128];
 
-  time_t t = time(NULL);
+  time_t t = time(nullptr);
   struct tm tmb;
   THRIFT_GMTIME(tmb, t);
 

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -37,8 +37,7 @@ namespace transport {
 THttpServer::THttpServer(std::shared_ptr<TTransport> transport) : THttpTransport(transport) {
 }
 
-THttpServer::~THttpServer() {
-}
+THttpServer::~THttpServer() = default;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
   #define THRIFT_GMTIME(TM, TIME)             gmtime_s(&TM, &TIME)

--- a/lib/cpp/src/thrift/transport/THttpServer.h
+++ b/lib/cpp/src/thrift/transport/THttpServer.h
@@ -30,14 +30,14 @@ class THttpServer : public THttpTransport {
 public:
   THttpServer(std::shared_ptr<TTransport> transport);
 
-  virtual ~THttpServer();
+  ~THttpServer() override;
 
   void flush() override;
 
 protected:
   void readHeaders();
-  virtual void parseHeader(char* header);
-  virtual bool parseStatusLine(char* status);
+  void parseHeader(char* header) override;
+  bool parseStatusLine(char* status) override;
   std::string getTimeRFC1123();
 };
 
@@ -48,7 +48,7 @@ class THttpServerTransportFactory : public TTransportFactory {
 public:
   THttpServerTransportFactory() {}
 
-  virtual ~THttpServerTransportFactory() {}
+  ~THttpServerTransportFactory() override {}
 
   /**
    * Wraps the transport into a buffered one.

--- a/lib/cpp/src/thrift/transport/THttpServer.h
+++ b/lib/cpp/src/thrift/transport/THttpServer.h
@@ -46,9 +46,9 @@ protected:
  */
 class THttpServerTransportFactory : public TTransportFactory {
 public:
-  THttpServerTransportFactory() {}
+  THttpServerTransportFactory() = default;
 
-  ~THttpServerTransportFactory() override {}
+  ~THttpServerTransportFactory() override = default;
 
   /**
    * Wraps the transport into a buffered one.

--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -257,7 +257,7 @@ void THttpTransport::write(const uint8_t* buf, uint32_t len) {
   writeBuffer_.write(buf, len);
 }
 
-const std::string THttpTransport::getOrigin() {
+const std::string THttpTransport::getOrigin() const {
   std::ostringstream oss;
   if (!origin_.empty()) {
     oss << origin_ << ", ";

--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -39,7 +39,7 @@ THttpTransport::THttpTransport(std::shared_ptr<TTransport> transport)
     chunkedDone_(false),
     chunkSize_(0),
     contentLength_(0),
-    httpBuf_(NULL),
+    httpBuf_(nullptr),
     httpPos_(0),
     httpBufLen_(0),
     httpBufSize_(1024) {
@@ -48,14 +48,14 @@ THttpTransport::THttpTransport(std::shared_ptr<TTransport> transport)
 
 void THttpTransport::init() {
   httpBuf_ = (char*)std::malloc(httpBufSize_ + 1);
-  if (httpBuf_ == NULL) {
+  if (httpBuf_ == nullptr) {
     throw std::bad_alloc();
   }
   httpBuf_[httpBufLen_] = '\0';
 }
 
 THttpTransport::~THttpTransport() {
-  if (httpBuf_ != NULL) {
+  if (httpBuf_ != nullptr) {
     std::free(httpBuf_);
   }
 }
@@ -132,7 +132,7 @@ void THttpTransport::readChunkedFooters() {
 
 uint32_t THttpTransport::parseChunkSize(char* line) {
   char* semi = strchr(line, ';');
-  if (semi != NULL) {
+  if (semi != nullptr) {
     *semi = '\0';
   }
   uint32_t size = 0;
@@ -166,12 +166,12 @@ uint32_t THttpTransport::readContent(uint32_t size) {
 
 char* THttpTransport::readLine() {
   while (true) {
-    char* eol = NULL;
+    char* eol = nullptr;
 
     eol = strstr(httpBuf_ + httpPos_, CRLF);
 
     // No CRLF yet?
-    if (eol == NULL) {
+    if (eol == nullptr) {
       // Shift whatever we have now to front and refill
       shift();
       refill();
@@ -203,7 +203,7 @@ void THttpTransport::refill() {
   if (avail <= (httpBufSize_ / 4)) {
     httpBufSize_ *= 2;
     char* tmpBuf = (char*)std::realloc(httpBuf_, httpBufSize_ + 1);
-    if (tmpBuf == NULL) {
+    if (tmpBuf == nullptr) {
       throw std::bad_alloc();
     }
     httpBuf_ = tmpBuf;

--- a/lib/cpp/src/thrift/transport/THttpTransport.h
+++ b/lib/cpp/src/thrift/transport/THttpTransport.h
@@ -56,7 +56,7 @@ public:
 
   void flush() override = 0;
 
-  const std::string getOrigin() override;
+  const std::string getOrigin() const override;
 
 protected:
   std::shared_ptr<TTransport> transport_;

--- a/lib/cpp/src/thrift/transport/THttpTransport.h
+++ b/lib/cpp/src/thrift/transport/THttpTransport.h
@@ -38,25 +38,25 @@ class THttpTransport : public TVirtualTransport<THttpTransport> {
 public:
   THttpTransport(std::shared_ptr<TTransport> transport);
 
-  virtual ~THttpTransport();
+  ~THttpTransport() override;
 
-  void open() { transport_->open(); }
+  void open() override { transport_->open(); }
 
   bool isOpen() { return transport_->isOpen(); }
 
-  bool peek() { return transport_->peek(); }
+  bool peek() override { return transport_->peek(); }
 
-  void close() { transport_->close(); }
+  void close() override { transport_->close(); }
 
   uint32_t read(uint8_t* buf, uint32_t len);
 
-  uint32_t readEnd();
+  uint32_t readEnd() override;
 
   void write(const uint8_t* buf, uint32_t len);
 
-  virtual void flush() = 0;
+  void flush() override = 0;
 
-  virtual const std::string getOrigin();
+  const std::string getOrigin() override;
 
 protected:
   std::shared_ptr<TTransport> transport_;

--- a/lib/cpp/src/thrift/transport/TNonblockingSSLServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TNonblockingSSLServerSocket.h
@@ -66,7 +66,7 @@ public:
                    std::shared_ptr<TSSLSocketFactory> factory);
 
 protected:
-  std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET socket);
+  std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET socket) override;
   std::shared_ptr<TSSLSocketFactory> factory_;
 };
 }

--- a/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
@@ -193,7 +193,7 @@ void TNonblockingServerSocket::listen() {
   hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
 
   // If address is not specified use wildcard address (NULL)
-  TGetAddrInfoWrapper info(address_.empty() ? NULL : &address_[0], port, &hints);
+  TGetAddrInfoWrapper info(address_.empty() ? nullptr : &address_[0], port, &hints);
 
   error = info.init();
   if (error) {
@@ -206,13 +206,13 @@ void TNonblockingServerSocket::listen() {
   // Pick the ipv6 address first since ipv4 addresses can be mapped
   // into ipv6 space.
   for (res = info.res(); res; res = res->ai_next) {
-    if (res->ai_family == AF_INET6 || res->ai_next == NULL)
+    if (res->ai_family == AF_INET6 || res->ai_next == nullptr)
       break;
   }
 
   if (!path_.empty()) {
     serverSocket_ = socket(PF_UNIX, SOCK_STREAM, IPPROTO_IP);
-  } else if (res != NULL) {
+  } else if (res != nullptr) {
     serverSocket_ = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
   }
 
@@ -372,7 +372,7 @@ void TNonblockingServerSocket::listen() {
 
     // Unix Domain Socket
     size_t len = path_.size() + 1;
-    if (len > sizeof(((sockaddr_un*)NULL)->sun_path)) {
+    if (len > sizeof(((sockaddr_un*)nullptr)->sun_path)) {
       errno_copy = THRIFT_GET_SOCKET_ERROR;
       GlobalOutput.perror("TSocket::listen() Unix Domain socket path too long", errno_copy);
       throw TTransportException(TTransportException::NOT_OPEN,

--- a/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
@@ -384,7 +384,7 @@ void TNonblockingServerSocket::listen() {
     address.sun_family = AF_UNIX;
     memcpy(address.sun_path, path_.c_str(), len);
 
-    socklen_t structlen = static_cast<socklen_t>(sizeof(address));
+    auto structlen = static_cast<socklen_t>(sizeof(address));
 
     if (!address.sun_path[0]) { // abstract namespace socket
 #ifdef __linux__
@@ -428,10 +428,10 @@ void TNonblockingServerSocket::listen() {
         GlobalOutput.perror("TNonblockingServerSocket::getPort() getsockname() ", errno_copy);
       } else {
         if (sa.ss_family == AF_INET6) {
-          const struct sockaddr_in6* sin = reinterpret_cast<const struct sockaddr_in6*>(&sa);
+          const auto* sin = reinterpret_cast<const struct sockaddr_in6*>(&sa);
           listenPort_ = ntohs(sin->sin6_port);
         } else {
-          const struct sockaddr_in* sin = reinterpret_cast<const struct sockaddr_in*>(&sa);
+          const auto* sin = reinterpret_cast<const struct sockaddr_in*>(&sa);
           listenPort_ = ntohs(sin->sin_port);
         }
       }

--- a/lib/cpp/src/thrift/transport/TNonblockingServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerSocket.h
@@ -71,7 +71,7 @@ public:
    */
   TNonblockingServerSocket(const std::string& path);
 
-  virtual ~TNonblockingServerSocket();
+  ~TNonblockingServerSocket() override;
 
   void setSendTimeout(int sendTimeout);
   void setRecvTimeout(int recvTimeout);
@@ -97,17 +97,17 @@ public:
   // socket, this is the place to do it.
   void setAcceptCallback(const socket_func_t& acceptCallback) { acceptCallback_ = acceptCallback; }
 
-  THRIFT_SOCKET getSocketFD() { return serverSocket_; }
+  THRIFT_SOCKET getSocketFD() override { return serverSocket_; }
 
-  int getPort();
+  int getPort() override;
   
-  int getListenPort();
+  int getListenPort() override;
 
   void listen() override;
   void close() override;
 
 protected:
-  std::shared_ptr<TSocket> acceptImpl();
+  std::shared_ptr<TSocket> acceptImpl() override;
   virtual std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET client);
 
 private:

--- a/lib/cpp/src/thrift/transport/TNonblockingServerTransport.h
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerTransport.h
@@ -35,7 +35,7 @@ namespace transport {
  */
 class TNonblockingServerTransport {
 public:
-  virtual ~TNonblockingServerTransport() {}
+  virtual ~TNonblockingServerTransport() = default;
 
   /**
    * Starts the server transport listening for new connections. Prior to this
@@ -82,7 +82,7 @@ public:
   virtual void close() = 0;
 
 protected:
-  TNonblockingServerTransport() {}
+  TNonblockingServerTransport() = default;
 
   /**
    * Subclasses should implement this function for accept.

--- a/lib/cpp/src/thrift/transport/TSSLServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLServerSocket.h
@@ -66,7 +66,7 @@ public:
                    std::shared_ptr<TSSLSocketFactory> factory);
 
 protected:
-  std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET socket);
+  std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET socket) override;
   std::shared_ptr<TSSLSocketFactory> factory_;
 };
 }

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -95,7 +95,7 @@ static CRYPTO_dynlock_value* dyn_create(const char*, int) {
 }
 
 static void dyn_lock(int mode, struct CRYPTO_dynlock_value* lock, const char*, int) {
-  if (lock != NULL) {
+  if (lock != nullptr) {
     if (mode & CRYPTO_LOCK) {
       lock->mutex.lock();
     } else {
@@ -180,7 +180,7 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
     throw TSSLException("SSL_CTX_new: Unknown protocol");
   }
 
-  if (ctx_ == NULL) {
+  if (ctx_ == nullptr) {
     string errors;
     buildErrors(errors);
     throw TSSLException("SSL_CTX_new: " + errors);
@@ -196,15 +196,15 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
 }
 
 SSLContext::~SSLContext() {
-  if (ctx_ != NULL) {
+  if (ctx_ != nullptr) {
     SSL_CTX_free(ctx_);
-    ctx_ = NULL;
+    ctx_ = nullptr;
   }
 }
 
 SSL* SSLContext::createSSL() {
   SSL* ssl = SSL_new(ctx_);
-  if (ssl == NULL) {
+  if (ssl == nullptr) {
     string errors;
     buildErrors(errors);
     throw TSSLException("SSL_new: " + errors);
@@ -214,33 +214,33 @@ SSL* SSLContext::createSSL() {
 
 // TSSLSocket implementation
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx)
-  : TSocket(), server_(false), ssl_(NULL), ctx_(ctx) {
+  : TSocket(), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
 }
 
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx, std::shared_ptr<THRIFT_SOCKET> interruptListener)
-        : TSocket(), server_(false), ssl_(NULL), ctx_(ctx) {
+        : TSocket(), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
   interruptListener_ = interruptListener;
 }
 
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx, THRIFT_SOCKET socket)
-  : TSocket(socket), server_(false), ssl_(NULL), ctx_(ctx) {
+  : TSocket(socket), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
 }
 
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx, THRIFT_SOCKET socket, std::shared_ptr<THRIFT_SOCKET> interruptListener)
-        : TSocket(socket, interruptListener), server_(false), ssl_(NULL), ctx_(ctx) {
+        : TSocket(socket, interruptListener), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
 }
 
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx, string host, int port)
-  : TSocket(host, port), server_(false), ssl_(NULL), ctx_(ctx) {
+  : TSocket(host, port), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
 }
 
 TSSLSocket::TSSLSocket(std::shared_ptr<SSLContext> ctx, string host, int port, std::shared_ptr<THRIFT_SOCKET> interruptListener)
-        : TSocket(host, port), server_(false), ssl_(NULL), ctx_(ctx) {
+        : TSocket(host, port), server_(false), ssl_(nullptr), ctx_(ctx) {
   init();
   interruptListener_ = interruptListener;
 }
@@ -267,7 +267,7 @@ void TSSLSocket::init() {
 }
 
 bool TSSLSocket::isOpen() {
-  if (ssl_ == NULL || !TSocket::isOpen()) {
+  if (ssl_ == nullptr || !TSocket::isOpen()) {
     return false;
   }
   int shutdown = SSL_get_shutdown(ssl_);
@@ -334,7 +334,7 @@ void TSSLSocket::open() {
  * Note: This method is not libevent safe.
 */
 void TSSLSocket::close() {
-  if (ssl_ != NULL) {
+  if (ssl_ != nullptr) {
     try {
       int rc;
       int errno_copy = 0;
@@ -375,7 +375,7 @@ void TSSLSocket::close() {
       GlobalOutput.printf("SSL_shutdown: %s", te.what());
     }
     SSL_free(ssl_);
-    ssl_ = NULL;
+    ssl_ = nullptr;
     handshakeCompleted_ = false;
     ERR_remove_state(0);
   }
@@ -552,14 +552,14 @@ uint32_t TSSLSocket::write_partial(const uint8_t* buf, uint32_t len) {
 
 void TSSLSocket::flush() {
   // Don't throw exception if not open. Thrift servers close socket twice.
-  if (ssl_ == NULL) {
+  if (ssl_ == nullptr) {
     return;
   }
   initializeHandshake();
   if (!checkHandshake())
     throw TSSLException("BIO_flush: Handshake is not completed");
   BIO* bio = SSL_get_wbio(ssl_);
-  if (bio == NULL) {
+  if (bio == nullptr) {
     throw TSSLException("SSL_get_wbio returns NULL");
   }
   if (BIO_flush(bio) != 1) {
@@ -597,7 +597,7 @@ void TSSLSocket::initializeHandshake() {
     return;
   }
 
-  if (ssl_ == NULL) {
+  if (ssl_ == nullptr) {
     initializeHandshakeParams();
   }
 
@@ -683,19 +683,19 @@ void TSSLSocket::authorize() {
   }
 
   X509* cert = SSL_get_peer_certificate(ssl_);
-  if (cert == NULL) {
+  if (cert == nullptr) {
     // certificate is not present
     if (SSL_get_verify_mode(ssl_) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) {
       throw TSSLException("authorize: required certificate not present");
     }
     // certificate was optional: didn't intend to authorize remote
-    if (server() && access_ != NULL) {
+    if (server() && access_ != nullptr) {
       throw TSSLException("authorize: certificate required for authorization");
     }
     return;
   }
   // certificate is present
-  if (access_ == NULL) {
+  if (access_ == nullptr) {
     X509_free(cert);
     return;
   }
@@ -721,12 +721,12 @@ void TSSLSocket::authorize() {
 
   // extract subjectAlternativeName
   auto* alternatives
-      = (STACK_OF(GENERAL_NAME)*)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
-  if (alternatives != NULL) {
+      = (STACK_OF(GENERAL_NAME)*)X509_get_ext_d2i(cert, NID_subject_alt_name, nullptr, nullptr);
+  if (alternatives != nullptr) {
     const int count = sk_GENERAL_NAME_num(alternatives);
     for (int i = 0; decision == AccessManager::SKIP && i < count; i++) {
       const GENERAL_NAME* name = sk_GENERAL_NAME_value(alternatives, i);
-      if (name == NULL) {
+      if (name == nullptr) {
         continue;
       }
       char* data = (char*)ASN1_STRING_data(name->d.ia5);
@@ -756,7 +756,7 @@ void TSSLSocket::authorize() {
 
   // extract commonName
   X509_NAME* name = X509_get_subject_name(cert);
-  if (name != NULL) {
+  if (name != nullptr) {
     X509_NAME_ENTRY* entry;
     unsigned char* utf8;
     int last = -1;
@@ -765,7 +765,7 @@ void TSSLSocket::authorize() {
       if (last == -1)
         break;
       entry = X509_NAME_get_entry(name, last);
-      if (entry == NULL)
+      if (entry == nullptr)
         continue;
       ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
       int size = ASN1_STRING_to_UTF8(&utf8, common);
@@ -795,7 +795,7 @@ unsigned int TSSLSocket::waitForEvent(bool wantRead) {
     bio = SSL_get_wbio(ssl_);
   }
 
-  if (bio == NULL) {
+  if (bio == nullptr) {
     throw TSSLException("SSL_get_?bio returned NULL");
   }
 
@@ -908,10 +908,10 @@ std::shared_ptr<TSSLSocket> TSSLSocketFactory::createSocket(const string& host, 
 
 void TSSLSocketFactory::setup(std::shared_ptr<TSSLSocket> ssl) {
   ssl->server(server());
-  if (access_ == NULL && !server()) {
+  if (access_ == nullptr && !server()) {
     access_ = std::shared_ptr<AccessManager>(new DefaultClientAccessManager);
   }
-  if (access_ != NULL) {
+  if (access_ != nullptr) {
     ssl->access(access_);
   }
 }
@@ -935,11 +935,11 @@ void TSSLSocketFactory::authenticate(bool required) {
   } else {
     mode = SSL_VERIFY_NONE;
   }
-  SSL_CTX_set_verify(ctx_->get(), mode, NULL);
+  SSL_CTX_set_verify(ctx_->get(), mode, nullptr);
 }
 
 void TSSLSocketFactory::loadCertificate(const char* path, const char* format) {
-  if (path == NULL || format == NULL) {
+  if (path == nullptr || format == nullptr) {
     throw TTransportException(TTransportException::BAD_ARGS,
                               "loadCertificateChain: either <path> or <format> is NULL");
   }
@@ -956,7 +956,7 @@ void TSSLSocketFactory::loadCertificate(const char* path, const char* format) {
 }
 
 void TSSLSocketFactory::loadPrivateKey(const char* path, const char* format) {
-  if (path == NULL || format == NULL) {
+  if (path == nullptr || format == nullptr) {
     throw TTransportException(TTransportException::BAD_ARGS,
                               "loadPrivateKey: either <path> or <format> is NULL");
   }
@@ -971,7 +971,7 @@ void TSSLSocketFactory::loadPrivateKey(const char* path, const char* format) {
 }
 
 void TSSLSocketFactory::loadTrustedCertificates(const char* path, const char* capath) {
-  if (path == NULL) {
+  if (path == nullptr) {
     throw TTransportException(TTransportException::BAD_ARGS,
                               "loadTrustedCertificates: <path> is NULL");
   }
@@ -1016,7 +1016,7 @@ void buildErrors(string& errors, int errno_copy, int sslerrno) {
       errors += "; ";
     }
     const char* reason = ERR_reason_error_string(errorCode);
-    if (reason == NULL) {
+    if (reason == nullptr) {
       THRIFT_SNPRINTF(message, sizeof(message) - 1, "SSL error # %lu", errorCode);
       reason = message;
     }
@@ -1054,7 +1054,7 @@ Decision DefaultClientAccessManager::verify(const sockaddr_storage& sa) noexcept
 Decision DefaultClientAccessManager::verify(const string& host,
                                             const char* name,
                                             int size) noexcept {
-  if (host.empty() || name == NULL || size <= 0) {
+  if (host.empty() || name == nullptr || size <= 0) {
     return SKIP;
   }
   return (matchName(host.c_str(), name, size) ? ALLOW : SKIP);

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -720,7 +720,7 @@ void TSSLSocket::authorize() {
   }
 
   // extract subjectAlternativeName
-  STACK_OF(GENERAL_NAME)* alternatives
+  auto* alternatives
       = (STACK_OF(GENERAL_NAME)*)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
   if (alternatives != NULL) {
     const int count = sk_GENERAL_NAME_num(alternatives);
@@ -993,7 +993,7 @@ void TSSLSocketFactory::overrideDefaultPasswordCallback() {
 }
 
 int TSSLSocketFactory::passwordCallback(char* password, int size, int, void* data) {
-  TSSLSocketFactory* factory = (TSSLSocketFactory*)data;
+  auto* factory = (TSSLSocketFactory*)data;
   string userPassword;
   factory->getPassword(userPassword, size);
   int length = static_cast<int>(userPassword.size());

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -69,19 +69,19 @@ void cleanupOpenSSL();
  */
 class TSSLSocket : public TSocket {
 public:
-  ~TSSLSocket();
+  ~TSSLSocket() override;
   /**
    * TTransport interface.
    */
   bool isOpen();
-  bool peek();
-  void open();
-  void close();
-  bool hasPendingDataToRead();
-  uint32_t read(uint8_t* buf, uint32_t len);
-  void write(const uint8_t* buf, uint32_t len);
-  uint32_t write_partial(const uint8_t* buf, uint32_t len);
-  void flush();
+  bool peek() override;
+  void open() override;
+  void close() override;
+  bool hasPendingDataToRead() override;
+  uint32_t read(uint8_t* buf, uint32_t len) override;
+  void write(const uint8_t* buf, uint32_t len) override;
+  uint32_t write_partial(const uint8_t* buf, uint32_t len) override;
+  void flush() override;
   /**
   * Set whether to use client or server side SSL handshake protocol.
   *
@@ -334,7 +334,7 @@ public:
   TSSLException(const std::string& message)
     : TTransportException(TTransportException::INTERNAL_ERROR, message) {}
 
-  virtual const char* what() const noexcept {
+  const char* what() const noexcept override {
     if (message_.empty()) {
       return "TSSLException";
     } else {
@@ -425,9 +425,9 @@ typedef AccessManager::Decision Decision;
 class DefaultClientAccessManager : public AccessManager {
 public:
   // AccessManager interface
-  Decision verify(const sockaddr_storage& sa) noexcept;
-  Decision verify(const std::string& host, const char* name, int size) noexcept;
-  Decision verify(const sockaddr_storage& sa, const char* data, int size) noexcept;
+  Decision verify(const sockaddr_storage& sa) noexcept override;
+  Decision verify(const std::string& host, const char* name, int size) noexcept override;
+  Decision verify(const sockaddr_storage& sa, const char* data, int size) noexcept override;
 };
 }
 }

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -273,7 +273,7 @@ public:
    *
    * @param path Path to trusted certificate file
    */
-  virtual void loadTrustedCertificates(const char* path, const char* capath = NULL);
+  virtual void loadTrustedCertificates(const char* path, const char* capath = nullptr);
   /**
    * Default randomize method.
    */

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -373,7 +373,7 @@ public:
   /**
    * Destructor
    */
-  virtual ~AccessManager() {}
+  virtual ~AccessManager() = default;
   /**
    * Determine whether the peer should be granted access or not. It's called
    * once after the SSL handshake completes successfully, before peer certificate

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -85,15 +85,15 @@ using std::shared_ptr;
 TGetAddrInfoWrapper::TGetAddrInfoWrapper(const char* node,
                                          const char* service,
                                          const struct addrinfo* hints)
-  : node_(node), service_(service), hints_(hints), res_(NULL) {}
+  : node_(node), service_(service), hints_(hints), res_(nullptr) {}
 
 TGetAddrInfoWrapper::~TGetAddrInfoWrapper() {
-  if (this->res_ != NULL)
+  if (this->res_ != nullptr)
     freeaddrinfo(this->res_);
 }
 
 int TGetAddrInfoWrapper::init() {
-  if (this->res_ == NULL)
+  if (this->res_ == nullptr)
     return getaddrinfo(this->node_, this->service_, this->hints_, &(this->res_));
   return 0;
 }
@@ -268,7 +268,7 @@ void TServerSocket::listen() {
   hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
 
   // If address is not specified use wildcard address (NULL)
-  TGetAddrInfoWrapper info(address_.empty() ? NULL : &address_[0], port, &hints);
+  TGetAddrInfoWrapper info(address_.empty() ? nullptr : &address_[0], port, &hints);
 
   error = info.init();
   if (error) {
@@ -281,13 +281,13 @@ void TServerSocket::listen() {
   // Pick the ipv6 address first since ipv4 addresses can be mapped
   // into ipv6 space.
   for (res = info.res(); res; res = res->ai_next) {
-    if (res->ai_family == AF_INET6 || res->ai_next == NULL)
+    if (res->ai_family == AF_INET6 || res->ai_next == nullptr)
       break;
   }
 
   if (!path_.empty()) {
     serverSocket_ = socket(PF_UNIX, SOCK_STREAM, IPPROTO_IP);
-  } else if (res != NULL) {
+  } else if (res != nullptr) {
     serverSocket_ = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
   }
 
@@ -434,7 +434,7 @@ void TServerSocket::listen() {
 
     // Unix Domain Socket
     size_t len = path_.size() + 1;
-    if (len > sizeof(((sockaddr_un*)NULL)->sun_path)) {
+    if (len > sizeof(((sockaddr_un*)nullptr)->sun_path)) {
       errno_copy = THRIFT_GET_SOCKET_ERROR;
       GlobalOutput.perror("TSocket::listen() Unix Domain socket path too long", errno_copy);
       throw TTransportException(TTransportException::NOT_OPEN,

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -446,7 +446,7 @@ void TServerSocket::listen() {
     address.sun_family = AF_UNIX;
     memcpy(address.sun_path, path_.c_str(), len);
 
-    socklen_t structlen = static_cast<socklen_t>(sizeof(address));
+    auto structlen = static_cast<socklen_t>(sizeof(address));
 
     if (!address.sun_path[0]) { // abstract namespace socket
 #ifdef __linux__
@@ -490,10 +490,10 @@ void TServerSocket::listen() {
         GlobalOutput.perror("TServerSocket::getPort() getsockname() ", errno_copy);
       } else {
         if (sa.ss_family == AF_INET6) {
-          const struct sockaddr_in6* sin = reinterpret_cast<const struct sockaddr_in6*>(&sa);
+          const auto* sin = reinterpret_cast<const struct sockaddr_in6*>(&sa);
           port_ = ntohs(sin->sin6_port);
         } else {
-          const struct sockaddr_in* sin = reinterpret_cast<const struct sockaddr_in*>(&sa);
+          const auto* sin = reinterpret_cast<const struct sockaddr_in*>(&sa);
           port_ = ntohs(sin->sin_port);
         }
       }

--- a/lib/cpp/src/thrift/transport/TServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TServerSocket.h
@@ -96,7 +96,7 @@ public:
    */
   TServerSocket(const std::string& path);
 
-  virtual ~TServerSocket();
+  ~TServerSocket() override;
 
   void setSendTimeout(int sendTimeout);
   void setRecvTimeout(int recvTimeout);
@@ -136,17 +136,17 @@ public:
   // \throws std::logic_error if listen() has been called
   void setInterruptableChildren(bool enable);
 
-  THRIFT_SOCKET getSocketFD() { return serverSocket_; }
+  THRIFT_SOCKET getSocketFD() override { return serverSocket_; }
 
   int getPort();
 
-  void listen();
-  void interrupt();
-  void interruptChildren();
-  void close();
+  void listen() override;
+  void interrupt() override;
+  void interruptChildren() override;
+  void close() override;
 
 protected:
-  std::shared_ptr<TTransport> acceptImpl();
+  std::shared_ptr<TTransport> acceptImpl() override;
   virtual std::shared_ptr<TSocket> createSocket(THRIFT_SOCKET client);
   bool interruptableChildren_;
   std::shared_ptr<THRIFT_SOCKET> pChildInterruptSockReader_; // if interruptableChildren_ this is shared with child TSockets

--- a/lib/cpp/src/thrift/transport/TServerTransport.h
+++ b/lib/cpp/src/thrift/transport/TServerTransport.h
@@ -35,7 +35,7 @@ namespace transport {
  */
 class TServerTransport {
 public:
-  virtual ~TServerTransport() {}
+  virtual ~TServerTransport() = default;
 
   /**
    * Starts the server transport listening for new connections. Prior to this
@@ -96,7 +96,7 @@ public:
   virtual void close() = 0;
 
 protected:
-  TServerTransport() {}
+  TServerTransport() = default;
 
   /**
    * Subclasses should implement this function for accept.

--- a/lib/cpp/src/thrift/transport/TShortReadTransport.h
+++ b/lib/cpp/src/thrift/transport/TShortReadTransport.h
@@ -43,11 +43,11 @@ public:
 
   bool isOpen() { return transport_->isOpen(); }
 
-  bool peek() { return transport_->peek(); }
+  bool peek() override { return transport_->peek(); }
 
-  void open() { transport_->open(); }
+  void open() override { transport_->open(); }
 
-  void close() { transport_->close(); }
+  void close() override { transport_->close(); }
 
   uint32_t read(uint8_t* buf, uint32_t len) {
     if (len == 0) {
@@ -62,7 +62,7 @@ public:
 
   void write(const uint8_t* buf, uint32_t len) { transport_->write(buf, len); }
 
-  void flush() { transport_->flush(); }
+  void flush() override { transport_->flush(); }
 
   const uint8_t* borrow(uint8_t* buf, uint32_t* len) { return transport_->borrow(buf, len); }
 

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -334,7 +334,7 @@ void TSocket::openConnection(struct addrinfo* res) {
     address.sun_family = AF_UNIX;
     memcpy(address.sun_path, path_.c_str(), len);
 
-    socklen_t structlen = static_cast<socklen_t>(sizeof(address));
+    auto structlen = static_cast<socklen_t>(sizeof(address));
 
     if (!address.sun_path[0]) { // abstract namespace socket
 #ifdef __linux__
@@ -593,7 +593,7 @@ try_again:
       // check if this is the lack of resources or timeout case
       struct timeval end;
       THRIFT_GETTIMEOFDAY(&end, NULL);
-      uint32_t readElapsedMicros = static_cast<uint32_t>(((end.tv_sec - begin.tv_sec) * 1000 * 1000)
+      auto readElapsedMicros = static_cast<uint32_t>(((end.tv_sec - begin.tv_sec) * 1000 * 1000)
                                                          + (end.tv_usec - begin.tv_usec));
 
       if (!eagainThresholdMicros || (readElapsedMicros < eagainThresholdMicros)) {

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -324,7 +324,7 @@ void TSocket::openConnection(struct addrinfo* res) {
 
 #ifndef _WIN32
     size_t len = path_.size() + 1;
-    if (len > sizeof(((sockaddr_un*)NULL)->sun_path)) {
+    if (len > sizeof(((sockaddr_un*)nullptr)->sun_path)) {
       int errno_copy = THRIFT_GET_SOCKET_ERROR;
       GlobalOutput.perror("TSocket::open() Unix Domain socket path too long", errno_copy);
       throw TTransportException(TTransportException::NOT_OPEN, " Unix Domain socket path too long");
@@ -433,7 +433,7 @@ void TSocket::open() {
 void TSocket::unix_open() {
   if (!path_.empty()) {
     // Unix Domain SOcket does not need addrinfo struct, so we pass NULL
-    openConnection(NULL);
+    openConnection(nullptr);
   }
 }
 
@@ -453,8 +453,8 @@ void TSocket::local_open() {
   }
 
   struct addrinfo hints, *res, *res0;
-  res = NULL;
-  res0 = NULL;
+  res = nullptr;
+  res0 = nullptr;
   int error;
   char port[sizeof("65535")];
   std::memset(&hints, 0, sizeof(hints));
@@ -540,7 +540,7 @@ try_again:
   // Read from the socket
   struct timeval begin;
   if (recvTimeout_ > 0) {
-    THRIFT_GETTIMEOFDAY(&begin, NULL);
+    THRIFT_GETTIMEOFDAY(&begin, nullptr);
   } else {
     // if there is no read timeout we don't need the TOD to determine whether
     // an THRIFT_EAGAIN is due to a timeout or an out-of-resource condition.
@@ -592,7 +592,7 @@ try_again:
       }
       // check if this is the lack of resources or timeout case
       struct timeval end;
-      THRIFT_GETTIMEOFDAY(&end, NULL);
+      THRIFT_GETTIMEOFDAY(&end, nullptr);
       auto readElapsedMicros = static_cast<uint32_t>(((end.tv_sec - begin.tv_sec) * 1000 * 1000)
                                                          + (end.tv_usec - begin.tv_usec));
 
@@ -834,7 +834,7 @@ std::string TSocket::getPeerHost() const {
 
     addrPtr = getCachedAddress(&addrLen);
 
-    if (addrPtr == NULL) {
+    if (addrPtr == nullptr) {
       addrLen = sizeof(addr);
       if (getpeername(socket_, (sockaddr*)&addr, &addrLen) != 0) {
         return peerHost_;
@@ -872,7 +872,7 @@ std::string TSocket::getPeerAddress() const {
 
     addrPtr = getCachedAddress(&addrLen);
 
-    if (addrPtr == NULL) {
+    if (addrPtr == nullptr) {
       addrLen = sizeof(addr);
       if (getpeername(socket_, (sockaddr*)&addr, &addrLen) != 0) {
         return peerAddress_;
@@ -937,7 +937,7 @@ sockaddr* TSocket::getCachedAddress(socklen_t* len) const {
     return (sockaddr*)&cachedPeerAddr_.ipv6;
 
   default:
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -807,7 +807,7 @@ void TSocket::setMaxRecvRetries(int maxRecvRetries) {
   maxRecvRetries_ = maxRecvRetries;
 }
 
-string TSocket::getSocketInfo() {
+string TSocket::getSocketInfo() const {
   std::ostringstream oss;
   if (path_.empty()) {
     if (host_.empty() || port_ == 0) {
@@ -822,7 +822,7 @@ string TSocket::getSocketInfo() {
   return oss.str();
 }
 
-std::string TSocket::getPeerHost() {
+std::string TSocket::getPeerHost() const {
   if (peerHost_.empty() && path_.empty()) {
     struct sockaddr_storage addr;
     struct sockaddr* addrPtr;
@@ -841,7 +841,7 @@ std::string TSocket::getPeerHost() {
       }
       addrPtr = (sockaddr*)&addr;
 
-      setCachedAddress(addrPtr, addrLen);
+      const_cast<TSocket&>(*this).setCachedAddress(addrPtr, addrLen);
     }
 
     char clienthost[NI_MAXHOST];
@@ -860,7 +860,7 @@ std::string TSocket::getPeerHost() {
   return peerHost_;
 }
 
-std::string TSocket::getPeerAddress() {
+std::string TSocket::getPeerAddress() const {
   if (peerAddress_.empty() && path_.empty()) {
     struct sockaddr_storage addr;
     struct sockaddr* addrPtr;
@@ -879,7 +879,7 @@ std::string TSocket::getPeerAddress() {
       }
       addrPtr = (sockaddr*)&addr;
 
-      setCachedAddress(addrPtr, addrLen);
+      const_cast<TSocket&>(*this).setCachedAddress(addrPtr, addrLen);
     }
 
     char clienthost[NI_MAXHOST];
@@ -899,7 +899,7 @@ std::string TSocket::getPeerAddress() {
   return peerAddress_;
 }
 
-int TSocket::getPeerPort() {
+int TSocket::getPeerPort() const {
   getPeerAddress();
   return peerPort_;
 }
@@ -949,7 +949,7 @@ bool TSocket::getUseLowMinRto() {
   return useLowMinRto_;
 }
 
-const std::string TSocket::getOrigin() {
+const std::string TSocket::getOrigin() const {
   std::ostringstream oss;
   oss << getPeerHost() << ":" << getPeerPort();
   return oss.str();

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -74,7 +74,7 @@ public:
   /**
    * Destroyes the socket object, closing it if necessary.
    */
-  virtual ~TSocket();
+  ~TSocket() override;
 
   /**
    * Whether the socket is alive.
@@ -259,7 +259,7 @@ public:
    *
    * @return string peer host identifier and port
    */
-  virtual const std::string getOrigin();
+  const std::string getOrigin() override;
 
   /**
    * Constructor to create socket from file descriptor.

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -208,22 +208,22 @@ public:
   /**
    * Get socket information formatted as a string <Host: x Port: x>
    */
-  std::string getSocketInfo();
+  std::string getSocketInfo() const;
 
   /**
    * Returns the DNS name of the host to which the socket is connected
    */
-  std::string getPeerHost();
+  std::string getPeerHost() const;
 
   /**
    * Returns the address of the host to which the socket is connected
    */
-  std::string getPeerAddress();
+  std::string getPeerAddress() const;
 
   /**
    * Returns the port of the host to which the socket is connected
    **/
-  int getPeerPort();
+  int getPeerPort() const;
 
   /**
    * Returns the underlying socket file descriptor.
@@ -259,7 +259,7 @@ public:
    *
    * @return string peer host identifier and port
    */
-  const std::string getOrigin() override;
+  const std::string getOrigin() const override;
 
   /**
    * Constructor to create socket from file descriptor.
@@ -295,13 +295,13 @@ protected:
   THRIFT_SOCKET socket_;
 
   /** Peer hostname */
-  std::string peerHost_;
+  mutable std::string peerHost_;
 
   /** Peer address */
-  std::string peerAddress_;
+  mutable std::string peerAddress_;
 
   /** Peer port */
-  int peerPort_;
+  mutable int peerPort_;
 
   /**
    * A shared socket pointer that will interrupt a blocking read if data

--- a/lib/cpp/src/thrift/transport/TSocketPool.cpp
+++ b/lib/cpp/src/thrift/transport/TSocketPool.cpp
@@ -216,7 +216,7 @@ void TSocketPool::open() {
 
     if (server->lastFailTime_ > 0) {
       // The server was marked as down, so check if enough time has elapsed to retry
-      time_t elapsedTime = time(NULL) - server->lastFailTime_;
+      time_t elapsedTime = time(nullptr) - server->lastFailTime_;
       if (elapsedTime > retryInterval_) {
         retryIntervalPassed = true;
       }
@@ -245,7 +245,7 @@ void TSocketPool::open() {
       if (server->consecutiveFailures_ > maxConsecutiveFailures_) {
         // Mark server as down
         server->consecutiveFailures_ = 0;
-        server->lastFailTime_ = time(NULL);
+        server->lastFailTime_ = time(nullptr);
       }
     }
   }

--- a/lib/cpp/src/thrift/transport/TSocketPool.h
+++ b/lib/cpp/src/thrift/transport/TSocketPool.h
@@ -105,7 +105,7 @@ public:
   /**
    * Destroyes the socket object, closing it if necessary.
    */
-  virtual ~TSocketPool();
+  ~TSocketPool() override;
 
   /**
    * Add a server to the pool
@@ -155,12 +155,12 @@ public:
   /**
    * Creates and opens the UNIX socket.
    */
-  void open();
+  void open() override;
 
   /*
    * Closes the UNIX socket
    */
-  void close();
+  void close() override;
 
 protected:
   void setCurrentServer(const std::shared_ptr<TSocketPoolServer>& server);

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -236,7 +236,7 @@ public:
    *
    * The returned value can be used in a log message for example
    */
-  virtual const std::string getOrigin() { return "Unknown"; }
+  virtual const std::string getOrigin() const { return "Unknown"; }
 
 protected:
   /**

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -209,7 +209,7 @@ public:
     T_VIRTUAL_CALL();
     return borrow_virt(buf, len);
   }
-  virtual const uint8_t* borrow_virt(uint8_t* /* buf */, uint32_t* /* len */) { return NULL; }
+  virtual const uint8_t* borrow_virt(uint8_t* /* buf */, uint32_t* /* len */) { return nullptr; }
 
   /**
    * Remove len bytes from the transport.  This should always follow a borrow

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -58,7 +58,7 @@ public:
   /**
    * Virtual deconstructor.
    */
-  virtual ~TTransport() {}
+  virtual ~TTransport() = default;
 
   /**
    * Whether this transport is open.
@@ -242,7 +242,7 @@ protected:
   /**
    * Simple constructor.
    */
-  TTransport() {}
+  TTransport() = default;
 };
 
 /**
@@ -253,9 +253,9 @@ protected:
  */
 class TTransportFactory {
 public:
-  TTransportFactory() {}
+  TTransportFactory() = default;
 
-  virtual ~TTransportFactory() {}
+  virtual ~TTransportFactory() = default;
 
   /**
    * Default implementation does nothing, just returns the transport given.

--- a/lib/cpp/src/thrift/transport/TTransportException.h
+++ b/lib/cpp/src/thrift/transport/TTransportException.h
@@ -65,7 +65,7 @@ public:
   TTransportException(TTransportExceptionType type, const std::string& message, int errno_copy)
     : apache::thrift::TException(message + ": " + TOutput::strerror_s(errno_copy)), type_(type) {}
 
-  virtual ~TTransportException() noexcept {}
+  ~TTransportException() noexcept override {}
 
   /**
    * Returns an error code that provides information about the type of error
@@ -75,7 +75,7 @@ public:
    */
   TTransportExceptionType getType() const noexcept { return type_; }
 
-  virtual const char* what() const noexcept;
+  const char* what() const noexcept override;
 
 protected:
   /** Just like strerror_r but returns a C++ string object. */

--- a/lib/cpp/src/thrift/transport/TTransportException.h
+++ b/lib/cpp/src/thrift/transport/TTransportException.h
@@ -65,7 +65,7 @@ public:
   TTransportException(TTransportExceptionType type, const std::string& message, int errno_copy)
     : apache::thrift::TException(message + ": " + TOutput::strerror_s(errno_copy)), type_(type) {}
 
-  ~TTransportException() noexcept override {}
+  ~TTransportException() noexcept override = default;
 
   /**
    * Returns an error code that provides information about the type of error

--- a/lib/cpp/src/thrift/transport/TTransportUtils.cpp
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.cpp
@@ -42,7 +42,7 @@ uint32_t TPipedTransport::read(uint8_t* buf, uint32_t len) {
     if (rLen_ == rBufSize_) {
       rBufSize_ *= 2;
       auto *tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
-      if (tmpBuf == NULL) {
+      if (tmpBuf == nullptr) {
        throw std::bad_alloc();
       }
       rBuf_ = tmpBuf;
@@ -78,7 +78,7 @@ void TPipedTransport::write(const uint8_t* buf, uint32_t len) {
       newBufSize *= 2;
     }
     auto *tmpBuf= (uint8_t*)std::realloc(wBuf_, sizeof(uint8_t) * newBufSize);
-    if (tmpBuf == NULL) {
+    if (tmpBuf == nullptr) {
       throw std::bad_alloc();
     }
     wBuf_ = tmpBuf;

--- a/lib/cpp/src/thrift/transport/TTransportUtils.cpp
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.cpp
@@ -41,7 +41,7 @@ uint32_t TPipedTransport::read(uint8_t* buf, uint32_t len) {
     // Double the size of the underlying buffer if it is full
     if (rLen_ == rBufSize_) {
       rBufSize_ *= 2;
-      uint8_t *tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
+      auto *tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
       if (tmpBuf == NULL) {
        throw std::bad_alloc();
       }
@@ -77,7 +77,7 @@ void TPipedTransport::write(const uint8_t* buf, uint32_t len) {
     while ((len + wLen_) >= newBufSize) {
       newBufSize *= 2;
     }
-    uint8_t *tmpBuf= (uint8_t*)std::realloc(wBuf_, sizeof(uint8_t) * newBufSize);
+    auto *tmpBuf= (uint8_t*)std::realloc(wBuf_, sizeof(uint8_t) * newBufSize);
     if (tmpBuf == NULL) {
       throw std::bad_alloc();
     }

--- a/lib/cpp/src/thrift/transport/TTransportUtils.cpp
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.cpp
@@ -108,8 +108,7 @@ TPipedFileReaderTransport::TPipedFileReaderTransport(
   : TPipedTransport(srcTrans, dstTrans), srcTrans_(srcTrans) {
 }
 
-TPipedFileReaderTransport::~TPipedFileReaderTransport() {
-}
+TPipedFileReaderTransport::~TPipedFileReaderTransport() = default;
 
 bool TPipedFileReaderTransport::isOpen() const {
   return TPipedTransport::isOpen();

--- a/lib/cpp/src/thrift/transport/TTransportUtils.h
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.h
@@ -42,9 +42,9 @@ namespace transport {
  */
 class TNullTransport : public TVirtualTransport<TNullTransport> {
 public:
-  TNullTransport() {}
+  TNullTransport() = default;
 
-  ~TNullTransport() override {}
+  ~TNullTransport() override = default;
 
   bool isOpen() { return true; }
 
@@ -207,11 +207,11 @@ protected:
  */
 class TPipedTransportFactory : public TTransportFactory {
 public:
-  TPipedTransportFactory() {}
+  TPipedTransportFactory() = default;
   TPipedTransportFactory(std::shared_ptr<TTransport> dstTrans) {
     initializeTargetTransport(dstTrans);
   }
-  ~TPipedTransportFactory() override {}
+  ~TPipedTransportFactory() override = default;
 
   /**
    * Wraps the base transport into a piped transport.
@@ -286,10 +286,10 @@ protected:
  */
 class TPipedFileReaderTransportFactory : public TPipedTransportFactory {
 public:
-  TPipedFileReaderTransportFactory() {}
+  TPipedFileReaderTransportFactory() = default;
   TPipedFileReaderTransportFactory(std::shared_ptr<TTransport> dstTrans)
     : TPipedTransportFactory(dstTrans) {}
-  ~TPipedFileReaderTransportFactory() override {}
+  ~TPipedFileReaderTransportFactory() override = default;
 
   std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> srcTrans) override {
     std::shared_ptr<TFileReaderTransport> pFileReaderTransport

--- a/lib/cpp/src/thrift/transport/TTransportUtils.h
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.h
@@ -44,11 +44,11 @@ class TNullTransport : public TVirtualTransport<TNullTransport> {
 public:
   TNullTransport() {}
 
-  ~TNullTransport() {}
+  ~TNullTransport() override {}
 
   bool isOpen() { return true; }
 
-  void open() {}
+  void open() override {}
 
   void write(const uint8_t* /* buf */, uint32_t /* len */) { return; }
 };
@@ -107,7 +107,7 @@ public:
     }
   }
 
-  ~TPipedTransport() {
+  ~TPipedTransport() override {
     std::free(rBuf_);
     std::free(wBuf_);
   }
@@ -142,7 +142,7 @@ public:
 
   uint32_t read(uint8_t* buf, uint32_t len);
 
-  uint32_t readEnd() {
+  uint32_t readEnd() override {
 
     if (pipeOnRead_) {
       dstTrans_->write(rBuf_, rPos_);
@@ -164,7 +164,7 @@ public:
 
   void write(const uint8_t* buf, uint32_t len);
 
-  uint32_t writeEnd() {
+  uint32_t writeEnd() override {
     if (pipeOnWrite_) {
       dstTrans_->write(wBuf_, wLen_);
       dstTrans_->flush();
@@ -172,7 +172,7 @@ public:
     return wLen_;
   }
 
-  void flush();
+  void flush() override;
 
   std::shared_ptr<TTransport> getTargetTransport() { return dstTrans_; }
 
@@ -211,7 +211,7 @@ public:
   TPipedTransportFactory(std::shared_ptr<TTransport> dstTrans) {
     initializeTargetTransport(dstTrans);
   }
-  virtual ~TPipedTransportFactory() {}
+  ~TPipedTransportFactory() override {}
 
   /**
    * Wraps the base transport into a piped transport.
@@ -243,7 +243,7 @@ public:
   TPipedFileReaderTransport(std::shared_ptr<TFileReaderTransport> srcTrans,
                             std::shared_ptr<TTransport> dstTrans);
 
-  ~TPipedFileReaderTransport();
+  ~TPipedFileReaderTransport() override;
 
   // TTransport functions
   bool isOpen() const override;
@@ -252,18 +252,18 @@ public:
   void close() override;
   uint32_t read(uint8_t* buf, uint32_t len);
   uint32_t readAll(uint8_t* buf, uint32_t len);
-  uint32_t readEnd();
+  uint32_t readEnd() override;
   void write(const uint8_t* buf, uint32_t len);
-  uint32_t writeEnd();
-  void flush();
+  uint32_t writeEnd() override;
+  void flush() override;
 
   // TFileReaderTransport functions
-  int32_t getReadTimeout();
-  void setReadTimeout(int32_t readTimeout);
-  uint32_t getNumChunks();
-  uint32_t getCurChunk();
-  void seekToChunk(int32_t chunk);
-  void seekToEnd();
+  int32_t getReadTimeout() override;
+  void setReadTimeout(int32_t readTimeout) override;
+  uint32_t getNumChunks() override;
+  uint32_t getCurChunk() override;
+  void seekToChunk(int32_t chunk) override;
+  void seekToEnd() override;
 
   /*
    * Override TTransport *_virt() functions to invoke our implementations.
@@ -289,9 +289,9 @@ public:
   TPipedFileReaderTransportFactory() {}
   TPipedFileReaderTransportFactory(std::shared_ptr<TTransport> dstTrans)
     : TPipedTransportFactory(dstTrans) {}
-  virtual ~TPipedFileReaderTransportFactory() {}
+  ~TPipedFileReaderTransportFactory() override {}
 
-  std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> srcTrans) {
+  std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> srcTrans) override {
     std::shared_ptr<TFileReaderTransport> pFileReaderTransport
         = std::dynamic_pointer_cast<TFileReaderTransport>(srcTrans);
     if (pFileReaderTransport.get() != NULL) {

--- a/lib/cpp/src/thrift/transport/TTransportUtils.h
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.h
@@ -77,11 +77,11 @@ public:
     pipeOnWrite_ = false;
 
     rBuf_ = (uint8_t*)std::malloc(sizeof(uint8_t) * rBufSize_);
-    if (rBuf_ == NULL) {
+    if (rBuf_ == nullptr) {
       throw std::bad_alloc();
     }
     wBuf_ = (uint8_t*)std::malloc(sizeof(uint8_t) * wBufSize_);
-    if (wBuf_ == NULL) {
+    if (wBuf_ == nullptr) {
       throw std::bad_alloc();
     }
   }
@@ -98,11 +98,11 @@ public:
       wLen_(0) {
 
     rBuf_ = (uint8_t*)std::malloc(sizeof(uint8_t) * rBufSize_);
-    if (rBuf_ == NULL) {
+    if (rBuf_ == nullptr) {
       throw std::bad_alloc();
     }
     wBuf_ = (uint8_t*)std::malloc(sizeof(uint8_t) * wBufSize_);
-    if (wBuf_ == NULL) {
+    if (wBuf_ == nullptr) {
       throw std::bad_alloc();
     }
   }
@@ -120,7 +120,7 @@ public:
       if (rLen_ == rBufSize_) {
         rBufSize_ *= 2;
         auto * tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
-	if (tmpBuf == NULL) {
+	if (tmpBuf == nullptr) {
 	  throw std::bad_alloc();
 	}
 	rBuf_ = tmpBuf;
@@ -221,7 +221,7 @@ public:
   }
 
   virtual void initializeTargetTransport(std::shared_ptr<TTransport> dstTrans) {
-    if (dstTrans_.get() == NULL) {
+    if (dstTrans_.get() == nullptr) {
       dstTrans_ = dstTrans;
     } else {
       throw TException("Target transport already initialized");
@@ -294,7 +294,7 @@ public:
   std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> srcTrans) override {
     std::shared_ptr<TFileReaderTransport> pFileReaderTransport
         = std::dynamic_pointer_cast<TFileReaderTransport>(srcTrans);
-    if (pFileReaderTransport.get() != NULL) {
+    if (pFileReaderTransport.get() != nullptr) {
       return getFileReaderTransport(pFileReaderTransport);
     } else {
       return std::shared_ptr<TTransport>();

--- a/lib/cpp/src/thrift/transport/TTransportUtils.h
+++ b/lib/cpp/src/thrift/transport/TTransportUtils.h
@@ -119,7 +119,7 @@ public:
       // Double the size of the underlying buffer if it is full
       if (rLen_ == rBufSize_) {
         rBufSize_ *= 2;
-        uint8_t * tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
+        auto * tmpBuf = (uint8_t*)std::realloc(rBuf_, sizeof(uint8_t) * rBufSize_);
 	if (tmpBuf == NULL) {
 	  throw std::bad_alloc();
 	}

--- a/lib/cpp/src/thrift/transport/TVirtualTransport.h
+++ b/lib/cpp/src/thrift/transport/TVirtualTransport.h
@@ -113,7 +113,7 @@ public:
    * the correct parent implementation, if desired.
    */
   uint32_t readAll(uint8_t* buf, uint32_t len) {
-    Transport_* trans = static_cast<Transport_*>(this);
+    auto* trans = static_cast<Transport_*>(this);
     return ::apache::thrift::transport::readAll(*trans, buf, len);
   }
 

--- a/lib/cpp/src/thrift/transport/TVirtualTransport.h
+++ b/lib/cpp/src/thrift/transport/TVirtualTransport.h
@@ -57,7 +57,7 @@ public:
   void consume(uint32_t len) { this->TTransport::consume_virt(len); }
 
 protected:
-  TTransportDefaults() {}
+  TTransportDefaults() = default;
 };
 
 /**
@@ -118,7 +118,7 @@ public:
   }
 
 protected:
-  TVirtualTransport() {}
+  TVirtualTransport() = default;
 
   /*
    * Templatized constructors, to allow arguments to be passed to the Super_

--- a/lib/cpp/src/thrift/transport/TZlibTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.cpp
@@ -331,7 +331,7 @@ const uint8_t* TZlibTransport::borrow(uint8_t* buf, uint32_t* len) {
     *len = (uint32_t)readAvail();
     return urbuf_ + urpos_;
   }
-  return NULL;
+  return nullptr;
 }
 
 void TZlibTransport::consume(uint32_t len) {

--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -36,7 +36,7 @@ public:
   TZlibTransportException(int status, const char* msg)
     : TTransportException(TTransportException::INTERNAL_ERROR, errorMessage(status, msg)),
       zlib_status_(status),
-      zlib_msg_(msg == NULL ? "(null)" : msg) {}
+      zlib_msg_(msg == nullptr ? "(null)" : msg) {}
 
   ~TZlibTransportException() noexcept override {}
 
@@ -93,12 +93,12 @@ public:
       crbuf_size_(crbuf_size),
       uwbuf_size_(uwbuf_size),
       cwbuf_size_(cwbuf_size),
-      urbuf_(NULL),
-      crbuf_(NULL),
-      uwbuf_(NULL),
-      cwbuf_(NULL),
-      rstream_(NULL),
-      wstream_(NULL),
+      urbuf_(nullptr),
+      crbuf_(nullptr),
+      uwbuf_(nullptr),
+      cwbuf_(nullptr),
+      rstream_(nullptr),
+      wstream_(nullptr),
       comp_level_(comp_level) {
     if (uwbuf_size_ < MIN_DIRECT_DEFLATE_SIZE) {
       // Have to copy this into a local because of a linking issue.

--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -38,7 +38,7 @@ public:
       zlib_status_(status),
       zlib_msg_(msg == nullptr ? "(null)" : msg) {}
 
-  ~TZlibTransportException() noexcept override {}
+  ~TZlibTransportException() noexcept override = default;
 
   int getZlibStatus() { return zlib_status_; }
   std::string getZlibMessage() { return zlib_msg_; }
@@ -227,9 +227,9 @@ protected:
  */
 class TZlibTransportFactory : public TTransportFactory {
 public:
-  TZlibTransportFactory() {}
+  TZlibTransportFactory() = default;
 
-  ~TZlibTransportFactory() override {}
+  ~TZlibTransportFactory() override = default;
 
   std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TTransport>(new TZlibTransport(trans));

--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -38,7 +38,7 @@ public:
       zlib_status_(status),
       zlib_msg_(msg == NULL ? "(null)" : msg) {}
 
-  virtual ~TZlibTransportException() noexcept {}
+  ~TZlibTransportException() noexcept override {}
 
   int getZlibStatus() { return zlib_status_; }
   std::string getZlibMessage() { return zlib_msg_; }
@@ -136,20 +136,20 @@ public:
    * unflushed data.  You must explicitly call flush() or finish() to ensure
    * that data is actually written and flushed to the underlying transport.
    */
-  ~TZlibTransport();
+  ~TZlibTransport() override;
 
   bool isOpen();
-  bool peek();
+  bool peek() override;
 
-  void open() { transport_->open(); }
+  void open() override { transport_->open(); }
 
-  void close() { transport_->close(); }
+  void close() override { transport_->close(); }
 
   uint32_t read(uint8_t* buf, uint32_t len);
 
   void write(const uint8_t* buf, uint32_t len);
 
-  void flush();
+  void flush() override;
 
   /**
    * Finalize the zlib stream.
@@ -229,7 +229,7 @@ class TZlibTransportFactory : public TTransportFactory {
 public:
   TZlibTransportFactory() {}
 
-  virtual ~TZlibTransportFactory() {}
+  ~TZlibTransportFactory() override {}
 
   std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> trans) override {
     return std::shared_ptr<TTransport>(new TZlibTransport(trans));

--- a/lib/cpp/test/Benchmark.cpp
+++ b/lib/cpp/test/Benchmark.cpp
@@ -36,12 +36,12 @@ class Timer {
 public:
   timeval vStart;
 
-  Timer() { THRIFT_GETTIMEOFDAY(&vStart, 0); }
-  void start() { THRIFT_GETTIMEOFDAY(&vStart, 0); }
+  Timer() { THRIFT_GETTIMEOFDAY(&vStart, nullptr); }
+  void start() { THRIFT_GETTIMEOFDAY(&vStart, nullptr); }
 
   double frame() {
     timeval vEnd;
-    THRIFT_GETTIMEOFDAY(&vEnd, 0);
+    THRIFT_GETTIMEOFDAY(&vEnd, nullptr);
     double dstart = vStart.tv_sec + ((double)vStart.tv_usec / 1000000.0);
     double dend = vEnd.tv_sec + ((double)vEnd.tv_usec / 1000000.0);
     return dend - dstart;
@@ -70,7 +70,7 @@ int main() {
   int num = 100000;
   std::shared_ptr<TMemoryBuffer> buf(new TMemoryBuffer(num*1000));
 
-  uint8_t* data = NULL;
+  uint8_t* data = nullptr;
   uint32_t datasize = 0;
 
   {
@@ -157,7 +157,7 @@ int main() {
   }
 
 
-  data = NULL;
+  data = nullptr;
   datasize = 0;
   num = 10000000;
 

--- a/lib/cpp/test/EnumTest.cpp
+++ b/lib/cpp/test/EnumTest.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_enum_ostream)
   BOOST_CHECK_EQUAL(EnumToString(MyEnumWithCustomOstream::CustoM2), "{2:CUSTOM!}");
 
   // some invalid or unknown value
-  MyEnum5::type uut = (MyEnum5::type)44;
+  auto uut = (MyEnum5::type)44;
   BOOST_CHECK_EQUAL(EnumToString(uut), "44");
 }
 

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -66,7 +66,7 @@ namespace utf = boost::unit_test;
 
 class OneWayServiceHandler : public onewaytest::OneWayServiceIf {
 public:
-  OneWayServiceHandler() {}
+  OneWayServiceHandler() = default;
 
   void roundTripRPC() override {
 #ifdef ENABLE_STDERR_LOGGING
@@ -82,7 +82,7 @@ public:
 
 class OneWayServiceCloneFactory : virtual public onewaytest::OneWayServiceIfFactory {
  public:
-  ~OneWayServiceCloneFactory() override {}
+  ~OneWayServiceCloneFactory() override = default;
   onewaytest::OneWayServiceIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo) override
   {
     (void)connInfo ;
@@ -96,7 +96,7 @@ class OneWayServiceCloneFactory : virtual public onewaytest::OneWayServiceIfFact
 class RPC0ThreadClass {
 public:
   RPC0ThreadClass(TThreadedServer& server) : server_(server) { } // Constructor
-~RPC0ThreadClass() { } // Destructor
+~RPC0ThreadClass() = default; // Destructor
 
 void Run() {
   server_.serve() ;
@@ -112,7 +112,7 @@ using apache::thrift::concurrency::Synchronized;
 class TServerReadyEventHandler : public TServerEventHandler, public Monitor {
 public:
   TServerReadyEventHandler() : isListening_(false), accepted_(0) {}
-  ~TServerReadyEventHandler() override {}
+  ~TServerReadyEventHandler() override = default;
   void preServe() override {
     Synchronized sync(*this);
     isListening_ = true;

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -73,7 +73,7 @@ public:
     cerr << "roundTripRPC()" << endl;
 #endif
   }
-  void oneWayRPC() {
+  void oneWayRPC() override {
 #ifdef ENABLE_STDERR_LOGGING
     cerr << "oneWayRPC()" << std::endl ;
 #endif
@@ -82,13 +82,13 @@ public:
 
 class OneWayServiceCloneFactory : virtual public onewaytest::OneWayServiceIfFactory {
  public:
-  virtual ~OneWayServiceCloneFactory() {}
-  virtual onewaytest::OneWayServiceIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo)
+  ~OneWayServiceCloneFactory() override {}
+  onewaytest::OneWayServiceIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo) override
   {
     (void)connInfo ;
     return new OneWayServiceHandler;
   }
-  virtual void releaseHandler( onewaytest::OneWayServiceIf* handler) {
+  void releaseHandler( onewaytest::OneWayServiceIf* handler) override {
     delete handler;
   }
 };
@@ -112,14 +112,14 @@ using apache::thrift::concurrency::Synchronized;
 class TServerReadyEventHandler : public TServerEventHandler, public Monitor {
 public:
   TServerReadyEventHandler() : isListening_(false), accepted_(0) {}
-  virtual ~TServerReadyEventHandler() {}
-  virtual void preServe() {
+  ~TServerReadyEventHandler() override {}
+  void preServe() override {
     Synchronized sync(*this);
     isListening_ = true;
     notify();
   }
-  virtual void* createContext(shared_ptr<TProtocol> input,
-                              shared_ptr<TProtocol> output) {
+  void* createContext(shared_ptr<TProtocol> input,
+                              shared_ptr<TProtocol> output) override {
     Synchronized sync(*this);
     ++accepted_;
     notify();

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -144,7 +144,7 @@ class TBlockableBufferedTransport : public TBufferedTransport {
   }
 
   uint32_t write_buffer_length() {
-    uint32_t have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
+    auto have_bytes = static_cast<uint32_t>(wBase_ - wBuf_.get());
     return have_bytes ;
   }
 

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -126,7 +126,7 @@ public:
 
     (void)input;
     (void)output;
-    return NULL;
+    return nullptr;
   }
   bool isListening() const { return isListening_; }
   uint64_t acceptedCount() const { return accepted_; }

--- a/lib/cpp/test/OpenSSLManualInitTest.cpp
+++ b/lib/cpp/test/OpenSSLManualInitTest.cpp
@@ -62,7 +62,7 @@ void test_openssl_availability() {
   // uninitialized.  It might also fail on very old versions of
   // OpenSSL...
   const EVP_MD* md = EVP_get_digestbyname("SHA256");
-  BOOST_CHECK(md != NULL);
+  BOOST_CHECK(md != nullptr);
   openssl_cleanup();
 }
 

--- a/lib/cpp/test/RecursiveTest.cpp
+++ b/lib/cpp/test/RecursiveTest.cpp
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE(test_recursive_2) {
 
   RecList resultlist;
   resultlist.read(prot.get());
-  BOOST_CHECK(resultlist.nextitem != NULL);
-  BOOST_CHECK(resultlist.nextitem->nextitem == NULL);
+  BOOST_CHECK(resultlist.nextitem != nullptr);
+  BOOST_CHECK(resultlist.nextitem->nextitem == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_recursive_3) {
@@ -75,8 +75,8 @@ BOOST_AUTO_TEST_CASE(test_recursive_3) {
   c.write(prot.get());
 
   c.read(prot.get());
-  BOOST_CHECK(c.other != NULL);
-  BOOST_CHECK(c.other->other.other == NULL);
+  BOOST_CHECK(c.other != nullptr);
+  BOOST_CHECK(c.other->other.other == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_recursive_4) {

--- a/lib/cpp/test/TFileTransportTest.cpp
+++ b/lib/cpp/test/TFileTransportTest.cpp
@@ -69,7 +69,7 @@ public:
   void fsync(int fd) {
     (void)fd;
     FsyncCall call;
-    THRIFT_GETTIMEOFDAY(&call.time, NULL);
+    THRIFT_GETTIMEOFDAY(&call.time, nullptr);
     calls_.push_back(call);
   }
 
@@ -123,7 +123,7 @@ public:
     if (path_) {
       ::unlink(path_);
       delete[] path_;
-      path_ = NULL;
+      path_ = nullptr;
     }
   }
 
@@ -195,9 +195,9 @@ BOOST_AUTO_TEST_CASE(test_destructor) {
     struct timeval start;
     struct timeval end;
 
-    THRIFT_GETTIMEOFDAY(&start, NULL);
+    THRIFT_GETTIMEOFDAY(&start, nullptr);
     delete transport;
-    THRIFT_GETTIMEOFDAY(&end, NULL);
+    THRIFT_GETTIMEOFDAY(&end, nullptr);
 
     int delta = time_diff(&start, &end);
 
@@ -264,7 +264,7 @@ void test_flush_max_us_impl(uint32_t flush_us, uint32_t write_us, uint32_t test_
   delete transport;
 
   // Stop logging new fsync() calls
-  fsync_log = NULL;
+  fsync_log = nullptr;
 
   // Examine the fsync() log
   //
@@ -278,7 +278,7 @@ void test_flush_max_us_impl(uint32_t flush_us, uint32_t write_us, uint32_t test_
   // Make sure TFileTransport called fsync at least once
   BOOST_WARN_GE(calls->size(), static_cast<FsyncLog::CallList::size_type>(1));
 
-  const struct timeval* prev_time = NULL;
+  const struct timeval* prev_time = nullptr;
   for (auto it = calls->begin(); it != calls->end(); ++it) {
     if (prev_time) {
       int delta = time_diff(prev_time, &it->time);
@@ -318,13 +318,13 @@ BOOST_AUTO_TEST_CASE(test_noop_flush) {
   transport.write(buf, 1);
 
   struct timeval start;
-  THRIFT_GETTIMEOFDAY(&start, NULL);
+  THRIFT_GETTIMEOFDAY(&start, nullptr);
 
   for (unsigned int n = 0; n < 10; ++n) {
     transport.flush();
 
     struct timeval now;
-    THRIFT_GETTIMEOFDAY(&now, NULL);
+    THRIFT_GETTIMEOFDAY(&now, nullptr);
 
     // Fail if at any point we've been running for longer than half a second.
     // (With the buggy code, TFileTransport used to take 3 seconds per flush())
@@ -349,11 +349,11 @@ void print_usage(FILE* f, const char* argv0) {
 
 void parse_args(int argc, char* argv[]) {
   struct option long_opts[]
-      = {{"help", false, NULL, 'h'}, {"tmp-dir", true, NULL, 't'}, {NULL, 0, NULL, 0}};
+      = {{"help", false, nullptr, 'h'}, {"tmp-dir", true, nullptr, 't'}, {nullptr, 0, nullptr, 0}};
 
   while (true) {
     optopt = 1;
-    int optchar = getopt_long(argc, argv, "ht:", long_opts, NULL);
+    int optchar = getopt_long(argc, argv, "ht:", long_opts, nullptr);
     if (optchar == -1) {
       break;
     }
@@ -378,7 +378,7 @@ void parse_args(int argc, char* argv[]) {
 
 #ifdef BOOST_TEST_DYN_LINK
 static int myArgc = 0;
-static char **myArgv = NULL;
+static char **myArgv = nullptr;
 
 bool init_unit_test_suite() {
   boost::unit_test::framework::master_test_suite().p_name.value = "TFileTransportTest";

--- a/lib/cpp/test/TFileTransportTest.cpp
+++ b/lib/cpp/test/TFileTransportTest.cpp
@@ -64,7 +64,7 @@ public:
   };
   typedef std::list<FsyncCall> CallList;
 
-  FsyncLog() {}
+  FsyncLog() = default;
 
   void fsync(int fd) {
     (void)fd;

--- a/lib/cpp/test/TFileTransportTest.cpp
+++ b/lib/cpp/test/TFileTransportTest.cpp
@@ -279,7 +279,7 @@ void test_flush_max_us_impl(uint32_t flush_us, uint32_t write_us, uint32_t test_
   BOOST_WARN_GE(calls->size(), static_cast<FsyncLog::CallList::size_type>(1));
 
   const struct timeval* prev_time = NULL;
-  for (FsyncLog::CallList::const_iterator it = calls->begin(); it != calls->end(); ++it) {
+  for (auto it = calls->begin(); it != calls->end(); ++it) {
     if (prev_time) {
       int delta = time_diff(prev_time, &it->time);
       BOOST_WARN( delta < max_allowed_delta );

--- a/lib/cpp/test/TNonblockingSSLServerTest.cpp
+++ b/lib/cpp/test/TNonblockingSSLServerTest.cpp
@@ -39,17 +39,17 @@ using apache::thrift::transport::TSSLSocketFactory;
 using apache::thrift::transport::TSSLSocket;
 
 struct Handler : public test::ParentServiceIf {
-  void addString(const std::string& s) { strings_.push_back(s); }
-  void getStrings(std::vector<std::string>& _return) { _return = strings_; }
+  void addString(const std::string& s) override { strings_.push_back(s); }
+  void getStrings(std::vector<std::string>& _return) override { _return = strings_; }
   std::vector<std::string> strings_;
 
   // dummy overrides not used in this test
-  int32_t incrementGeneration() { return 0; }
-  int32_t getGeneration() { return 0; }
-  void getDataWait(std::string&, const int32_t) {}
-  void onewayWait() {}
-  void exceptionWait(const std::string&) {}
-  void unexpectedExceptionWait(const std::string&) {}
+  int32_t incrementGeneration() override { return 0; }
+  int32_t getGeneration() override { return 0; }
+  void getDataWait(std::string&, const int32_t) override {}
+  void onewayWait() override {}
+  void exceptionWait(const std::string&) override {}
+  void unexpectedExceptionWait(const std::string&) override {}
 };
 
 boost::filesystem::path keyDir;
@@ -131,7 +131,7 @@ private:
     public:
       ListenEventHandler(Mutex* mutex) : listenMonitor_(mutex), ready_(false) {}
 
-      void preServe() /* override */ {
+      void preServe() override /* override */ {
         Guard g(listenMonitor_.mutex());
         ready_ = true;
         listenMonitor_.notify();
@@ -155,7 +155,7 @@ private:
       listenHandler.reset(new ListenEventHandler(&mutex_));
     }
 
-    virtual void run() {
+    void run() override {
       // When binding to explicit port, allow retrying to workaround bind failures on ports in use
       int retryCount = port ? 10 : 0;
       pServerSocketFactory = createServerSocketFactory();  

--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -44,17 +44,17 @@ using std::shared_ptr;
 using namespace apache::thrift;
 
 struct Handler : public test::ParentServiceIf {
-  void addString(const std::string& s) { strings_.push_back(s); }
-  void getStrings(std::vector<std::string>& _return) { _return = strings_; }
+  void addString(const std::string& s) override { strings_.push_back(s); }
+  void getStrings(std::vector<std::string>& _return) override { _return = strings_; }
   std::vector<std::string> strings_;
 
   // dummy overrides not used in this test
-  int32_t incrementGeneration() { return 0; }
-  int32_t getGeneration() { return 0; }
-  void getDataWait(std::string&, const int32_t) {}
-  void onewayWait() {}
-  void exceptionWait(const std::string&) {}
-  void unexpectedExceptionWait(const std::string&) {}
+  int32_t incrementGeneration() override { return 0; }
+  int32_t getGeneration() override { return 0; }
+  void getDataWait(std::string&, const int32_t) override {}
+  void onewayWait() override {}
+  void exceptionWait(const std::string&) override {}
+  void unexpectedExceptionWait(const std::string&) override {}
 };
 
 class Fixture {
@@ -63,7 +63,7 @@ private:
     public:
       ListenEventHandler(Mutex* mutex) : listenMonitor_(mutex), ready_(false) {}
 
-      void preServe() /* override */ {
+      void preServe() override /* override */ {
         Guard g(listenMonitor_.mutex());
         ready_ = true;
         listenMonitor_.notify();
@@ -86,7 +86,7 @@ private:
       listenHandler.reset(new ListenEventHandler(&mutex_));
     }
 
-    virtual void run() {
+    void run() override {
       // When binding to explicit port, allow retrying to workaround bind failures on ports in use
       int retryCount = port ? 10 : 0;
       startServer(retryCount);

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -74,7 +74,7 @@ using boost::posix_time::milliseconds;
 class TServerReadyEventHandler : public TServerEventHandler, public Monitor {
 public:
   TServerReadyEventHandler() : isListening_(false), accepted_(0) {}
-  ~TServerReadyEventHandler() override {}
+  ~TServerReadyEventHandler() override = default;
   void preServe() override {
     Synchronized sync(*this);
     isListening_ = true;

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -74,14 +74,14 @@ using boost::posix_time::milliseconds;
 class TServerReadyEventHandler : public TServerEventHandler, public Monitor {
 public:
   TServerReadyEventHandler() : isListening_(false), accepted_(0) {}
-  virtual ~TServerReadyEventHandler() {}
-  virtual void preServe() {
+  ~TServerReadyEventHandler() override {}
+  void preServe() override {
     Synchronized sync(*this);
     isListening_ = true;
     notify();
   }
-  virtual void* createContext(shared_ptr<TProtocol> input,
-                              shared_ptr<TProtocol> output) {
+  void* createContext(shared_ptr<TProtocol> input,
+                              shared_ptr<TProtocol> output) override {
     Synchronized sync(*this);
     ++accepted_;
     notify();
@@ -105,36 +105,36 @@ class ParentHandler : public ParentServiceIf {
 public:
   ParentHandler() : generation_(0) {}
 
-  int32_t incrementGeneration() {
+  int32_t incrementGeneration() override {
     Guard g(mutex_);
     return ++generation_;
   }
 
-  int32_t getGeneration() {
+  int32_t getGeneration() override {
     Guard g(mutex_);
     return generation_;
   }
 
-  void addString(const std::string& s) {
+  void addString(const std::string& s) override {
     Guard g(mutex_);
     strings_.push_back(s);
   }
 
-  void getStrings(std::vector<std::string>& _return) {
+  void getStrings(std::vector<std::string>& _return) override {
     Guard g(mutex_);
     _return = strings_;
   }
 
-  void getDataWait(std::string& _return, const int32_t length) {
+  void getDataWait(std::string& _return, const int32_t length) override {
     THRIFT_UNUSED_VARIABLE(_return);
     THRIFT_UNUSED_VARIABLE(length);
   }
 
-  void onewayWait() {}
+  void onewayWait() override {}
 
-  void exceptionWait(const std::string& message) { THRIFT_UNUSED_VARIABLE(message); }
+  void exceptionWait(const std::string& message) override { THRIFT_UNUSED_VARIABLE(message); }
 
-  void unexpectedExceptionWait(const std::string& message) { THRIFT_UNUSED_VARIABLE(message); }
+  void unexpectedExceptionWait(const std::string& message) override { THRIFT_UNUSED_VARIABLE(message); }
 
 protected:
   Mutex mutex_;

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -264,7 +264,7 @@ public:
    * \returns  the server port number
    */
   int getServerPort() {
-    TServerSocket* pSock = dynamic_cast<TServerSocket*>(pServer->getServerTransport().get());
+    auto* pSock = dynamic_cast<TServerSocket*>(pServer->getServerTransport().get());
     if (!pSock) { throw std::logic_error("how come?"); }
     return pSock->getPort();
   }

--- a/lib/cpp/test/TServerIntegrationTest.cpp
+++ b/lib/cpp/test/TServerIntegrationTest.cpp
@@ -88,7 +88,7 @@ public:
 
     (void)input;
     (void)output;
-    return NULL;
+    return nullptr;
   }
   bool isListening() const { return isListening_; }
   uint64_t acceptedCount() const { return accepted_; }

--- a/lib/cpp/test/TServerTransportTest.cpp
+++ b/lib/cpp/test/TServerTransportTest.cpp
@@ -34,11 +34,11 @@ class TestTTransport : public TTransport {};
 class TestTServerTransport : public TServerTransport {
 public:
   TestTServerTransport() : valid_(true) {}
-  void close() {}
+  void close() override {}
   bool valid_;
 
 protected:
-  shared_ptr<TTransport> acceptImpl() {
+  shared_ptr<TTransport> acceptImpl() override {
     return valid_ ? shared_ptr<TestTTransport>(new TestTTransport)
                   : shared_ptr<TestTTransport>();
   }

--- a/lib/cpp/test/TransportTest.cpp
+++ b/lib/cpp/test/TransportTest.cpp
@@ -65,8 +65,8 @@ public:
 class ConstantSizeGenerator : public SizeGenerator {
 public:
   ConstantSizeGenerator(uint32_t value) : value_(value) {}
-  uint32_t nextSize() { return value_; }
-  std::string describe() const {
+  uint32_t nextSize() override { return value_; }
+  std::string describe() const override {
     std::ostringstream desc;
     desc << value_;
     return desc.str();
@@ -81,9 +81,9 @@ public:
   RandomSizeGenerator(uint32_t min, uint32_t max)
     : generator_(rng, boost::uniform_int<int>(min, max)) {}
 
-  uint32_t nextSize() { return generator_(); }
+  uint32_t nextSize() override { return generator_(); }
 
-  std::string describe() const {
+  std::string describe() const override {
     std::ostringstream desc;
     desc << "rand(" << getMin() << ", " << getMax() << ")";
     return desc.str();
@@ -109,8 +109,8 @@ public:
   GenericSizeGenerator(uint32_t min, uint32_t max)
     : generator_(new RandomSizeGenerator(min, max)) {}
 
-  uint32_t nextSize() { return generator_->nextSize(); }
-  std::string describe() const { return generator_->describe(); }
+  uint32_t nextSize() override { return generator_->nextSize(); }
+  std::string describe() const override { return generator_->describe(); }
 
 private:
   std::shared_ptr<SizeGenerator> generator_;
@@ -282,7 +282,7 @@ public:
     out.reset(new TFileTransport(filename));
   }
 
-  ~CoupledFileTransports() { remove(filename.c_str()); }
+  ~CoupledFileTransports() override { remove(filename.c_str()); }
 
   std::string filename;
 };

--- a/lib/cpp/test/TransportTest.cpp
+++ b/lib/cpp/test/TransportTest.cpp
@@ -57,7 +57,7 @@ void initrand(unsigned int seed) {
 
 class SizeGenerator {
 public:
-  virtual ~SizeGenerator() {}
+  virtual ~SizeGenerator() = default;
   virtual uint32_t nextSize() = 0;
   virtual std::string describe() const = 0;
 };
@@ -131,7 +131,7 @@ private:
 template <class Transport_>
 class CoupledTransports {
 public:
-  virtual ~CoupledTransports() {}
+  virtual ~CoupledTransports() = default;
   typedef Transport_ TransportType;
 
   CoupledTransports() : in(), out() {}

--- a/lib/cpp/test/TransportTest.cpp
+++ b/lib/cpp/test/TransportTest.cpp
@@ -377,7 +377,7 @@ void alarm_handler() {
   }
 
   // Write some data to the transport to hopefully unblock it.
-  uint8_t* buf = new uint8_t[info->writeLength];
+  auto* buf = new uint8_t[info->writeLength];
   memset(buf, 'b', info->writeLength);
   boost::scoped_array<uint8_t> array(buf);
   info->transport->write(buf, info->writeLength);
@@ -421,7 +421,7 @@ void alarm_handler_wrapper() {
 void add_trigger(unsigned int seconds,
                  const std::shared_ptr<TTransport>& transport,
                  uint32_t write_len) {
-  TriggerInfo* info = new TriggerInfo(seconds, transport, write_len);
+  auto* info = new TriggerInfo(seconds, transport, write_len);
   {
     apache::thrift::concurrency::Synchronized s(g_alarm_monitor);
     if (g_triggerInfo == NULL) {

--- a/lib/cpp/test/TransportTest.cpp
+++ b/lib/cpp/test/TransportTest.cpp
@@ -341,7 +341,7 @@ public:
 
 struct TriggerInfo {
   TriggerInfo(int seconds, const std::shared_ptr<TTransport>& transport, uint32_t writeLength)
-    : timeoutSeconds(seconds), transport(transport), writeLength(writeLength), next(NULL) {}
+    : timeoutSeconds(seconds), transport(transport), writeLength(writeLength), next(nullptr) {}
 
   int timeoutSeconds;
   std::shared_ptr<TTransport> transport;
@@ -355,7 +355,7 @@ unsigned int g_numTriggersFired;
 bool g_teardown = false;
 
 void alarm_handler() {
-  TriggerInfo* info = NULL;
+  TriggerInfo* info = nullptr;
   {
     apache::thrift::concurrency::Synchronized s(g_alarm_monitor);
     // The alarm timed out, which almost certainly means we're stuck
@@ -366,7 +366,7 @@ void alarm_handler() {
     // tools/test/runner only records stdout messages in the failure messages for
     // boost tests.  (boost prints its test info to stdout.)
     printf("Timeout alarm expired; attempting to unblock transport\n");
-    if (g_triggerInfo == NULL) {
+    if (g_triggerInfo == nullptr) {
       printf("  trigger stack is empty!\n");
     }
 
@@ -395,7 +395,7 @@ void alarm_handler_wrapper() {
       if (g_teardown)
         return;
       // calculate timeout
-      if (g_triggerInfo == NULL) {
+      if (g_triggerInfo == nullptr) {
         timeout = 0;
       } else {
         timeout = g_triggerInfo->timeoutSeconds * 1000;
@@ -424,7 +424,7 @@ void add_trigger(unsigned int seconds,
   auto* info = new TriggerInfo(seconds, transport, write_len);
   {
     apache::thrift::concurrency::Synchronized s(g_alarm_monitor);
-    if (g_triggerInfo == NULL) {
+    if (g_triggerInfo == nullptr) {
       // This is the first trigger.
       // Set g_triggerInfo, and schedule the alarm
       g_triggerInfo = info;
@@ -441,17 +441,17 @@ void add_trigger(unsigned int seconds,
 }
 
 void clear_triggers() {
-  TriggerInfo* info = NULL;
+  TriggerInfo* info = nullptr;
 
   {
     apache::thrift::concurrency::Synchronized s(g_alarm_monitor);
     info = g_triggerInfo;
-    g_triggerInfo = NULL;
+    g_triggerInfo = nullptr;
     g_numTriggersFired = 0;
     g_alarm_monitor.notify();
   }
 
-  while (info != NULL) {
+  while (info != nullptr) {
     TriggerInfo* next = info->next;
     delete info;
     info = next;
@@ -500,8 +500,8 @@ void test_rw(uint32_t totalSize,
              SizeGenerator& rChunkGenerator,
              uint32_t maxOutstanding) {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   boost::shared_array<uint8_t> wbuf = boost::shared_array<uint8_t>(new uint8_t[totalSize]);
   boost::shared_array<uint8_t> rbuf = boost::shared_array<uint8_t>(new uint8_t[totalSize]);
@@ -593,8 +593,8 @@ void test_rw(uint32_t totalSize,
 template <class CoupledTransports>
 void test_read_part_available() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t write_buf[16];
   uint8_t read_buf[16];
@@ -615,8 +615,8 @@ void test_read_part_available() {
 template <class CoupledTransports>
 void test_read_part_available_in_chunks() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t write_buf[16];
   uint8_t read_buf[16];
@@ -642,8 +642,8 @@ void test_read_part_available_in_chunks() {
 template <class CoupledTransports>
 void test_read_partial_midframe() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t write_buf[16];
   uint8_t read_buf[16];
@@ -700,8 +700,8 @@ void test_read_partial_midframe() {
 template <class CoupledTransports>
 void test_borrow_part_available() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t write_buf[16];
   uint8_t read_buf[16];
@@ -715,7 +715,7 @@ void test_borrow_part_available() {
   uint32_t borrow_len = 10;
   const uint8_t* borrowed_buf = transports.in->borrow(read_buf, &borrow_len);
   BOOST_CHECK_EQUAL(g_numTriggersFired, (unsigned int)0);
-  BOOST_CHECK(borrowed_buf == NULL);
+  BOOST_CHECK(borrowed_buf == nullptr);
 
   clear_triggers();
 }
@@ -723,8 +723,8 @@ void test_borrow_part_available() {
 template <class CoupledTransports>
 void test_read_none_available() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t read_buf[16];
 
@@ -751,8 +751,8 @@ void test_read_none_available() {
 template <class CoupledTransports>
 void test_borrow_none_available() {
   CoupledTransports transports;
-  BOOST_REQUIRE(transports.in != NULL);
-  BOOST_REQUIRE(transports.out != NULL);
+  BOOST_REQUIRE(transports.in != nullptr);
+  BOOST_REQUIRE(transports.out != nullptr);
 
   uint8_t write_buf[16];
   memset(write_buf, 'a', sizeof(write_buf));
@@ -760,8 +760,8 @@ void test_borrow_none_available() {
   // Attempting to borrow when no data is available should fail immediately
   set_trigger(1, transports.out, 10);
   uint32_t borrow_len = 10;
-  const uint8_t* borrowed_buf = transports.in->borrow(NULL, &borrow_len);
-  BOOST_CHECK(borrowed_buf == NULL);
+  const uint8_t* borrowed_buf = transports.in->borrow(nullptr, &borrow_len);
+  BOOST_CHECK(borrowed_buf == nullptr);
   BOOST_CHECK_EQUAL(g_numTriggersFired, (unsigned int)0);
 
   clear_triggers();
@@ -1055,7 +1055,7 @@ BOOST_GLOBAL_FIXTURE(global_fixture)
 #ifdef BOOST_TEST_DYN_LINK
 bool init_unit_test_suite() {
   struct timeval tv;
-  THRIFT_GETTIMEOFDAY(&tv, NULL);
+  THRIFT_GETTIMEOFDAY(&tv, nullptr);
   int seed = tv.tv_sec ^ tv.tv_usec;
 
   initrand(seed);

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -58,7 +58,7 @@ boost::mt19937 rng;
 
 class SizeGenerator {
 public:
-  virtual ~SizeGenerator() {}
+  virtual ~SizeGenerator() = default;
   virtual unsigned int getSize() = 0;
 };
 

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -79,7 +79,7 @@ public:
   unsigned int getSize() override {
     // Loop until we get a size of 1 or more
     while (true) {
-      unsigned int value = static_cast<unsigned int>(gen_());
+      auto value = static_cast<unsigned int>(gen_());
       if (value >= 1) {
         return value;
       }
@@ -91,13 +91,13 @@ private:
 };
 
 boost::shared_array<uint8_t> gen_uniform_buffer(uint32_t buf_len, uint8_t c) {
-  uint8_t* buf = new uint8_t[buf_len];
+  auto* buf = new uint8_t[buf_len];
   memset(buf, c, buf_len);
   return boost::shared_array<uint8_t>(buf);
 }
 
 boost::shared_array<uint8_t> gen_compressible_buffer(uint32_t buf_len) {
-  uint8_t* buf = new uint8_t[buf_len];
+  auto* buf = new uint8_t[buf_len];
 
   // Generate small runs of alternately increasing and decreasing bytes
   boost::uniform_smallint<uint32_t> run_length_distribution(1, 64);
@@ -129,7 +129,7 @@ boost::shared_array<uint8_t> gen_compressible_buffer(uint32_t buf_len) {
 }
 
 boost::shared_array<uint8_t> gen_random_buffer(uint32_t buf_len) {
-  uint8_t* buf = new uint8_t[buf_len];
+  auto* buf = new uint8_t[buf_len];
 
   boost::uniform_smallint<uint8_t> distribution(0, UINT8_MAX);
   boost::variate_generator<boost::mt19937, boost::uniform_smallint<uint8_t> >
@@ -427,7 +427,7 @@ void print_usage(FILE* f, const char* argv0) {
 
 #ifdef BOOST_TEST_DYN_LINK
 bool init_unit_test_suite() {
-  uint32_t seed = static_cast<uint32_t>(time(NULL));
+  auto seed = static_cast<uint32_t>(time(NULL));
 #ifdef HAVE_INTTYPES_H
   printf("seed: %" PRIu32 "\n", seed);
 #endif

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -427,7 +427,7 @@ void print_usage(FILE* f, const char* argv0) {
 
 #ifdef BOOST_TEST_DYN_LINK
 bool init_unit_test_suite() {
-  auto seed = static_cast<uint32_t>(time(NULL));
+  auto seed = static_cast<uint32_t>(time(nullptr));
 #ifdef HAVE_INTTYPES_H
   printf("seed: %" PRIu32 "\n", seed);
 #endif

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -65,7 +65,7 @@ public:
 class ConstantSizeGenerator : public SizeGenerator {
 public:
   ConstantSizeGenerator(unsigned int value) : value_(value) {}
-  virtual unsigned int getSize() { return value_; }
+  unsigned int getSize() override { return value_; }
 
 private:
   unsigned int value_;
@@ -76,7 +76,7 @@ public:
   LogNormalSizeGenerator(double mean, double std_dev)
     : gen_(rng, boost::lognormal_distribution<double>(mean, std_dev)) {}
 
-  virtual unsigned int getSize() {
+  unsigned int getSize() override {
     // Loop until we get a size of 1 or more
     while (true) {
       unsigned int value = static_cast<unsigned int>(gen_());

--- a/lib/cpp/test/concurrency/Tests.cpp
+++ b/lib/cpp/test/concurrency/Tests.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     args[ix - 1] = std::string(argv[ix]);
   }
 
-  if (getenv("VALGRIND") != 0) {
+  if (getenv("VALGRIND") != nullptr) {
 	  // lower the scale of every test
 	  WEIGHT = 1;
   }

--- a/lib/cpp/test/concurrency/ThreadFactoryTests.h
+++ b/lib/cpp/test/concurrency/ThreadFactoryTests.h
@@ -51,7 +51,7 @@ public:
   public:
     ReapNTask(Monitor& monitor, int& activeCount) : _monitor(monitor), _count(activeCount) {}
 
-    void run() {
+    void run() override {
       Synchronized s(_monitor);
       
       if (--_count == 0) {
@@ -122,7 +122,7 @@ public:
 
     SynchStartTask(Monitor& monitor, volatile STATE& state) : _monitor(monitor), _state(state) {}
 
-    void run() {
+    void run() override {
       {
         Synchronized s(_monitor);
         if (_state == SynchStartTask::STARTING) {
@@ -247,14 +247,14 @@ public:
   class FloodTask : public Runnable {
   public:
     FloodTask(const size_t id, Monitor& mon) : _id(id), _mon(mon) {}
-    ~FloodTask() {
+    ~FloodTask() override {
       if (_id % 10000 == 0) {
 		Synchronized sync(_mon);
         std::cout << "\t\tthread " << _id << " done" << std::endl;
       }
     }
 
-    void run() {
+    void run() override {
       if (_id % 10000 == 0) {
 		Synchronized sync(_mon);
         std::cout << "\t\tthread " << _id << " started" << std::endl;

--- a/lib/cpp/test/concurrency/ThreadManagerTests.h
+++ b/lib/cpp/test/concurrency/ThreadManagerTests.h
@@ -63,7 +63,7 @@ public:
     Task(Monitor& monitor, size_t& count, int64_t timeout)
       : _monitor(monitor), _count(count), _timeout(timeout), _startTime(0), _endTime(0), _done(false) {}
 
-    void run() {
+    void run() override {
 
       _startTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
@@ -201,7 +201,7 @@ public:
     BlockTask(Monitor& entryMonitor, Monitor& blockMonitor, bool& blocked, Monitor& doneMonitor, size_t& count)
       : _entryMonitor(entryMonitor), _entered(false), _blockMonitor(blockMonitor), _blocked(blocked), _doneMonitor(doneMonitor), _count(count) {}
 
-    void run() {
+    void run() override {
       {
         Synchronized s(_entryMonitor);
         _entered = true;

--- a/lib/cpp/test/concurrency/ThreadManagerTests.h
+++ b/lib/cpp/test/concurrency/ThreadManagerTests.h
@@ -124,7 +124,7 @@ public:
 
     int64_t time00 = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
-    for (std::set<shared_ptr<ThreadManagerTests::Task> >::iterator ix = tasks.begin();
+    for (auto ix = tasks.begin();
          ix != tasks.end();
          ix++) {
 
@@ -151,7 +151,7 @@ public:
     int64_t minTime = 9223372036854775807LL;
     int64_t maxTime = 0;
 
-    for (std::set<shared_ptr<ThreadManagerTests::Task> >::iterator ix = tasks.begin();
+    for (auto ix = tasks.begin();
          ix != tasks.end();
          ix++) {
 
@@ -275,7 +275,7 @@ public:
             new ThreadManagerTests::BlockTask(entryMonitor, blockMonitor, blocked[1], doneMonitor, activeCounts[1])));
       }
 
-      for (std::vector<shared_ptr<ThreadManagerTests::BlockTask> >::iterator ix = tasks.begin();
+      for (auto ix = tasks.begin();
            ix != tasks.end();
            ix++) {
         threadManager->add(*ix);

--- a/lib/cpp/test/concurrency/TimerManagerTests.h
+++ b/lib/cpp/test/concurrency/TimerManagerTests.h
@@ -44,9 +44,9 @@ public:
         _success(false),
         _done(false) {}
 
-    ~Task() { std::cerr << this << std::endl; }
+    ~Task() override { std::cerr << this << std::endl; }
 
-    void run() {
+    void run() override {
 
       _endTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
       _success = (_endTime - _startTime) >= _timeout;

--- a/lib/cpp/test/concurrency/TimerManagerTests.h
+++ b/lib/cpp/test/concurrency/TimerManagerTests.h
@@ -215,7 +215,7 @@ public:
     // Verify behavior when removing the removed task
     try {
       timerManager.remove(timer);
-      assert(0 == "ERROR: This remove should send a NoSuchTaskException exception.");
+      assert(nullptr == "ERROR: This remove should send a NoSuchTaskException exception.");
     } catch (NoSuchTaskException&) {
     }
 
@@ -244,7 +244,7 @@ public:
     // Verify behavior when removing the expired task
     try {
       timerManager.remove(timer);
-      assert(0 == "ERROR: This remove should send a NoSuchTaskException exception.");
+      assert(nullptr == "ERROR: This remove should send a NoSuchTaskException exception.");
     } catch (NoSuchTaskException&) {
     }
 

--- a/lib/cpp/test/processor/EventLog.cpp
+++ b/lib/cpp/test/processor/EventLog.cpp
@@ -110,7 +110,7 @@ Event EventLog::waitForEvent(int64_t timeout) {
 Event EventLog::waitForConnEvent(uint32_t connId, int64_t timeout) {
   Synchronized s(monitor_);
 
-  EventList::iterator it = events_.begin();
+  auto it = events_.begin();
   while (true) {
     try {
       // TODO: it would be nicer to honor timeout for the duration of this

--- a/lib/cpp/test/processor/Handlers.h
+++ b/lib/cpp/test/processor/Handlers.h
@@ -32,31 +32,31 @@ public:
   ParentHandler(const std::shared_ptr<EventLog>& log)
     : triggerMonitor(&mutex_), generation_(0), wait_(false), log_(log) {}
 
-  int32_t incrementGeneration() {
+  int32_t incrementGeneration() override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_INCREMENT_GENERATION, 0, 0);
     return ++generation_;
   }
 
-  int32_t getGeneration() {
+  int32_t getGeneration() override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_GET_GENERATION, 0, 0);
     return generation_;
   }
 
-  void addString(const std::string& s) {
+  void addString(const std::string& s) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_ADD_STRING, 0, 0);
     strings_.push_back(s);
   }
 
-  void getStrings(std::vector<std::string>& _return) {
+  void getStrings(std::vector<std::string>& _return) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_GET_STRINGS, 0, 0);
     _return = strings_;
   }
 
-  void getDataWait(std::string& _return, const int32_t length) {
+  void getDataWait(std::string& _return, const int32_t length) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_GET_DATA_WAIT, 0, 0);
 
@@ -65,14 +65,14 @@ public:
     _return.append(length, 'a');
   }
 
-  void onewayWait() {
+  void onewayWait() override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_ONEWAY_WAIT, 0, 0);
 
     blockUntilTriggered();
   }
 
-  void exceptionWait(const std::string& message) {
+  void exceptionWait(const std::string& message) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_EXCEPTION_WAIT, 0, 0);
 
@@ -83,7 +83,7 @@ public:
     throw e;
   }
 
-  void unexpectedExceptionWait(const std::string& message) {
+  void unexpectedExceptionWait(const std::string& message) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_UNEXPECTED_EXCEPTION_WAIT, 0, 0);
 
@@ -148,7 +148,7 @@ class ChildHandler : public ParentHandler, virtual public ChildServiceIf {
 public:
   ChildHandler(const std::shared_ptr<EventLog>& log) : ParentHandler(log), value_(0) {}
 
-  int32_t setValue(const int32_t value) {
+  int32_t setValue(const int32_t value) override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_SET_VALUE, 0, 0);
 
@@ -157,7 +157,7 @@ public:
     return oldValue;
   }
 
-  int32_t getValue() {
+  int32_t getValue() override {
     concurrency::Guard g(mutex_);
     log_->append(EventLog::ET_CALL_GET_VALUE, 0, 0);
 
@@ -198,19 +198,19 @@ class ServerEventHandler : public server::TServerEventHandler {
 public:
   ServerEventHandler(const std::shared_ptr<EventLog>& log) : nextId_(1), log_(log) {}
 
-  virtual void preServe() {}
+  void preServe() override {}
 
-  virtual void* createContext(std::shared_ptr<protocol::TProtocol> input,
-                              std::shared_ptr<protocol::TProtocol> output) {
+  void* createContext(std::shared_ptr<protocol::TProtocol> input,
+                              std::shared_ptr<protocol::TProtocol> output) override {
     ConnContext* context = new ConnContext(input, output, nextId_);
     ++nextId_;
     log_->append(EventLog::ET_CONN_CREATED, context->id, 0);
     return context;
   }
 
-  virtual void deleteContext(void* serverContext,
+  void deleteContext(void* serverContext,
                              std::shared_ptr<protocol::TProtocol> input,
-                             std::shared_ptr<protocol::TProtocol> output) {
+                             std::shared_ptr<protocol::TProtocol> output) override {
     ConnContext* context = reinterpret_cast<ConnContext*>(serverContext);
 
     if (input != context->input) {
@@ -225,8 +225,8 @@ public:
     delete context;
   }
 
-  virtual void processContext(void* serverContext,
-                              std::shared_ptr<transport::TTransport> transport) {
+  void processContext(void* serverContext,
+                              std::shared_ptr<transport::TTransport> transport) override {
 // TODO: We currently don't test the behavior of the processContext()
 // calls.  The various server implementations call processContext() at
 // slightly different times, and it is too annoying to try and account for
@@ -258,7 +258,7 @@ class ProcessorEventHandler : public TProcessorEventHandler {
 public:
   ProcessorEventHandler(const std::shared_ptr<EventLog>& log) : nextId_(1), log_(log) {}
 
-  void* getContext(const char* fnName, void* serverContext) {
+  void* getContext(const char* fnName, void* serverContext) override {
     ConnContext* connContext = reinterpret_cast<ConnContext*>(serverContext);
 
     CallContext* context = new CallContext(connContext, nextId_, fnName);
@@ -268,46 +268,46 @@ public:
     return context;
   }
 
-  void freeContext(void* ctx, const char* fnName) {
+  void freeContext(void* ctx, const char* fnName) override {
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_CALL_FINISHED, context->connContext->id, context->id, fnName);
     delete context;
   }
 
-  void preRead(void* ctx, const char* fnName) {
+  void preRead(void* ctx, const char* fnName) override {
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_PRE_READ, context->connContext->id, context->id, fnName);
   }
 
-  void postRead(void* ctx, const char* fnName, uint32_t bytes) {
+  void postRead(void* ctx, const char* fnName, uint32_t bytes) override {
     THRIFT_UNUSED_VARIABLE(bytes);
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_POST_READ, context->connContext->id, context->id, fnName);
   }
 
-  void preWrite(void* ctx, const char* fnName) {
+  void preWrite(void* ctx, const char* fnName) override {
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_PRE_WRITE, context->connContext->id, context->id, fnName);
   }
 
-  void postWrite(void* ctx, const char* fnName, uint32_t bytes) {
+  void postWrite(void* ctx, const char* fnName, uint32_t bytes) override {
     THRIFT_UNUSED_VARIABLE(bytes);
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_POST_WRITE, context->connContext->id, context->id, fnName);
   }
 
-  void asyncComplete(void* ctx, const char* fnName) {
+  void asyncComplete(void* ctx, const char* fnName) override {
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_ASYNC_COMPLETE, context->connContext->id, context->id, fnName);
   }
 
-  void handlerError(void* ctx, const char* fnName) {
+  void handlerError(void* ctx, const char* fnName) override {
     CallContext* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_HANDLER_ERROR, context->connContext->id, context->id, fnName);

--- a/lib/cpp/test/processor/Handlers.h
+++ b/lib/cpp/test/processor/Handlers.h
@@ -211,7 +211,7 @@ public:
   void deleteContext(void* serverContext,
                              std::shared_ptr<protocol::TProtocol> input,
                              std::shared_ptr<protocol::TProtocol> output) override {
-    ConnContext* context = reinterpret_cast<ConnContext*>(serverContext);
+    auto* context = reinterpret_cast<ConnContext*>(serverContext);
 
     if (input != context->input) {
       abort();
@@ -259,7 +259,7 @@ public:
   ProcessorEventHandler(const std::shared_ptr<EventLog>& log) : nextId_(1), log_(log) {}
 
   void* getContext(const char* fnName, void* serverContext) override {
-    ConnContext* connContext = reinterpret_cast<ConnContext*>(serverContext);
+    auto* connContext = reinterpret_cast<ConnContext*>(serverContext);
 
     CallContext* context = new CallContext(connContext, nextId_, fnName);
     ++nextId_;
@@ -269,46 +269,46 @@ public:
   }
 
   void freeContext(void* ctx, const char* fnName) override {
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_CALL_FINISHED, context->connContext->id, context->id, fnName);
     delete context;
   }
 
   void preRead(void* ctx, const char* fnName) override {
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_PRE_READ, context->connContext->id, context->id, fnName);
   }
 
   void postRead(void* ctx, const char* fnName, uint32_t bytes) override {
     THRIFT_UNUSED_VARIABLE(bytes);
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_POST_READ, context->connContext->id, context->id, fnName);
   }
 
   void preWrite(void* ctx, const char* fnName) override {
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_PRE_WRITE, context->connContext->id, context->id, fnName);
   }
 
   void postWrite(void* ctx, const char* fnName, uint32_t bytes) override {
     THRIFT_UNUSED_VARIABLE(bytes);
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_POST_WRITE, context->connContext->id, context->id, fnName);
   }
 
   void asyncComplete(void* ctx, const char* fnName) override {
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_ASYNC_COMPLETE, context->connContext->id, context->id, fnName);
   }
 
   void handlerError(void* ctx, const char* fnName) override {
-    CallContext* context = reinterpret_cast<CallContext*>(ctx);
+    auto* context = reinterpret_cast<CallContext*>(ctx);
     checkName(context, fnName);
     log_->append(EventLog::ET_HANDLER_ERROR, context->connContext->id, context->id, fnName);
   }

--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -116,7 +116,7 @@ public:
     // TNonblockingServer automatically uses TFramedTransport.
     // Raise an exception if the supplied transport factory is not a
     // TFramedTransportFactory
-    TFramedTransportFactory* framedFactory
+    auto* framedFactory
         = dynamic_cast<TFramedTransportFactory*>(transportFactory.get());
     if (framedFactory == NULL) {
       throw TException("TNonblockingServer must use TFramedTransport");
@@ -145,7 +145,7 @@ public:
     // TNonblockingServer automatically uses TFramedTransport.
     // Raise an exception if the supplied transport factory is not a
     // TFramedTransportFactory
-    TFramedTransportFactory* framedFactory
+    auto* framedFactory
         = dynamic_cast<TFramedTransportFactory*>(transportFactory.get());
     if (framedFactory == NULL) {
       throw TException("TNonblockingServer must use TFramedTransport");
@@ -524,7 +524,7 @@ void testEventSequencing() {
   // can test the timing for the preRead() call.
   string requestName = "getDataWait";
   string eventName = "ParentService.getDataWait";
-  int32_t seqid = int32_t(time(NULL));
+  auto seqid = int32_t(time(NULL));
   TBinaryProtocol protocol(socket);
   protocol.writeMessageBegin(requestName, T_CALL, seqid);
   socket->flush();

--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -118,7 +118,7 @@ public:
     // TFramedTransportFactory
     auto* framedFactory
         = dynamic_cast<TFramedTransportFactory*>(transportFactory.get());
-    if (framedFactory == NULL) {
+    if (framedFactory == nullptr) {
       throw TException("TNonblockingServer must use TFramedTransport");
     }
 
@@ -147,7 +147,7 @@ public:
     // TFramedTransportFactory
     auto* framedFactory
         = dynamic_cast<TFramedTransportFactory*>(transportFactory.get());
-    if (framedFactory == NULL) {
+    if (framedFactory == nullptr) {
       throw TException("TNonblockingServer must use TFramedTransport");
     }
 
@@ -524,7 +524,7 @@ void testEventSequencing() {
   // can test the timing for the preRead() call.
   string requestName = "getDataWait";
   string eventName = "ParentService.getDataWait";
-  auto seqid = int32_t(time(NULL));
+  auto seqid = int32_t(time(nullptr));
   TBinaryProtocol protocol(socket);
   protocol.writeMessageBegin(requestName, T_CALL, seqid);
   socket->flush();

--- a/lib/cpp/test/processor/ProcessorTest.cpp
+++ b/lib/cpp/test/processor/ProcessorTest.cpp
@@ -244,14 +244,14 @@ public:
     processor_->setEventHandler(processorEventHandler_);
   }
 
-  std::shared_ptr<TServer> createServer(uint16_t port) {
+  std::shared_ptr<TServer> createServer(uint16_t port) override {
     ServerTraits_ serverTraits;
     return serverTraits.createServer(processor_, port, transportFactory_, protocolFactory_);
   }
 
-  std::shared_ptr<TServerEventHandler> getServerEventHandler() { return serverEventHandler_; }
+  std::shared_ptr<TServerEventHandler> getServerEventHandler() override { return serverEventHandler_; }
 
-  void bindSuccessful(uint16_t port) { port_ = port; }
+  void bindSuccessful(uint16_t port) override { port_ = port; }
 
   uint16_t getPort() const { return port_; }
 

--- a/lib/cpp/test/processor/ServerThread.h
+++ b/lib/cpp/test/processor/ServerThread.h
@@ -105,9 +105,9 @@ protected:
   public:
     Helper(ServerThread* serverThread) : serverThread_(serverThread) {}
 
-    void run() { serverThread_->run(); }
+    void run() override { serverThread_->run(); }
 
-    void preServe() { serverThread_->preServe(); }
+    void preServe() override { serverThread_->preServe(); }
 
   private:
     ServerThread* serverThread_;

--- a/lib/cpp/test/processor/ServerThread.h
+++ b/lib/cpp/test/processor/ServerThread.h
@@ -35,7 +35,7 @@ namespace test {
  */
 class ServerState {
 public:
-  virtual ~ServerState() {}
+  virtual ~ServerState() = default;
 
   /**
    * Create a server to listen on the specified port.

--- a/lib/cpp/test/qt/TQTcpServerTest.cpp
+++ b/lib/cpp/test/qt/TQTcpServerTest.cpp
@@ -20,25 +20,25 @@ using namespace apache::thrift;
 
 struct AsyncHandler : public test::ParentServiceCobSvIf {
   std::vector<std::string> strings;
-  virtual void addString(std::function<void()> cob, const std::string& s) {
+  void addString(std::function<void()> cob, const std::string& s) override {
     strings.push_back(s);
     cob();
   }
-  virtual void getStrings(std::function<void(std::vector<std::string> const& _return)> cob) {
+  void getStrings(std::function<void(std::vector<std::string> const& _return)> cob) override {
     cob(strings);
   }
 
   // Overrides not used in this test
-  virtual void incrementGeneration(std::function<void(int32_t const& _return)> cob) {}
-  virtual void getGeneration(std::function<void(int32_t const& _return)> cob) {}
-  virtual void getDataWait(std::function<void(std::string const& _return)> cob,
-                           const int32_t length) {}
-  virtual void onewayWait(std::function<void()> cob) {}
-  virtual void exceptionWait(
+  void incrementGeneration(std::function<void(int32_t const& _return)> cob) override {}
+  void getGeneration(std::function<void(int32_t const& _return)> cob) override {}
+  void getDataWait(std::function<void(std::string const& _return)> cob,
+                           const int32_t length) override {}
+  void onewayWait(std::function<void()> cob) override {}
+  void exceptionWait(
       std::function<void()> cob,
       std::function<void(::apache::thrift::TDelayedException* _throw)> /* exn_cob */,
-      const std::string& message) {}
-  virtual void unexpectedExceptionWait(std::function<void()> cob, const std::string& message) {}
+      const std::string& message) override {}
+  void unexpectedExceptionWait(std::function<void()> cob, const std::string& message) override {}
 };
 
 class TQTcpServerTest : public QObject {

--- a/test/cpp/src/StressTest.cpp
+++ b/test/cpp/src/StressTest.cpp
@@ -64,7 +64,7 @@ typedef map<const char*, int, ltstr> count_map;
 
 class Server : public ServiceIf {
 public:
-  Server() {}
+  Server() = default;
 
   void count(const char* method) {
     Guard m(lock_);

--- a/test/cpp/src/StressTest.cpp
+++ b/test/cpp/src/StressTest.cpp
@@ -524,7 +524,7 @@ int main(int argc, char** argv) {
       }
     }
 
-    for (std::set<std::shared_ptr<Thread> >::const_iterator thread = clientThreads.begin();
+    for (auto thread = clientThreads.begin();
          thread != clientThreads.end();
          thread++) {
       (*thread)->start();
@@ -557,7 +557,7 @@ int main(int argc, char** argv) {
     int64_t minTime = 9223372036854775807LL;
     int64_t maxTime = 0;
 
-    for (set<std::shared_ptr<Thread> >::iterator ix = clientThreads.begin();
+    for (auto ix = clientThreads.begin();
          ix != clientThreads.end();
          ix++) {
 

--- a/test/cpp/src/StressTest.cpp
+++ b/test/cpp/src/StressTest.cpp
@@ -72,7 +72,7 @@ public:
     counts_[method] = ++ct;
   }
 
-  void echoVoid() {
+  void echoVoid() override {
     count("echoVoid");
     return;
   }
@@ -82,18 +82,18 @@ public:
     return counts_;
   }
 
-  int8_t echoByte(const int8_t arg) { return arg; }
-  int32_t echoI32(const int32_t arg) { return arg; }
-  int64_t echoI64(const int64_t arg) { return arg; }
-  void echoString(string& out, const string& arg) {
+  int8_t echoByte(const int8_t arg) override { return arg; }
+  int32_t echoI32(const int32_t arg) override { return arg; }
+  int64_t echoI64(const int64_t arg) override { return arg; }
+  void echoString(string& out, const string& arg) override {
     if (arg != "hello") {
       T_ERROR_ABORT("WRONG STRING (%s)!!!!", arg.c_str());
     }
     out = arg;
   }
-  void echoList(vector<int8_t>& out, const vector<int8_t>& arg) { out = arg; }
-  void echoSet(set<int8_t>& out, const set<int8_t>& arg) { out = arg; }
-  void echoMap(map<int8_t, int8_t>& out, const map<int8_t, int8_t>& arg) { out = arg; }
+  void echoList(vector<int8_t>& out, const vector<int8_t>& arg) override { out = arg; }
+  void echoSet(set<int8_t>& out, const set<int8_t>& arg) override { out = arg; }
+  void echoMap(map<int8_t, int8_t>& out, const map<int8_t, int8_t>& arg) override { out = arg; }
 
 private:
   count_map counts_;
@@ -121,7 +121,7 @@ public:
       _loopType(loopType),
       _behavior(behavior) {}
 
-  void run() {
+  void run() override {
 
     // Wait for all worker threads to start
 
@@ -239,7 +239,7 @@ public:
 class TStartObserver : public apache::thrift::server::TServerEventHandler {
 public:
   TStartObserver() : awake_(false) {}
-  virtual void preServe() {
+  void preServe() override {
     apache::thrift::concurrency::Synchronized s(m_);
     awake_ = true;
     m_.notifyAll();

--- a/test/cpp/src/StressTestNonBlocking.cpp
+++ b/test/cpp/src/StressTestNonBlocking.cpp
@@ -67,7 +67,7 @@ typedef map<const char*, int, ltstr> count_map;
 
 class Server : public ServiceIf {
 public:
-  Server() {}
+  Server() = default;
 
   void count(const char* method) {
     Guard m(lock_);

--- a/test/cpp/src/StressTestNonBlocking.cpp
+++ b/test/cpp/src/StressTestNonBlocking.cpp
@@ -462,7 +462,7 @@ int main(int argc, char** argv) {
           new ClientThread(socket, serviceClient, monitor, threadCount, loopCount, loopType))));
     }
 
-    for (std::set<std::shared_ptr<Thread> >::const_iterator thread = clientThreads.begin();
+    for (auto thread = clientThreads.begin();
          thread != clientThreads.end();
          thread++) {
       (*thread)->start();
@@ -495,7 +495,7 @@ int main(int argc, char** argv) {
     int64_t minTime = 9223372036854775807LL;
     int64_t maxTime = 0;
 
-    for (set<std::shared_ptr<Thread> >::iterator ix = clientThreads.begin();
+    for (auto ix = clientThreads.begin();
          ix != clientThreads.end();
          ix++) {
 

--- a/test/cpp/src/StressTestNonBlocking.cpp
+++ b/test/cpp/src/StressTestNonBlocking.cpp
@@ -75,7 +75,7 @@ public:
     counts_[method] = ++ct;
   }
 
-  void echoVoid() {
+  void echoVoid() override {
     count("echoVoid");
     // Sleep to simulate work
     THRIFT_SLEEP_USEC(1);
@@ -87,18 +87,18 @@ public:
     return counts_;
   }
 
-  int8_t echoByte(const int8_t arg) { return arg; }
-  int32_t echoI32(const int32_t arg) { return arg; }
-  int64_t echoI64(const int64_t arg) { return arg; }
-  void echoString(string& out, const string& arg) {
+  int8_t echoByte(const int8_t arg) override { return arg; }
+  int32_t echoI32(const int32_t arg) override { return arg; }
+  int64_t echoI64(const int64_t arg) override { return arg; }
+  void echoString(string& out, const string& arg) override {
     if (arg != "hello") {
       T_ERROR_ABORT("WRONG STRING (%s)!!!!", arg.c_str());
     }
     out = arg;
   }
-  void echoList(vector<int8_t>& out, const vector<int8_t>& arg) { out = arg; }
-  void echoSet(set<int8_t>& out, const set<int8_t>& arg) { out = arg; }
-  void echoMap(map<int8_t, int8_t>& out, const map<int8_t, int8_t>& arg) { out = arg; }
+  void echoList(vector<int8_t>& out, const vector<int8_t>& arg) override { out = arg; }
+  void echoSet(set<int8_t>& out, const set<int8_t>& arg) override { out = arg; }
+  void echoMap(map<int8_t, int8_t>& out, const map<int8_t, int8_t>& arg) override { out = arg; }
 
 private:
   count_map counts_;
@@ -120,7 +120,7 @@ public:
       _loopCount(loopCount),
       _loopType(loopType) {}
 
-  void run() {
+  void run() override {
 
     // Wait for all worker threads to start
 

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -65,7 +65,7 @@ uint64_t now() {
   int64_t ret;
   struct timeval tv;
 
-  THRIFT_GETTIMEOFDAY(&tv, NULL);
+  THRIFT_GETTIMEOFDAY(&tv, nullptr);
   ret = tv.tv_sec;
   ret = ret * 1000 * 1000 + tv.tv_usec;
   return ret;

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -942,11 +942,11 @@ int main(int argc, char** argv) {
       if (it1 == whoa.end()) {
         failed = true;
       } else {
-        map<Numberz::type, Insanity>::const_iterator it12 = it1->second.find(Numberz::TWO);
+        auto it12 = it1->second.find(Numberz::TWO);
         if (it12 == it1->second.end() || it12->second != insane) {
           failed = true;
         }
-        map<Numberz::type, Insanity>::const_iterator it13 = it1->second.find(Numberz::THREE);
+        auto it13 = it1->second.find(Numberz::THREE);
         if (it13 == it1->second.end() || it13->second != insane) {
           failed = true;
         }
@@ -955,7 +955,7 @@ int main(int argc, char** argv) {
       if (it2 == whoa.end()) {
         failed = true;
       } else {
-        map<Numberz::type, Insanity>::const_iterator it26 = it2->second.find(Numberz::SIX);
+        auto it26 = it2->second.find(Numberz::SIX);
         if (it26 == it2->second.end() || it26->second != Insanity()) {
           failed = true;
         }

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -90,7 +90,7 @@ void signal_handler(int signum)
 
 class TestHandler : public ThriftTestIf {
 public:
-  TestHandler() {}
+  TestHandler() = default;
 
   void testVoid() override { printf("testVoid()\n"); }
 
@@ -395,7 +395,7 @@ class TestProcessorEventHandler : public TProcessorEventHandler {
 class TestHandlerAsync : public ThriftTestCobSvIf {
 public:
   TestHandlerAsync(std::shared_ptr<TestHandler>& handler) : _delegate(handler) {}
-  ~TestHandlerAsync() override {}
+  ~TestHandlerAsync() override = default;
 
   void testVoid(std::function<void()> cob) override {
     _delegate->testVoid();

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -672,7 +672,7 @@ int main(int argc, char** argv) {
     std::shared_ptr<TProtocolFactory> jsonProtocolFactory(new TJSONProtocolFactory());
     protocolFactory = jsonProtocolFactory;
   } else if (protocol_type == "compact" || protocol_type == "multic") {
-    TCompactProtocolFactoryT<TBufferBase> *compactProtocolFactory = new TCompactProtocolFactoryT<TBufferBase>();
+    auto *compactProtocolFactory = new TCompactProtocolFactoryT<TBufferBase>();
     compactProtocolFactory->setContainerSizeLimit(container_limit);
     compactProtocolFactory->setStringSizeLimit(string_limit);
     protocolFactory.reset(compactProtocolFactory);
@@ -680,7 +680,7 @@ int main(int argc, char** argv) {
     std::shared_ptr<TProtocolFactory> headerProtocolFactory(new THeaderProtocolFactory());
     protocolFactory = headerProtocolFactory;
   } else {
-    TBinaryProtocolFactoryT<TBufferBase>* binaryProtocolFactory = new TBinaryProtocolFactoryT<TBufferBase>();
+    auto* binaryProtocolFactory = new TBinaryProtocolFactoryT<TBufferBase>();
     binaryProtocolFactory->setContainerSizeLimit(container_limit);
     binaryProtocolFactory->setStringSizeLimit(string_limit);
     protocolFactory.reset(binaryProtocolFactory);

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -810,7 +810,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  if (server.get() != NULL) {
+  if (server.get() != nullptr) {
     if (protocol_type == "header") {
       // Tell the server to use the same protocol for input / output
       // if using header

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -92,46 +92,46 @@ class TestHandler : public ThriftTestIf {
 public:
   TestHandler() {}
 
-  void testVoid() { printf("testVoid()\n"); }
+  void testVoid() override { printf("testVoid()\n"); }
 
-  void testString(string& out, const string& thing) {
+  void testString(string& out, const string& thing) override {
     printf("testString(\"%s\")\n", thing.c_str());
     out = thing;
   }
 
-  bool testBool(const bool thing) {
+  bool testBool(const bool thing) override {
     printf("testBool(%s)\n", thing ? "true" : "false");
     return thing;
   }
 
-  int8_t testByte(const int8_t thing) {
+  int8_t testByte(const int8_t thing) override {
     printf("testByte(%d)\n", (int)thing);
     return thing;
   }
 
-  int32_t testI32(const int32_t thing) {
+  int32_t testI32(const int32_t thing) override {
     printf("testI32(%d)\n", thing);
     return thing;
   }
 
-  int64_t testI64(const int64_t thing) {
+  int64_t testI64(const int64_t thing) override {
     printf("testI64(%" PRId64 ")\n", thing);
     return thing;
   }
 
-  double testDouble(const double thing) {
+  double testDouble(const double thing) override {
     printf("testDouble(%f)\n", thing);
     return thing;
   }
 
-  void testBinary(std::string& _return, const std::string& thing) {
+  void testBinary(std::string& _return, const std::string& thing) override {
     std::ostringstream hexstr;
     hexstr << std::hex << thing;
     printf("testBinary(%lu: %s)\n", safe_numeric_cast<unsigned long>(thing.size()), hexstr.str().c_str());
     _return = thing;
   }
 
-  void testStruct(Xtruct& out, const Xtruct& thing) {
+  void testStruct(Xtruct& out, const Xtruct& thing) override {
     printf("testStruct({\"%s\", %d, %d, %" PRId64 "})\n",
            thing.string_thing.c_str(),
            (int)thing.byte_thing,
@@ -140,7 +140,7 @@ public:
     out = thing;
   }
 
-  void testNest(Xtruct2& out, const Xtruct2& nest) {
+  void testNest(Xtruct2& out, const Xtruct2& nest) override {
     const Xtruct& thing = nest.struct_thing;
     printf("testNest({%d, {\"%s\", %d, %d, %" PRId64 "}, %d})\n",
            (int)nest.byte_thing,
@@ -152,7 +152,7 @@ public:
     out = nest;
   }
 
-  void testMap(map<int32_t, int32_t>& out, const map<int32_t, int32_t>& thing) {
+  void testMap(map<int32_t, int32_t>& out, const map<int32_t, int32_t>& thing) override {
     printf("testMap({");
     map<int32_t, int32_t>::const_iterator m_iter;
     bool first = true;
@@ -169,7 +169,7 @@ public:
   }
 
   void testStringMap(map<std::string, std::string>& out,
-                     const map<std::string, std::string>& thing) {
+                     const map<std::string, std::string>& thing) override {
     printf("testMap({");
     map<std::string, std::string>::const_iterator m_iter;
     bool first = true;
@@ -185,7 +185,7 @@ public:
     out = thing;
   }
 
-  void testSet(set<int32_t>& out, const set<int32_t>& thing) {
+  void testSet(set<int32_t>& out, const set<int32_t>& thing) override {
     printf("testSet({");
     set<int32_t>::const_iterator s_iter;
     bool first = true;
@@ -201,7 +201,7 @@ public:
     out = thing;
   }
 
-  void testList(vector<int32_t>& out, const vector<int32_t>& thing) {
+  void testList(vector<int32_t>& out, const vector<int32_t>& thing) override {
     printf("testList({");
     vector<int32_t>::const_iterator l_iter;
     bool first = true;
@@ -217,17 +217,17 @@ public:
     out = thing;
   }
 
-  Numberz::type testEnum(const Numberz::type thing) {
+  Numberz::type testEnum(const Numberz::type thing) override {
     printf("testEnum(%d)\n", thing);
     return thing;
   }
 
-  UserId testTypedef(const UserId thing) {
+  UserId testTypedef(const UserId thing) override {
     printf("testTypedef(%" PRId64 ")\n", thing);
     return thing;
   }
 
-  void testMapMap(map<int32_t, map<int32_t, int32_t> >& mapmap, const int32_t hello) {
+  void testMapMap(map<int32_t, map<int32_t, int32_t> >& mapmap, const int32_t hello) override {
     printf("testMapMap(%d)\n", hello);
 
     map<int32_t, int32_t> pos;
@@ -241,7 +241,7 @@ public:
     mapmap.insert(make_pair(-4, neg));
   }
 
-  void testInsanity(map<UserId, map<Numberz::type, Insanity> >& insane, const Insanity& argument) {
+  void testInsanity(map<UserId, map<Numberz::type, Insanity> >& insane, const Insanity& argument) override {
     printf("testInsanity()\n");
 
     Insanity looney;
@@ -297,7 +297,7 @@ public:
                  const int64_t arg2,
                  const std::map<int16_t, std::string>& arg3,
                  const Numberz::type arg4,
-                 const UserId arg5) {
+                 const UserId arg5) override {
     (void)arg3;
     (void)arg4;
     (void)arg5;
@@ -310,7 +310,7 @@ public:
     hello.i64_thing = (int64_t)arg2;
   }
 
-  void testException(const std::string& arg) {
+  void testException(const std::string& arg) override {
     printf("testException(%s)\n", arg.c_str());
     if (arg.compare("Xception") == 0) {
       Xception e;
@@ -329,7 +329,7 @@ public:
 
   void testMultiException(Xtruct& result,
                           const std::string& arg0,
-                          const std::string& arg1) {
+                          const std::string& arg1) override {
 
     printf("testMultiException(%s, %s)\n", arg0.c_str(), arg1.c_str());
 
@@ -349,7 +349,7 @@ public:
     }
   }
 
-  void testOneway(const int32_t aNum) {
+  void testOneway(const int32_t aNum) override {
     printf("testOneway(%d): call received\n", aNum);
   }
 };
@@ -357,33 +357,33 @@ public:
 class SecondHandler : public SecondServiceIf
 {
   public:
-    void secondtestString(std::string& result, const std::string& thing)
+    void secondtestString(std::string& result, const std::string& thing) override
     { result = "testString(\"" + thing + "\")"; }
 };
 
 class TestProcessorEventHandler : public TProcessorEventHandler {
-  virtual void* getContext(const char* fn_name, void* serverContext) {
+  void* getContext(const char* fn_name, void* serverContext) override {
     (void)serverContext;
     return new std::string(fn_name);
   }
-  virtual void freeContext(void* ctx, const char* fn_name) {
+  void freeContext(void* ctx, const char* fn_name) override {
     (void)fn_name;
     delete static_cast<std::string*>(ctx);
   }
-  virtual void preRead(void* ctx, const char* fn_name) { communicate("preRead", ctx, fn_name); }
-  virtual void postRead(void* ctx, const char* fn_name, uint32_t bytes) {
+  void preRead(void* ctx, const char* fn_name) override { communicate("preRead", ctx, fn_name); }
+  void postRead(void* ctx, const char* fn_name, uint32_t bytes) override {
     (void)bytes;
     communicate("postRead", ctx, fn_name);
   }
-  virtual void preWrite(void* ctx, const char* fn_name) { communicate("preWrite", ctx, fn_name); }
-  virtual void postWrite(void* ctx, const char* fn_name, uint32_t bytes) {
+  void preWrite(void* ctx, const char* fn_name) override { communicate("preWrite", ctx, fn_name); }
+  void postWrite(void* ctx, const char* fn_name, uint32_t bytes) override {
     (void)bytes;
     communicate("postWrite", ctx, fn_name);
   }
-  virtual void asyncComplete(void* ctx, const char* fn_name) {
+  void asyncComplete(void* ctx, const char* fn_name) override {
     communicate("asyncComplete", ctx, fn_name);
   }
-  virtual void handlerError(void* ctx, const char* fn_name) {
+  void handlerError(void* ctx, const char* fn_name) override {
     communicate("handlerError", ctx, fn_name);
   }
 
@@ -395,136 +395,136 @@ class TestProcessorEventHandler : public TProcessorEventHandler {
 class TestHandlerAsync : public ThriftTestCobSvIf {
 public:
   TestHandlerAsync(std::shared_ptr<TestHandler>& handler) : _delegate(handler) {}
-  virtual ~TestHandlerAsync() {}
+  ~TestHandlerAsync() override {}
 
-  virtual void testVoid(std::function<void()> cob) {
+  void testVoid(std::function<void()> cob) override {
     _delegate->testVoid();
     cob();
   }
 
-  virtual void testString(std::function<void(std::string const& _return)> cob,
-                          const std::string& thing) {
+  void testString(std::function<void(std::string const& _return)> cob,
+                          const std::string& thing) override {
     std::string res;
     _delegate->testString(res, thing);
     cob(res);
   }
 
-  virtual void testBool(std::function<void(bool const& _return)> cob, const bool thing) {
+  void testBool(std::function<void(bool const& _return)> cob, const bool thing) override {
     bool res = _delegate->testBool(thing);
     cob(res);
   }
 
-  virtual void testByte(std::function<void(int8_t const& _return)> cob, const int8_t thing) {
+  void testByte(std::function<void(int8_t const& _return)> cob, const int8_t thing) override {
     int8_t res = _delegate->testByte(thing);
     cob(res);
   }
 
-  virtual void testI32(std::function<void(int32_t const& _return)> cob, const int32_t thing) {
+  void testI32(std::function<void(int32_t const& _return)> cob, const int32_t thing) override {
     int32_t res = _delegate->testI32(thing);
     cob(res);
   }
 
-  virtual void testI64(std::function<void(int64_t const& _return)> cob, const int64_t thing) {
+  void testI64(std::function<void(int64_t const& _return)> cob, const int64_t thing) override {
     int64_t res = _delegate->testI64(thing);
     cob(res);
   }
 
-  virtual void testDouble(std::function<void(double const& _return)> cob, const double thing) {
+  void testDouble(std::function<void(double const& _return)> cob, const double thing) override {
     double res = _delegate->testDouble(thing);
     cob(res);
   }
 
-  virtual void testBinary(std::function<void(std::string const& _return)> cob,
-                          const std::string& thing) {
+  void testBinary(std::function<void(std::string const& _return)> cob,
+                          const std::string& thing) override {
     std::string res;
     _delegate->testBinary(res, thing);
     cob(res);
   }
 
-  virtual void testStruct(std::function<void(Xtruct const& _return)> cob, const Xtruct& thing) {
+  void testStruct(std::function<void(Xtruct const& _return)> cob, const Xtruct& thing) override {
     Xtruct res;
     _delegate->testStruct(res, thing);
     cob(res);
   }
 
-  virtual void testNest(std::function<void(Xtruct2 const& _return)> cob, const Xtruct2& thing) {
+  void testNest(std::function<void(Xtruct2 const& _return)> cob, const Xtruct2& thing) override {
     Xtruct2 res;
     _delegate->testNest(res, thing);
     cob(res);
   }
 
-  virtual void testMap(std::function<void(std::map<int32_t, int32_t> const& _return)> cob,
-                       const std::map<int32_t, int32_t>& thing) {
+  void testMap(std::function<void(std::map<int32_t, int32_t> const& _return)> cob,
+                       const std::map<int32_t, int32_t>& thing) override {
     std::map<int32_t, int32_t> res;
     _delegate->testMap(res, thing);
     cob(res);
   }
 
-  virtual void testStringMap(
+  void testStringMap(
       std::function<void(std::map<std::string, std::string> const& _return)> cob,
-      const std::map<std::string, std::string>& thing) {
+      const std::map<std::string, std::string>& thing) override {
     std::map<std::string, std::string> res;
     _delegate->testStringMap(res, thing);
     cob(res);
   }
 
-  virtual void testSet(std::function<void(std::set<int32_t> const& _return)> cob,
-                       const std::set<int32_t>& thing) {
+  void testSet(std::function<void(std::set<int32_t> const& _return)> cob,
+                       const std::set<int32_t>& thing) override {
     std::set<int32_t> res;
     _delegate->testSet(res, thing);
     cob(res);
   }
 
-  virtual void testList(std::function<void(std::vector<int32_t> const& _return)> cob,
-                        const std::vector<int32_t>& thing) {
+  void testList(std::function<void(std::vector<int32_t> const& _return)> cob,
+                        const std::vector<int32_t>& thing) override {
     std::vector<int32_t> res;
     _delegate->testList(res, thing);
     cob(res);
   }
 
-  virtual void testEnum(std::function<void(Numberz::type const& _return)> cob,
-                        const Numberz::type thing) {
+  void testEnum(std::function<void(Numberz::type const& _return)> cob,
+                        const Numberz::type thing) override {
     Numberz::type res = _delegate->testEnum(thing);
     cob(res);
   }
 
-  virtual void testTypedef(std::function<void(UserId const& _return)> cob, const UserId thing) {
+  void testTypedef(std::function<void(UserId const& _return)> cob, const UserId thing) override {
     UserId res = _delegate->testTypedef(thing);
     cob(res);
   }
 
-  virtual void testMapMap(
+  void testMapMap(
       std::function<void(std::map<int32_t, std::map<int32_t, int32_t> > const& _return)> cob,
-      const int32_t hello) {
+      const int32_t hello) override {
     std::map<int32_t, std::map<int32_t, int32_t> > res;
     _delegate->testMapMap(res, hello);
     cob(res);
   }
 
-  virtual void testInsanity(
+  void testInsanity(
       std::function<void(std::map<UserId, std::map<Numberz::type, Insanity> > const& _return)> cob,
-      const Insanity& argument) {
+      const Insanity& argument) override {
     std::map<UserId, std::map<Numberz::type, Insanity> > res;
     _delegate->testInsanity(res, argument);
     cob(res);
   }
 
-  virtual void testMulti(std::function<void(Xtruct const& _return)> cob,
+  void testMulti(std::function<void(Xtruct const& _return)> cob,
                          const int8_t arg0,
                          const int32_t arg1,
                          const int64_t arg2,
                          const std::map<int16_t, std::string>& arg3,
                          const Numberz::type arg4,
-                         const UserId arg5) {
+                         const UserId arg5) override {
     Xtruct res;
     _delegate->testMulti(res, arg0, arg1, arg2, arg3, arg4, arg5);
     cob(res);
   }
 
-  virtual void testException(
+  void testException(
       std::function<void()> cob,
       std::function<void(::apache::thrift::TDelayedException* _throw)> exn_cob,
-      const std::string& arg) {
+      const std::string& arg) override {
     try {
       _delegate->testException(arg);
     } catch (const apache::thrift::TException& e) {
@@ -534,11 +534,11 @@ public:
     cob();
   }
 
-  virtual void testMultiException(
+  void testMultiException(
       std::function<void(Xtruct const& _return)> cob,
       std::function<void(::apache::thrift::TDelayedException* _throw)> exn_cob,
       const std::string& arg0,
-      const std::string& arg1) {
+      const std::string& arg1) override {
     Xtruct res;
     try {
       _delegate->testMultiException(res, arg0, arg1);
@@ -549,7 +549,7 @@ public:
     cob(res);
   }
 
-  virtual void testOneway(std::function<void()> cob, const int32_t secondsToSleep) {
+  void testOneway(std::function<void()> cob, const int32_t secondsToSleep) override {
     _delegate->testOneway(secondsToSleep);
     cob();
   }

--- a/tutorial/cpp/CppServer.cpp
+++ b/tutorial/cpp/CppServer.cpp
@@ -48,14 +48,14 @@ class CalculatorHandler : public CalculatorIf {
 public:
   CalculatorHandler() {}
 
-  void ping() { cout << "ping()" << endl; }
+  void ping() override { cout << "ping()" << endl; }
 
-  int32_t add(const int32_t n1, const int32_t n2) {
+  int32_t add(const int32_t n1, const int32_t n2) override {
     cout << "add(" << n1 << ", " << n2 << ")" << endl;
     return n1 + n2;
   }
 
-  int32_t calculate(const int32_t logid, const Work& work) {
+  int32_t calculate(const int32_t logid, const Work& work) override {
     cout << "calculate(" << logid << ", " << work << ")" << endl;
     int32_t val;
 
@@ -94,12 +94,12 @@ public:
     return val;
   }
 
-  void getStruct(SharedStruct& ret, const int32_t logid) {
+  void getStruct(SharedStruct& ret, const int32_t logid) override {
     cout << "getStruct(" << logid << ")" << endl;
     ret = log[logid];
   }
 
-  void zip() { cout << "zip()" << endl; }
+  void zip() override { cout << "zip()" << endl; }
 
 protected:
   map<int32_t, SharedStruct> log;
@@ -113,8 +113,8 @@ protected:
 */
 class CalculatorCloneFactory : virtual public CalculatorIfFactory {
  public:
-  virtual ~CalculatorCloneFactory() {}
-  virtual CalculatorIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo)
+  ~CalculatorCloneFactory() override {}
+  CalculatorIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo) override
   {
     std::shared_ptr<TSocket> sock = std::dynamic_pointer_cast<TSocket>(connInfo.transport);
     cout << "Incoming connection\n";
@@ -124,7 +124,7 @@ class CalculatorCloneFactory : virtual public CalculatorIfFactory {
     cout << "\tPeerPort: "    << sock->getPeerPort() << "\n";
     return new CalculatorHandler;
   }
-  virtual void releaseHandler( ::shared::SharedServiceIf* handler) {
+  void releaseHandler( ::shared::SharedServiceIf* handler) override {
     delete handler;
   }
 };

--- a/tutorial/cpp/CppServer.cpp
+++ b/tutorial/cpp/CppServer.cpp
@@ -46,7 +46,7 @@ using namespace shared;
 
 class CalculatorHandler : public CalculatorIf {
 public:
-  CalculatorHandler() {}
+  CalculatorHandler() = default;
 
   void ping() override { cout << "ping()" << endl; }
 
@@ -113,7 +113,7 @@ protected:
 */
 class CalculatorCloneFactory : virtual public CalculatorIfFactory {
  public:
-  ~CalculatorCloneFactory() override {}
+  ~CalculatorCloneFactory() override = default;
   CalculatorIf* getHandler(const ::apache::thrift::TConnectionInfo& connInfo) override
   {
     std::shared_ptr<TSocket> sock = std::dynamic_pointer_cast<TSocket>(connInfo.transport);


### PR DESCRIPTION
I basically used clang-tidy to apply the following C++11 refactorings (which make very much sense to me)

- make use of `override` keyword whenever a virtual function is overwritten
- make use of `auto` keyword for iterators
- make use of `auto` keyword when every a redundancy can be avoided, e.g. 
`uint32_t len = static_cast<uint32_t>(str.length());
vs.
`auto len = static_cast<uint32_t>(str.length());`
- replaced `NULL` with `nullptr`
- make use of explicitly-defaulted function definition

Additionally, I applied some more const-correctness to some functions.

