### PR TITLE
Fix rust tutorial following enum output change

### DIFF
--- a/tutorial/rs/README.md
+++ b/tutorial/rs/README.md
@@ -35,12 +35,13 @@ extern crate thrift;
 extern crate try_from;
 
 // generated Rust module
-use tutorial;
+mod tutorial;
 
 use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol};
 use thrift::protocol::{TInputProtocol, TOutputProtocol};
 use thrift::transport::{TFramedReadTransport, TFramedWriteTransport};
 use thrift::transport::{TIoChannel, TTcpChannel};
+
 use tutorial::{CalculatorSyncClient, TCalculatorSyncClient};
 use tutorial::{Operation, Work};
 
@@ -60,7 +61,7 @@ fn run() -> thrift::Result<()> {
     //
 
     println!("connect to server on 127.0.0.1:9090");
-    let mut c = TTcpTransport::new();
+    let mut c = TTcpChannel::new();
     c.open("127.0.0.1:9090")?;
 
     let (i_chan, o_chan) = c.split()?;
@@ -72,7 +73,7 @@ fn run() -> thrift::Result<()> {
         TFramedWriteTransport::new(o_chan)
     );
 
-    let client = CalculatorSyncClient::new(i_prot, o_prot);
+    let mut client = CalculatorSyncClient::new(i_prot, o_prot);
 
     //
     // alright! - let's make some calls

--- a/tutorial/rs/README.md
+++ b/tutorial/rs/README.md
@@ -84,14 +84,14 @@ fn run() -> thrift::Result<()> {
     // two-way with some return
     let res = client.calculate(
         72,
-        Work::new(7, 8, Operation::MULTIPLY, None)
+        Work::new(7, 8, Operation::Multiply, None)
     )?;
     println!("multiplied 7 and 8, got {}", res);
 
     // two-way and returns a Thrift-defined exception
     let res = client.calculate(
         77,
-        Work::new(2, 0, Operation::DIVIDE, None)
+        Work::new(2, 0, Operation::Divide, None)
     );
     match res {
         Ok(v) => panic!("shouldn't have succeeded with result {}", v),


### PR DESCRIPTION
upgrade to thrift 0.12.0

[THRIFT-4529] - Rust enum variants are now camel-cased instead of uppercased to conform to Rust naming conventions

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
