### PR TITLE
THRIFT-3060: clear the offline queue when written

### DIFF
--- a/lib/nodejs/lib/thrift/connection.js
+++ b/lib/nodejs/lib/thrift/connection.js
@@ -74,10 +74,7 @@ var Connection = exports.Connection = function(stream, options) {
     this.framePos = 0;
     this.frame = null;
     self.initialize_retry_vars();
-
-    self.offline_queue.forEach(function(data) {
-      self.connection.write(data);
-    });
+    self.flush_offline_queue();
 
     self.emit("connect");
   });
@@ -175,6 +172,18 @@ Connection.prototype.initialize_retry_vars = function () {
   this.retry_delay = 150;
   this.retry_backoff = 1.7;
   this.attempts = 0;
+};
+
+Connection.prototype.flush_offline_queue = function () {
+  var self = this;
+  var offline_queue = this.offline_queue;
+
+  // Reset offline queue
+  this.offline_queue = [];
+  // Attempt to write queued items
+  offline_queue.forEach(function(data) {
+    self.write(data);
+  });
 };
 
 Connection.prototype.write = function(data) {
@@ -311,10 +320,7 @@ var StdIOConnection = exports.StdIOConnection = function(command, options) {
   this.frame = null;
   this.connected = true;
 
-  self.offline_queue.forEach(function(data) {
-      self.connection.write(data);
-  });
-
+  self.flush_offline_queue();
 
   this.connection.addListener("error", function(err) {
     self.emit("error", err);
@@ -357,6 +363,18 @@ util.inherits(StdIOConnection, EventEmitter);
 
 StdIOConnection.prototype.end = function() {
   this.connection.end();
+};
+
+StdIOConnection.prototype.flush_offline_queue = function () {
+  var self = this;
+  var offline_queue = this.offline_queue;
+
+  // Reset offline queue
+  this.offline_queue = [];
+  // Attempt to write queued items
+  offline_queue.forEach(function(data) {
+    self.write(data);
+  });
 };
 
 StdIOConnection.prototype.write = function(data) {


### PR DESCRIPTION
This PR addresses an issue in the NodeJS module where data would be sent multiple times when the socket reconnects multiple times because the `offline_queue` would never be emptied.

This fix clears the `offline_queue` when the socket reconnects and the queued data is written. 

Fixes [THRIFT-3060](https://issues.apache.org/jira/browse/THRIFT-3060).