### PR TITLE
THRIFT-4849: Do not Ignore InterruptedException

### DIFF
--- a/lib/java/src/org/apache/thrift/server/TNonblockingServer.java
+++ b/lib/java/src/org/apache/thrift/server/TNonblockingServer.java
@@ -86,8 +86,8 @@ public class TNonblockingServer extends AbstractNonblockingServer {
     try {
       selectAcceptThread_.join();
     } catch (InterruptedException e) {
-      // for now, just silently ignore. technically this means we'll have less of
-      // a graceful shutdown as a result.
+      LOGGER.debug("Interrupted while waiting for accept thread", e);
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
Do not ignore interrupted exceptions in TNonblockingServer.java