### PR TITLE
Fix deprecation for init immutable data in static constructors.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_d_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_d_generator.cc
@@ -137,7 +137,7 @@ protected:
         indent(f_consts) << "immutable(" << render_type_name(type) << ") " << name << ";" << endl;
       }
 
-      f_consts << endl << "static this() {" << endl;
+      f_consts << endl << "shared static this() {" << endl;
       indent_up();
 
       bool first = true;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Initialisation of immutable data in static constructors has been deprecated.
They now need to be initialised in shared static constructors.

This trivial change brings the generator for D up to date with the latest
version of the compiler, but it should continue to work with older
versions.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
