### PR TITLE
THRIFT-4766: Fix JDK11 build

### DIFF
--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -174,9 +174,7 @@ RUN apt-get install -y --no-install-recommends \
 `# Java dependencies` \
       ant \
       ant-optional \
-      openjdk-8-jdk \
-      maven && \
-    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      maven
 
 RUN apt-get install -y --no-install-recommends \
 `# Lua dependencies` \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       debhelper \
       flex \
       gdb \
+      libasound2 \
       llvm \
       ninja-build \
       pkg-config \
@@ -175,7 +176,7 @@ RUN apt-get install -y --no-install-recommends \
       ant \
       ant-optional \
       maven \
-      openjdk-11-jdk
+      openjdk-11-jdk-headless
 
 RUN apt-get install -y --no-install-recommends \
 `# Lua dependencies` \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -172,10 +172,10 @@ RUN apt-get install -y --no-install-recommends \
 
 RUN apt-get install -y --no-install-recommends \
 `# Java dependencies` \
-      openjdk-11-jdk-headless \
       ant \
       ant-optional \
-      maven
+      maven \
+      openjdk-11-jdk-headless
 
 RUN apt-get install -y --no-install-recommends \
 `# Lua dependencies` \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       flex \
       gdb \
       libasound2 \
+      libatk-bridge2.0-0 \
       llvm \
       ninja-build \
       pkg-config \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       gdb \
       libasound2 \
       libatk-bridge2.0-0 \
+      libgtk-3-0 \
       llvm \
       ninja-build \
       pkg-config \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -172,6 +172,7 @@ RUN apt-get install -y --no-install-recommends \
 
 RUN apt-get install -y --no-install-recommends \
 `# Java dependencies` \
+      openjdk-11-jdk-headless \
       ant \
       ant-optional \
       maven

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -175,7 +175,7 @@ RUN apt-get install -y --no-install-recommends \
       ant \
       ant-optional \
       maven \
-      openjdk-11-jdk-headless
+      openjdk-11-jdk
 
 RUN apt-get install -y --no-install-recommends \
 `# Lua dependencies` \

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), build-essential, mono-mcs, python-dev, ant,
     pkg-config, libtool, bison, flex, libboost-dev | libboost1.53-dev | libboost1.63-all-dev,
     python-all, python-setuptools, python-all-dev, python-all-dbg,
     python3-all, python3-setuptools, python3-all-dev, python3-all-dbg,
-    openjdk-8-jdk | openjdk-11-jdk | default-jdk,
+    openjdk-8-jdk | openjdk-8-jdk-headless | openjdk-11-jdk | openjdk-11-jdk-headless | default-jdk,
     libboost-test-dev | libboost-test1.53-dev | libboost-test1.63-dev, libevent-dev, libssl-dev, perl (>= 5.8.0-7),
     php (>= 5), php-dev (>= 5), libglib2.0-dev, qtchooser, qtbase5-dev-tools
 Maintainer: Thrift Developer's <dev@thrift.apache.org>

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), build-essential, mono-mcs, python-dev, ant,
     pkg-config, libtool, bison, flex, libboost-dev | libboost1.53-dev | libboost1.63-all-dev,
     python-all, python-setuptools, python-all-dev, python-all-dbg,
     python3-all, python3-setuptools, python3-all-dev, python3-all-dbg,
-    openjdk-7-jdk | openjdk-8-jdk | default-jdk,
+    openjdk-8-jdk | openjdk-8-jdk-headless | openjdk-11-jdk | openjdk-11-jdk-headless | default-jdk,
     libboost-test-dev | libboost-test1.53-dev | libboost-test1.63-dev, libevent-dev, libssl-dev, perl (>= 5.8.0-7),
     php (>= 5), php-dev (>= 5), libglib2.0-dev, qtchooser, qtbase5-dev-tools
 Maintainer: Thrift Developer's <dev@thrift.apache.org>

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), build-essential, mono-mcs, python-dev, ant,
     pkg-config, libtool, bison, flex, libboost-dev | libboost1.53-dev | libboost1.63-all-dev,
     python-all, python-setuptools, python-all-dev, python-all-dbg,
     python3-all, python3-setuptools, python3-all-dev, python3-all-dbg,
