### PR TITLE
THRIFT-4971: Fix lib/rb/spec/union_spec.rb so that CI succeeds

### DIFF
--- a/lib/rb/spec/union_spec.rb
+++ b/lib/rb/spec/union_spec.rb
@@ -51,8 +51,7 @@ describe 'Union' do
     it "should raise for wrong set field when hash initialized and type checking is off" do
       Thrift.type_checking = false
       union = SpecNamespace::My_union.new({incorrect_field: :incorrect})
-      example = lambda { Thrift::Serializer.new.serialize(union) }
-      expect(example).to raise_error(RuntimeError, "set_field is not valid for this union!")
+      expect { Thrift::Serializer.new.serialize(union) }.to raise_error(RuntimeError, "set_field is not valid for this union!")
     end
 
     it "should not be equal to nil" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

To address rspec-expectations error introduced from v3.8.5, this PR updates RSpec2 style exception matcher to RSpec3 style.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
