### PR TITLE
thrift lua TcompactProtocol bug fix

### DIFF
--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -124,8 +124,8 @@ function TCompactProtocol:writeStructBegin(name)
 end
 
 function TCompactProtocol:writeStructEnd()
-  self.lastFieldIndex = self.lastFieldIndex - 1
   self.lastFieldId = self.lastField[self.lastFieldIndex]
+  self.lastFieldIndex = self.lastFieldIndex - 1
 end
 
 function TCompactProtocol:writeFieldBegin(name, ttype, id)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  when TCompactProtocol write a struct, the self.lastFieldIndex + 1 first,  then store the self.lastFieldId;
but when write end, the self.lastFieldId is taken after  self.lastFieldIndex - 1. so it may result some field has a wrong index!

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
