### PR TITLE
THRIFT-4939 TThriftListImpl<T>.Sort() does not use comparer

### DIFF
--- a/lib/delphi/src/Thrift.Collections.pas
+++ b/lib/delphi/src/Thrift.Collections.pas
@@ -639,7 +639,7 @@ end;
 
 procedure TThriftListImpl<T>.Sort(const AComparer: IComparer<T>);
 begin
-  FList.Sort;
+  FList.Sort(AComparer);
 end;
 
 function TThriftListImpl<T>.ToArray: TArray<T>;


### PR DESCRIPTION
Added object for custom sort.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
