### PR TITLE
THRIFT-4933 Java build mode is incorrect in doc/install

### DIFF
--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -28,7 +28,7 @@ These are only required if you choose to build the libraries for the given langu
     * zlib (optional)
 * Java
     * Java 1.8
-    * Apache Ant
+    * Gradle
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)
 * PHP 5.0 (optionally including header files for extension modules)

--- a/doc/install/debian.md
+++ b/doc/install/debian.md
@@ -18,7 +18,7 @@ Debian 7/Ubuntu 12 users need to manually install a more recent version of autom
 If you would like to build Apache Thrift libraries for other programming languages you may need to install additional packages. The following languages require the specified additional packages:
 
  * Java
-	* packages: ant  
+	* packages: gradle 
 	* You will also need Java JDK v1.8 or higher. Type **javac** to see a list of available packages, pick the one you prefer and **apt-get install** it (e.g. default-jdk).
  * Ruby
 	* ruby-full ruby-dev ruby-rspec rake rubygems bundler


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  Starting with version 0.12.0, the lib/java build method has been changed to Gradle.
so I changed the error description in the documentation.
Thanks.
best regards.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
