### PR TITLE
Fix unknown pragma warnings on mingw

### DIFF
--- a/lib/cpp/test/processor/Handlers.h
+++ b/lib/cpp/test/processor/Handlers.h
@@ -139,7 +139,7 @@ protected:
   std::shared_ptr<EventLog> log_;
 };
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   #pragma warning( push )
   #pragma warning (disable : 4250 ) //inheriting methods via dominance
 #endif
@@ -168,7 +168,7 @@ protected:
   int32_t value_;
 };
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   #pragma warning( pop )
 #endif
 


### PR DESCRIPTION
These pragmas are only valid for MSVC. Fixes warnings found in the logs:

> In file included from C:\projects\thrift\lib\cpp\test\processor\ProcessorTest.cpp:40:
731C:\projects\thrift\lib\cpp\test\processor\Handlers.h:143: warning: ignoring #pragma warning  [-Wunknown-pragmas]
732  143 |   #pragma warning( push )
733      |
734C:\projects\thrift\lib\cpp\test\processor\Handlers.h:144: warning: ignoring #pragma warning  [-Wunknown-pragmas]
735  144 |   #pragma warning (disable : 4250 ) //inheriting methods via dominance
736      |
737C:\projects\thrift\lib\cpp\test\processor\Handlers.h:172: warning: ignoring #pragma warning  [-Wunknown-pragmas]
738  172 |   #pragma warning( pop )
739      |

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.