### PR TITLE
THRIFT-4405: identify and fix sequence id handling errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,**/gen-*/**,contrib/**,docs/source/conf.py,old,build,dist
+ignore = W504,E402,E501
+max-complexity = 30
+max-line-length = 120

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,18 +16,18 @@
 	
 ### Breaking Changes
 
-- [THRIFT-4743](https://issues.apache.org/jira/browse/THRIFT-4743) - compiler: remove plug-in mechanism
+- [THRIFT-4743](https://issues.apache.org/jira/browse/THRIFT-4743) - compiler: removed the plug-in mechanism
 - [THRIFT-4720](https://issues.apache.org/jira/browse/THRIFT-4720) - cpp: C++03/C++98 support has been removed; also removed boost as a runtime dependency
 - [THRIFT-4730](https://issues.apache.org/jira/browse/THRIFT-4730) - cpp: BoostThreadFactory, PosixThreadFactory, StdThreadFactory removed
 - [THRIFT-4732](https://issues.apache.org/jira/browse/THRIFT-4732) - cpp: CMake build changed to use BUILD_SHARED_LIBS
 - [THRIFT-4735](https://issues.apache.org/jira/browse/THRIFT-4735) - cpp: Removed Qt4 support
 - [THRIFT-4740](https://issues.apache.org/jira/browse/THRIFT-4740) - cpp: Use std::chrono::duration for timeouts
+- [THRIFT-4672](https://issues.apache.org/jira/browse/THRIFT-4672) - cpp: TTransport::getOrigin() is now const
 - [THRIFT-4702](https://issues.apache.org/jira/browse/THRIFT-4702) - java: class org.apache.thrift.AutoExpandingBuffer is no longer public
 - [THRIFT-4709](https://issues.apache.org/jira/browse/THRIFT-4709) - java: changes to UTF-8 handling require JDK 1.7 at a minimum
 - [THRIFT-4712](https://issues.apache.org/jira/browse/THRIFT-4712) - java: class org.apache.thrift.ShortStack is no longer public
 - [THRIFT-4725](https://issues.apache.org/jira/browse/THRIFT-4725) - java: change return type signature of 'process' methods
 - [THRIFT-4675](https://issues.apache.org/jira/browse/THRIFT-4675) - js: now uses node-int64 for 64 bit integer constants
-- [THRIFT-4672](https://issues.apache.org/jira/browse/THRIFT-4672) - C++: TTransport::getOrigin() is now const
 
 ### Known Issues (Blocker or Critical)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ CLEANFILES = \
 DISTCLEANFILES = \
 	Makefile \
 	Makefile.in \
+	aclocal.m4 \
 	apache-thrift-test-library \
 	autoscan.log \
 	compile \

--- a/build/appveyor/CYGW-appveyor-install.bat
+++ b/build/appveyor/CYGW-appveyor-install.bat
@@ -26,6 +26,12 @@ CALL cl_setenv.bat                         || EXIT /B
 CALL cl_showenv.bat                        || EXIT /B
 
 ::
+:: Upgrades cygwin to the latest, if you want...
+::
+:: appveyor DownloadFile "https://cygwin.com/setup-x86_64.exe"
+:: setup-x86_64.exe --quiet-mode --wait --upgrade-also --packages="gcc-g++"
+
+::
 :: Install apt-cyg for package management
 ::
 

--- a/build/docker/scripts/sca.sh
+++ b/build/docker/scripts/sca.sh
@@ -39,15 +39,7 @@ cppcheck --force --quiet --inline-suppr --error-exitcode=1 -j2 lib/cpp/src lib/c
 cppcheck --force --quiet --inline-suppr --error-exitcode=1 -j2 lib/c_glib/src lib/c_glib/test test/c_glib/src tutorial/c_glib
 
 # Python code style
-flake8 --ignore=W504,E501 lib/py
-flake8 --exclude=tutorial/py/build tutorial/py
-# THRIFT-4371 : generated files are excluded because they haven't been scrubbed yet
-flake8 --ignore=E501 --exclude="*/gen-py*/*",test/py/build test/py
-flake8 test/py.twisted
-flake8 test/py.tornado
-flake8 --ignore=E501 test/test.py
-flake8 --ignore=E501,E722 test/crossrunner
-flake8 test/features
+flake8
 
 # PHP code style
 composer install --quiet

--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -42,9 +42,9 @@ using std::vector;
 
 static const string endl = "\n"; // avoid ostream << std::endl flushes
 // largest consecutive integer representable by a double (2 ^ 53 - 1)
-static const long max_safe_integer = 0x1fffffffffffff;
+static const int64_t max_safe_integer = 0x1fffffffffffff;
 // smallest consecutive number representable by a double (-2 ^ 53 + 1)
-static const long min_safe_integer = -max_safe_integer;
+static const int64_t min_safe_integer = -max_safe_integer;
 
 #include "thrift/generate/t_oop_generator.h"
 

--- a/doc/specs/SequenceNumbers.md
+++ b/doc/specs/SequenceNumbers.md
@@ -1,0 +1,23 @@
+# Sequence Number #
+
+Apache Thrift built sequence numbers into every protocol exchange to allow
+for clients that may submit multiple outstanding requests on a single transport
+connection.  This is typically done by asynchronous clients.
+
+The following rules apply to sequence numbers:
+
+1. A sequence number is a signed 32-bit integer.  Negative values are allowed.
+1. Sequence numbers `MUST` be unique across all outstanding requests on a
+   given transport connection.  There is no requirement for unique numbers
+   between different transport connections even if they are from the same client.
+1. A server `MUST` reply to a client with the same sequence number that was
+   used in the request.  This includes any exception-based reply.
+1. A client `MAY` use sequence numbers if it needs them for proper operation.
+1. A client `SHOULD` set the sequence number to zero if it does not rely
+   on them.
+1. Wrapped protocols (such as THeaderProtocol) `SHOULD` use the same sequence
+   number on the wrapping as is used on the payload protocol.
+
+Servers will not inspect or make any logic choices based on the sequence number
+sent by the client.  The server's only job is to process the request and reply
+with the same sequence number.

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_stored_message_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_stored_message_protocol.c
@@ -172,7 +172,7 @@ thrift_stored_message_protocol_class_init (ThriftStoredMessageProtocolClass *kla
       g_param_spec_int ("seqid",
 			"Sequence id type in the wire",
 			"Set the Sequence id in the wire",
-			0, G_MAXINT,
+			G_MININT, G_MAXINT,
 			0,
 			(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE));
 

--- a/lib/cpp/src/thrift/TBase.h
+++ b/lib/cpp/src/thrift/TBase.h
@@ -28,7 +28,7 @@ namespace thrift {
 
 class TBase {
 public:
-  virtual ~TBase()= default;;
+  virtual ~TBase() = default;
   virtual uint32_t read(protocol::TProtocol* iprot) = 0;
   virtual uint32_t write(protocol::TProtocol* oprot) const = 0;
 };

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -98,7 +98,7 @@ public:
   template <class E>
   static TDelayedException* delayException(const E& e);
   virtual void throw_it() = 0;
-  virtual ~TDelayedException()= default;;
+  virtual ~TDelayedException() = default;
 };
 
 template <class E>

--- a/lib/cpp/src/thrift/concurrency/Thread.h
+++ b/lib/cpp/src/thrift/concurrency/Thread.h
@@ -39,7 +39,7 @@ class Thread;
 class Runnable {
 
 public:
-  virtual ~Runnable()= default;;
+  virtual ~Runnable() = default;
   virtual void run() = 0;
 
   /**

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -948,7 +948,7 @@ uint32_t TJSONProtocol::readMessageBegin(std::string& name,
                                          TMessageType& messageType,
                                          int32_t& seqid) {
   uint32_t result = readJSONArrayStart();
-  uint64_t tmpVal = 0;
+  int64_t tmpVal = 0;
   result += readJSONInteger(tmpVal);
   if (tmpVal != kThriftVersion1) {
     throw TProtocolException(TProtocolException::BAD_VERSION, "Message contained bad version.");
@@ -957,8 +957,9 @@ uint32_t TJSONProtocol::readMessageBegin(std::string& name,
   result += readJSONInteger(tmpVal);
   messageType = (TMessageType)tmpVal;
   result += readJSONInteger(tmpVal);
-  if (tmpVal > static_cast<uint64_t>((std::numeric_limits<int32_t>::max)()))
-    throw TProtocolException(TProtocolException::SIZE_LIMIT);
+  if (tmpVal > (std::numeric_limits<int32_t>::max)() ||
+      tmpVal < (std::numeric_limits<int32_t>::min)())
+    throw TProtocolException(TProtocolException::INVALID_DATA, "sequence id is not int32_t");
   seqid = static_cast<int32_t>(tmpVal);
   return result;
 }

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -303,9 +303,9 @@ static bool isLowSurrogate(uint16_t val) {
 class TJSONContext {
 
 public:
-  TJSONContext()= default;;
+  TJSONContext() = default;
 
-  virtual ~TJSONContext()= default;;
+  virtual ~TJSONContext() = default;
 
   /**
    * Write context data to the transport. Default is to do nothing.

--- a/lib/nodejs/examples/httpServer.py
+++ b/lib/nodejs/examples/httpServer.py
@@ -5,10 +5,12 @@ from hello import HelloSvc
 from thrift.protocol import TJSONProtocol
 from thrift.server import THttpServer
 
+
 class HelloSvcHandler:
-  def hello_func(self):
-    print("Hello Called")
-    return "hello from Python"
+    def hello_func(self):
+        print("Hello Called")
+        return "hello from Python"
+
 
 processor = HelloSvc.Processor(HelloSvcHandler())
 protoFactory = TJSONProtocol.TJSONProtocolFactory()

--- a/lib/py/src/ext/endian.h
+++ b/lib/py/src/ext/endian.h
@@ -79,6 +79,10 @@
 #include <byteswap.h>
 #define ntohll(n) bswap_64(n)
 #define htonll(n) bswap_64(n)
+#elif defined(_MSC_VER)
+#include <stdlib.h>
+#define ntohll(n) _byteswap_uint64(n)
+#define htonll(n) _byteswap_uint64(n)
 #else /* GNUC & GLIBC */
 #define ntohll(n) ((((unsigned long long)ntohl(n)) << 32) + ntohl(n >> 32))
 #define htonll(n) ((((unsigned long long)htonl(n)) << 32) + htonl(n >> 32))

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -58,6 +58,7 @@ def fromZigZag(n):
 
 
 def writeVarint(trans, n):
