### PR TITLE
THRIFT-4794: finish php json cross test

### DIFF
--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -217,6 +217,7 @@ RUN apt-get install -y --no-install-recommends \
       php \
       php-cli \
       php-dev \
+      php-json \
       php-pear \
       re2c \
       composer

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -218,6 +218,7 @@ RUN apt-get install -y --no-install-recommends \
       php7.0 \
       php7.0-cli \
       php7.0-dev \
+      php-json \
       php-pear \
       re2c \
       composer

--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -26,6 +26,7 @@ stubs: ../ThriftTest.thrift
 php_ext_dir:
 	mkdir -p php_ext_dir
 	ln -s ../../../lib/php/src/ext/thrift_protocol/modules/thrift_protocol.so php_ext_dir/
+	ln -s "$$(php-config --extension-dir)/json.so" php_ext_dir/
 	ln -s "$$(php-config --extension-dir)/sockets.so" php_ext_dir/
 
 precross: stubs php_ext_dir

--- a/test/php/test_php.ini
+++ b/test/php/test_php.ini
@@ -1,2 +1,3 @@
 extension=thrift_protocol.so
+extension=json.so
 extension=sockets.so

--- a/test/tests.json
+++ b/test/tests.json
@@ -545,8 +545,9 @@
       ],
       "protocols": [
         "binary",
+        "binary:accel",
         "compact",
-        "binary:accel"
+        "json"
       ],
       "command": [
         "php",


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The code was implemented in the test client but nothing was invoking it.

<!-- We recommend you review the checklist before submitting a pull request. -->

- [x] Did you squash your changes to a single commit?

- [x] Do you need an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?<details><summary>Expand for guidance...</summary>
    - `Yes` if your change requires a release note.
    - `Yes` if your change is a breaking change.
    - `No` if you change is trivial, such as fixing a typo.
</details>
 
- [ ] Is this change worthy of a release note? <details><summary>Examples of Release Note-worthy examples...</summary>
    - Breaking Changes
    - New, Deprecated, or Removed Languages
    - Security Fixes
    - Significant Refactoring
    - Changing how the product is built
</details>

- [ ] Breaking changes have additional requirements: <details><summary>Expand for instructions...</summary>
    - Add or reference an existing Apache Jira THRIFT ticket.
    - Add a `Breaking-Change` label to the Jira ticket.
    - Add a note to the `lib/<language>/README.md` file.
    - Add a line to the `CHANGES.md` file.
</details>

- [x] Does this change require a build? <details><summary>Expand for guidance...</summary>
    - `Yes` for any code change
    - `Yes` for any build script change
    - `Yes` for any docker build environment change
    - `Yes` for any change affecting the cross test suite
    - `No` for documentation-only changes
    - `No` for trivial changes, for example fixing a typo.
    <br/>
    If your change does not require a build, you can add [ci skip] to the end of your commit message.<br/>
    This will avoid costly and unnecessary builds in both the pull request and once it is merged.
</details>

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
