### PR TITLE
THRIFT-4868: Golang: Fix compilation for optional sets with default values

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -3237,8 +3237,12 @@ void t_go_generator::generate_serialize_container(ostream& out,
     t_set* tset = (t_set*)ttype;
     out << indent() << "for i := 0; i<len(" << prefix << "); i++ {" << endl;
     out << indent() << "  for j := i+1; j<len(" << prefix << "); j++ {" << endl;
-    out << indent() << "    if reflect.DeepEqual(" << prefix << "[i]," << prefix << "[j]) { " << endl;
-    out << indent() << "      return thrift.PrependError(\"\", fmt.Errorf(\"%T error writing set field: slice is not unique\", " << prefix << "[i]))" << endl;
+    string wrapped_prefix = prefix;
+    if (pointer_field) {
+      wrapped_prefix = "(" + prefix + ")";
+    }
+    out << indent() << "    if reflect.DeepEqual(" << wrapped_prefix << "[i]," << wrapped_prefix << "[j]) { " << endl;
+    out << indent() << "      return thrift.PrependError(\"\", fmt.Errorf(\"%T error writing set field: slice is not unique\", " << wrapped_prefix << "[i]))" << endl;
     out << indent() << "    }" << endl;
     out << indent() << "  }" << endl;
     out << indent() << "}" << endl;

--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -409,3 +409,7 @@ struct StructB {
   1: optional StructA aa;
   2: required StructA ab;
 }
+
+struct OptionalSetDefaultTest {
+  1: optional set<string> with_default = [ "test" ]
+}


### PR DESCRIPTION
See [THRIFT-4868](https://issues.apache.org/jira/browse/THRIFT-4868) for details. In short, Golang compilation is broken for optional sets with default values. For example:

`1: optional set<string> with_default = [ "test" ]`

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"