### PR TITLE
THRIFT-4959: Pin Chocolately Haskell packages

### DIFF
--- a/build/appveyor/MSVC-appveyor-install.bat
+++ b/build/appveyor/MSVC-appveyor-install.bat
@@ -56,7 +56,7 @@ pip.exe ^
             tornado ^
             twisted                       || EXIT /B
 
-cinst -y ghc                              || EXIT /B
+cinst -y ghc --version 8.6.5              || EXIT /B
 
 :: Adobe Flex SDK 4.6 for ActionScript
 MKDIR "C:\Adobe\Flex\SDK\4.6"             || EXIT /B

--- a/build/appveyor/MSVC-appveyor-install.bat
+++ b/build/appveyor/MSVC-appveyor-install.bat
@@ -56,6 +56,7 @@ pip.exe ^
             tornado ^
             twisted                       || EXIT /B
 
+cinst -y cabal --version 2.4.1.0          || EXIT /B
 cinst -y ghc --version 8.6.5              || EXIT /B
 
 :: Adobe Flex SDK 4.6 for ActionScript


### PR DESCRIPTION
The current ghc package has a dependency on cabal and currently is set to version >= 3.0. However this version is incompatible with the previous, so we need to separately pin cabal as well.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.