### PR TITLE
Remove unused exception variable

### DIFF
--- a/lib/py/src/ext/protocol.tcc
+++ b/lib/py/src/ext/protocol.tcc
@@ -174,7 +174,7 @@ inline bool ProtocolBase<Impl>::writeBuffer(char* data, size_t size) {
   if (output_->buf.capacity() < need) {
     try {
       output_->buf.reserve(need);
-    } catch (std::bad_alloc& ex) {
+    } catch (std::bad_alloc&) {
       PyErr_SetString(PyExc_MemoryError, "Failed to allocate write buffer");
       return false;
     }


### PR DESCRIPTION
Fixes MSVC warning seen in logs:

> [00:11:03] src\ext/protocol.tcc(177): warning C4101: 'ex': unreferenced local variable [C:\projects\build\MSVC2015\x86\lib\py\python_build.vcxproj]

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.