### PR TITLE
THRIFT-4805: Fix THRIFT-3769, THRIFT-2268

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TSaslTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TSaslTransport.java
@@ -427,6 +427,18 @@ abstract class TSaslTransport extends TTransport {
       readFrame();
     } catch (SaslException e) {
       throw new TTransportException(e);
+    } catch (TTransportException transportException) {
+      /*
+       * If there is no-data or no-sasl header in the stream, throw a different
+       * type of exception so we can handle this scenario differently.
+       */
+      if (transportException.getType() == TTransportException.END_OF_FILE) {
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("No data or no sasl data in the stream");
+        }
+        throw new TSaslTransportException("No data or no sasl data in the stream");
+      }
+      throw transportException;
     }
 
     return readBuffer.read(buf, off, len);


### PR DESCRIPTION
Two fixes here:
1. Additional logic to properly catch and handle TTransportException.
    Currently, T(SASL)TransportException gets caught and handled in
    the wrong catch-block.
2. The fix for THRIFT-3769 mutes *all* TTransportExceptions in TThreadPoolServer.
    This might mute legitimate failures. The intent of THRIFT-3769 (and
    THRIFT-2268) was to mute the noise caused by TTransportException.END_OF_FILE.
    This commit lets legitimate failures to be bubbled upwards.

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes) (THRIFT-4805)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
