### PR TITLE
THRIFT-4839: Remove embedded buffering/framed options from TCP transp…

### DIFF
--- a/lib/netstd/Thrift/Server/TSimpleAsyncServer.cs
+++ b/lib/netstd/Thrift/Server/TSimpleAsyncServer.cs
@@ -33,24 +33,58 @@ namespace Thrift.Server
         private readonly int _clientWaitingDelay;
         private volatile Task _serverTask;
 
-        public TSimpleAsyncServer(ITAsyncProcessor processor, TServerTransport serverTransport,
-            TProtocolFactory inputProtocolFactory, TProtocolFactory outputProtocolFactory,
-            ILoggerFactory loggerFactory, int clientWaitingDelay = 10)
-            : this(new TSingletonProcessorFactory(processor), serverTransport,
-                new TTransportFactory(), new TTransportFactory(),
-                inputProtocolFactory, outputProtocolFactory,
-                loggerFactory.CreateLogger(nameof(TSimpleAsyncServer)), clientWaitingDelay)
+        public TSimpleAsyncServer(ITProcessorFactory itProcessorFactory,
+            TServerTransport serverTransport,
+            TTransportFactory inputTransportFactory,
+            TTransportFactory outputTransportFactory,
+            TProtocolFactory inputProtocolFactory,
+            TProtocolFactory outputProtocolFactory,
+            ILogger logger,
+            int clientWaitingDelay = 10)
+            : base(itProcessorFactory,
+                  serverTransport,
+                  inputTransportFactory,
+                  outputTransportFactory,
+                  inputProtocolFactory,
+                  outputProtocolFactory,
+                  logger)
+        {
+            _clientWaitingDelay = clientWaitingDelay;
+        }
+
+        public TSimpleAsyncServer(ITProcessorFactory itProcessorFactory,
+            TServerTransport serverTransport,
+            TTransportFactory inputTransportFactory,
+            TTransportFactory outputTransportFactory,
+            TProtocolFactory inputProtocolFactory,
+            TProtocolFactory outputProtocolFactory,
+            ILoggerFactory loggerFactory,
+            int clientWaitingDelay = 10)
+            : this(itProcessorFactory,
+                  serverTransport,
+                  inputTransportFactory,
+                  outputTransportFactory,
+                  inputProtocolFactory,
+                  outputProtocolFactory,
+                  loggerFactory.CreateLogger<TSimpleAsyncServer>())
         {
         }
 
-        public TSimpleAsyncServer(ITProcessorFactory itProcessorFactory, TServerTransport serverTransport,
-            TTransportFactory inputTransportFactory, TTransportFactory outputTransportFactory,
-            TProtocolFactory inputProtocolFactory, TProtocolFactory outputProtocolFactory,
-            ILogger logger, int clientWaitingDelay = 10)
-            : base(itProcessorFactory, serverTransport, inputTransportFactory, outputTransportFactory,
-                inputProtocolFactory, outputProtocolFactory, logger)
+        public TSimpleAsyncServer(ITAsyncProcessor processor,
+            TServerTransport serverTransport,
+            TProtocolFactory inputProtocolFactory,
+            TProtocolFactory outputProtocolFactory,
+            ILoggerFactory loggerFactory,
+            int clientWaitingDelay = 10)
+            : this(new TSingletonProcessorFactory(processor),
+                  serverTransport,
+                  new TTransportFactory(),
+                  new TTransportFactory(),
+                  inputProtocolFactory,
+                  outputProtocolFactory,
+                  loggerFactory.CreateLogger(nameof(TSimpleAsyncServer)),
+                  clientWaitingDelay)
         {
-            _clientWaitingDelay = clientWaitingDelay;
         }
 
         public override async Task ServeAsync(CancellationToken cancellationToken)

--- a/lib/netstd/Thrift/Thrift.csproj
+++ b/lib/netstd/Thrift/Thrift.csproj
@@ -39,7 +39,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />

--- a/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
@@ -34,10 +34,8 @@ namespace Thrift.Transport.Server
         ///     This is the address of the Pipe on the localhost.
         /// </summary>
         private readonly string _pipeAddress;
-
         private bool _asyncMode = true;
         private volatile bool _isPending = true;
-
         private NamedPipeServerStream _stream = null;
 
         public TNamedPipeServerTransport(string pipeAddress)

