### PR TITLE
Update and fix js dependencies

### DIFF
--- a/lib/js/package.json
+++ b/lib/js/package.json
@@ -11,21 +11,21 @@
   "repository": "https://github.com/apache/thrift",
   "license": "Apache-2.0",
   "devDependencies": {
-    "browserify": "^16.2.3",
-    "grunt": "^1.0.3",
-    "grunt-cli": "^1.3.2",
-    "grunt-contrib-concat": "^1.0.1",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-qunit": "^3.1.0",
-    "grunt-contrib-uglify": "^1.0.1",
-    "grunt-jsdoc": "^2.2.1",
-    "grunt-shell-spawn": "^0.4.0",
-    "jslint": "^0.12.0",
-    "node-int64": "^0.4.0"
+    "browserify": "~16.2",
+    "grunt": "~1.0",
+    "grunt-cli": "~1.3",
+    "grunt-contrib-concat": "~1.0",
+    "grunt-contrib-jshint": "~2.1",
+    "grunt-contrib-qunit": "~3.1",
+    "grunt-contrib-uglify": "~4.0",
+    "grunt-jsdoc": "~2.3",
+    "grunt-shell-spawn": "~0.4",
+    "jslint": "~0.12",
+    "node-int64": "~0.4.0"
   },
   "dependencies": {
-    "jsdoc": "^3.5.5",
-    "json-int64": "^1.0.0",
-    "nopt": "^4.0.1"
+    "jsdoc": "~3.5",
+    "json-int64": "~1.0",
+    "nopt": "~4.0"
   }
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Build failures occurred since jsdoc was updated to v3.6, since it requires Node 8.5 and we support Node 4.x on Xenial.  This fixes the js package.json file.

<!-- We recommend you review the checklist before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
