### PR TITLE
THRIFT-4821 Normalized the constructors in TServerSocketTransport

### DIFF
--- a/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
@@ -28,47 +28,27 @@ namespace Thrift.Transport.Server
     public class TServerSocketTransport : TServerTransport
     {
         private readonly int _clientTimeout;
-        private readonly int _port;
         private readonly bool _useBufferedSockets;
         private readonly bool _useFramedTransport;
         private TcpListener _server;
 
-        public TServerSocketTransport(TcpListener listener)
-            : this(listener, 0)
-        {
-        }
-
-        public TServerSocketTransport(TcpListener listener, int clientTimeout)
+        public TServerSocketTransport(TcpListener listener, int clientTimeout = 0, bool useBufferedSockets = false, bool useFramedTransport = false)
         {
             _server = listener;
             _clientTimeout = clientTimeout;
+            _useBufferedSockets = useBufferedSockets;
+            _useFramedTransport = useFramedTransport;
         }
 
-        public TServerSocketTransport(int port)
-            : this(port, 0)
+        public TServerSocketTransport(int port, int clientTimeout = 0, bool useBufferedSockets = false, bool useFramedTransport = false)
         {
-        }
-
-        public TServerSocketTransport(int port, int clientTimeout)
-            : this(port, clientTimeout, false)
-        {
-        }
-
-        public TServerSocketTransport(int port, int clientTimeout, bool useBufferedSockets):
-            this(port, clientTimeout, useBufferedSockets, false)
-        {
-        }
-        
-        public TServerSocketTransport(int port, int clientTimeout, bool useBufferedSockets, bool useFramedTransport)
-        {
-            _port = port;
             _clientTimeout = clientTimeout;
             _useBufferedSockets = useBufferedSockets;
             _useFramedTransport = useFramedTransport;
             try
             {
                 // Make server socket
-                _server = new TcpListener(IPAddress.Any, _port);
+                _server = new TcpListener(IPAddress.Any, port);
                 _server.Server.NoDelay = true;
             }
             catch (Exception)


### PR DESCRIPTION
…allow parity between the TcpListerer and port options.

Client: netstd
Patch: Kyle Smith

<!-- Explain the changes in the pull request below: -->
I refactored the constructors in the TServerSocketTransport so that you can use the build-in framed and buffered options while passing in a TcpListener object. Using default values, I was able to reduce the total number of constructors to maintain from 6 to 2 without breaking changes.

<!-- We recommend you review the checklist before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
