### PR TITLE
THRIFT-4830: Add to_string helper function for cpp generator

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -663,7 +663,7 @@ void t_cpp_generator::generate_enum_to_string_helper_function(std::ostream& out,
              << tenum->get_name() << "_VALUES_TO_NAMES.find(val);" << endl;
     out << indent() << "if (it != _" << tenum->get_name() << "_VALUES_TO_NAMES.end()) {" << endl;
     indent_up();
-    out << indent() << "out = std::to_string(it->second);" << endl;
+    out << indent() << "out = std::string(it->second);" << endl;
     indent_down();
     out << indent() << "} else {" << endl;
     indent_up();

--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -114,6 +114,8 @@ public:
   void generate_enum(t_enum* tenum) override;
   void generate_enum_ostream_operator_decl(std::ostream& out, t_enum* tenum);
   void generate_enum_ostream_operator(std::ostream& out, t_enum* tenum);
+  void generate_enum_to_string_helper_function_decl(std::ostream& out, t_enum* tenum);
+  void generate_enum_to_string_helper_function(std::ostream& out, t_enum* tenum);
   void generate_forward_declaration(t_struct* tstruct) override;
   void generate_struct(t_struct* tstruct) override { generate_cpp_struct(tstruct, false); }
   void generate_xception(t_struct* txception) override { generate_cpp_struct(txception, true); }
@@ -584,6 +586,9 @@ void t_cpp_generator::generate_enum(t_enum* tenum) {
 
   generate_enum_ostream_operator_decl(f_types_, tenum);
   generate_enum_ostream_operator(f_types_impl_, tenum);
+
+  generate_enum_to_string_helper_function_decl(f_types_, tenum);
+  generate_enum_to_string_helper_function(f_types_impl_, tenum);
 }
 
 void t_cpp_generator::generate_enum_ostream_operator_decl(std::ostream& out, t_enum* tenum) {
@@ -622,6 +627,47 @@ void t_cpp_generator::generate_enum_ostream_operator(std::ostream& out, t_enum* 
     out << indent() << "} else {" << endl;
     indent_up();
     out << indent() << "out << static_cast<int>(val);" << endl;
+    indent_down();
+    out << indent() << "}" << endl;
+
+    out << indent() << "return out;" << endl;
+    scope_down(out);
+    out << endl;
+  }
+}
+
+void t_cpp_generator::generate_enum_to_string_helper_function_decl(std::ostream& out, t_enum* tenum) {
+  out << "std::string to_string(const ";
+  if (gen_pure_enums_) {
+    out << tenum->get_name();
+  } else {
+    out << tenum->get_name() << "::type&";
+  }
+  out << " val);" << endl;
+  out << endl;
+}
+
+void t_cpp_generator::generate_enum_to_string_helper_function(std::ostream& out, t_enum* tenum) {
+  if (!has_custom_ostream(tenum)) {
+    out << "std::string to_string(const ";
+    if (gen_pure_enums_) {
+      out << tenum->get_name();
+    } else {
+      out << tenum->get_name() << "::type&";
+    }
+    out << " val) " ;
+	scope_up(out);
+
+    out << indent() << "std::string out;" << endl;
+    out << indent() << "std::map<int, const char*>::const_iterator it = _"
+             << tenum->get_name() << "_VALUES_TO_NAMES.find(val);" << endl;
+    out << indent() << "if (it != _" << tenum->get_name() << "_VALUES_TO_NAMES.end()) {" << endl;
+    indent_up();
+    out << indent() << "out = std::to_string(it->second);" << endl;
+    indent_down();
+    out << indent() << "} else {" << endl;
+    indent_up();
+    out << indent() << "out = std::to_string(static_cast<int>(val));" << endl;
     indent_down();
     out << indent() << "}" << endl;
 

--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -658,20 +658,18 @@ void t_cpp_generator::generate_enum_to_string_helper_function(std::ostream& out,
     out << " val) " ;
 	scope_up(out);
 
-    out << indent() << "std::string out;" << endl;
     out << indent() << "std::map<int, const char*>::const_iterator it = _"
              << tenum->get_name() << "_VALUES_TO_NAMES.find(val);" << endl;
     out << indent() << "if (it != _" << tenum->get_name() << "_VALUES_TO_NAMES.end()) {" << endl;
     indent_up();
-    out << indent() << "out = std::string(it->second);" << endl;
+    out << indent() << "return std::string(it->second);" << endl;
     indent_down();
     out << indent() << "} else {" << endl;
     indent_up();
-    out << indent() << "out = std::to_string(static_cast<int>(val));" << endl;
+    out << indent() << "return std::to_string(static_cast<int>(val));" << endl;
     indent_down();
     out << indent() << "}" << endl;
 
-    out << indent() << "return out;" << endl;
     scope_down(out);
     out << endl;
   }

--- a/lib/cpp/test/EnumTest.cpp
+++ b/lib/cpp/test/EnumTest.cpp
@@ -26,6 +26,13 @@ std::ostream& operator <<(std::ostream& os, const MyEnumWithCustomOstream::type&
   return os;
 }
 
+std::string to_string(const MyEnumWithCustomOstream::type& val)
+{
+  std::ostringstream os;
+  os << val;
+  return os.str();
+}
+
 BOOST_AUTO_TEST_SUITE(EnumTest)
 
 BOOST_AUTO_TEST_CASE(test_enum_value) {
@@ -66,7 +73,6 @@ std::string EnumToString(_T e)
   return ss.str();
 }
 
-
 BOOST_AUTO_TEST_CASE(test_enum_ostream)
 {
   BOOST_CHECK_EQUAL(EnumToString(MyEnum1::ME1_0), "ME1_0");
@@ -75,8 +81,20 @@ BOOST_AUTO_TEST_CASE(test_enum_ostream)
   BOOST_CHECK_EQUAL(EnumToString(MyEnumWithCustomOstream::CustoM2), "{2:CUSTOM!}");
 
   // some invalid or unknown value
-  auto uut = (MyEnum5::type)44;
+  auto uut = static_cast<MyEnum5::type>(44);
   BOOST_CHECK_EQUAL(EnumToString(uut), "44");
+}
+
+BOOST_AUTO_TEST_CASE(test_enum_to_string)
+{
+  BOOST_CHECK_EQUAL(::to_string(MyEnum1::ME1_0), "ME1_0");
+  BOOST_CHECK_EQUAL(::to_string(MyEnum5::e2), "e2");
+  BOOST_CHECK_EQUAL(::to_string(MyEnum3::ME3_N1), "ME3_N1");
+  BOOST_CHECK_EQUAL(::to_string(MyEnumWithCustomOstream::CustoM2), "{2:CUSTOM!}");
+
+  // some invalid or unknown value
+  auto uut = static_cast<MyEnum5::type>(44);
+  BOOST_CHECK_EQUAL(::to_string(uut), "44");
 }
 
 BOOST_AUTO_TEST_CASE(test_enum_constant)


### PR DESCRIPTION
ITNOA

Hi,

I add to_string helper function for enum in cpp, because it is increase usability and performance.
  

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"
