### PR TITLE
THRIFT-4914: Add GetResponseHeadersFromClient helper function

### DIFF
--- a/lib/go/thrift/header_protocol.go
+++ b/lib/go/thrift/header_protocol.go
@@ -303,3 +303,17 @@ func (p *THeaderProtocol) ReadBinary() (value []byte, err error) {
 func (p *THeaderProtocol) Skip(fieldType TType) error {
 	return p.protocol.Skip(fieldType)
 }
+
+// GetResponseHeadersFromClient is a helper function to get the read THeaderMap
+// from the last response received from the given client.
+//
+// If the last response was not sent over THeader protocol,
+// a nil map will be returned.
+func GetResponseHeadersFromClient(c TClient) THeaderMap {
+	if sc, ok := c.(*TStandardClient); ok {
+		if hp, ok := sc.iprot.(*THeaderProtocol); ok {
+			return hp.transport.readHeaders
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Clients: go

This is the fourth and final part of THRIFT-4914, which handles the
client reading part in the response (server -> client direction).
