### PR TITLE
THRIFT-4976: Delay 1 second before recompiling

### DIFF
--- a/compiler/cpp/test/compiler/staleness_check.py
+++ b/compiler/cpp/test/compiler/staleness_check.py
@@ -46,7 +46,7 @@ class TestStalenessCheck(unittest.TestCase):
 
         first_modification_time = os.path.getmtime(os.path.join(used_file_path))
 
-        time.sleep(0.1)
+        time.sleep(1.0)
 
         subprocess.call(command)
 
@@ -74,7 +74,7 @@ class TestStalenessCheck(unittest.TestCase):
         used_file.write("\n/* This is a comment */\n")
         used_file.close()
 
-        time.sleep(0.1)
+        time.sleep(1.0)
 
         subprocess.call(command)
 
@@ -112,7 +112,7 @@ class TestStalenessCheck(unittest.TestCase):
         temp_included_file.write("\nconst i32 an_integer = 42\n")
         temp_included_file.close()
 
-        time.sleep(0.1)
+        time.sleep(1.0)
 
         subprocess.call(command)
 


### PR DESCRIPTION
In some environment, the file system only has second accuracy on
file modification timestamp. In such cases delay of 0.1 second before
recompiling could makes the modification timestamp unchanged,
thus tests fail.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
