### PR TITLE
Add pointer helpers for missing types

### DIFF
--- a/lib/go/thrift/pointerize.go
+++ b/lib/go/thrift/pointerize.go
@@ -41,6 +41,8 @@ package thrift
 func Float32Ptr(v float32) *float32 { return &v }
 func Float64Ptr(v float64) *float64 { return &v }
 func IntPtr(v int) *int             { return &v }
+func Int8Ptr(v int8) *int8          { return &v }
+func Int16Ptr(v int16) *int16       { return &v }
 func Int32Ptr(v int32) *int32       { return &v }
 func Int64Ptr(v int64) *int64       { return &v }
 func StringPtr(v string) *string    { return &v }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  Added pointer helper functions for int8 and int16 types.