-    openjdk-8-jdk | openjdk-8-jdk-headless | openjdk-11-jdk | openjdk-11-jdk-headless | default-jdk,
+    openjdk-8-jdk | openjdk-11-jdk | default-jdk,
     libboost-test-dev | libboost-test1.53-dev | libboost-test1.63-dev, libevent-dev, libssl-dev, perl (>= 5.8.0-7),
     php (>= 5), php-dev (>= 5), libglib2.0-dev, qtchooser, qtbase5-dev-tools
 Maintainer: Thrift Developer's <dev@thrift.apache.org>

--- a/lib/java/gradle.properties
+++ b/lib/java/gradle.properties
@@ -31,3 +31,4 @@ slf4j.version=1.7.25
 servlet.version=2.5
 junit.version=4.12
 mockito.version=1.9.5
+javax.annotation.version=1.3.2

--- a/lib/java/gradle/environment.gradle
+++ b/lib/java/gradle/environment.gradle
@@ -48,6 +48,7 @@ ext.servletVersion = property('servlet.version')
 ext.slf4jVersion = property('slf4j.version')
 ext.junitVersion = property('junit.version')
 ext.mockitoVersion = property('mockito.version')
+ext.javaxAnnotationVersion = property('javax.annotation.version')
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -66,6 +67,7 @@ dependencies {
     compile "org.apache.httpcomponents:httpclient:${httpclientVersion}"
     compile "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
     compile "javax.servlet:servlet-api:${servletVersion}"
+    compile "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
 
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.mockito:mockito-all:${mockitoVersion}"


### PR DESCRIPTION
### Pull Request Guidance ###

Otherwise it will fail with:
```
make[4]: Entering directory '/thrift/tutorial/cpp'
make[4]: Nothing to be done for 'install-exec-am'.
make[4]: Nothing to be done for 'install-data-am'.
make[4]: Leaving directory '/thrift/tutorial/cpp'
make[3]: Leaving directory '/thrift/tutorial/cpp'
make[2]: Leaving directory '/thrift/tutorial/cpp'
Making install in java
make[2]: Entering directory '/thrift/tutorial/java'
/usr/bin/ant  compile
Buildfile: /thrift/tutorial/java/build.xml

init:
    [mkdir] Created dir: /thrift/tutorial/java/build
    [mkdir] Created dir: /thrift/tutorial/java/build/log

generate:

compile:
    [javac] Compiling 7 source files to /thrift/tutorial/java/build
    [javac] /thrift/tutorial/java/gen-java/shared/SharedService.java:10: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] /thrift/tutorial/java/gen-java/shared/SharedStruct.java:10: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] /thrift/tutorial/java/gen-java/tutorial/Calculator.java:10: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] /thrift/tutorial/java/gen-java/tutorial/Work.java:19: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] /thrift/tutorial/java/gen-java/tutorial/InvalidOperation.java:13: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] /thrift/tutorial/java/gen-java/tutorial/Operation.java:14: error: package javax.annotation does not exist
    [javac] @javax.annotation.Generated(value = "Autogenerated by Thrift Compiler (0.13.0)", date = "2019-01-30")
    [javac]                  ^
    [javac] 6 errors

BUILD FAILED
/thrift/tutorial/java/build.xml:55: Compile failed; see the compiler error output for details.

```

Review the following items to ensure a smooth pull request experience.

- [ ] Did you make a breaking change?  If so:

  - [ ] Add (or reference) an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) THRIFT ticket.
  - [ ] Add a `Breaking-Change` label to the Jira ticket.
  - [ ] Add a note to the `lib/<language>/README.md` file.
  - [ ] Add a line to the `CHANGES.md` file.

- [x] Is this change significant enough to be in release notes?

This will add JDK9+ compatibility to Thirft

- [x] If there is an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket: 

  - [x] Is the [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) THRIFT ticket identifier in the PR title?

        THRIFT-4766: an example pull request title

  - [x] Is the [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) THRIFT ticket identifier and affected languages in the commit message?

        THRIFT-4766: [summary of fix, one line if possible]
        Client: [language(s) affected, comma separated, use lib/ directory names please]

- [x] Did you squash your changes to a single commit?

        Committers can squash when they merge, but sometimes we forget, and it makes the history
        pretty dirty.  Please squash your pull requests to a single commit if you can.

For more information about committing, see CONTRIBUTING.md
