### PR TITLE
THRIFT-4938 resolved compatibility display version error

### DIFF
--- a/compiler/cpp/src/thrift/version.h.in
+++ b/compiler/cpp/src/thrift/version.h.in
@@ -24,6 +24,10 @@
 #pragma once
 #endif // _MSC_VER
 
+#if defined(_MSC_VER) && (_MSC_VER > 1200)
+#define THRIFT_VERSION "0.13.0"
+#else 
 #define THRIFT_VERSION "@PACKAGE_VERSION@"
+#endif // VERSION
 
 #endif // _THRIFT_VERSION_H_


### PR DESCRIPTION
I test it on window 7 by visual studio 2015, dirtory is: compiler\cpp\src\thrift\version.h.in

`#ifndef THRIFT_VERSION_H
#define THRIFT_VERSION_H 1

#if defined(_MSC_VER) && (_MSC_VER > 1200)
#pragma once
#endif // _MSC_VER

#if defined(_MSC_VER) && (_MSC_VER > 1200)
#define THRIFT_VERSION "0.13.0"
#else
#define THRIFT_VERSION "@PACKAGE_VERSION@"
#endif // VERSION

#endif // THRIFT_VERSION_H`

it shows like this:
`thrift.exe -version

thrift version PACKAGE_VERSION@`

when we built by script, it`s ok.this problem is from the version value defined in built script.
hope it`s helpful.

thanks.
zhouhu.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
