### PR TITLE
THRIFT-4941 thrift compiler will not auto update gen-cpp directory

### DIFF
--- a/compiler/cpp/src/thrift/platform.h
+++ b/compiler/cpp/src/thrift/platform.h
@@ -38,7 +38,7 @@
 
 // ignore EEXIST, throw on any other error
 #ifdef _WIN32
-#define MKDIR(x) { int r = _mkdir(x); if (r == -1 && errno != EEXIST) { throw (std::string(x) + ": ") + strerror(errno); } }
+#define MKDIR(x) { int r = _mkdir(x); if (r == -1) { throw (std::string(x) + ": ") + strerror(errno); } }
 #else
 #define MKDIR(x) { int r = mkdir(x, S_IRWXU | S_IRWXG | S_IRWXO); if (r == -1 && errno != EEXIST) { throw (std::string(x) + ": ") + strerror(errno); } }
 #endif


### PR DESCRIPTION
hi, @Jens-G 
     when we generate code in compiler\cpp\src\thrift\generate\t_generate.cc, thrift compiler will not auto update gen-cpp directory existed and nothing happend on terminal.
     i test it on windows 7 so i only change the windows macro.
     it will shows link this:
`thrift --gen cpp faceDector.thrift
[FAILURE:generation:1] Error: ./gen-cpp/:  File exists
`
 i give some suggestion to solved this problem completely on JIRA,  if we want to show the guy what happend. hope you can think about it,
  

thanks.
zhouhu.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
