### PR TITLE
THRIFT-4002: Make generated exception classes immutable by default

### DIFF
--- a/lib/py/src/Thrift.py
+++ b/lib/py/src/Thrift.py
@@ -17,8 +17,6 @@
 # under the License.
 #
 
-import sys
-
 
 class TType(object):
     STOP = 0
@@ -89,15 +87,6 @@ class TProcessor(object):
 
 class TException(Exception):
     """Base class for all thrift exceptions."""
-
-    # BaseException.message is deprecated in Python v[2.6,3.0)
-    if (2, 6, 0) <= sys.version_info < (3, 0):
-        def _get_message(self):
-            return self._message
-
-        def _set_message(self, message):
-            self._message = message
-        message = property(_get_message, _set_message)
 
     def __init__(self, message=None):
         Exception.__init__(self, message)

--- a/lib/py/src/protocol/TBase.py
+++ b/lib/py/src/protocol/TBase.py
@@ -80,3 +80,7 @@ class TFrozenBase(TBase):
                                       [self.__class__, self.thrift_spec])
         else:
             return iprot.readStruct(cls, cls.thrift_spec, True)
+
+
+class TFrozenExceptionBase(TFrozenBase, TExceptionBase):
+    pass

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -303,8 +303,14 @@ class TProtocolBase(object):
 
     def readContainerStruct(self, spec):
         (obj_class, obj_spec) = spec
-        obj = obj_class()
-        obj.read(self)
+
+        # If obj_class.read is a classmethod (e.g. in frozen structs),
+        # call it as such.
+        if getattr(obj_class.read, '__self__', None) is obj_class:
+            obj = obj_class.read(self)
+        else:
+            obj = obj_class()
+            obj.read(self)
         return obj
 
     def readContainerMap(self, spec):

--- a/test/DebugProtoTest.thrift
+++ b/test/DebugProtoTest.thrift
@@ -241,6 +241,10 @@ exception ExceptionWithAMap {
   2: map<string, string> map_field;
 }
 
+exception MutableException {
+  1: string msg;
+} (python.immutable = "false")
+
 service ServiceForExceptionWithAMap {
   void methodThatThrowsAnException() throws (1: ExceptionWithAMap xwamap);
 }

--- a/test/py.tornado/test_suite.py
+++ b/test/py.tornado/test_suite.py
@@ -82,10 +82,7 @@ class TestHandler(object):
 
     def testException(self, s):
         if s == 'Xception':
-            x = Xception()
-            x.errorCode = 1001
-            x.message = s
-            raise x
+            raise Xception(1001, s)
         elif s == 'throw_undeclared':
             raise ValueError('testing undeclared exception')
 

--- a/test/py.twisted/test_suite.py
+++ b/test/py.twisted/test_suite.py
@@ -76,10 +76,7 @@ class TestHandler:
 
     def testException(self, s):
         if s == 'Xception':
-            x = Xception()
-            x.errorCode = 1001
-            x.message = s
-            raise x
+            raise Xception(1001, s)
         elif s == "throw_undeclared":
             raise ValueError("foo")
 

--- a/test/py/TestFrozen.py
+++ b/test/py/TestFrozen.py
@@ -19,7 +19,9 @@
 # under the License.
 #
 
+from DebugProtoTest import Srv
 from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty, Wrapper
+from DebugProtoTest.ttypes import ExceptionWithAMap, MutableException
 from thrift.Thrift import TFrozenDict
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TCompactProtocol
@@ -93,6 +95,21 @@ class TestFrozenBase(unittest.TestCase):
         self.assertEqual(x.foo, Empty())
         x2 = self._roundtrip(x, Wrapper)
         self.assertEqual(x2.foo, Empty())
+
+    def test_frozen_exception(self):
+        exc = ExceptionWithAMap(blah='foo')
+        with self.assertRaises(TypeError):
+            exc.blah = 'bar'
+        mutexc = MutableException(msg='foo')
+        mutexc.msg = 'bar'
+        self.assertEqual(mutexc.msg, 'bar')
+
+    def test_frozen_exception_serialization(self):
+        result = Srv.declaredExceptionMethod_result(
+            xwamap=ExceptionWithAMap(blah="error"))
+        deserialized = self._roundtrip(
+            result, Srv.declaredExceptionMethod_result())
+        self.assertEqual(result, deserialized)
 
 
 class TestFrozen(TestFrozenBase):


### PR DESCRIPTION
Currently, the generated exception classes are not hashable under Python 3
because of the generated `__eq__` method.  Exception objects are generally
expected to be hashable by the Python standard library. Post-construction
mutation of an exception object seems like a very unlikely case, so enable
hashing for all exceptions by making them immutable by default.  This also
adds a way to opt-out of immutability by setting the `python.immutable`
annotation to `"false"`.