### PR TITLE
THRIFT-4612: Avoid double wrapping THeaderTransport

### DIFF
--- a/lib/go/thrift/header_transport.go
+++ b/lib/go/thrift/header_transport.go
@@ -271,7 +271,12 @@ var _ TTransport = (*THeaderTransport)(nil)
 // Please note that THeaderTransport handles framing and zlib by itself,
 // so the underlying transport should be the raw socket transports (TSocket or TSSLSocket),
 // instead of rich transports like TZlibTransport or TFramedTransport.
+//
+// If trans is already a *THeaderTransport, it will be returned as is.
 func NewTHeaderTransport(trans TTransport) *THeaderTransport {
+	if ht, ok := trans.(*THeaderTransport); ok {
+		return ht
+	}
 	return &THeaderTransport{
 		transport:    trans,
 		reader:       bufio.NewReader(trans),

--- a/lib/go/thrift/header_transport_test.go
+++ b/lib/go/thrift/header_transport_test.go
@@ -106,3 +106,13 @@ func TestTHeaderHeadersReadWrite(t *testing.T) {
 		)
 	}
 }
+
+func TestTHeaderTransportNoDoubleWrapping(t *testing.T) {
+	trans := NewTMemoryBuffer()
+	orig := NewTHeaderTransport(trans)
+	wrapped := NewTHeaderTransport(orig)
+
+	if wrapped != orig {
+		t.Errorf("NewTHeaderTransport double wrapped THeaderTransport")
+	}
+}


### PR DESCRIPTION
Client: go

Previously we did not check against that, so when people using
NewTSimpleServerN with both THeaderTransportFactory and
THeaderProtocolFactory, inside THeaderProtocolFactory we will actually
double wrap the transport with THeaderTransport. What make things worse
is that in that case, the transport still appear to work, because
THeaderTransport has backward compatible to TBinaryProtocol and
TCompactProtocol so the outer layer of THeaderTransport wrap (the one
directly accessible from the protocol) will only think that the client
does not support THeader, and fallback. So when double wrapping happens,
it will appear that everything works, except you cannot get the headers
from the protocol (because they are actually in the inner
THeaderTransport, not the outer one that's directly accessible from the
protocol), makes it very hard to debug.

This change adds protection against double wrapping.