### PR TITLE
THRIFT-4967: Node.js tutorial server fails if the zip function invoked

### DIFF
--- a/tutorial/nodejs/NodeServer.js
+++ b/tutorial/nodejs/NodeServer.js
@@ -77,7 +77,6 @@ var server = thrift.createServer(Calculator, {
 
   zip: function() {
     console.log("zip()");
-    result(null);
   }
 
 });


### PR DESCRIPTION
Client: nodejs

<!-- Explain the changes in the pull request below: -->

This PR fixes tutorial/nodejs/NodeServer.js not to fail when receiving an invocation for the zip function.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
