### PR TITLE
THRIFT-4828: Added the framed/buffered options to the TNamedPipeServerTransport

### DIFF
--- a/tutorial/netstd/Server/Program.cs
+++ b/tutorial/netstd/Server/Program.cs
@@ -93,6 +93,8 @@ Options:
         tcp - (default) tcp transport will be used (host - ""localhost"", port - 9090)
         tcpbuffered - tcp buffered transport will be used (host - ""localhost"", port - 9090)
         namedpipe - namedpipe transport will be used (pipe address - "".test"")
+        namedpipebuffered - buffered namedpipe transport will be used (pipe address - "".test"")
+        namedpipeframed - framed namedpipe transport will be used (pipe address - "".test"")
         http - http transport will be used (http address - ""localhost:9090"")
         tcptls - tcp transport with tls will be used (host - ""localhost"", port - 9090)
         framed - tcp framed transport will be used (host - ""localhost"", port - 9090)
@@ -157,6 +159,12 @@ Sample:
                     break;
                 case Transport.NamedPipe:
                     serverTransport = new TNamedPipeServerTransport(".test");
+                    break;
+                case Transport.NamedPipeBuffered:
+                    serverTransport = new TNamedPipeServerTransport(".test", buffering: Buffering.BufferedTransport);
+                    break;
+                case Transport.NamedPipeFramed:
+                    serverTransport = new TNamedPipeServerTransport(".test", buffering: Buffering.FramedTransport);
                     break;
                 case Transport.TcpTls:
                     serverTransport = new TTlsServerSocketTransport(9090, GetCertificate(), Buffering.None, ClientCertValidator, LocalCertificateSelectionCallback);
@@ -272,6 +280,8 @@ Sample:
             Tcp,
             TcpBuffered,
             NamedPipe,
+            NamedPipeBuffered,
+            NamedPipeFramed,
             Http,
             TcpTls,
             Framed


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
THRIFT-4828: Added the frame/buffered options to the TNamedPipeServerTransport
Client: netstd
Patch: Kyle Smith

<!-- We recommend you review the checklist before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
