### PR TITLE
THRIFT-4797: Golang: Fix import collisions

### DIFF
--- a/lib/go/test/ConflictNamespaceServiceTest.thrift
+++ b/lib/go/test/ConflictNamespaceServiceTest.thrift
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+namespace go conflict.context
+
+include "ConflictNamespaceTestD.thrift"
+
+service ConflictService {
+    ConflictNamespaceTestD.ThingD thingFunc()
+}

--- a/lib/go/test/ConflictNamespaceTestA.thrift
+++ b/lib/go/test/ConflictNamespaceTestA.thrift
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+namespace go conflicta.common
+
+struct ThingA {
+  1: bool value
+}

--- a/lib/go/test/ConflictNamespaceTestB.thrift
+++ b/lib/go/test/ConflictNamespaceTestB.thrift
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+namespace go conflictb.common
+
+struct ThingB {
+  1: bool value
+}

--- a/lib/go/test/ConflictNamespaceTestC.thrift
+++ b/lib/go/test/ConflictNamespaceTestC.thrift
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+namespace go common
+
+struct ThingC {
+  1: bool value
+}

--- a/lib/go/test/ConflictNamespaceTestD.thrift
+++ b/lib/go/test/ConflictNamespaceTestD.thrift
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+namespace go conflictd.context
+
+struct ThingD {
+  1: bool value
+}

--- a/lib/go/test/ConflictNamespaceTestSuperThing.thrift
+++ b/lib/go/test/ConflictNamespaceTestSuperThing.thrift
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+include "ConflictNamespaceTestA.thrift"
+include "ConflictNamespaceTestB.thrift"
+include "ConflictNamespaceTestC.thrift"
+include "ConflictNamespaceTestD.thrift"
+
+struct SuperThing {
+  1: ConflictNamespaceTestA.ThingA thing_a
+  2: ConflictNamespaceTestB.ThingB thing_b
+  3: ConflictNamespaceTestC.ThingC thing_c
+  4: ConflictNamespaceTestD.ThingD thing_d
+}

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -44,7 +44,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConflictNamespaceTestB.thrift \
 				ConflictNamespaceTestC.thrift \
 				ConflictNamespaceTestD.thrift \
-				ConflictNamespaceTestSuperThing.thrift
+				ConflictNamespaceTestSuperThing.thrift \
+				ConflictNamespaceServiceTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -69,6 +70,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestC.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestD.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestSuperThing.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceServiceTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock || true
 	sed -i 's/\"context\"/\"golang.org\/x\/net\/context\"/g' gopath/src/github.com/golang/mock/gomock/controller.go || true
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
@@ -90,7 +92,8 @@ check: gopath
 				dontexportrwtest \
 				ignoreinitialismstest \
 				unionbinarytest \
-				conflictnamespacetestsuperthing
+				conflictnamespacetestsuperthing \
+				conflict/context/conflict_service-remote
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:
@@ -125,3 +128,4 @@ EXTRA_DIST = \
 	ConflictNamespaceTestC.thrift \
 	ConflictNamespaceTestD.thrift \
 	ConflictNamespaceTestSuperThing.thrift
+	ConflictNamespaceServiceTest.thrift

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -39,7 +39,12 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				InitialismsTest.thrift \
 				DontExportRWTest.thrift \
 				dontexportrwtest/compile_test.go \
-				IgnoreInitialismsTest.thrift
+				IgnoreInitialismsTest.thrift \
+				ConflictNamespaceTestA.thrift \
+				ConflictNamespaceTestB.thrift \
+				ConflictNamespaceTestC.thrift \
+				ConflictNamespaceTestD.thrift \
+				ConflictNamespaceTestSuperThing.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -59,6 +64,11 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) InitialismsTest.thrift
 	$(THRIFT) $(THRIFTARGS),read_write_private DontExportRWTest.thrift
 	$(THRIFT) $(THRIFTARGS),ignore_initialisms IgnoreInitialismsTest.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestA.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestB.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestC.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestD.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestSuperThing.thrift
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock || true
 	sed -i 's/\"context\"/\"golang.org\/x\/net\/context\"/g' gopath/src/github.com/golang/mock/gomock/controller.go || true
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
@@ -79,7 +89,8 @@ check: gopath
 				initialismstest \
 				dontexportrwtest \
 				ignoreinitialismstest \
-				unionbinarytest
+				unionbinarytest \
+				conflictnamespacetestsuperthing
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:
@@ -108,4 +119,9 @@ EXTRA_DIST = \
 	NamesTest.thrift \
 	InitialismsTest.thrift \
 	DontExportRWTest.thrift \
-	IgnoreInitialismsTest.thrift
+	IgnoreInitialismsTest.thrift \
+	ConflictNamespaceTestA.thrift \
+	ConflictNamespaceTestB.thrift \
+	ConflictNamespaceTestC.thrift \
+	ConflictNamespaceTestD.thrift \
+	ConflictNamespaceTestSuperThing.thrift


### PR DESCRIPTION
See [THRIFT-4797](https://issues.apache.org/jira/browse/THRIFT-4797) for details. In short, Golang compilation fails when a Thrift file includes two files that have the same final namespace component (e.g. `namespace go packagea.common` and `namespace go packageb.common`)

Somewhat based on [fbthrift's implementation](https://github.com/facebook/fbthrift/commit/b6754fe7a6a6e00ce288f14cd4e88cfa3d0cc3e4#diff-803353e952116d4e88caab467a62f35b) though their implementation simply always adds an alias with a unique numerical prefix.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"