### PR TITLE
THRIFT-5002: Golang: Fix for argument containers for inherited functions

### DIFF
--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -93,7 +93,8 @@ check: gopath
 				ignoreinitialismstest \
 				unionbinarytest \
 				conflictnamespacetestsuperthing \
-				conflict/context/conflict_service-remote
+				conflict/context/conflict_service-remote \
+				servicestest/container_test-remote
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:
@@ -127,5 +128,5 @@ EXTRA_DIST = \
 	ConflictNamespaceTestB.thrift \
 	ConflictNamespaceTestC.thrift \
 	ConflictNamespaceTestD.thrift \
-	ConflictNamespaceTestSuperThing.thrift
+	ConflictNamespaceTestSuperThing.thrift \
 	ConflictNamespaceServiceTest.thrift

--- a/lib/go/test/ServicesTest.thrift
+++ b/lib/go/test/ServicesTest.thrift
@@ -107,5 +107,12 @@ service a_serv {
     struct_a struct_a_func_2ex_1int_1s(1: i64 i, 2: string s) throws(1: moderate_disaster err1, 2:total_disaster err2)
 
     struct_a struct_a_func_1struct_a(1: struct_a st)
+}
 
+service container_test_parent {
+  void parent_only_func(1: set<i32> s)
+}
+
+service container_test extends container_test_parent {
+  void child_only_func(1: set<i32> s)
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
See [THRIFT-5002](https://issues.apache.org/jira/browse/THRIFT-5002) for more details.

Currently the remote.go client fails to compile when services extend other services and the parent service has a function that needs a container for its arguments.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
