### PR TITLE
THRIFT-4842 - Fix memory leak on set property c_glib

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -76,9 +76,7 @@ thrift_multiplexed_protocol_set_property (GObject      *object,
   switch (property_id)
   {
   case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
-    if(self->service_name){
-      g_free(self->service_name);
-    }
+    g_free(self->service_name);
     self->service_name = g_value_dup_string (value);
     break;
 

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c
@@ -76,6 +76,9 @@ thrift_multiplexed_protocol_set_property (GObject      *object,
   switch (property_id)
   {
   case PROP_THRIFT_MULTIPLEXED_PROTOCOL_SERVICE_NAME:
+    if(self->service_name){
+      g_free(self->service_name);
+    }
     self->service_name = g_value_dup_string (value);
     break;
 


### PR DESCRIPTION
I've just release a string created in the constructor or previous call to set. 
It was not freed so it was leaked by previous commit.

The original issue is here: https://issues.apache.org/jira/browse/THRIFT-4842