### PR TITLE
THRIFT-4865:Replace expired Charsets with StandardCharsets

### DIFF
--- a/lib/java/test/org/apache/thrift/transport/TestTByteBuffer.java
+++ b/lib/java/test/org/apache/thrift/transport/TestTByteBuffer.java
@@ -1,7 +1,7 @@
 package org.apache.thrift.transport;
 
 import junit.framework.TestCase;
-import org.apache.commons.codec.Charsets;
+import java.nio.charset.StandardCharsets;
 import org.apache.thrift.TException;
 
 import java.nio.ByteBuffer;
@@ -9,25 +9,25 @@ import java.nio.ByteBuffer;
 public class TestTByteBuffer extends TestCase {
   public void testReadWrite() throws Exception {
     final TByteBuffer byteBuffer = new TByteBuffer(ByteBuffer.allocate(16));
-    byteBuffer.write("Hello World".getBytes(Charsets.UTF_8));
-    assertEquals("Hello World", new String(byteBuffer.flip().toByteArray(), Charsets.UTF_8));
+    byteBuffer.write("Hello World".getBytes(StandardCharsets.UTF_8));
+    assertEquals("Hello World", new String(byteBuffer.flip().toByteArray(), StandardCharsets.UTF_8));
   }
 
   public void testReuseReadWrite() throws Exception {
     final TByteBuffer byteBuffer = new TByteBuffer(ByteBuffer.allocate(16));
-    byteBuffer.write("Hello World".getBytes(Charsets.UTF_8));
-    assertEquals("Hello World", new String(byteBuffer.flip().toByteArray(), Charsets.UTF_8));
+    byteBuffer.write("Hello World".getBytes(StandardCharsets.UTF_8));
+    assertEquals("Hello World", new String(byteBuffer.flip().toByteArray(), StandardCharsets.UTF_8));
 
     byteBuffer.clear();
 
-    byteBuffer.write("Goodbye Horses".getBytes(Charsets.UTF_8));
-    assertEquals("Goodbye Horses", new String(byteBuffer.flip().toByteArray(), Charsets.UTF_8));
+    byteBuffer.write("Goodbye Horses".getBytes(StandardCharsets.UTF_8));
+    assertEquals("Goodbye Horses", new String(byteBuffer.flip().toByteArray(), StandardCharsets.UTF_8));
   }
 
   public void testOverflow() throws Exception {
     final TByteBuffer byteBuffer = new TByteBuffer(ByteBuffer.allocate(4));
     try {
-      byteBuffer.write("Hello World".getBytes(Charsets.UTF_8));
+      byteBuffer.write("Hello World".getBytes(StandardCharsets.UTF_8));
       fail("Expected write operation to fail with TTransportException");
     } catch (TTransportException e) {
       assertEquals("Not enough room in output buffer", e.getMessage());


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Warning: [Deprecated] UTF_8 in Charsets has been deprecated, but StandardCharsets can be used to solve this problem.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
