### PR TITLE
THRIFT-4984: Handle wrapped io.EOF errors

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -221,7 +221,9 @@ func treatEOFErrorsAsNil(err error) error {
 	if err == nil {
 		return nil
 	}
-	if err == io.EOF {
+	// err could be io.EOF wrapped with TProtocolException,
+	// so that err == io.EOF doesn't necessarily work in some cases.
+	if err.Error() == io.EOF.Error() {
 		return nil
 	}
 	if err, ok := err.(TTransportException); ok && err.TypeId() == END_OF_FILE {


### PR DESCRIPTION
Client: go

TCompactProtocol (which is used by THeaderTransport to read headers)
could wrap the underlying error with TProtocolException, which breaks
err == io.EOF test in some cases.
