### PR TITLE
THRIFT-4960 Bare Trait Warnings

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -901,7 +901,7 @@ void t_rs_generator::render_enum_impl(const string& enum_name) {
 
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(&self, o_prot: &mut TOutputProtocol) -> thrift::Result<()> {"
+    << "pub fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
   f_gen_ << indent() << "o_prot.write_i32(*self as i32)" << endl;
@@ -910,7 +910,7 @@ void t_rs_generator::render_enum_impl(const string& enum_name) {
 
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut TInputProtocol) -> thrift::Result<" << enum_name << "> {"
+    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << enum_name << "> {"
     << endl;
   indent_up();
 
@@ -1401,7 +1401,7 @@ void t_rs_generator::render_struct_sync_write(
   f_gen_
     << indent()
     << visibility_qualifier(struct_type)
-    << "fn write_to_out_protocol(&self, o_prot: &mut TOutputProtocol) -> thrift::Result<()> {"
+    << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
 
@@ -1433,7 +1433,7 @@ void t_rs_generator::render_struct_sync_write(
 void t_rs_generator::render_union_sync_write(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(&self, o_prot: &mut TOutputProtocol) -> thrift::Result<()> {"
+    << "pub fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
 
@@ -1675,7 +1675,7 @@ void t_rs_generator::render_struct_sync_read(
   f_gen_
     << indent()
     << visibility_qualifier(struct_type)
-    << "fn read_from_in_protocol(i_prot: &mut TInputProtocol) -> thrift::Result<" << struct_name << "> {"
+    << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << struct_name << "> {"
     << endl;
 
   indent_up();
@@ -1797,7 +1797,7 @@ void t_rs_generator::render_struct_sync_read(
 void t_rs_generator::render_union_sync_read(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut TInputProtocol) -> thrift::Result<" << union_name << "> {"
+    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << union_name << "> {"
     << endl;
   indent_up();
 
@@ -2206,8 +2206,8 @@ void t_rs_generator::render_sync_client_tthriftclient_impl(const string &client_
     << " {" << endl;
   indent_up();
 
-  f_gen_ << indent() << "fn i_prot_mut(&mut self) -> &mut TInputProtocol { &mut self._i_prot }" << endl;
-  f_gen_ << indent() << "fn o_prot_mut(&mut self) -> &mut TOutputProtocol { &mut self._o_prot }" << endl;
+  f_gen_ << indent() << "fn i_prot_mut(&mut self) -> &mut dyn TInputProtocol { &mut self._i_prot }" << endl;
+  f_gen_ << indent() << "fn o_prot_mut(&mut self) -> &mut dyn TOutputProtocol { &mut self._o_prot }" << endl;
   f_gen_ << indent() << "fn sequence_number(&self) -> i32 { self._sequence_number }" << endl;
   f_gen_
     << indent()
@@ -2564,7 +2564,7 @@ void t_rs_generator::render_sync_processor_definition_and_impl(t_service *tservi
 
   f_gen_
     << indent()
-    << "fn process(&self, i_prot: &mut TInputProtocol, o_prot: &mut TOutputProtocol) -> thrift::Result<()> {"
+    << "fn process(&self, i_prot: &mut dyn TInputProtocol, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
 
@@ -2609,8 +2609,8 @@ void t_rs_generator::render_sync_process_delegation_functions(t_service *tservic
       << "fn " << function_name
       << "(&self, "
       << "incoming_sequence_number: i32, "
-      << "i_prot: &mut TInputProtocol, "
-      << "o_prot: &mut TOutputProtocol) "
+      << "i_prot: &mut dyn TInputProtocol, "
+      << "o_prot: &mut dyn TOutputProtocol) "
       << "-> thrift::Result<()> {"
       << endl;
     indent_up();
@@ -2674,8 +2674,8 @@ void t_rs_generator::render_sync_process_function(t_function *tfunc, const strin
     << "<H: " << handler_type << ">"
     << "(handler: &H, "
     << sequence_number_param << ": i32, "
-    << "i_prot: &mut TInputProtocol, "
-    << output_protocol_param << ": &mut TOutputProtocol) "
+    << "i_prot: &mut dyn TInputProtocol, "
+    << output_protocol_param << ": &mut dyn TOutputProtocol) "
     << "-> thrift::Result<()> {"
     << endl;
 

--- a/lib/rs/src/autogen.rs
+++ b/lib/rs/src/autogen.rs
@@ -29,10 +29,10 @@ use protocol::{TInputProtocol, TOutputProtocol};
 pub trait TThriftClient {
     /// Returns the input protocol used to read serialized Thrift messages
     /// from the Thrift server.
-    fn i_prot_mut(&mut self) -> &mut TInputProtocol;
+    fn i_prot_mut(&mut self) -> &mut dyn TInputProtocol;
     /// Returns the output protocol used to write serialized Thrift messages
     /// to the Thrift server.
-    fn o_prot_mut(&mut self) -> &mut TOutputProtocol;
+    fn o_prot_mut(&mut self) -> &mut dyn TOutputProtocol;
     /// Returns the sequence number of the last message written to the Thrift
     /// server. Returns `0` if no messages have been written. Sequence
     /// numbers should *never* be negative, and this method returns an `i32`

--- a/lib/rs/src/errors.rs
+++ b/lib/rs/src/errors.rs
@@ -188,7 +188,7 @@ pub enum Error {
     /// functions are automatically returned as an `ApplicationError`.
     Application(ApplicationError),
     /// IDL-defined exception structs.
-    User(Box<error::Error + Sync + Send>),
+    User(Box<dyn error::Error + Sync + Send>),
 }
 
 impl Error {
@@ -196,7 +196,7 @@ impl Error {
     ///
     /// Application code **should never** call this method directly.
     pub fn read_application_error_from_in_protocol(
-        i: &mut TInputProtocol,
+        i: &mut dyn TInputProtocol,
     ) -> ::Result<ApplicationError> {
         let mut message = "general remote error".to_owned();
         let mut kind = ApplicationErrorKind::Unknown;
@@ -247,7 +247,7 @@ impl Error {
     /// Application code **should never** call this method directly.
     pub fn write_application_error_to_out_protocol(
         e: &ApplicationError,
-        o: &mut TOutputProtocol,
+        o: &mut dyn TOutputProtocol,
     ) -> ::Result<()> {
         o.write_struct_begin(&TStructIdentifier {
             name: "TApplicationException".to_owned(),

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -47,6 +47,7 @@
 
 #![crate_type = "lib"]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
+#![deny(bare_trait_objects)]
 
 extern crate byteorder;
 extern crate ordered_float;

--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -249,7 +249,7 @@ impl TBinaryInputProtocolFactory {
 }
 
 impl TInputProtocolFactory for TBinaryInputProtocolFactory {
-    fn create(&self, transport: Box<TReadTransport + Send>) -> Box<TInputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TReadTransport + Send>) -> Box<dyn TInputProtocol + Send> {
         Box::new(TBinaryInputProtocol::new(transport, true))
     }
 }
@@ -453,7 +453,7 @@ impl TBinaryOutputProtocolFactory {
 }
 
 impl TOutputProtocolFactory for TBinaryOutputProtocolFactory {
-    fn create(&self, transport: Box<TWriteTransport + Send>) -> Box<TOutputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TWriteTransport + Send>) -> Box<dyn TOutputProtocol + Send> {
         Box::new(TBinaryOutputProtocol::new(transport, true))
     }
 }

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -322,7 +322,7 @@ impl TCompactInputProtocolFactory {
 }
 
 impl TInputProtocolFactory for TCompactInputProtocolFactory {
-    fn create(&self, transport: Box<TReadTransport + Send>) -> Box<TInputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TReadTransport + Send>) -> Box<dyn TInputProtocol + Send> {
         Box::new(TCompactInputProtocol::new(transport))
     }
 }
@@ -593,7 +593,7 @@ impl TCompactOutputProtocolFactory {
 }
 
 impl TOutputProtocolFactory for TCompactOutputProtocolFactory {
-    fn create(&self, transport: Box<TWriteTransport + Send>) -> Box<TOutputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TWriteTransport + Send>) -> Box<dyn TOutputProtocol + Send> {
         Box::new(TCompactOutputProtocol::new(transport))
     }
 }

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -546,14 +546,14 @@ where
 /// ```
 pub trait TInputProtocolFactory {
     // Create a `TInputProtocol` that reads bytes from `transport`.
-    fn create(&self, transport: Box<TReadTransport + Send>) -> Box<TInputProtocol + Send>;
+    fn create(&self, transport: Box<dyn TReadTransport + Send>) -> Box<dyn TInputProtocol + Send>;
 }
 
 impl<T> TInputProtocolFactory for Box<T>
 where
     T: TInputProtocolFactory + ?Sized,
 {
-    fn create(&self, transport: Box<TReadTransport + Send>) -> Box<TInputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TReadTransport + Send>) -> Box<dyn TInputProtocol + Send> {
         (**self).create(transport)
     }
 }
@@ -577,14 +577,14 @@ where
 /// ```
 pub trait TOutputProtocolFactory {
     /// Create a `TOutputProtocol` that writes bytes to `transport`.
-    fn create(&self, transport: Box<TWriteTransport + Send>) -> Box<TOutputProtocol + Send>;
+    fn create(&self, transport: Box<dyn TWriteTransport + Send>) -> Box<dyn TOutputProtocol + Send>;
 }
 
 impl<T> TOutputProtocolFactory for Box<T>
 where
     T: TOutputProtocolFactory + ?Sized,
 {
-    fn create(&self, transport: Box<TWriteTransport + Send>) -> Box<TOutputProtocol + Send> {
+    fn create(&self, transport: Box<dyn TWriteTransport + Send>) -> Box<dyn TOutputProtocol + Send> {
         (**self).create(transport)
     }
 }
@@ -926,29 +926,29 @@ mod tests {
 
     #[test]
     fn must_create_usable_input_protocol_from_concrete_input_protocol() {
-        let r: Box<TReadTransport> = Box::new(Cursor::new([0, 1, 2]));
+        let r: Box<dyn TReadTransport> = Box::new(Cursor::new([0, 1, 2]));
         let mut t = TCompactInputProtocol::new(r);
         takes_input_protocol(&mut t)
     }
 
     #[test]
     fn must_create_usable_input_protocol_from_boxed_input() {
-        let r: Box<TReadTransport> = Box::new(Cursor::new([0, 1, 2]));
-        let mut t: Box<TInputProtocol> = Box::new(TCompactInputProtocol::new(r));
+        let r: Box<dyn TReadTransport> = Box::new(Cursor::new([0, 1, 2]));
+        let mut t: Box<dyn TInputProtocol> = Box::new(TCompactInputProtocol::new(r));
         takes_input_protocol(&mut t)
     }
 
     #[test]
     fn must_create_usable_output_protocol_from_concrete_output_protocol() {
-        let w: Box<TWriteTransport> = Box::new(vec![0u8; 10]);
+        let w: Box<dyn TWriteTransport> = Box::new(vec![0u8; 10]);
         let mut t = TCompactOutputProtocol::new(w);
         takes_output_protocol(&mut t)
     }
 
     #[test]
     fn must_create_usable_output_protocol_from_boxed_output() {
-        let w: Box<TWriteTransport> = Box::new(vec![0u8; 10]);
-        let mut t: Box<TOutputProtocol> = Box::new(TCompactOutputProtocol::new(w));
+        let w: Box<dyn TWriteTransport> = Box::new(vec![0u8; 10]);
+        let mut t: Box<dyn TOutputProtocol> = Box::new(TCompactOutputProtocol::new(w));
         takes_output_protocol(&mut t)
     }
 

--- a/lib/rs/src/protocol/stored.rs
+++ b/lib/rs/src/protocol/stored.rs
@@ -79,7 +79,7 @@ use ProtocolErrorKind;
 /// ```
 // FIXME: implement Debug
 pub struct TStoredInputProtocol<'a> {
-    inner: &'a mut TInputProtocol,
+    inner: &'a mut dyn TInputProtocol,
     message_ident: Option<TMessageIdentifier>,
 }
 
@@ -90,7 +90,7 @@ impl<'a> TStoredInputProtocol<'a> {
     /// with service name stripped - that will be passed to
     /// `wrapped.read_message_begin(...)`.
     pub fn new(
-        wrapped: &mut TInputProtocol,
+        wrapped: &mut dyn TInputProtocol,
         message_ident: TMessageIdentifier,
     ) -> TStoredInputProtocol {
         TStoredInputProtocol {

--- a/lib/rs/src/server/mod.rs
+++ b/lib/rs/src/server/mod.rs
@@ -91,7 +91,7 @@ pub trait TProcessor {
     /// the response to `o`.
     ///
     /// Returns `()` if the handler was executed; `Err` otherwise.
-    fn process(&self, i: &mut TInputProtocol, o: &mut TOutputProtocol) -> ::Result<()>;
+    fn process(&self, i: &mut dyn TInputProtocol, o: &mut dyn TOutputProtocol) -> ::Result<()>;
 }
 
 /// Convenience function used in generated `TProcessor` implementations to
@@ -99,7 +99,7 @@ pub trait TProcessor {
 pub fn handle_process_result(
     msg_ident: &TMessageIdentifier,
     res: ::Result<()>,
-    o_prot: &mut TOutputProtocol,
+    o_prot: &mut dyn TOutputProtocol,
 ) -> ::Result<()> {
     if let Err(e) = res {
         let e = match e {

--- a/lib/rs/src/server/threaded.rs
+++ b/lib/rs/src/server/threaded.rs
@@ -194,7 +194,7 @@ where
     fn new_protocols_for_connection(
         &mut self,
         stream: TcpStream,
-    ) -> ::Result<(Box<TInputProtocol + Send>, Box<TOutputProtocol + Send>)> {
+    ) -> ::Result<(Box<dyn TInputProtocol + Send>, Box<dyn TOutputProtocol + Send>)> {
         // create the shared tcp stream
         let channel = TTcpChannel::with_stream(stream);
 
@@ -216,8 +216,8 @@ where
 
 fn handle_incoming_connection<PRC>(
     processor: Arc<PRC>,
-    i_prot: Box<TInputProtocol>,
-    o_prot: Box<TOutputProtocol>,
+    i_prot: Box<dyn TInputProtocol>,
+    o_prot: Box<dyn TOutputProtocol>,
 ) where
     PRC: TProcessor,
 {

--- a/lib/rs/src/transport/buffered.rs
+++ b/lib/rs/src/transport/buffered.rs
@@ -139,7 +139,7 @@ impl TBufferedReadTransportFactory {
 
 impl TReadTransportFactory for TBufferedReadTransportFactory {
     /// Create a `TBufferedReadTransport`.
-    fn create(&self, channel: Box<Read + Send>) -> Box<TReadTransport + Send> {
+    fn create(&self, channel: Box<dyn Read + Send>) -> Box<dyn TReadTransport + Send> {
         Box::new(TBufferedReadTransport::new(channel))
     }
 }
@@ -254,7 +254,7 @@ impl TBufferedWriteTransportFactory {
 
 impl TWriteTransportFactory for TBufferedWriteTransportFactory {
     /// Create a `TBufferedWriteTransport`.
-    fn create(&self, channel: Box<Write + Send>) -> Box<TWriteTransport + Send> {
+    fn create(&self, channel: Box<dyn Write + Send>) -> Box<dyn TWriteTransport + Send> {
         Box::new(TBufferedWriteTransport::new(channel))
     }
 }

--- a/lib/rs/src/transport/framed.rs
+++ b/lib/rs/src/transport/framed.rs
@@ -121,7 +121,7 @@ impl TFramedReadTransportFactory {
 
 impl TReadTransportFactory for TFramedReadTransportFactory {
     /// Create a `TFramedReadTransport`.
-    fn create(&self, channel: Box<Read + Send>) -> Box<TReadTransport + Send> {
+    fn create(&self, channel: Box<dyn Read + Send>) -> Box<dyn TReadTransport + Send> {
         Box::new(TFramedReadTransport::new(channel))
     }
 }
@@ -231,7 +231,7 @@ impl TFramedWriteTransportFactory {
 
 impl TWriteTransportFactory for TFramedWriteTransportFactory {
     /// Create a `TFramedWriteTransport`.
-    fn create(&self, channel: Box<Write + Send>) -> Box<TWriteTransport + Send> {
+    fn create(&self, channel: Box<dyn Write + Send>) -> Box<dyn TWriteTransport + Send> {
         Box::new(TFramedWriteTransport::new(channel))
     }
 }

--- a/lib/rs/src/transport/mod.rs
+++ b/lib/rs/src/transport/mod.rs
@@ -64,7 +64,7 @@ pub trait TReadTransport: Read {}
 /// accepted client connections.
 pub trait TReadTransportFactory {
     /// Create a `TTransport` that wraps a channel over which bytes are to be read.
-    fn create(&self, channel: Box<Read + Send>) -> Box<TReadTransport + Send>;
+    fn create(&self, channel: Box<dyn Read + Send>) -> Box<dyn TReadTransport + Send>;
 }
 
 /// Identifies a transport used by `TOutputProtocol` to send bytes.
@@ -74,7 +74,7 @@ pub trait TWriteTransport: Write {}
 /// accepted client connections.
 pub trait TWriteTransportFactory {
     /// Create a `TTransport` that wraps a channel over which bytes are to be sent.
-    fn create(&self, channel: Box<Write + Send>) -> Box<TWriteTransport + Send>;
+    fn create(&self, channel: Box<dyn Write + Send>) -> Box<dyn TWriteTransport + Send>;
 }
 
 impl<T> TReadTransport for T where T: Read {}
@@ -87,7 +87,7 @@ impl<T> TReadTransportFactory for Box<T>
 where
     T: TReadTransportFactory + ?Sized,
 {
-    fn create(&self, channel: Box<Read + Send>) -> Box<TReadTransport + Send> {
+    fn create(&self, channel: Box<dyn Read + Send>) -> Box<dyn TReadTransport + Send> {
         (**self).create(channel)
     }
 }
@@ -96,7 +96,7 @@ impl<T> TWriteTransportFactory for Box<T>
 where
     T: TWriteTransportFactory + ?Sized,
 {
-    fn create(&self, channel: Box<Write + Send>) -> Box<TWriteTransport + Send> {
+    fn create(&self, channel: Box<dyn Write + Send>) -> Box<dyn TWriteTransport + Send> {
         (**self).create(channel)
     }
 }
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn must_create_usable_read_channel_from_boxed_read() {
-        let r: Box<Read> = Box::new(Cursor::new([0, 1, 2]));
+        let r: Box<dyn Read> = Box::new(Cursor::new([0, 1, 2]));
         let _ = TBufferedReadTransport::new(r);
     }
 
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn must_create_usable_write_channel_from_boxed_write() {
-        let w: Box<Write> = Box::new(vec![0u8; 10]);
+        let w: Box<dyn Write> = Box::new(vec![0u8; 10]);
         let _ = TBufferedWriteTransport::new(w);
     }
 
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn must_create_usable_read_transport_from_boxed_read() {
         let r = Cursor::new([0, 1, 2]);
-        let mut t: Box<TReadTransport> = Box::new(TBufferedReadTransport::new(r));
+        let mut t: Box<dyn TReadTransport> = Box::new(TBufferedReadTransport::new(r));
         takes_read_transport(&mut t)
     }
 
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn must_create_usable_write_transport_from_boxed_write() {
         let w = vec![0u8; 10];
-        let mut t: Box<TWriteTransport> = Box::new(TBufferedWriteTransport::new(w));
+        let mut t: Box<dyn TWriteTransport> = Box::new(TBufferedWriteTransport::new(w));
         takes_write_transport(&mut t)
     }
 


### PR DESCRIPTION
Fixes bare trait (dyn) warnings in the library as well as generated code.

<!-- Explain the changes in the pull request below: -->
  
Bare traits, e.g. `&mut TInputProtocol` currently generate warnings which will be an error in a future rust version. Bare traits are now fixed in the rust lib and generated code to include `dyn`.
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?  (not required for trivial changes)
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
