### PR TITLE
THRIFT-4950 fix bind print error and Macro call errors in thrift_server_socket.c

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_server_socket.c
@@ -85,7 +85,7 @@ thrift_server_socket_listen (ThriftServerTransport *transport, GError **error)
     {
       g_set_error (error, THRIFT_SERVER_SOCKET_ERROR,
                    THRIFT_SERVER_SOCKET_ERROR_BIND,
-                   "failed to bind to path %s",
+                   "failed to bind to path %s: - %s",
                    tsocket->path, strerror(errno));
       return FALSE;
     }
@@ -115,7 +115,7 @@ thrift_server_socket_listen (ThriftServerTransport *transport, GError **error)
     {
       g_set_error (error, THRIFT_SERVER_SOCKET_ERROR,
                    THRIFT_SERVER_SOCKET_ERROR_BIND,
-                   "failed to bind to path %s",
+                   "failed to bind to path %s: - %s",
                    tsocket->path, strerror(errno));
       return FALSE;
     }

--- a/test/c_glib/src/thrift_test_handler.c
+++ b/test/c_glib/src/thrift_test_handler.c
@@ -30,7 +30,7 @@
 
 G_DEFINE_TYPE (ThriftTestHandler,
                thrift_test_handler,
-               T_TEST_TYPE_THRIFT_TEST_HANDLER);
+               T_TEST_TYPE_THRIFT_TEST_HANDLER)
 
 gboolean
 thrift_test_handler_test_void (TTestThriftTestIf  *iface,


### PR DESCRIPTION
fix bind print error and Macro call errors thrift_server_socket

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
