### PR TITLE
THRIFT-4962 Fix deadlock in TimerManager::stop

### DIFF
--- a/lib/cpp/src/thrift/concurrency/TimerManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/TimerManager.cpp
@@ -132,7 +132,7 @@ public:
       Synchronized s(manager_->monitor_);
       if (manager_->state_ == TimerManager::STOPPING) {
         manager_->state_ = TimerManager::STOPPED;
-        manager_->monitor_.notify();
+        manager_->monitor_.notifyAll();
       }
     }
     return;


### PR DESCRIPTION
Client: cpp

<!-- Explain the changes in the pull request below: -->
  
Use notifyAll to ensure all threads waiting on TimerManager::stop are awakened

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
