### PR TITLE
Make Field definition follow Literal definition

### DIFF
--- a/doc/specs/idl.md
+++ b/doc/specs/idl.md
@@ -96,7 +96,7 @@ A service provides the interface for a set of functionality provided by a Thrift
 
 ## Field
 
-    [16] Field           ::=  FieldID? FieldReq? FieldType Identifier ('= ConstValue)? XsdFieldOptions ListSeparator?
+    [16] Field           ::=  FieldID? FieldReq? FieldType Identifier ('=' ConstValue)? XsdFieldOptions ListSeparator?
 
 ### Field ID
 


### PR DESCRIPTION
I think this is a violation of your Literal syntax.

Could you explain what i'm missing in the language definition?
Is this supposed to be a litteral '='?

Literal         ::=  ('"' [^"]* '"') | ("'" [^']* "'")

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [ ] Did you squash your changes to a single commit?
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
