### PR TITLE
THRIFT-4845: Stop ignoring small timeouts

### DIFF
--- a/lib/php/lib/Transport/TCurlClient.php
+++ b/lib/php/lib/Transport/TCurlClient.php
@@ -230,7 +230,12 @@ class TCurlClient extends TTransport
         curl_setopt(self::$curlHandle, CURLOPT_HTTPHEADER, $headers);
 
         if ($this->timeout_ > 0) {
-            curl_setopt(self::$curlHandle, CURLOPT_TIMEOUT, $this->timeout_);
+            if ($this->timeout_ < 1.0) {
+                // Timestamps smaller than 1 second are ignored when CURLOPT_TIMEOUT is used
+                curl_setopt(self::$curlHandle, CURLOPT_TIMEOUT_MS, 1000 * $this->timeout_);
+            } else {
+                curl_setopt(self::$curlHandle, CURLOPT_TIMEOUT, $this->timeout_);
+            }
         }
         curl_setopt(self::$curlHandle, CURLOPT_POSTFIELDS, $this->request_);
         $this->request_ = '';


### PR DESCRIPTION
Client: php

CURLOPT_TIMEOUT requires a long [0], so it seems that small values
like 0.2 are being rounded to 0, resulting in a lack of any timeout.

This change uses CURLOPT_TIMEOUT_MS, which the PHP documentation
says was "added in cURL 7.16.2. Available since PHP 5.2.3."

[0] https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html
