### PR TITLE
THRIFT-4536: TryFrom stable

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -550,20 +550,17 @@ void t_rs_generator::render_attributes_and_includes() {
   f_gen_ << endl;
 
   // add standard includes
-  f_gen_ << "extern crate ordered_float;" << endl;
   f_gen_ << "extern crate thrift;" << endl;
-  f_gen_ << "extern crate try_from;" << endl;
   f_gen_ << endl;
-  f_gen_ << "use ordered_float::OrderedFloat;" << endl;
+  f_gen_ << "use thrift::OrderedFloat;" << endl;
   f_gen_ << "use std::cell::RefCell;" << endl;
   f_gen_ << "use std::collections::{BTreeMap, BTreeSet};" << endl;
-  f_gen_ << "use std::convert::From;" << endl;
+  f_gen_ << "use std::convert::{From, TryFrom};" << endl;
   f_gen_ << "use std::default::Default;" << endl;
   f_gen_ << "use std::error::Error;" << endl;
   f_gen_ << "use std::fmt;" << endl;
   f_gen_ << "use std::fmt::{Display, Formatter};" << endl;
   f_gen_ << "use std::rc::Rc;" << endl;
-  f_gen_ << "use try_from::TryFrom;" << endl;
   f_gen_ << endl;
   f_gen_ << "use thrift::{ApplicationError, ApplicationErrorKind, ProtocolError, ProtocolErrorKind, TThriftClient};" << endl;
   f_gen_ << "use thrift::protocol::{TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TInputProtocol, TOutputProtocol, TSetIdentifier, TStructIdentifier, TType};" << endl;
@@ -932,9 +929,9 @@ void t_rs_generator::render_enum_conversion(t_enum* tenum, const string& enum_na
   f_gen_ << "impl TryFrom<i32> for " << enum_name << " {" << endl;
   indent_up();
 
-  f_gen_ << indent() << "type Err = thrift::Error;";
+  f_gen_ << indent() << "type Error = thrift::Error;";
 
-  f_gen_ << indent() << "fn try_from(i: i32) -> Result<Self, Self::Err> {" << endl;
+  f_gen_ << indent() << "fn try_from(i: i32) -> Result<Self, Self::Error> {" << endl;
   indent_up();
 
   f_gen_ << indent() << "match i {" << endl;

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -11,9 +11,8 @@ exclude = ["Makefile*", "test/**", "*.iml"]
 keywords = ["thrift"]
 
 [dependencies]
-byteorder = "~1.2.1"
-integer-encoding = "~1.0.4"
-log = "~0.3.8"
-threadpool = "~1.7.1"
-try_from = "~0.2.2"
-
+ordered-float = "0.5"
+byteorder = "1"
+integer-encoding = "1"
+log = "0.4"
+threadpool = "1.7"

--- a/lib/rs/src/errors.rs
+++ b/lib/rs/src/errors.rs
@@ -19,7 +19,7 @@ use std::convert::{From, Into};
 use std::error::Error as StdError;
 use std::fmt::{Debug, Display, Formatter};
 use std::{error, fmt, io, string};
-use try_from::TryFrom;
+use std::convert::TryFrom;
 
 use protocol::{TFieldIdentifier, TInputProtocol, TOutputProtocol, TStructIdentifier, TType};
 
@@ -413,8 +413,8 @@ impl Display for TransportError {
 }
 
 impl TryFrom<i32> for TransportErrorKind {
-    type Err = Error;
-    fn try_from(from: i32) -> Result<Self, Self::Err> {
+    type Error = Error;
+    fn try_from(from: i32) -> Result<Self, Self::Error> {
         match from {
             0 => Ok(TransportErrorKind::Unknown),
             1 => Ok(TransportErrorKind::NotOpen),
@@ -543,8 +543,8 @@ impl Display for ProtocolError {
 }
 
 impl TryFrom<i32> for ProtocolErrorKind {
-    type Err = Error;
-    fn try_from(from: i32) -> Result<Self, Self::Err> {
+    type Error = Error;
+    fn try_from(from: i32) -> Result<Self, Self::Error> {
         match from {
             0 => Ok(ProtocolErrorKind::Unknown),
             1 => Ok(ProtocolErrorKind::InvalidData),
@@ -647,8 +647,8 @@ impl Display for ApplicationError {
 }
 
 impl TryFrom<i32> for ApplicationErrorKind {
-    type Err = Error;
-    fn try_from(from: i32) -> Result<Self, Self::Err> {
+    type Error = Error;
+    fn try_from(from: i32) -> Result<Self, Self::Error> {
         match from {
             0 => Ok(ApplicationErrorKind::Unknown),
             1 => Ok(ApplicationErrorKind::UnknownMethod),

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -49,9 +49,9 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
 extern crate byteorder;
+extern crate ordered_float;
 extern crate integer_encoding;
 extern crate threadpool;
-extern crate try_from;
 
 #[macro_use]
 extern crate log;
@@ -85,3 +85,6 @@ pub use autogen::*;
 /// As is convention this is a typedef of `std::result::Result`
 /// with `E` defined as the `thrift::Error` type.
 pub type Result<T> = std::result::Result<T, self::Error>;
+
+// Re-export ordered-float, since it is used by the generator
+pub use ordered_float::OrderedFloat as OrderedFloat;

--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
-use std::convert::From;
-use try_from::TryFrom;
+use std::convert::{From, TryFrom};
 
 use super::{
     TFieldIdentifier, TInputProtocol, TInputProtocolFactory, TListIdentifier, TMapIdentifier,

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -17,9 +17,8 @@
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use integer_encoding::{VarIntReader, VarIntWriter};
-use std::convert::From;
+use std::convert::{From, TryFrom};
 use std::io;
-use try_from::TryFrom;
 
 use super::{
     TFieldIdentifier, TInputProtocol, TInputProtocolFactory, TListIdentifier, TMapIdentifier,

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -57,10 +57,9 @@
 //! protocol.write_field_end().unwrap();
 //! ```
 
-use std::convert::From;
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use try_from::TryFrom;
 
 use transport::{TReadTransport, TWriteTransport};
 use {ProtocolError, ProtocolErrorKind};
@@ -770,8 +769,8 @@ impl From<TMessageType> for u8 {
 }
 
 impl TryFrom<u8> for TMessageType {
-    type Err = ::Error;
-    fn try_from(b: u8) -> ::Result<Self> {
+    type Error = ::Error;
+    fn try_from(b: u8) -> Result<Self, Self::Error> {
         match b {
             0x01 => Ok(TMessageType::Call),
             0x02 => Ok(TMessageType::Reply),

--- a/lib/rs/test/src/lib.rs
+++ b/lib/rs/test/src/lib.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-extern crate ordered_float;
 extern crate thrift;
-extern crate try_from;
 
 pub mod base_one;
 pub mod base_two;


### PR DESCRIPTION
Submitting this as a draft PR to determine issues that should be created and which parts of PR should be merged.

TryFrom is now stable, so use that instead of try_from crate. Additionally re-export OrderedFloat since
it is used by the generated code. Relax dependencies to reduce downstream
conflicts.
 
- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"
