### PR TITLE
THRIFT-4897: generate test resource for thrift-maven-plugin

### DIFF
--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -33,6 +33,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -47,6 +48,47 @@
             <thriftExecutable>${thrift.compiler}</thriftExecutable>
           </systemPropertyVariables>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>generate-jar-for-test</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <classifier>idl</classifier>
+              <excludes>
+                <exclude>**/*.class</exclude>
+              </excludes>
+              <includes>
+                <include>**/*.thrift</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>rename-jar-for-test</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>rename</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${project.artifactId}-${project.version}-idl.jar</sourceFile>
+              <destinationFile>${project.build.directory}/SharedIdl.jar</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -88,5 +130,6 @@
     <thrift.root>${basedir}/../..</thrift.root>
     <thrift.compiler>${thrift.root}/compiler/cpp/thrift</thrift.compiler>
     <thrift.test.home>${thrift.root}/test</thrift.test.home>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -51,42 +51,20 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.2</version>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
         <executions>
           <execution>
             <id>generate-jar-for-test</id>
-            <phase>process-test-classes</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
+            <phase>generate-test-resources</phase>
             <configuration>
-              <classifier>idl</classifier>
-              <excludes>
-                <exclude>**/*.class</exclude>
-              </excludes>
-              <includes>
-                <include>**/*.thrift</include>
-              </includes>
+              <target>
+                <jar destfile="${project.build.directory}/SharedIdl.jar" basedir="${basedir}/src/test/resources" includes="**/*.thrift" />
+              </target>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.coderplus.maven.plugins</groupId>
-        <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
-        <executions>
-          <execution>
-            <id>rename-jar-for-test</id>
-            <phase>process-test-classes</phase>
             <goals>
-              <goal>rename</goal>
+              <goal>run</goal>
             </goals>
-            <configuration>
-              <sourceFile>${project.build.directory}/${project.artifactId}-${project.version}-idl.jar</sourceFile>
-              <destinationFile>${project.build.directory}/SharedIdl.jar</destinationFile>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestAbstractThriftMojo.java
+++ b/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestAbstractThriftMojo.java
@@ -59,7 +59,7 @@ public class TestAbstractThriftMojo {
         // used by other tests. It's used here to represent a dependency of the project maven is building,
         // one that is contributing .thrift IDL files as well as any other artifacts.
         final Iterable<File> classpathElementFiles = Lists.newArrayList(
-                new File("src/test/resources/dependency-jar-test/SharedIdl.jar")
+                new File("target/SharedIdl.jar")
         );
 
         final Set<File> thriftDirectories = mojo.makeThriftPathFromJars(temporaryThriftFileDirectory, classpathElementFiles);
@@ -70,7 +70,7 @@ public class TestAbstractThriftMojo {
         // means it points to the directory containing the "idl" hierarchy rather than to the idl directory
         // itself.
         final Set<File> expected = Sets.newHashSet(
-                new File(testRootDir, "src/test/resources/dependency-jar-test/SharedIdl.jar")
+                new File(testRootDir, "target/SharedIdl.jar")
         );
 
         assertEquals("makeThriftPathFromJars should return thrift IDL base path from within JAR", expected, thriftDirectories);


### PR DESCRIPTION
generate SharedIdl.jar for passing the test case for thrift-maven-plugin

see issue: https://issues.apache.org/jira/projects/THRIFT/issues/THRIFT-4897
