### PR TITLE
Fix casting uint64_t to size_t

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -372,7 +372,7 @@ void TMemoryBuffer::ensureCanWrite(uint32_t len) {
   }
 
   // Allocate into a new pointer so we don't bork ours if it fails.
-  auto* new_buffer = static_cast<uint8_t*>(std::realloc(buffer_, new_size));
+  auto* new_buffer = static_cast<uint8_t*>(std::realloc(buffer_, static_cast<std::size_t>(new_size)));
   if (new_buffer == nullptr) {
     throw std::bad_alloc();
   }


### PR DESCRIPTION
This fixes a MSVC warning seen in the logs:

> C:\projects\thrift\lib\cpp\src\thrift\transport\TBufferTransports.cpp(375): warning C4244: 'argument': conversion from 'uint64_t' to 'std::size_t', possible loss of data [C:\projects\build\MSVC2015\x86\lib\cpp\thrift.vcxproj]
  

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.