+    assert n >= 0, "Input to TCompactProtocol writeVarint cannot be negative!"
     out = bytearray()
     while True:
         if n & ~0x7f == 0:
@@ -156,7 +157,14 @@ class TCompactProtocol(TProtocolBase):
         assert self.state == CLEAR
         self.__writeUByte(self.PROTOCOL_ID)
         self.__writeUByte(self.VERSION | (type << self.TYPE_SHIFT_AMOUNT))
-        self.__writeVarint(seqid)
+        # The sequence id is a signed 32-bit integer but the compact protocol
+        # writes this out as a "var int" which is always positive, and attempting
+        # to write a negative number results in an infinite loop, so we may
+        # need to do some conversion here...
+        tseqid = seqid;
+        if tseqid < 0:
+            tseqid = 2147483648 + (2147483648 + tseqid)
+        self.__writeVarint(tseqid)
         self.__writeBinary(str_to_binary(name))
         self.state = VALUE_WRITE
 
@@ -334,6 +342,10 @@ class TCompactProtocol(TProtocolBase):
             raise TProtocolException(TProtocolException.BAD_VERSION,
                                      'Bad version: %d (expect %d)' % (version, self.VERSION))
         seqid = self.__readVarint()
+        # the sequence is a compact "var int" which is treaded as unsigned,
+        # however the sequence is actually signed...
+        if seqid > 2147483647:
+            seqid = -2147483648 - (2147483648 - seqid)
         name = binary_to_str(self.__readBinary())
         return (name, type, seqid)
 

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -161,7 +161,7 @@ class TCompactProtocol(TProtocolBase):
         # writes this out as a "var int" which is always positive, and attempting
         # to write a negative number results in an infinite loop, so we may
         # need to do some conversion here...
