### PR TITLE
THRIFT-4892: fixed data type conflict with simoultaneus usage of bytes and str

### DIFF
--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -376,7 +376,7 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
         if not self.transport.isOpen():
             self.transport.open()
 
-        self.send_sasl_msg(self.START, self.sasl.mechanism)
+        self.send_sasl_msg(self.START, bytes(self.sasl.mechanism, 'ascii'))
         self.send_sasl_msg(self.OK, self.sasl.process())
 
         while True:
@@ -417,7 +417,7 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     def flush(self):
         data = self.__wbuf.getvalue()
         encoded = self.sasl.wrap(data)
-        self.transport.write(''.join((pack("!i", len(encoded)), encoded)))
+        self.transport.write(pack("!i", len(encoded)) + encoded)
         self.transport.flush()
         self.__wbuf = BufferIO()
 


### PR DESCRIPTION
A small data type  mistake were observed during usage of SASL mechanism="PLAIN".
on 379-380 lines there're 2 calls of send_sasl_msg, where 1st uses sels.sasl.mechanism, which is of type str(), while 2nd uses self.sasl.process(), which generates bytes().

exception happens on line 402, where header generated on line 401 using pack() which returns type bytes() being concatenated with body provided to send_sasl_msg() func.
Since self.transport.write accepts bytes() only, it's better to use bytes everywhere...

on the line 420 we have similar error, where str().join() is being called, but both parameters passed to it are of type bytes(), which raises an exception.
