### PR TITLE
THRIFT-4969: PHP test doesn't check the code generation with php:classmap

### DIFF
--- a/test/php/Makefile.am
+++ b/test/php/Makefile.am
@@ -21,7 +21,7 @@ stubs: ../ThriftTest.thrift
 	$(THRIFT) --gen php ../ThriftTest.thrift
 	$(THRIFT) --gen php:inlined ../ThriftTest.thrift
 	$(MKDIR_P) gen-php-classmap
-	$(THRIFT) -out gen-php-classmap --gen php ../ThriftTest.thrift
+	$(THRIFT) -out gen-php-classmap --gen php:classmap ../ThriftTest.thrift
 
 php_ext_dir:
 	mkdir -p php_ext_dir


### PR DESCRIPTION
Client: PHP

<!-- Explain the changes in the pull request below: -->

`make check` in test/php tests some options such as `:inlined` and `:classmap`, but the latter is not specified mistakenly. This PR fixes it.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
