### PR TITLE
Fix a typo in rust tutorial README.md. [skip ci]

### DIFF
--- a/tutorial/rs/README.md
+++ b/tutorial/rs/README.md
@@ -8,7 +8,7 @@
 
 ```toml
 thrift = "x.y.z" # x.y.z is the version of the thrift compiler
-ordered_float = "0.3.0"
+ordered-float = "0.3.0"
 try_from = "0.2.0"
 ```
 


### PR DESCRIPTION
The crate is named `ordered-float`, not `ordered_float`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
