### PR TITLE
Fix wrong command examples in build/docker/README.md [skip ci]

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -109,12 +109,12 @@ new one for you:
 
 To run all unit tests (just like Travis CI does):
 
-    thrift$ dockerrun ubuntu-bionic
+    thrift$ dockerrun thrift/thrift-build:ubuntu-bionic
     root@8caf56b0ce7b:/thrift/src# build/docker/scripts/autotools.sh
 
 To run the cross tests (just like Travis CI does):
 
-    thrift$ dockerrun ubuntu-bionic
+    thrift$ dockerrun thrift/thrift-build:ubuntu-bionic
     root@8caf56b0ce7b:/thrift/src# build/docker/scripts/cross-test.sh
 
 When you are done, you want to clean up occasionally so that docker isn't using lots of extra disk space:


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
I tried to run tests locally following the instructions in `build/docker/README.md`, but the following command failed:

```
thrift$ dockerrun ubuntu-bionic
```

It requires a preceding repository name, specified as `$DOCKER_REPO` in the previous command:

```
thrift$ DOCKER_REPO=thrift/thrift-build DISTRO=ubuntu-bionic build/docker/refresh.sh
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)

No, because it's a trivial change just for the documentation.

- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
