### PR TITLE
THRIFT-4887 Clear redundant data in transport after each request to a…

### DIFF
--- a/lib/java/src/org/apache/thrift/TServiceClient.java
+++ b/lib/java/src/org/apache/thrift/TServiceClient.java
@@ -85,7 +85,11 @@ public abstract class TServiceClient {
       throw new TApplicationException(TApplicationException.BAD_SEQUENCE_ID,
           String.format("%s failed: out of sequence response: expected %d but got %d", methodName, seqid_, msg.seqid));
     }
-    result.read(iprot_);
+    try {
+      result.read(iprot_);
+    } finally {
+      iprot_.getTransport().safeClear();
+    }
     iprot_.readMessageEnd();
   }
 }

--- a/lib/java/src/org/apache/thrift/transport/TByteBuffer.java
+++ b/lib/java/src/org/apache/thrift/transport/TByteBuffer.java
@@ -62,9 +62,8 @@ public final class TByteBuffer extends TTransport {
   /**
    * Convenience method to call clear() on the underlying NIO ByteBuffer.
    */
-  public TByteBuffer clear() {
+  public void clear() {
     byteBuffer.clear();
-    return this;
   }
 
   /**

--- a/lib/java/src/org/apache/thrift/transport/TFastFramedTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TFastFramedTransport.java
@@ -169,7 +169,8 @@ public class TFastFramedTransport extends TTransport {
   /**
    * Only clears the read buffer!
    */
-  public void clear() {
+  @Override
+  protected void clear() {
     readBuffer = new AutoExpandingBufferReadTransport(initialBufferCapacity);
   }
 

--- a/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TFramedTransport.java
@@ -131,7 +131,8 @@ public class TFramedTransport extends TTransport {
     readBuffer_.consumeBuffer(len);
   }
 
-  public void clear() {
+  @Override
+  protected void clear() {
     readBuffer_.clear();
   }
 

--- a/lib/java/src/org/apache/thrift/transport/TMemoryInputTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TMemoryInputTransport.java
@@ -45,7 +45,8 @@ public final class TMemoryInputTransport extends TTransport {
     endPos_ = offset + length;
   }
 
-  public void clear() {
+  @Override
+  protected void clear() {
     buf_ = null;
   }
 

--- a/lib/java/src/org/apache/thrift/transport/TSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TSocket.java
@@ -245,4 +245,15 @@ public class TSocket extends TIOStreamTransport {
     }
   }
 
+  @Override
+  protected void clear() {
+    try {
+      int len = this.inputStream_.available();
+      if (len > 0) {
+        this.inputStream_.skip(len);
+      }
+    } catch (IOException e) {
+      LOGGER.warn("Could not clear inputstream: {}", e.getMessage());
+    }
+  }
 }

--- a/lib/java/src/org/apache/thrift/transport/TTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TTransport.java
@@ -19,6 +19,9 @@
 
 package org.apache.thrift.transport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 
 /**
@@ -27,6 +30,7 @@ import java.io.Closeable;
  *
  */
 public abstract class TTransport implements Closeable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TTransport.class.getName());
 
   /**
    * Queries whether the transport is open.
@@ -57,6 +61,22 @@ public abstract class TTransport implements Closeable {
    */
   public abstract void close();
 
+  /**
+   * Safe clear transport on necessary, will log warn message if error occurs
+   */
+  public void safeClear(){
+    try {
+      this.clear();
+    } catch(Exception e){
+      LOGGER.warn("Could not clear inputstream: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Clear transport when necessary
+   */
+  protected void clear(){
+  }
   /**
    * Reads up to len bytes into buffer buf, starting at offset off.
    *


### PR DESCRIPTION
…void OOM

Client: Java
Path: Xiaoqing Zhang

<!-- Explain the changes in the pull request below: -->
1. Add a safeClear() method in TTransport and it calls clear() method, implement clear() method in TSocket/TFramedTransport etc.
2. TServiceClient calls TTransport.safeClear() after each request

<!-- We recommend you review the checklist before submitting a pull request. -->

- [Y] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [Y] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [Y] Did you squash your changes to a single commit?
- [Y] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

By the way a detailed explanation for this bug and how to reproduce it could be found at: https://github.com/aqingsao/thrift-oom
