### PR TITLE
THRIFT-4995 Use `ToSocketAddrs` for expressing network addresses

### DIFF
--- a/lib/rs/src/server/threaded.rs
+++ b/lib/rs/src/server/threaded.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::net::{TcpListener, TcpStream};
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 use threadpool::ThreadPool;
 
@@ -162,14 +162,13 @@ where
 
     /// Listen for incoming connections on `listen_address`.
     ///
-    /// `listen_address` should be in the form `host:port`,
-    /// for example: `127.0.0.1:8080`.
+    /// `listen_address` should implement `ToSocketAddrs` trait.
     ///
     /// Return `()` if successful.
     ///
     /// Return `Err` when the server cannot bind to `listen_address` or there
     /// is an unrecoverable error.
-    pub fn listen(&mut self, listen_address: &str) -> ::Result<()> {
+    pub fn listen<A: ToSocketAddrs>(&mut self, listen_address: A) -> ::Result<()> {
         let listener = TcpListener::bind(listen_address)?;
         for stream in listener.incoming() {
             match stream {

--- a/lib/rs/src/transport/socket.rs
+++ b/lib/rs/src/transport/socket.rs
@@ -18,7 +18,7 @@
 use std::convert::From;
 use std::io;
 use std::io::{ErrorKind, Read, Write};
-use std::net::{Shutdown, TcpStream};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 
 use super::{ReadHalf, TIoChannel, WriteHalf};
 use {new_transport_error, TransportErrorKind};
@@ -81,8 +81,8 @@ impl TTcpChannel {
         }
     }
 
-    /// Connect to `remote_address`, which should have the form `host:port`.
-    pub fn open(&mut self, remote_address: &str) -> ::Result<()> {
+    /// Connect to `remote_address`, which should implement `ToSocketAddrs` trait.
+    pub fn open<A: ToSocketAddrs>(&mut self, remote_address: A) -> ::Result<()> {
         if self.stream.is_some() {
             Err(new_transport_error(
                 TransportErrorKind::AlreadyOpen,


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Right now addresses must be a ```&str``` and must match format ```host:port```. However, there are no obstacles for replacing ```&str``` with types bound by ```ToSocketAddrs``` trait.

  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
