### PR TITLE
THRIFT-4898 Pipe write operations across a network are limited to 65,…

### DIFF
--- a/lib/delphi/test/TestServer.pas
+++ b/lib/delphi/test/TestServer.pas
@@ -144,7 +144,7 @@ end;
 
 function TTestServer.TTestHandlerImpl.testBinary(const thing: TBytes): TBytes;
 begin
-  Console.WriteLine('testBinary("' + BytesToHex( thing ) + '")');
+  Console.WriteLine('testBinary('+IntToStr(Length(thing)) + ' bytes)');
   Result := thing;
 end;
 

--- a/lib/netstd/Thrift/Transport/Client/TNamedPipeTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TNamedPipeTransport.cs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace Thrift.Transport.Client
     // ReSharper disable once InconsistentNaming
     public class TNamedPipeTransport : TTransport
     {
-        private NamedPipeClientStream _client;
+        private NamedPipeClientStream PipeStream;
         private int ConnectTimeout;
 
         public TNamedPipeTransport(string pipe, int timeout = Timeout.Infinite) 
@@ -37,10 +38,10 @@ namespace Thrift.Transport.Client
             var serverName = string.IsNullOrWhiteSpace(server) ? server : ".";
             ConnectTimeout = (timeout > 0) ? timeout : Timeout.Infinite;
 
-            _client = new NamedPipeClientStream(serverName, pipe, PipeDirection.InOut, PipeOptions.None);
+            PipeStream = new NamedPipeClientStream(serverName, pipe, PipeDirection.InOut, PipeOptions.None);
         }
 
-        public override bool IsOpen => _client != null && _client.IsConnected;
+        public override bool IsOpen => PipeStream != null && PipeStream.IsConnected;
 
         public override async Task OpenAsync(CancellationToken cancellationToken)
         {
@@ -49,36 +50,46 @@ namespace Thrift.Transport.Client
                 throw new TTransportException(TTransportException.ExceptionType.AlreadyOpen);
             }
 
-            await _client.ConnectAsync( ConnectTimeout, cancellationToken);
+            await PipeStream.ConnectAsync( ConnectTimeout, cancellationToken);
         }
 
         public override void Close()
         {
-            if (_client != null)
+            if (PipeStream != null)
             {
-                _client.Dispose();
-                _client = null;
+                PipeStream.Dispose();
+                PipeStream = null;
             }
         }
 
         public override async ValueTask<int> ReadAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)
         {
-            if (_client == null)
+            if (PipeStream == null)
             {
                 throw new TTransportException(TTransportException.ExceptionType.NotOpen);
             }
 
-            return await _client.ReadAsync(buffer, offset, length, cancellationToken);
+            return await PipeStream.ReadAsync(buffer, offset, length, cancellationToken);
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)
         {
-            if (_client == null)
+            if (PipeStream == null)
             {
                 throw new TTransportException(TTransportException.ExceptionType.NotOpen);
             }
 
-            await _client.WriteAsync(buffer, offset, length, cancellationToken);
+            // if necessary, send the data in chunks
+            // there's a system limit around 0x10000 bytes that we hit otherwise
+            // MSDN: "Pipe write operations across a network are limited to 65,535 bytes per write. For more information regarding pipes, see the Remarks section."
+            var nBytes = Math.Min(15 * 4096, length); // 16 would exceed the limit
+            while (nBytes > 0)
+            {
+                await PipeStream.WriteAsync(buffer, offset, nBytes, cancellationToken);
+                offset += nBytes;
+                length -= nBytes;
+                nBytes = Math.Min(nBytes, length);
+            }
         }
 
         public override async Task FlushAsync(CancellationToken cancellationToken)
@@ -91,7 +102,7 @@ namespace Thrift.Transport.Client
 
         protected override void Dispose(bool disposing)
         {
-            _client.Dispose();
+            PipeStream.Dispose();
         }
     }
 }

--- a/test/netstd/Server/TestServer.cs
+++ b/test/netstd/Server/TestServer.cs
@@ -246,8 +246,7 @@ namespace ThriftTest
 
             public Task<byte[]> testBinaryAsync(byte[] thing, CancellationToken cancellationToken)
             {
-                var hex = BitConverter.ToString(thing).Replace("-", string.Empty);
-                logger.Invoke("testBinary({0:X})", hex);
+                logger.Invoke("testBinary({0} bytes)", thing.Length);
                 return Task.FromResult(thing);
             }
 


### PR DESCRIPTION
…535 bytes per write.

Including improved test cases for netstd and Delphi (acted as the test counterpart)