-        tseqid = seqid;
+        tseqid = seqid
         if tseqid < 0:
             tseqid = 2147483648 + (2147483648 + tseqid)
         self.__writeVarint(tseqid)

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -69,12 +69,12 @@ using namespace thrift::test;
 // agreement between client and server.
 //
 
-template<class _P>
-class TPedanticProtocol : public _P
+template<typename Proto>
+class TPedanticProtocol : public Proto 
 {
     public:
         TPedanticProtocol(std::shared_ptr<TTransport>& transport)
-          : _P(transport), m_last_seqid((std::numeric_limits<int32_t>::max)() - 10) { }
+          : Proto(transport), m_last_seqid((std::numeric_limits<int32_t>::max)() - 10) { }
 
         virtual uint32_t writeMessageBegin_virt(const std::string& name,
                                            const TMessageType messageType,
@@ -85,14 +85,14 @@ class TPedanticProtocol : public _P
                 seqid = ++m_last_seqid;
             }
 
-            return _P::writeMessageBegin_virt(name, messageType, seqid);
+            return Proto::writeMessageBegin_virt(name, messageType, seqid);
         }
 
         virtual uint32_t readMessageBegin_virt(std::string& name,
                                           TMessageType& messageType,
                                           int32_t& seqid) override
         {
-            uint32_t result = _P::readMessageBegin_virt(name, messageType, seqid);
+            uint32_t result = Proto::readMessageBegin_virt(name, messageType, seqid);
             if (seqid != m_last_seqid) {
                 std::stringstream ss;
                 ss << "ERROR: send request with seqid " << m_last_seqid << " and got reply with seqid " << seqid;

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -74,7 +74,7 @@ class TPedanticProtocol : public _P
 {
     public:
         TPedanticProtocol(std::shared_ptr<TTransport>& transport)
-          : _P(transport), m_last_seqid(std::numeric_limits<int32_t>::max() - 10) { }
+          : _P(transport), m_last_seqid((std::numeric_limits<int32_t>::max)() - 10) { }
 
         virtual uint32_t writeMessageBegin_virt(const std::string& name,
                                            const TMessageType messageType,

--- a/test/crossrunner/run.py
+++ b/test/crossrunner/run.py
@@ -259,7 +259,7 @@ def run_test(testdir, logdir, test_dict, max_retry, async_mode=True):
             raise
         logger.warn('Error executing [%s]', test.name, exc_info=True)
         return (retry_count, RESULT_ERROR)
-    except:
+    except Exception:
         logger.info('Interrupted execution', exc_info=True)
         if not async_mode:
             raise

--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -23,9 +23,14 @@ import os
 import sys
 import time
 import unittest
-from optparse import OptionParser
 
+from optparse import OptionParser
 from util import local_libpath
+
+sys.path.insert(0, local_libpath())
+
+from thrift.protocol import TProtocolDecorator
+from thrift.protocol import TProtocol
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -268,6 +273,43 @@ class AbstractTest(unittest.TestCase):
         self.assertEqual(self.client.testString('Python'), 'Python')
 
 
+# LAST_SEQID is a global because we have one transport and multiple protocols
+# running on it (when multiplexec)
+LAST_SEQID = None
+
+class TPedanticSequenceIdProtocolWrapper(TProtocolDecorator.TProtocolDecorator):
+    """
+    Wraps any protocol with sequence ID checking: looks for outbound
+    uniqueness as well as request/response alignment.
+    """
+    def __init__(self, protocol):
+        # TProtocolDecorator.__new__ does all the heavy lifting
+        pass
+
+    def writeMessageBegin(self, name, type, seqid):
+        global LAST_SEQID
+        if LAST_SEQID and LAST_SEQID == seqid:
+            raise TProtocol.TProtocolException(INVALID_DATA,
+                "Python client reused sequence ID {0}".format(seqid))
+        LAST_SEQID = seqid
+        super(TPedanticSequenceIdProtocolWrapper, self).writeMessageBegin(
+            name, type, seqid)
+
+    def readMessageBegin(self):
+        global LAST_SEQID
+        (name, type, seqid) =\
+            super(TPedanticSequenceIdProtocolWrapper, self).readMessageBegin()
+        if LAST_SEQID != seqid:
+            raise TProtocol.TProtocolException(INVALID_DATA,
+                "We sent seqid {0} and server returned seqid {1}".format(
+                    self.last, seqid))
+        return (name, type, seqid)
+
+
+def make_pedantic(proto):
+    """ Wrap a protocol in the pedantic sequence ID wrapper. """
+    return TPedanticSequenceIdProtocolWrapper(proto)
+
 class MultiplexedOptionalTest(AbstractTest):
     def get_protocol2(self, transport):
         return None
@@ -275,83 +317,83 @@ class MultiplexedOptionalTest(AbstractTest):
 
 class BinaryTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        return TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport)
+        return make_pedantic(TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport))
 
 
 class MultiplexedBinaryTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        wrapped_proto = TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "ThriftTest")
 
     def get_protocol2(self, transport):
-        wrapped_proto = TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TBinaryProtocol.TBinaryProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "SecondService")
 
 
 class AcceleratedBinaryTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        return TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        return make_pedantic(TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
 
 
 class MultiplexedAcceleratedBinaryTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        wrapped_proto = TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        wrapped_proto = make_pedantic(TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "ThriftTest")
 
     def get_protocol2(self, transport):
-        wrapped_proto = TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        wrapped_proto = make_pedantic(TBinaryProtocol.TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "SecondService")
 
 
 class CompactTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        return TCompactProtocol.TCompactProtocolFactory().getProtocol(transport)
+        return make_pedantic(TCompactProtocol.TCompactProtocolFactory().getProtocol(transport))
 
 
 class MultiplexedCompactTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        wrapped_proto = TCompactProtocol.TCompactProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TCompactProtocol.TCompactProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "ThriftTest")
 
     def get_protocol2(self, transport):
