### PR TITLE
THRIFT-4919 THttpTransport/THttpClientTransport have bad timeout code

### DIFF
--- a/lib/netcore/Thrift/Transports/Client/THttpClientTransport.cs
+++ b/lib/netcore/Thrift/Transports/Client/THttpClientTransport.cs
@@ -63,6 +63,7 @@ namespace Thrift.Transports.Client
         public int ConnectTimeout
         {
             set { _connectTimeout = value; }
+            get { return _connectTimeout; }
         }
 
         public override bool IsOpen => true;
@@ -145,7 +146,7 @@ namespace Thrift.Transports.Client
 
             if (_connectTimeout > 0)
             {
-                httpClient.Timeout = TimeSpan.FromSeconds(_connectTimeout);
+                httpClient.Timeout = TimeSpan.FromMilliseconds(_connectTimeout);
             }
 
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-thrift"));

--- a/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
@@ -145,7 +145,7 @@ namespace Thrift.Transport.Client
 
             if (_connectTimeout > 0)
             {
-                httpClient.Timeout = TimeSpan.FromSeconds(_connectTimeout);
+                httpClient.Timeout = TimeSpan.FromMilliseconds(_connectTimeout);
             }
 
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-thrift"));


### PR DESCRIPTION
THRIFT-4919 THttpTransport.cs (netstd) and THttpClientTransport (netcore) have bad timeout code
Patch: Jens Geyer
