### PR TITLE
THRIFT-4855: Pin golang/mock to 1.2.0

### DIFF
--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -58,8 +58,7 @@ check: gopath genmock
 	GOPATH=`pwd` $(GO) test -v common/...
 
 genmock: gopath
-	GOPATH=`pwd` $(GO) install github.com/golang/mock/mockgen
-	GOPATH=`pwd` bin/mockgen -destination=src/common/mock_handler.go -package=common gen/thrifttest ThriftTest
+	sh genmock.sh
 
 EXTRA_DIST = \
 	src/bin \

--- a/test/go/genmock.sh
+++ b/test/go/genmock.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+export GOPATH=`pwd`
+export GOBIN=`pwd`/bin
+export GO111MODULE=off
+
+mkdir -p src/github.com/golang/mock
+cd src/github.com/golang
+curl -fsSL https://github.com/golang/mock/archive/v1.2.0.tar.gz -o mock.tar.gz
+tar -xzvf mock.tar.gz -C mock --strip-components=1
+cd mock/mockgen
+go install .
+cd ../../../../../
+bin/mockgen -destination=src/common/mock_handler.go -package=common gen/thrifttest ThriftTest


### PR DESCRIPTION
The latest version (1.3.0) of golang/mock requires us to switch to Go modules for our tests, but that's not trivial given our directory structure.

Additionally, modules are still considered experimental and won't be finalized until at least Go 1.13, so we have some time to consider our options.

For now, this commit just fixes the CI issues by pinning the version.