### PR TITLE
THRIFT-4846. Topologically sort structs before generation

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -106,6 +106,10 @@ public:
   void init_generator() override;
   void close_generator() override;
 
+  bool strict_definition_order() const override {
+    return true;
+  }
+
   /* generation functions */
   void generate_typedef(t_typedef* ttypedef) override;
   void generate_enum(t_enum* tenum) override;

--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -104,12 +104,14 @@ public:
   void init_generator() override;
   void close_generator() override;
 
-  void generate_consts(std::vector<t_const*> consts) override;
+  bool strict_definition_order() const override {
+    return true;
+  }
 
   /**
    * Program-level generation functions
    */
-
+  void generate_consts(std::vector<t_const*> consts) override;
   void generate_typedef(t_typedef* ttypedef) override;
   void generate_enum(t_enum* tenum) override;
   void generate_enum_ostream_operator_decl(std::ostream& out, t_enum* tenum);

--- a/compiler/cpp/src/thrift/generate/t_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_generator.h
@@ -124,6 +124,12 @@ protected:
   template <typename T>
   void validate(const std::vector<T>& list) const;
 
+  // Return true if the target language requires that contained structs
+  // be defined after their containing structs.
+  virtual bool strict_definition_order() const {
+    return false;
+  }
+
   /**
    * Optional methods that may be implemented by subclasses to take necessary
    * steps at the beginning or end of code generation.

--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -401,15 +401,21 @@ struct BoolTest {
   2: optional string s = "true";
 }
 
-struct StructA {
-  1: required string s;
+struct ListOfStructB {
+  // Reference StructB which is defined later.
+  1: list<StructB> list_of_structs;
 }
 
 struct StructB {
+  // Reference StructA which is defined below this.
   1: optional StructA aa;
   2: required StructA ab;
 }
 
 struct OptionalSetDefaultTest {
   1: optional set<string> with_default = [ "test" ]
+}
+
+struct StructA {
+  1: required string s;
 }


### PR DESCRIPTION
This adds a toposort step prior to emitting generating code for structs.
For many languages (eg Java) this isn't necessary as there is no
"ordering" in the generated code. However, with C and C++, it's
important to define structs prior to their inclusion in another struct.

This also makes Thrift fail when generating C/C++ code with cyclic
references as the toposort is impossible.

A new test includes some structs defined in the "wrong" order to ensure
that the sort produces working code.

I manually tested a file with a true cycle in it, and verified the error
output.