### PR TITLE
THRIFT-4959: Fix Haskell tests

### DIFF
--- a/lib/hs/CMakeLists.txt
+++ b/lib/hs/CMakeLists.txt
@@ -37,7 +37,7 @@ set(haskell_sources
 )
 
 if(BUILD_TESTING)
-    list(APPEND haskell_soruces
+    list(APPEND haskell_sources
         test/Spec.hs
         test/BinarySpec.hs
         test/CompactSpec.hs
@@ -47,7 +47,7 @@ if(BUILD_TESTING)
 endif()
 
 set(haskell_artifacts thrift_cabal.stamp)
-# Adding *.hi files so that any missing file triggers the build
+# Adding *.hs files so that any missing file triggers the build
 foreach(SRC ${haskell_sources})
     get_filename_component(EX ${SRC} EXT)
     if(${EX} STREQUAL ".hs")
@@ -68,10 +68,10 @@ add_custom_command(
     OUTPUT ${haskell_artifacts}
     COMMAND ${CABAL} update
     # Build dependencies first without --builddir, otherwise it fails.
-    COMMAND ${CABAL} install --only-dependencies ${hs_enable_test}
+    COMMAND ${CABAL} build --only-dependencies ${hs_enable_test}
     COMMAND ${CABAL} configure ${hs_optimize} ${hs_enable_test} --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
     COMMAND ${CABAL} build --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
-    COMMAND ${CABAL} install --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
+    COMMAND ${CABAL} install --lib --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
     COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/thrift_cabal.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${haskell_sources}
@@ -85,9 +85,6 @@ if(BUILD_TESTING)
             COMMAND ${CABAL} check
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     add_test(NAME HaskellCabalTest
-            # Cabal fails to find built executable when --builddir is specified.
-            # So we invoke the executable directly.
-            # COMMAND ${CABAL} test --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
-            # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-            COMMAND dist/build/spec/spec)
+            COMMAND ${CABAL} test --test-show-details=streaming --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/test/hs/CMakeLists.txt
+++ b/test/hs/CMakeLists.txt
@@ -68,10 +68,19 @@ else()
   set(hs_optimize -O1)
 endif()
 
+set(hs_crosstest_package_args
+    -package hashable
+    -package unordered-containers
+    -package vector
+    -package QuickCheck
+    -package split
+    -package network
+    -package network-uri
+)
 add_custom_command(
     OUTPUT ${hs_crosstest_apps}
-    COMMAND ${GHC} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestServer.hs -o TestServer
-    COMMAND ${GHC} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestClient.hs -o TestClient
+    COMMAND ${GHC} ${hs_crosstest_package_args} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestServer.hs -o TestServer
+    COMMAND ${GHC} ${hs_crosstest_package_args} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestClient.hs -o TestClient
     DEPENDS ${hs_test_gen} haskell_library TestServer.hs TestClient.hs
 )
 add_custom_target(haskell_crosstest ALL


### PR DESCRIPTION
- Need to fix use of latest cabal package manager and haskell compiler
- Fix "haskell_soruces" typo (copied from #1910)
- Update tests to show output live instead of hidden in a log file

(Please note this is my first ever change related to Haskell. I was able to get it installed on my Mac with Homebrew via `brew install ghc cabal-install` to test.)

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.