### PR TITLE
THRIFT-4858: Provide a meaningful error message

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TIOStreamTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TIOStreamTransport.java
@@ -129,7 +129,7 @@ public class TIOStreamTransport extends TTransport {
       throw new TTransportException(TTransportException.UNKNOWN, iox);
     }
     if (bytesRead < 0) {
-      throw new TTransportException(TTransportException.END_OF_FILE);
+      throw new TTransportException(TTransportException.END_OF_FILE, "Socket is closed by peer.");
     }
     return bytesRead;
   }


### PR DESCRIPTION
When the peer closes the socket, currently TIOStreamTransport throws an TTransportException without message, this is sometimes confusing.
