### PR TITLE
THRIFT-4990: Use netstandard2.0 as target for .NET Core 3.0

### DIFF
--- a/lib/netstd/Thrift/Thrift.csproj
+++ b/lib/netstd/Thrift/Thrift.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Thrift</AssemblyName>
     <PackageId>Thrift</PackageId>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/tutorial/netstd/Interfaces/Interfaces.csproj
+++ b/tutorial/netstd/Interfaces/Interfaces.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Interfaces</AssemblyName>
     <PackageId>Interfaces</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
THRIFT-4990: Upgrade to .NET Core 3.0 
Client: netstsd 
Patch: Edward Zhuravlov  
Use netstandard2.0 as target for .NET Core 3.0

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [No] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [Yes] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [Yes] Did you squash your changes to a single commit?  (not required, but preferred)
- [Yes] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
Must be stay on netstandard2.0 if no plan use specific API's from net core 3.0 - its Microsoft recomendation in netstandard 2.1 announcing:
https://devblogs.microsoft.com/dotnet/announcing-net-standard-2-1/

> Library authors who need to support .NET Framework customers should stay on .NET Standard 2.0. **In fact, most libraries should be able to stay on .NET Standard 2.0**, as the API additions are largely for advanced scenarios. However, this doesn’t mean that library authors cannot take advantage of these APIs even if they have to support .NET Framework. In those cases they can use multi-targeting to compile for both .NET Standard 2.0 as well as .NET Standard 2.1. This allows writing code that can expose more features or provide a more efficient implementation on runtimes that support .NET Standard 2.1 while not giving up on the bigger reach that .NET Standard 2.0 offers.
