### PR TITLE
Fix mingw appveyor build issue [skip travis]

### DIFF
--- a/build/appveyor/MING-appveyor-install.bat
+++ b/build/appveyor/MING-appveyor-install.bat
@@ -36,10 +36,16 @@ SET PACKAGES=^
 
 ::mingw-w64-%MINGWPLAT%-qt5 : WAY too large (1GB download!) - tested in cygwin builds anyway
 
+:: the following uninstall and system upgrade was causing issues; appveyor's is relatively new
 :: Remove old packages that no longer exist to avoid an error
-%BASH% -lc "pacman --noconfirm --remove libcatgets catgets || true" || EXIT /B
+:: %BASH% -lc "pacman --noconfirm --remove libcatgets catgets || true" || EXIT /B
+
+:: Remove incompatible packages 8.2.0-3 and 7.3.0-2 (mingw packaging bugs if you ask me!)
+:: %BASH% -lc "pacman --noconfirm --remove mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc || true" || EXIT /B
+:: %BASH% -lc "pacman --noconfirm --remove mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc || true" || EXIT /B
 
 :: Upgrade things
-%BASH% -lc "pacman --noconfirm -Syu %IGNORE%"                       || EXIT /B
-%BASH% -lc "pacman --noconfirm -Su %IGNORE%"                        || EXIT /B
+:: %BASH% -lc "pacman --noconfirm -Syu %IGNORE%"                       || EXIT /B
+:: %BASH% -lc "pacman --noconfirm -Su %IGNORE%"                        || EXIT /B
+::
 %BASH% -lc "pacman --noconfirm %PACKAGES%"                          || EXIT /B


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Builds on mingw ran into a package dependency issue during installation (reproduced locally):
```
Jim@pulsar MINGW64 ~
$ pacman -Syu --noconfirm
:: Synchronizing package databases...
 mingw32 is up to date
 mingw64 is up to date
 msys is up to date
:: Starting core system upgrade...
 there is nothing to do
:: Starting full system upgrade...
:: Replace mingw-w64-x86_64-ncurses with mingw64/mingw-w64-x86_64-pdcurses? [Y/n]
:: Replace mingw-w64-x86_64-termcap with mingw64/mingw-w64-x86_64-pdcurses? [Y/n]
resolving dependencies...
looking for conflicting packages...
error: failed to prepare transaction (could not satisfy dependencies)
:: installing mingw-w64-x86_64-gcc (9.1.0-2) breaks dependency 'mingw-w64-x86_64-gcc=8.3.0-2' required by mingw-w64-x86_64-gcc-ada
:: installing mingw-w64-x86_64-gcc (9.1.0-2) breaks dependency 'mingw-w64-x86_64-gcc=8.3.0-2' required by mingw-w64-x86_64-gcc-objc
```

This change removes the incompatible ada and objc packages during appveyor install.

<!-- We recommend you review the checklist before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
