### PR TITLE
THRIFT-4932: Using a default string on a binary field results in invalid Java code.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -731,7 +731,11 @@ string t_java_generator::render_const_value(ostream& out, t_type* type, t_const_
     t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
     switch (tbase) {
     case t_base_type::TYPE_STRING:
-      render << '"' << get_escaped_string(value) << '"';
+      if (((t_base_type*)type)->is_binary()) {
+        render << "java.nio.ByteBuffer.wrap(\"" << get_escaped_string(value) << "\".getBytes())";
+      } else {
+        render << '"' << get_escaped_string(value) << '"';
+      }
       break;
     case t_base_type::TYPE_BOOL:
       render << ((value->get_integer() > 0) ? "true" : "false");

--- a/lib/java/gradle/generateTestThrift.gradle
+++ b/lib/java/gradle/generateTestThrift.gradle
@@ -80,6 +80,7 @@ task generateJava(group: 'Build') {
     thriftCompile(it, 'ManyOptionals.thrift')
     thriftCompile(it, 'JavaDeepCopyTest.thrift')
     thriftCompile(it, 'EnumContainersTest.thrift')
+    thriftCompile(it, 'JavaBinaryDefault.thrift')
 }
 
 task generateBeanJava(group: 'Build') {

--- a/test/JavaBinaryDefault.thrift
+++ b/test/JavaBinaryDefault.thrift
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct StringAndBinary {
+  1: optional string strval = ""
+  2: optional binary binval = ""
+}

--- a/test/JavaTypes.thrift
+++ b/test/JavaTypes.thrift
@@ -27,6 +27,10 @@ struct String {
   1: string val
 }
 
+struct Binary {
+  1: binary val
+}
+
 struct Boolean {
   1: bool val
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -158,6 +158,7 @@ EXTRA_DIST = \
 	Include.thrift \
 	Int64Test.thrift \
 	JavaBeansTest.thrift \
+	JavaBinaryDefault.thrift \
 	JavaDeepCopyTest.thrift \
 	JavaTypes.thrift \
 	JsDeepConstructorTest.thrift \


### PR DESCRIPTION
When a binary field has a default value the value is treated as a String. However you cannot set a string to a bytebuffer so this fails to compile.
  

- [x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.