### PR TITLE
THRIFT-4908: remove reader&writer in Golang's TBinaryProtocol

### DIFF
--- a/lib/go/thrift/binary_protocol.go
+++ b/lib/go/thrift/binary_protocol.go
@@ -32,8 +32,6 @@ import (
 type TBinaryProtocol struct {
 	trans         TRichTransport
 	origTransport TTransport
-	reader        io.Reader
-	writer        io.Writer
 	strictRead    bool
 	strictWrite   bool
 	buffer        [64]byte
@@ -55,8 +53,6 @@ func NewTBinaryProtocol(t TTransport, strictRead, strictWrite bool) *TBinaryProt
 	} else {
 		p.trans = NewTRichTransport(t)
 	}
-	p.reader = p.trans
-	p.writer = p.trans
 	return p
 }
 
@@ -192,21 +188,21 @@ func (p *TBinaryProtocol) WriteByte(value int8) error {
 func (p *TBinaryProtocol) WriteI16(value int16) error {
 	v := p.buffer[0:2]
 	binary.BigEndian.PutUint16(v, uint16(value))
-	_, e := p.writer.Write(v)
+	_, e := p.trans.Write(v)
 	return NewTProtocolException(e)
 }
 
 func (p *TBinaryProtocol) WriteI32(value int32) error {
 	v := p.buffer[0:4]
 	binary.BigEndian.PutUint32(v, uint32(value))
-	_, e := p.writer.Write(v)
+	_, e := p.trans.Write(v)
 	return NewTProtocolException(e)
 }
 
 func (p *TBinaryProtocol) WriteI64(value int64) error {
 	v := p.buffer[0:8]
 	binary.BigEndian.PutUint64(v, uint64(value))
-	_, err := p.writer.Write(v)
+	_, err := p.trans.Write(v)
 	return NewTProtocolException(err)
 }
 
@@ -228,7 +224,7 @@ func (p *TBinaryProtocol) WriteBinary(value []byte) error {
 	if e != nil {
 		return e
 	}
-	_, err := p.writer.Write(value)
+	_, err := p.trans.Write(value)
 	return NewTProtocolException(err)
 }
 
@@ -468,7 +464,7 @@ func (p *TBinaryProtocol) Transport() TTransport {
 }
 
 func (p *TBinaryProtocol) readAll(buf []byte) error {
-	_, err := io.ReadFull(p.reader, buf)
+	_, err := io.ReadFull(p.trans, buf)
 	return NewTProtocolException(err)
 }
 


### PR DESCRIPTION
Client: go

<!-- Explain the changes in the pull request below: -->
  It seems the reader and writer in TBinaryProtocol is not necessary, because this class is serialize/deserialize the struct and write/read the data stream via trans, `reader` & `writer` here are duplicated with `trans` in this struct

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [Y ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [Y ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [Y ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ Y] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [Y ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
