### PR TITLE
Fix UTF-8 Decoding Errors

### DIFF
--- a/lib/py/src/compat.py
+++ b/lib/py/src/compat.py
@@ -37,7 +37,7 @@ else:
     from io import BytesIO as BufferIO  # noqa
 
     def binary_to_str(bin_val):
-        return bin_val.decode('utf8')
+        return bin_val.decode('utf8','replace')
 
     def str_to_binary(str_val):
         return bytes(str_val, 'utf8')


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
If a binary string contains non-utf8 decodable characters, this will cause an exception.
