### PR TITLE
THRIFT-4807: Fix php segfault on reference pass

### DIFF
--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol.cpp
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol.cpp
@@ -1013,7 +1013,7 @@ void binary_serialize_spec(zval* zthis, PHPOutputTransport& transport, HashTable
     zval* prop = zend_read_property(Z_OBJCE_P(zthis), zthis, varname, strlen(varname), false, &rv);
 
     if (Z_TYPE_P(prop) == IS_REFERENCE){
-      ZVAL_UNREF(prop);
+      ZVAL_DEREF(prop);
     }
     if (Z_TYPE_P(prop) != IS_NULL) {
       transport.writeI8(ttype);


### PR DESCRIPTION
Client: php (extension)

When reference is passed to php extension, it's unreferenced (instead of
derefrenced). The next time one tries to use the same variable PHP
segaults. Even if not used again, php segfaults on
user_shutdown_function_call.

Tested by rerunning code in Jira THRIFT-4807 with the patch - passes