### PR TITLE
THRIFT-4844: createConnection ignores connect_timeout option

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -256,7 +256,11 @@ Connection.prototype.connection_gone = function () {
 };
 
 exports.createConnection = function(host, port, options) {
-  var stream = net.createConnection(port, host);
+  var stream = net.createConnection( {
+    port: port, 
+    host: host,
+    timeout: options.connect_timeout || options.timeout || 0
+  });
   var connection = new Connection(stream, options);
   connection.host = host;
   connection.port = port;


### PR DESCRIPTION
To fix the defect I passed connect_timeout option or timeout option directly to net.createConnection.
This allows to use the nodeJs's internal mechanism for connection timeout handling.