### PR TITLE
THRIFT-5019: Duplicate imports from multiple includes from a namespace

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -777,9 +777,14 @@ string t_go_generator::render_included_programs(string& unused_prot) {
   const vector<t_program*>& includes = program_->get_includes();
   string result = "";
   string local_namespace = program_->get_namespace("go");
+  std::set<std::string> included;
   for (auto include : includes) {
     if (!local_namespace.empty() && local_namespace == include->get_namespace("go")) {
       continue;
+    }
+
+    if (!included.insert(include->get_namespace("go")).second) {
+        continue;
     }
 
     result += render_program_import(include, unused_prot);

--- a/lib/go/test/DuplicateImportsTest.thrift
+++ b/lib/go/test/DuplicateImportsTest.thrift
@@ -1,0 +1,5 @@
+include "common/a.thrift"
+include "common/b.thrift"
+
+typedef a.A A
+typedef b.B B

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -45,7 +45,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConflictNamespaceTestC.thrift \
 				ConflictNamespaceTestD.thrift \
 				ConflictNamespaceTestSuperThing.thrift \
-				ConflictNamespaceServiceTest.thrift
+				ConflictNamespaceServiceTest.thrift \
+				DuplicateImportsTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -71,6 +72,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestD.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestSuperThing.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceServiceTest.thrift
+	$(THRIFT) $(THRIFTARGS) -r DuplicateImportsTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock || true
 	sed -i 's/\"context\"/\"golang.org\/x\/net\/context\"/g' gopath/src/github.com/golang/mock/gomock/controller.go || true
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
@@ -94,7 +96,8 @@ check: gopath
 				unionbinarytest \
 				conflictnamespacetestsuperthing \
 				conflict/context/conflict_service-remote \
-				servicestest/container_test-remote
+				servicestest/container_test-remote \
+				duplicateimportstest
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:

--- a/lib/go/test/common/a.thrift
+++ b/lib/go/test/common/a.thrift
@@ -1,0 +1,5 @@
+namespace go common
+
+struct A {
+    1: optional string a
+}

--- a/lib/go/test/common/b.thrift
+++ b/lib/go/test/common/b.thrift
@@ -1,0 +1,5 @@
+namespace go common
+
+struct B {
+    1: optional string b
+}


### PR DESCRIPTION
If a thrift file includes two files from the same namespace into a
separate file, the generated Go code has duplicate imports for that
namespace. This fixes that.

Client: go
