### PR TITLE
THRIFT-4989: Fix run time exception when using Swift TCompactProtocol

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -697,7 +697,9 @@ void t_swift_generator::generate_swift_struct(ostream& out,
     }
 
     block_open(out);
-    for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
+    vector<t_field*> sorted = members;
+    sort(sorted.begin(), sorted.end(), [](t_field *a, t_field *b) { return (a->get_key() < b->get_key()); } );
+    for (m_iter = sorted.begin(); m_iter != sorted.end(); ++m_iter) {
       out << endl;
       // TODO: Defaults
 


### PR DESCRIPTION
Sort TStruct members by key before generating Swift class properties so that Swift Thrift lib can safely assume properties are ordered when using delta encoding for TCompactProtocol.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
