### PR TITLE
THRIFT-4848: Add ability to set Content-Type,Accept headers in HTTP c…

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
@@ -172,24 +172,13 @@ namespace Thrift.Transport.Client
                 {
                     contentStream.Headers.ContentType = ContentType ?? new MediaTypeHeaderValue(@"application/x-thrift");
 
-                    try
-                    {
-                        var response = (await _httpClient.PostAsync(_uri, contentStream, cancellationToken)).EnsureSuccessStatusCode();
+                    var response = (await _httpClient.PostAsync(_uri, contentStream, cancellationToken)).EnsureSuccessStatusCode();
 
-                        _inputStream?.Dispose();
-                        _inputStream = await response.Content.ReadAsStreamAsync();                        
-                        if (_inputStream.CanSeek)
-                        {
-                            _inputStream.Seek(0, SeekOrigin.Begin);
-                        }
-                    }
-                    catch (HttpRequestException rex)
+                    _inputStream?.Dispose();
+                    _inputStream = await response.Content.ReadAsStreamAsync();
+                    if (_inputStream.CanSeek)
                     {
-                        throw new TTransportException(TTransportException.ExceptionType.Unknown, $"Failed to connect: {rex.Message}");
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new TTransportException(TTransportException.ExceptionType.Unknown, ex.Message);
+                        _inputStream.Seek(0, SeekOrigin.Begin);
                     }
                 }
             }
@@ -201,6 +190,10 @@ namespace Thrift.Transport.Client
             {
                 throw new TTransportException(TTransportException.ExceptionType.Unknown,
                     "Couldn't connect to server: " + wx);
+            }
+            catch (Exception ex)
+            {
+                throw new TTransportException(TTransportException.ExceptionType.Unknown, ex.Message);
             }
             finally
             {


### PR DESCRIPTION
…lient

Client: netstd
Patch: Kyle Smith

<!-- Explain the changes in the pull request below: -->
I added the RequestHeaders property that exposes the DefaultRequestHeaders property on the HTTP client instance which allows a developer to set request headers that are not otherwise available using the existing CustomHeaders method. The problem with using CustomHeaders is that it does not allow you to set certain properties (namely Accept). I also added the ContentType property that for specifying the Content-Type request header before sending a request to the server. Our use case is for us to set these headers so that our server can use the correct protocols depending on the clients request. 

Other cleanup items include removal of the ConnectTimeout write-only property as the the underlying _connectTimeout field is only ever use on creation, so setting this property was a no-op. I also implemented the OpenAsync and IsOpen fields to work more inline with the other transports.
<!-- We recommend you review the checklist before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
