### PR TITLE
THRIFT-4829 HTTP server transport lacks TransportFactory arguments

### DIFF
--- a/lib/netstd/Thrift/Transport/Server/THttpServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/THttpServerTransport.cs
@@ -38,27 +38,43 @@ namespace Thrift.Transport.Server
         protected ITProtocolFactory InputProtocolFactory;
         protected ITProtocolFactory OutputProtocolFactory;
 
+        protected TTransportFactory InputTransportFactory;
+        protected TTransportFactory OutputTransportFactory;
+
         protected ITAsyncProcessor Processor;
 
         public THttpServerTransport(ITAsyncProcessor processor, RequestDelegate next = null, ILoggerFactory loggerFactory = null)
-            : this(processor, new TBinaryProtocol.Factory(), next, loggerFactory)
+            : this(processor, new TBinaryProtocol.Factory(), null, next, loggerFactory)
         {
         }
 
-        public THttpServerTransport(ITAsyncProcessor processor, ITProtocolFactory protocolFactory, RequestDelegate next = null,
+        public THttpServerTransport(
+            ITAsyncProcessor processor, 
+            ITProtocolFactory protocolFactory, 
+            TTransportFactory transFactory = null, 
+            RequestDelegate next = null,
             ILoggerFactory loggerFactory = null)
-            : this(processor, protocolFactory, protocolFactory, next, loggerFactory)
+            : this(processor, protocolFactory, protocolFactory, transFactory, transFactory, next, loggerFactory)
         {
         }
 
-        public THttpServerTransport(ITAsyncProcessor processor, ITProtocolFactory inputProtocolFactory,
-            ITProtocolFactory outputProtocolFactory, RequestDelegate next = null, ILoggerFactory loggerFactory = null)
+        public THttpServerTransport(
+            ITAsyncProcessor processor, 
+            ITProtocolFactory inputProtocolFactory,
+            ITProtocolFactory outputProtocolFactory,
+            TTransportFactory inputTransFactory = null,
+            TTransportFactory outputTransFactory = null,
+            RequestDelegate next = null, 
+            ILoggerFactory loggerFactory = null)
         {
             // loggerFactory == null is not illegal anymore
 
             Processor = processor ?? throw new ArgumentNullException(nameof(processor));
             InputProtocolFactory = inputProtocolFactory ?? throw new ArgumentNullException(nameof(inputProtocolFactory));
             OutputProtocolFactory = outputProtocolFactory ?? throw new ArgumentNullException(nameof(outputProtocolFactory));
+
+            InputTransportFactory = inputTransFactory;
+            OutputTransportFactory = outputTransFactory;
 
             _next = next;
             _logger = (loggerFactory != null) ? loggerFactory.CreateLogger<THttpServerTransport>() : new NullLogger<THttpServerTransport>();
@@ -76,8 +92,11 @@ namespace Thrift.Transport.Server
 
             try
             {
-                var input = InputProtocolFactory.GetProtocol(transport);
-                var output = OutputProtocolFactory.GetProtocol(transport);
+                var intrans = (InputTransportFactory != null) ? InputTransportFactory.GetTransport(transport) : transport;
+                var outtrans = (OutputTransportFactory != null) ? OutputTransportFactory.GetTransport(transport) : transport;
+
+                var input = InputProtocolFactory.GetProtocol(intrans);
+                var output = OutputProtocolFactory.GetProtocol(outtrans);
 
                 while (await Processor.ProcessAsync(input, output, cancellationToken))
                 {
@@ -86,6 +105,8 @@ namespace Thrift.Transport.Server
             catch (TTransportException)
             {
                 // Client died, just move on
+                if (!context.Response.HasStarted)
+                    context.Response.StatusCode = 500;
             }
             finally
             {


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer
