### PR TITLE
THRIFT-4878 - [c_glib] add unix domain socket support to ThriftSocket

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.h
@@ -50,6 +50,7 @@ struct _ThriftServerSocket
 
   /* private */
   guint port;
+  gchar *path;
   gshort backlog;
   int sd;
   guint8 *buf;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
@@ -51,6 +51,7 @@ struct _ThriftSocket
   /* private */
   gchar *hostname;
   guint port;
+  gchar *path;
   int sd;
 };
 

--- a/test/tests.json
+++ b/test/tests.json
@@ -32,7 +32,8 @@
       "framed"
     ],
     "sockets": [
-      "ip"
+      "ip",
+      "domain"
     ],
     "protocols": [
       "binary",


### PR DESCRIPTION
ThriftSocket only supports connecting to a socket via a host and port, so this adds support for unix domain sockets for communication between local processes.