### PR TITLE
THRIFT-4779: fix exception type in TMultiplexedProcessor

### DIFF
--- a/lib/java/src/org/apache/thrift/TMultiplexedProcessor.java
+++ b/lib/java/src/org/apache/thrift/TMultiplexedProcessor.java
@@ -87,7 +87,7 @@ public class TMultiplexedProcessor implements TProcessor {
      *         that allows readMessageBegin() to return the original TMessage.</li>
      * </ol>
      *
-     * @throws TException If the message type is not CALL or ONEWAY, if
+     * @throws TProtocolException If the message type is not CALL or ONEWAY, if
      * the service name was not found in the message, or if the service
      * name was not found in the service map.  You called {@link #registerProcessor(String, TProcessor) registerProcessor}
      * during initialization, right? :)
@@ -101,7 +101,8 @@ public class TMultiplexedProcessor implements TProcessor {
         TMessage message = iprot.readMessageBegin();
 
         if (message.type != TMessageType.CALL && message.type != TMessageType.ONEWAY) {
-            throw new TException("This should not have happened!?");
+            throw new TProtocolException(TProtocolException.NOT_IMPLEMENTED,
+                "This should not have happened!?");
         }
 
         // Extract the service name
@@ -112,16 +113,18 @@ public class TMultiplexedProcessor implements TProcessor {
                 defaultProcessor.process(new StoredMessageProtocol(iprot, message), oprot);
                 return;
           }
-            throw new TException("Service name not found in message name: " + message.name + ".  Did you " +
-                    "forget to use a TMultiplexProtocol in your client?");
+            throw new TProtocolException(TProtocolException.NOT_IMPLEMENTED,
+                "Service name not found in message name: " + message.name + ".  Did you " +
+                "forget to use a TMultiplexProtocol in your client?");
         }
 
         // Create a new TMessage, something that can be consumed by any TProtocol
         String serviceName = message.name.substring(0, index);
         TProcessor actualProcessor = SERVICE_PROCESSOR_MAP.get(serviceName);
         if (actualProcessor == null) {
-            throw new TException("Service name not found: " + serviceName + ".  Did you forget " +
-                    "to call registerProcessor()?");
+            throw new TProtocolException(TProtocolException.NOT_IMPLEMENTED,
+                "Service name not found: " + serviceName + ".  Did you forget " +
+                "to call registerProcessor()?");
         }
 
         // Create a new TMessage, removing the service name

--- a/lib/py/src/TMultiplexedProcessor.py
+++ b/lib/py/src/TMultiplexedProcessor.py
@@ -17,8 +17,9 @@
 # under the License.
 #
 
-from thrift.Thrift import TProcessor, TMessageType, TException
+from thrift.Thrift import TProcessor, TMessageType
 from thrift.protocol import TProtocolDecorator, TMultiplexedProtocol
+from thrift.protocol.TProtocol import TProtocolException
 
 
 class TMultiplexedProcessor(TProcessor):
@@ -31,19 +32,28 @@ class TMultiplexedProcessor(TProcessor):
     def process(self, iprot, oprot):
         (name, type, seqid) = iprot.readMessageBegin()
         if type != TMessageType.CALL and type != TMessageType.ONEWAY:
-            raise TException("TMultiplexed protocol only supports CALL & ONEWAY")
+            raise TProtocolException(
+                TProtocolException.NOT_IMPLEMENTED,
+                "TMultiplexedProtocol only supports CALL & ONEWAY")
 
         index = name.find(TMultiplexedProtocol.SEPARATOR)
         if index < 0:
-            raise TException("Service name not found in message name: " + name + ". Did you forget to use TMultiplexedProtocol in your client?")
+            raise TProtocolException(
+                TProtocolException.NOT_IMPLEMENTED,
+                "Service name not found in message name: " + name + ".  " +
+                "Did you forget to use TMultiplexedProtocol in your client?")
 
         serviceName = name[0:index]
         call = name[index + len(TMultiplexedProtocol.SEPARATOR):]
         if serviceName not in self.services:
-            raise TException("Service name not found: " + serviceName + ". Did you forget to call registerProcessor()?")
+            raise TProtocolException(
+                TProtocolException.NOT_IMPLEMENTED,
+                "Service name not found: " + serviceName + ".  " +
+                "Did you forget to call registerProcessor()?")
 
         standardMessage = (call, type, seqid)
-        return self.services[serviceName].process(StoredMessageProtocol(iprot, standardMessage), oprot)
+        return self.services[serviceName].process(
+            StoredMessageProtocol(iprot, standardMessage), oprot)
 
 
 class StoredMessageProtocol(TProtocolDecorator.TProtocolDecorator):


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
fix exception type in TMultiplexedProcessor

<!-- We recommend you review the checklist before submitting a pull request. -->

- [x] Did you squash your changes to a single commit?

- [x] Do you need an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?<details><summary>Expand for guidance...</summary>
    - `Yes` if your change requires a release note.
    - `Yes` if your change is a breaking change.
    - `No` if you change is trivial, such as fixing a typo.
</details>
 
- [x] Is this change worthy of a release note? <details><summary>Examples of Release Note-worthy examples...</summary>
    - Breaking Changes
    - New, Deprecated, or Removed Languages
    - Security Fixes
    - Significant Refactoring
    - Changing how the product is built
</details>

- [ ] Breaking changes have additional requirements: <details><summary>Expand for instructions...</summary>
    - Add or reference an existing Apache Jira THRIFT ticket.
    - Add a `Breaking-Change` label to the Jira ticket.
    - Add a note to the `lib/<language>/README.md` file.
    - Add a line to the `CHANGES.md` file.
</details>

- [x] Does this change require a build? <details><summary>Expand for guidance...</summary>
    - `Yes` for any code change
    - `Yes` for any build script change
    - `Yes` for any docker build environment change
    - `Yes` for any change affecting the cross test suite
    - `No` for documentation-only changes
    - `No` for trivial changes, for example fixing a typo.
    <br/>
    If your change does not require a build, you can add [ci skip] to the end of your commit message.<br/>
    This will avoid costly and unnecessary builds in both the pull request and once it is merged.
</details>

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