-        wrapped_proto = TCompactProtocol.TCompactProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TCompactProtocol.TCompactProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "SecondService")
 
 
 class AcceleratedCompactTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        return TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        return make_pedantic(TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
 
 
 class MultiplexedAcceleratedCompactTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        wrapped_proto = TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        wrapped_proto = make_pedantic(TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "ThriftTest")
 
     def get_protocol2(self, transport):
-        wrapped_proto = TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport)
+        wrapped_proto = make_pedantic(TCompactProtocol.TCompactProtocolAcceleratedFactory(fallback=False).getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "SecondService")
 
 
 class JSONTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        return TJSONProtocol.TJSONProtocolFactory().getProtocol(transport)
+        return make_pedantic(TJSONProtocol.TJSONProtocolFactory().getProtocol(transport))
 
 
 class MultiplexedJSONTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
-        wrapped_proto = TJSONProtocol.TJSONProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TJSONProtocol.TJSONProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "ThriftTest")
 
     def get_protocol2(self, transport):
-        wrapped_proto = TJSONProtocol.TJSONProtocolFactory().getProtocol(transport)
+        wrapped_proto = make_pedantic(TJSONProtocol.TJSONProtocolFactory().getProtocol(transport))
         return TMultiplexedProtocol.TMultiplexedProtocol(wrapped_proto, "SecondService")
 
 
 class HeaderTest(MultiplexedOptionalTest):
     def get_protocol(self, transport):
         factory = THeaderProtocol.THeaderProtocolFactory()
