### PR TITLE
THRIFT-4914: Send context THeaders for client writes

### DIFF
--- a/lib/go/thrift/client.go
+++ b/lib/go/thrift/client.go
@@ -24,6 +24,16 @@ func NewTStandardClient(inputProtocol, outputProtocol TProtocol) *TStandardClien
 }
 
 func (p *TStandardClient) Send(ctx context.Context, oprot TProtocol, seqId int32, method string, args TStruct) error {
+	// Set headers from context object on THeaderProtocol
+	if headerProt, ok := oprot.(*THeaderProtocol); ok {
+		headerProt.ClearWriteHeaders()
+		for _, key := range GetWriteHeaderList(ctx) {
+			if value, ok := GetHeader(ctx, key); ok {
+				headerProt.SetWriteHeader(key, value)
+			}
+		}
+	}
+
 	if err := oprot.WriteMessageBegin(method, CALL, seqId); err != nil {
 		return err
 	}

--- a/lib/go/thrift/header_context.go
+++ b/lib/go/thrift/header_context.go
@@ -32,6 +32,7 @@ type (
 // Values for headerKeyList.
 const (
 	headerKeyListRead headerKeyList = iota
+	headerKeyListWrite
 )
 
 // SetHeader sets a header in the context.
@@ -63,6 +64,25 @@ func SetReadHeaderList(ctx context.Context, keys []string) context.Context {
 // GetReadHeaderList returns the key list of read THeaders from the context.
 func GetReadHeaderList(ctx context.Context) []string {
 	if v := ctx.Value(headerKeyListRead); v != nil {
+		if value, ok := v.([]string); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+// SetWriteHeaderList sets the key list of THeaders to write in the context.
+func SetWriteHeaderList(ctx context.Context, keys []string) context.Context {
+	return context.WithValue(
+		ctx,
+		headerKeyListWrite,
+		keys,
+	)
+}
+
+// GetWriteHeaderList returns the key list of THeaders to write from the context.
+func GetWriteHeaderList(ctx context.Context) []string {
+	if v := ctx.Value(headerKeyListWrite); v != nil {
 		if value, ok := v.([]string); ok {
 			return value
 		}

--- a/lib/go/thrift/header_context_test.go
+++ b/lib/go/thrift/header_context_test.go
@@ -70,7 +70,7 @@ func TestSetGetHeader(t *testing.T) {
 	)
 }
 
-func TestKeyList(t *testing.T) {
+func TestReadKeyList(t *testing.T) {
 	headers := THeaderMap{
 		"key1": "value1",
 		"key2": "value2",
@@ -93,5 +93,36 @@ func TestKeyList(t *testing.T) {
 
 	if !reflect.DeepEqual(headers, got) {
 		t.Errorf("Expected header map %+v, got %+v", headers, got)
+	}
+
+	writtenKeys := GetWriteHeaderList(ctx)
+	if len(writtenKeys) > 0 {
+		t.Errorf(
+			"Expected empty GetWriteHeaderList() result, got %+v",
+			writtenKeys,
+		)
+	}
+}
+
+func TestWriteKeyList(t *testing.T) {
+	keys := []string{
+		"key1",
+		"key2",
+	}
+	ctx := context.Background()
+
+	ctx = SetWriteHeaderList(ctx, keys)
+	got := GetWriteHeaderList(ctx)
+
+	if !reflect.DeepEqual(keys, got) {
+		t.Errorf("Expected header keys %+v, got %+v", keys, got)
+	}
+
+	readKeys := GetReadHeaderList(ctx)
+	if len(readKeys) > 0 {
+		t.Errorf(
+			"Expected empty GetReadHeaderList() result, got %+v",
+			readKeys,
+		)
 	}
 }


### PR DESCRIPTION
Client: go

This is the second part of THRIFT-4914, which handles the client writing
part in the requests (client -> server direction).

In TStandardClient, when the context has write headers set, and the
protocol is THeaderProtocol, automatically extract all headers from the
context object and set to THeaderProtocol to send over the wire.

Client code can set headers into the context object by using the helper
functions in header_context.go.

Note that we have separated keys for read and write header key list, so
that for code that's both a server and a client (example: a server that
calls other upstream thrift servers), they don't automatically forward
all headers to their upstream servers, and need to explicitly set which
headers to forward.

In order to make auto forwarding easier, also add SetForwardHeaders
function to TSimpleServer, which will help the users to auto forward
selected headers.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
