### PR TITLE
THRIFT-5022: Fix TIOStreamTransport.isOpen for input or output only use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - [THRIFT-4981](https://issues.apache.org/jira/browse/THRIFT-4981) - Remove deprecated netcore bindings from the code base
 - [THRIFT-5006](https://issues.apache.org/jira/browse/THRIFT-5006) - Implement DEFAULT_MAX_LENGTH at TFramedTransport
 
+### Java
+
+- [THRIFT-5022](https://issues.apache.org/jira/browse/THRIFT-5022) - TIOStreamTransport.isOpen returns true for one-sided transports (see THRIFT-2530).
 ## 0.13.0
 
 ### New Languages

--- a/lib/java/src/org/apache/thrift/transport/TIOStreamTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TIOStreamTransport.java
@@ -83,7 +83,7 @@ public class TIOStreamTransport extends TTransport {
    * @return false after close is called.
    */
   public boolean isOpen() {
-    return inputStream_ != null && outputStream_ != null;
+    return inputStream_ != null || outputStream_ != null;
   }
 
   /**
@@ -95,20 +95,23 @@ public class TIOStreamTransport extends TTransport {
    * Closes both the input and output streams.
    */
   public void close() {
-    if (inputStream_ != null) {
-      try {
-        inputStream_.close();
-      } catch (IOException iox) {
-        LOGGER.warn("Error closing input stream.", iox);
+    try {
+      if (inputStream_ != null) {
+        try {
+          inputStream_.close();
+        } catch (IOException iox) {
+          LOGGER.warn("Error closing input stream.", iox);
+        }
       }
+      if (outputStream_ != null) {
+        try {
+          outputStream_.close();
+        } catch (IOException iox) {
+          LOGGER.warn("Error closing output stream.", iox);
+        }
+      }
+    } finally {
       inputStream_ = null;
-    }
-    if (outputStream_ != null) {
-      try {
-        outputStream_.close();
-      } catch (IOException iox) {
-        LOGGER.warn("Error closing output stream.", iox);
-      }
       outputStream_ = null;
     }
   }

--- a/lib/java/test/org/apache/thrift/transport/TestTIOStreamTransport.java
+++ b/lib/java/test/org/apache/thrift/transport/TestTIOStreamTransport.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.thrift.transport;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import junit.framework.TestCase;
+
+public class TestTIOStreamTransport extends TestCase {
+
+  // THRIFT-5022
+  public void testOpenClose_2streams() throws TTransportException {
+    byte[] dummy = {20}; // So the input stream isn't EOF immediately.
+    InputStream input = new ByteArrayInputStream(dummy);
+    OutputStream output = new ByteArrayOutputStream();
+    TTransport transport = new TIOStreamTransport(input, output);
+    runOpenClose(transport);
+  }
+
+  // THRIFT-5022
+  public void testOpenClose_1input() throws TTransportException {
+    byte[] dummy = {20};
+    InputStream input = new ByteArrayInputStream(dummy);
+    TTransport transport = new TIOStreamTransport(input);
+    runOpenClose(transport);
+  }
+
+  // THRIFT-5022
+  public void testIOpenClose_1output() throws TTransportException {
+    OutputStream output = new ByteArrayOutputStream();
+    TTransport transport = new TIOStreamTransport(output);
+    runOpenClose(transport);
+  }
+
+  private void runOpenClose(TTransport transport) throws TTransportException {
+    transport.open();
+    boolean b1 = transport.isOpen();
+    assertTrue(b1);
+    transport.close();
+    boolean b2 = transport.isOpen();
+    assertFalse(b2);
+  }
+}


### PR DESCRIPTION
Fix for  TIOStreamTransport.isOpen

[THRIFT-5022](https://issues.apache.org/jira/browse/THRIFT-5022)
