### PR TITLE
Fix lack of fs, tls, child_process of nodejs code on browsers

### DIFF
--- a/lib/nodejs/lib/thrift/index.js
+++ b/lib/nodejs/lib/thrift/index.js
@@ -18,58 +18,61 @@
  */
 exports.Thrift = require('./thrift');
 
-var log = require('./log');
-exports.setLogFunc = log.setLogFunc;
-exports.setLogLevel = log.setLogLevel;
-exports.getLogLevel = log.getLogLevel;
+// Server classes. Browsers fail with them. Just use browser.js on browsers.
+if (typeof window === 'undefined') {
 
-var connection = require('./connection');
-exports.Connection = connection.Connection;
-exports.createClient = connection.createClient;
-exports.createConnection = connection.createConnection;
-exports.createUDSConnection = connection.createUDSConnection;
-exports.createSSLConnection = connection.createSSLConnection;
-exports.createStdIOClient = connection.createStdIOClient;
-exports.createStdIOConnection = connection.createStdIOConnection;
+  var log = require('./log');
+  exports.setLogFunc = log.setLogFunc;
+  exports.setLogLevel = log.setLogLevel;
+  exports.getLogLevel = log.getLogLevel;
 
-var httpConnection = require('./http_connection');
-exports.HttpConnection = httpConnection.HttpConnection;
-exports.createHttpConnection = httpConnection.createHttpConnection;
-exports.createHttpUDSConnection = httpConnection.createHttpUDSConnection;
-exports.createHttpClient = httpConnection.createHttpClient;
+  var connection = require('./connection');
+  exports.Connection = connection.Connection;
+  exports.createClient = connection.createClient;
+  exports.createConnection = connection.createConnection;
+  exports.createUDSConnection = connection.createUDSConnection;
+  exports.createSSLConnection = connection.createSSLConnection;
+  exports.createStdIOClient = connection.createStdIOClient;
+  exports.createStdIOConnection = connection.createStdIOConnection;
 
-var wsConnection = require('./ws_connection');
-exports.WSConnection = wsConnection.WSConnection;
-exports.createWSConnection = wsConnection.createWSConnection;
-exports.createWSClient = wsConnection.createWSClient;
+  var httpConnection = require('./http_connection');
+  exports.HttpConnection = httpConnection.HttpConnection;
+  exports.createHttpConnection = httpConnection.createHttpConnection;
+  exports.createHttpUDSConnection = httpConnection.createHttpUDSConnection;
+  exports.createHttpClient = httpConnection.createHttpClient;
 
-var xhrConnection = require('./xhr_connection');
-exports.XHRConnection = xhrConnection.XHRConnection;
-exports.createXHRConnection = xhrConnection.createXHRConnection;
-exports.createXHRClient = xhrConnection.createXHRClient;
+  var wsConnection = require('./ws_connection');
+  exports.WSConnection = wsConnection.WSConnection;
+  exports.createWSConnection = wsConnection.createWSConnection;
+  exports.createWSClient = wsConnection.createWSClient;
 
-var server = require('./server');
-exports.createServer = server.createServer;
-exports.createMultiplexServer = server.createMultiplexServer;
+  var xhrConnection = require('./xhr_connection');
+  exports.XHRConnection = xhrConnection.XHRConnection;
+  exports.createXHRConnection = xhrConnection.createXHRConnection;
+  exports.createXHRClient = xhrConnection.createXHRClient;
 
-var web_server = require('./web_server');
-exports.createWebServer = web_server.createWebServer;
+  var server = require('./server');
+  exports.createServer = server.createServer;
+  exports.createMultiplexServer = server.createMultiplexServer;
 
-exports.Int64 = require('node-int64');
-exports.Q = require('q');
+  var web_server = require('./web_server');
+  exports.createWebServer = web_server.createWebServer;
 
-var mprocessor = require('./multiplexed_processor');
-var mprotocol = require('./multiplexed_protocol');
-exports.Multiplexer = mprotocol.Multiplexer;
-exports.MultiplexedProcessor = mprocessor.MultiplexedProcessor;
+  exports.Int64 = require('node-int64');
+  exports.Q = require('q');
 
-/*
- * Export transport and protocol so they can be used outside of a
- * cassandra/server context
- */
-exports.TFramedTransport = require('./framed_transport');
-exports.TBufferedTransport = require('./buffered_transport');
-exports.TBinaryProtocol = require('./binary_protocol');
-exports.TJSONProtocol = require('./json_protocol');
-exports.TCompactProtocol = require('./compact_protocol');
-exports.THeaderProtocol = require('./header_protocol');
+  var mprocessor = require('./multiplexed_processor');
+  var mprotocol = require('./multiplexed_protocol');
+  exports.Multiplexer = mprotocol.Multiplexer;
+  exports.MultiplexedProcessor = mprocessor.MultiplexedProcessor;
+
+  /*
+   * Export transport and protocol so they can be used outside of a
+   * cassandra/server context
+   */
+  exports.TFramedTransport = require('./framed_transport');
+  exports.TBufferedTransport = require('./buffered_transport');
+  exports.TBinaryProtocol = require('./binary_protocol');
+  exports.TJSONProtocol = require('./json_protocol');
+  exports.TCompactProtocol = require('./compact_protocol');
+}


### PR DESCRIPTION
When you use generated code on nodejs on browsers, lib/nodejs/lib/thrift/index.js fails because it lacks fs, tls and child_process. This fix skips index.js on browsers.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
