### PR TITLE
THRIFT-4914: Add THeader to context object for server reads

### DIFF
--- a/lib/go/thrift/header_context.go
+++ b/lib/go/thrift/header_context.go
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"context"
+)
+
+// See https://godoc.org/context#WithValue on why do we need the unexported typedefs.
+type (
+	headerKey     string
+	headerKeyList int
+)
+
+// Values for headerKeyList.
+const (
+	headerKeyListRead headerKeyList = iota
+)
+
+// SetHeader sets a header in the context.
+func SetHeader(ctx context.Context, key, value string) context.Context {
+	return context.WithValue(
+		ctx,
+		headerKey(key),
+		value,
+	)
+}
+
+// GetHeader returns a value of the given header from the context.
+func GetHeader(ctx context.Context, key string) (value string, ok bool) {
+	if v := ctx.Value(headerKey(key)); v != nil {
+		value, ok = v.(string)
+	}
+	return
+}
+
+// SetReadHeaderList sets the key list of read THeaders in the context.
+func SetReadHeaderList(ctx context.Context, keys []string) context.Context {
+	return context.WithValue(
+		ctx,
+		headerKeyListRead,
+		keys,
+	)
+}
+
+// GetReadHeaderList returns the key list of read THeaders from the context.
+func GetReadHeaderList(ctx context.Context) []string {
+	if v := ctx.Value(headerKeyListRead); v != nil {
+		if value, ok := v.([]string); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+// AddReadTHeaderToContext adds the whole THeader headers into context.
+func AddReadTHeaderToContext(ctx context.Context, headers THeaderMap) context.Context {
+	keys := make([]string, 0, len(headers))
+	for key, value := range headers {
+		ctx = SetHeader(ctx, key, value)
+		keys = append(keys, key)
+	}
+	return SetReadHeaderList(ctx, keys)
+}

--- a/lib/go/thrift/header_context_test.go
+++ b/lib/go/thrift/header_context_test.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestSetGetHeader(t *testing.T) {
+	const (
+		key   = "foo"
+		value = "bar"
+	)
+	ctx := context.Background()
+
+	ctx = SetHeader(ctx, key, value)
+
+	checkGet := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+		got, ok := GetHeader(ctx, key)
+		if !ok {
+			t.Fatalf("Cannot get header %q back after setting it.", key)
+		}
+		if got != value {
+			t.Fatalf("Header value expected %q, got %q instead", value, got)
+		}
+	}
+
+	checkGet(t, ctx)
+
+	t.Run(
+		"NoConflicts",
+		func(t *testing.T) {
+			type otherType string
+			const otherValue = "bar2"
+
+			ctx = context.WithValue(ctx, otherType(key), otherValue)
+			checkGet(t, ctx)
+		},
+	)
+
+	t.Run(
+		"GetHeaderOnNonExistKey",
+		func(t *testing.T) {
+			const otherKey = "foo2"
+
+			if _, ok := GetHeader(ctx, otherKey); ok {
+				t.Errorf("GetHeader returned ok on non-existing key %q", otherKey)
+			}
+		},
+	)
+}
+
+func TestKeyList(t *testing.T) {
+	headers := THeaderMap{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	ctx := context.Background()
+
+	ctx = AddReadTHeaderToContext(ctx, headers)
+
+	got := make(THeaderMap)
+	keys := GetReadHeaderList(ctx)
+	t.Logf("keys: %+v", keys)
+	for _, key := range keys {
+		value, ok := GetHeader(ctx, key)
+		if ok {
+			got[key] = value
+		} else {
+			t.Errorf("Cannot get key %q from context", key)
+		}
+	}
+
+	if !reflect.DeepEqual(headers, got) {
+		t.Errorf("Expected header map %+v, got %+v", headers, got)
+	}
+}

--- a/lib/go/thrift/header_protocol.go
+++ b/lib/go/thrift/header_protocol.go
@@ -188,6 +188,11 @@ func (p *THeaderProtocol) WriteBinary(value []byte) error {
 	return p.protocol.WriteBinary(value)
 }
 
+// ReadFrame calls underlying THeaderTransport's ReadFrame function.
+func (p *THeaderProtocol) ReadFrame() error {
+	return p.transport.ReadFrame()
+}
+
 func (p *THeaderProtocol) ReadMessageBegin() (name string, typeID TMessageType, seqID int32, err error) {
 	if err = p.transport.ReadFrame(); err != nil {
 		return

--- a/lib/go/thrift/header_transport_test.go
+++ b/lib/go/thrift/header_transport_test.go
@@ -21,6 +21,7 @@ package thrift
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"testing"
 )
@@ -73,9 +74,20 @@ func TestTHeaderHeadersReadWrite(t *testing.T) {
 	}
 
 	// Read
+
+	// Make sure multiple calls to ReadFrame is fine.
+	if err := reader.ReadFrame(); err != nil {
+		t.Errorf("reader.ReadFrame returned error: %v", err)
+	}
+	if err := reader.ReadFrame(); err != nil {
+		t.Errorf("reader.ReadFrame returned error: %v", err)
+	}
 	read, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Errorf("Read returned error: %v", err)
+	}
+	if err := reader.ReadFrame(); err != nil && err != io.EOF {
+		t.Errorf("reader.ReadFrame returned error: %v", err)
 	}
 	if string(read) != payload1+payload2 {
 		t.Errorf(


### PR DESCRIPTION
Client: go

This is the first part of THRIFT-4914, which handles the server reading
part in the requests (client -> server direction).

In TSimpleServer implementation, when the protocol is THeaderProtocol,
auto add all the headers read into the context object before passing
that to processor, so the processor code can access them from the
context object directly, via the new helper functions added in
header_context.go file.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