-        return factory.getProtocol(transport)
+        return make_pedantic(factory.getProtocol(transport))
 
 
 def suite():
@@ -424,7 +466,6 @@ if __name__ == "__main__":
 
     if options.genpydir:
         sys.path.insert(0, os.path.join(SCRIPT_DIR, options.genpydir))
-    sys.path.insert(0, local_libpath())
 
     if options.http_path:
         options.trans = 'http'

--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -26,9 +26,7 @@ import unittest
 
 from optparse import OptionParser
 from util import local_libpath
-
 sys.path.insert(0, local_libpath())
-
 from thrift.protocol import TProtocolDecorator
 from thrift.protocol import TProtocol
 
@@ -277,6 +275,7 @@ class AbstractTest(unittest.TestCase):
 # running on it (when multiplexec)
 LAST_SEQID = None
 
+
 class TPedanticSequenceIdProtocolWrapper(TProtocolDecorator.TProtocolDecorator):
     """
     Wraps any protocol with sequence ID checking: looks for outbound
@@ -289,7 +288,8 @@ class TPedanticSequenceIdProtocolWrapper(TProtocolDecorator.TProtocolDecorator):
     def writeMessageBegin(self, name, type, seqid):
         global LAST_SEQID
         if LAST_SEQID and LAST_SEQID == seqid:
-            raise TProtocol.TProtocolException(INVALID_DATA,
+            raise TProtocol.TProtocolException(
+                TProtocol.TProtocolException.INVALID_DATA,
                 "Python client reused sequence ID {0}".format(seqid))
         LAST_SEQID = seqid
         super(TPedanticSequenceIdProtocolWrapper, self).writeMessageBegin(
@@ -300,7 +300,8 @@ class TPedanticSequenceIdProtocolWrapper(TProtocolDecorator.TProtocolDecorator):
         (name, type, seqid) =\
             super(TPedanticSequenceIdProtocolWrapper, self).readMessageBegin()
         if LAST_SEQID != seqid:
-            raise TProtocol.TProtocolException(INVALID_DATA,
+            raise TProtocol.TProtocolException(
+                TProtocol.TProtocolException.INVALID_DATA,
                 "We sent seqid {0} and server returned seqid {1}".format(
                     self.last, seqid))
         return (name, type, seqid)
@@ -309,6 +310,7 @@ class TPedanticSequenceIdProtocolWrapper(TProtocolDecorator.TProtocolDecorator):
 def make_pedantic(proto):
     """ Wrap a protocol in the pedantic sequence ID wrapper. """
     return TPedanticSequenceIdProtocolWrapper(proto)
+
 
 class MultiplexedOptionalTest(AbstractTest):
     def get_protocol2(self, transport):

--- a/tutorial/php/runserver.py
+++ b/tutorial/php/runserver.py
@@ -30,4 +30,5 @@ os.chdir(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 class Handler(CGIHTTPServer.CGIHTTPRequestHandler):
     cgi_directories = ['/php']
 
+
 BaseHTTPServer.HTTPServer(('', 8080), Handler).serve_forever()

--- a/tutorial/py.twisted/PythonClient.py
+++ b/tutorial/py.twisted/PythonClient.py
@@ -67,6 +67,7 @@ def main(client):
     print(('Check log: %s' % (log.value)))
     reactor.stop()
 
+
 if __name__ == '__main__':
     d = ClientCreator(reactor,
                       TTwisted.ThriftClientProtocol,

--- a/tutorial/py.twisted/PythonServer.py
+++ b/tutorial/py.twisted/PythonServer.py
@@ -85,6 +85,7 @@ class CalculatorHandler:
     def zip(self):
         print('zip()')
 
+
 if __name__ == '__main__':
     handler = CalculatorHandler()
     processor = Calculator.Processor(handler)


### PR DESCRIPTION
The following tests were added:

- The cpp client for cross test now uses a sequence ID that starts at INT32_MAX - 10, and advances until it wraps around.
- The cpp client verifies the sequence ID that returns matches what was sent.
- The python client was changed to use pedantic sequence ID checking on all protocols.

The following errors were identified and fixed:

- In c_glib, thrift_stored_message_protocol was limiting the sequence ID to [0..G_INTMAX].  This was changed to allow any 32-bit value, matching other implementations.
- In cpp, JSON protocol, when the server read the header, it used a uint64_t for processing; this interacted with a bugfix from 2017 that dropped boost::lexical_cast and switched to std::stringstream, and this corrupted the negative sequence IDs.
- In python, compact protocol, a negative sequence ID was not handled properly.

Documentation was added for sequence number handling.