--- a/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
@@ -16,7 +16,6 @@
 // under the License.
 
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -30,20 +29,17 @@ namespace Thrift.Transport.Server
     public class TServerSocketTransport : TServerTransport
     {
         private readonly int _clientTimeout;
-        private readonly Buffering _buffering;
         private TcpListener _server;
 
-        public TServerSocketTransport(TcpListener listener, int clientTimeout = 0, Buffering buffering = Buffering.None)
+        public TServerSocketTransport(TcpListener listener, int clientTimeout = 0)
         {
             _server = listener;
             _clientTimeout = clientTimeout;
-            _buffering = buffering;
         }
 
-        public TServerSocketTransport(int port, int clientTimeout = 0, Buffering buffering = Buffering.None)
+        public TServerSocketTransport(int port, int clientTimeout = 0)
+            : this(null, clientTimeout)
         {
-            _clientTimeout = clientTimeout;
-            _buffering = buffering;
             try
             {
                 // Make server socket
@@ -101,21 +97,6 @@ namespace Thrift.Transport.Server
                     {
                         Timeout = _clientTimeout
                     };
-
-                    switch (_buffering)
-                    {
-                        case Buffering.BufferedTransport:
-                            tSocketTransport = new TBufferedTransport(tSocketTransport);
-                            break;
-
-                        case Buffering.FramedTransport:
-                            tSocketTransport = new TFramedTransport(tSocketTransport);
-                            break;
-
-                        default:
-                            Debug.Assert(_buffering == Buffering.None);
-                            break;
-                    }
 
                     return tSocketTransport;
                 }

--- a/lib/netstd/Thrift/Transport/TFramedTransport.cs
+++ b/lib/netstd/Thrift/Transport/TFramedTransport.cs
@@ -22,15 +22,6 @@ using System.Threading.Tasks;
 
 namespace Thrift.Transport
 {
-    // it does not make much sense to use buffered when we already use framed
-    public enum Buffering
-    {
-        None,
-        BufferedTransport,
-        FramedTransport
-    }
-
-
     // ReSharper disable once InconsistentNaming
     public class TFramedTransport : TTransport
     {

--- a/test/netstd/Server/TestServer.cs
+++ b/test/netstd/Server/TestServer.cs
@@ -50,9 +50,16 @@ namespace ThriftTest
         NamedPipe
     }
 
+    internal enum BufferChoice
+    {
+        None,
+        Buffered,
+        Framed
+    }
+
     internal class ServerParam
     {
-        internal Buffering buffering = Buffering.None;
+        internal BufferChoice buffering = BufferChoice.None;
         internal ProtocolChoice protocol = ProtocolChoice.Binary;
         internal TransportChoice transport = TransportChoice.Socket;
         internal int port = 9090;
@@ -75,11 +82,11 @@ namespace ThriftTest
                 }
                 else if (args[i] == "-b" || args[i] == "--buffered" || args[i] == "--transport=buffered")
                 {
-                    buffering = Buffering.BufferedTransport;
+                    buffering = BufferChoice.Buffered;
                 }
                 else if (args[i] == "-f" || args[i] == "--framed" || args[i] == "--transport=framed")
                 {
-                    buffering = Buffering.FramedTransport;
+                    buffering = BufferChoice.Framed;
                 }
                 else if (args[i] == "--binary" || args[i] == "--protocol=binary")
                 {
@@ -560,7 +567,7 @@ namespace ThriftTest
                         }
 
                         transFactory = new TTransportFactory(); // framed/buffered is built into socket transports
-                        trans = new TTlsServerSocketTransport( param.port, cert, param.buffering,
+                        trans = new TTlsServerSocketTransport( param.port, cert,
                             (sender, certificate, chain, errors) => true, 
                             null, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12);
                         break;
@@ -568,7 +575,7 @@ namespace ThriftTest
                     case TransportChoice.Socket:
                     default:  
                         transFactory = new TTransportFactory(); // framed/buffered is built into socket transports
-                        trans = new TServerSocketTransport(param.port, 0, param.buffering);
+                        trans = new TServerSocketTransport(param.port, 0);
                         break;
                 }
 
@@ -577,10 +584,10 @@ namespace ThriftTest
                 {
                     switch (param.buffering)
                     {
-                        case Buffering.FramedTransport:
+                        case BufferChoice.Framed:
                             transFactory = new TFramedTransport.Factory();
                             break;
-                        case Buffering.BufferedTransport:
+                        case BufferChoice.Buffered:
                             transFactory = new TBufferedTransport.Factory();
                             break;
                     }
@@ -617,8 +624,8 @@ namespace ThriftTest
                 var where = (! string.IsNullOrEmpty(param.pipe)) ? "on pipe " + param.pipe : "on port " + param.port;
                 Console.WriteLine("Starting the AsyncBaseServer " + where +
                                   " with processor TPrototypeProcessorFactory prototype factory " +
-                                  (param.buffering == Buffering.BufferedTransport ? " with buffered transport" : "") +
-                                  (param.buffering == Buffering.FramedTransport ? " with framed transport" : "") +
+                                  (param.buffering == BufferChoice.Buffered ? " with buffered transport" : "") +
+                                  (param.buffering == BufferChoice.Framed ? " with framed transport" : "") +
                                   (param.transport == TransportChoice.TlsSocket ? " with encryption" : "") +
                                   (param.protocol == ProtocolChoice.Compact ? " with compact protocol" : "") +
                                   (param.protocol == ProtocolChoice.Json ? " with json protocol" : "") +

--- a/tutorial/netstd/Client/Client.csproj
+++ b/tutorial/netstd/Client/Client.csproj
@@ -30,6 +30,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Interfaces\Interfaces.csproj" />
     <ProjectReference Include="..\..\..\lib\netstd\Thrift\Thrift.csproj" />
   </ItemGroup>

--- a/tutorial/netstd/Client/Program.cs
+++ b/tutorial/netstd/Client/Program.cs
@@ -47,17 +47,20 @@ Usage:
     Client.exe -help
         will diplay help information 
 
-    Client.exe -tr:<transport> -pr:<protocol> -mc:<numClients>
+    Client.exe -tr:<transport> -bf:<buffering> -pr:<protocol> -mc:<numClients>
         will run client with specified arguments (tcp transport and binary protocol by default) and with 1 client
 
 Options:
     -tr (transport): 
         tcp - (default) tcp transport will be used (host - ""localhost"", port - 9090)
-        tcpbuffered - buffered transport over tcp will be used (host - ""localhost"", port - 9090)
         namedpipe - namedpipe transport will be used (pipe address - "".test"")
         http - http transport will be used (address - ""http://localhost:9090"")        
         tcptls - tcp tls transport will be used (host - ""localhost"", port - 9090)
-        framed - tcp framed transport will be used (host - ""localhost"", port - 9090)
+
+    -bf (buffering): 
+        none - (default) no buffering will be used
+        buffered - buffered transport will be used
+        framed - framed transport will be used
 
     -pr (protocol): 
         binary - (default) binary protocol will be used
@@ -139,29 +142,49 @@ Sample:
 
         private static TTransport GetTransport(string[] args)
         {
-            var transport = args.FirstOrDefault(x => x.StartsWith("-tr"))?.Split(':')?[1];
+            TTransport transport = new TSocketTransport(IPAddress.Loopback, 9090);
 
-            Transport selectedTransport;
-            if (Enum.TryParse(transport, true, out selectedTransport))
+            var transportArg = args.FirstOrDefault(x => x.StartsWith("-tr"))?.Split(':')?[1];
+
+            if (Enum.TryParse(transportArg, true, out Transport selectedTransport))
             {
                 switch (selectedTransport)
                 {
                     case Transport.Tcp:
-                        return new TSocketTransport(IPAddress.Loopback, 9090);
+                        transport = new TSocketTransport(IPAddress.Loopback, 9090);
+                        break;
+
                     case Transport.NamedPipe:
-                        return new TNamedPipeTransport(".test");
+                        transport = new TNamedPipeTransport(".test");
+                        break;
+
                     case Transport.Http:
-                        return new THttpTransport(new Uri("http://localhost:9090"), null);
-                    case Transport.TcpBuffered:
-                        return new TBufferedTransport(new TSocketTransport(IPAddress.Loopback, 9090));
+                        transport = new THttpTransport(new Uri("http://localhost:9090"), null);
+                        break;
+
                     case Transport.TcpTls:
-                        return new TTlsSocketTransport(IPAddress.Loopback, 9090, GetCertificate(), CertValidator, LocalCertificateSelectionCallback);
-                    case Transport.Framed:
-                        return new TFramedTransport(new TSocketTransport(IPAddress.Loopback, 9090));
+                        transport = new TTlsSocketTransport(IPAddress.Loopback, 9090, GetCertificate(), CertValidator, LocalCertificateSelectionCallback);
+                        break;
                 }
             }
 
-            return new TSocketTransport(IPAddress.Loopback, 9090);
+            var bufferingArg = args.FirstOrDefault(x => x.StartsWith("-bf"))?.Split(':')?[1];
+
+            if (Enum.TryParse<Buffering>(bufferingArg, out var selectedBuffering))
+            {
+                switch (selectedBuffering)
+                {
+                    case Buffering.Buffered:
+                        transport = new TBufferedTransport(transport);
+                        break;
+
+                    case Buffering.Framed:
+                        transport = new TFramedTransport(transport);
+                        break;
+                }
+            }
+
+            return transport;
         }
 
         private static int GetNumberOfClients(string[] args)
@@ -362,6 +385,13 @@ Sample:
             Compact,
             Json,
             Multiplexed
+        }
+
+        private enum Buffering
+        {
+            None,
+            Buffered,
+            Framed
         }
     }
 }


### PR DESCRIPTION
…orts

Client: netstd
Patch: Kyle Smith

<!-- Explain the changes in the pull request below: -->
Removed the embedded buffered/framed code from the socket and tls socket transports.  I also updated the tests and tutorial files to use the existing TFramedTransport.Factory and TBufferedTransport.Factory classes.

<!-- We recommend you review the checklist before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
