### PR TITLE
THRIFT-5010: BinaryPrimitives.Read/WriteInt32BigEndian should be used to convert to/from network byte order

### DIFF
--- a/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Buffers.Binary;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -215,9 +216,7 @@ namespace Thrift.Protocol
             {
                 return;
             }
-
-            PreAllocatedBuffer[0] = (byte)(0xff & (i16 >> 8));
-            PreAllocatedBuffer[1] = (byte)(0xff & i16);
+            BinaryPrimitives.WriteInt16BigEndian(PreAllocatedBuffer, i16);
 
             await Trans.WriteAsync(PreAllocatedBuffer, 0, 2, cancellationToken);
         }
@@ -229,10 +228,7 @@ namespace Thrift.Protocol
                 return;
             }
 
-            PreAllocatedBuffer[0] = (byte)(0xff & (i32 >> 24));
-            PreAllocatedBuffer[1] = (byte)(0xff & (i32 >> 16));
-            PreAllocatedBuffer[2] = (byte)(0xff & (i32 >> 8));
-            PreAllocatedBuffer[3] = (byte)(0xff & i32);
+            BinaryPrimitives.WriteInt32BigEndian(PreAllocatedBuffer, i32);
 
             await Trans.WriteAsync(PreAllocatedBuffer, 0, 4, cancellationToken);
         }
@@ -245,14 +241,7 @@ namespace Thrift.Protocol
                 return;
             }
 
-            PreAllocatedBuffer[0] = (byte)(0xff & (i64 >> 56));
-            PreAllocatedBuffer[1] = (byte)(0xff & (i64 >> 48));
-            PreAllocatedBuffer[2] = (byte)(0xff & (i64 >> 40));
-            PreAllocatedBuffer[3] = (byte)(0xff & (i64 >> 32));
-            PreAllocatedBuffer[4] = (byte)(0xff & (i64 >> 24));
-            PreAllocatedBuffer[5] = (byte)(0xff & (i64 >> 16));
-            PreAllocatedBuffer[6] = (byte)(0xff & (i64 >> 8));
-            PreAllocatedBuffer[7] = (byte)(0xff & i64);
+            BinaryPrimitives.WriteInt64BigEndian(PreAllocatedBuffer, i64);
 
             await Trans.WriteAsync(PreAllocatedBuffer, 0, 8, cancellationToken);
         }
@@ -470,7 +459,7 @@ namespace Thrift.Protocol
             }
 
             await Trans.ReadAllAsync(PreAllocatedBuffer, 0, 2, cancellationToken);
-            var result = (short) (((PreAllocatedBuffer[0] & 0xff) << 8) | PreAllocatedBuffer[1] & 0xff);
+            var result = BinaryPrimitives.ReadInt16BigEndian(PreAllocatedBuffer);
             return result;
         }
 
@@ -483,33 +472,10 @@ namespace Thrift.Protocol
 
             await Trans.ReadAllAsync(PreAllocatedBuffer, 0, 4, cancellationToken);
 
-            var result = 
-                ((PreAllocatedBuffer[0] & 0xff) << 24) | 
-                ((PreAllocatedBuffer[1] & 0xff) << 16) | 
-                ((PreAllocatedBuffer[2] & 0xff) << 8) |
-                PreAllocatedBuffer[3] & 0xff;
+            var result = BinaryPrimitives.ReadInt32BigEndian(PreAllocatedBuffer);
 
             return result;
         }
-
-#pragma warning disable 675
-
-        protected internal long ReadI64FromPreAllocatedBuffer()
-        {
-            var result =
-                ((long) (PreAllocatedBuffer[0] & 0xff) << 56) |
-                ((long) (PreAllocatedBuffer[1] & 0xff) << 48) |
-                ((long) (PreAllocatedBuffer[2] & 0xff) << 40) |
-                ((long) (PreAllocatedBuffer[3] & 0xff) << 32) |
-                ((long) (PreAllocatedBuffer[4] & 0xff) << 24) |
-                ((long) (PreAllocatedBuffer[5] & 0xff) << 16) |
-                ((long) (PreAllocatedBuffer[6] & 0xff) << 8) |
-                PreAllocatedBuffer[7] & 0xff;
-
-            return result;
-        }
-
-#pragma warning restore 675
 
         public override async ValueTask<long> ReadI64Async(CancellationToken cancellationToken)
         {
@@ -519,7 +485,7 @@ namespace Thrift.Protocol
             }
 
             await Trans.ReadAllAsync(PreAllocatedBuffer, 0, 8, cancellationToken);
-            return ReadI64FromPreAllocatedBuffer();
+            return BinaryPrimitives.ReadInt64BigEndian(PreAllocatedBuffer);
         }
 
         public override async ValueTask<double> ReadDoubleAsync(CancellationToken cancellationToken)

--- a/lib/netstd/Thrift/Transport/TFramedTransport.cs
+++ b/lib/netstd/Thrift/Transport/TFramedTransport.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,7 +87,7 @@ namespace Thrift.Transport
         private async ValueTask ReadFrameAsync(CancellationToken cancellationToken)
         {
             await InnerTransport.ReadAllAsync(HeaderBuf, 0, HeaderSize, cancellationToken);
-            var size = DecodeFrameSize(HeaderBuf);
+            var size = BinaryPrimitives.ReadInt32BigEndian(HeaderBuf);
 
             ReadBuffer.SetLength(size);
             ReadBuffer.Seek(0, SeekOrigin.Begin);
@@ -133,7 +134,7 @@ namespace Thrift.Transport
             }
 
             // Inject message header into the reserved buffer space
-            EncodeFrameSize(dataLen, bufSegment.Array);
+            BinaryPrimitives.WriteInt32BigEndian(bufSegment.Array, dataLen);
 
             // Send the entire message at once
             await InnerTransport.WriteAsync(bufSegment.Array, 0, bufSegment.Count, cancellationToken);
@@ -149,24 +150,6 @@ namespace Thrift.Transport
             WriteBuffer.SetLength(HeaderSize);
             WriteBuffer.Seek(0, SeekOrigin.End);
         }
-
-        private static void EncodeFrameSize(int frameSize, byte[] buf)
-        {
-            buf[0] = (byte) (0xff & (frameSize >> 24));
-            buf[1] = (byte) (0xff & (frameSize >> 16));
-            buf[2] = (byte) (0xff & (frameSize >> 8));
-            buf[3] = (byte) (0xff & (frameSize));
-        }
-
-        private static int DecodeFrameSize(byte[] buf)
-        {
-            return
-                ((buf[0] & 0xff) << 24) |
-                ((buf[1] & 0xff) << 16) |
-                ((buf[2] & 0xff) << 8) |
-                (buf[3] & 0xff);
-        }
-
 
         private void CheckNotDisposed()
         {


### PR DESCRIPTION

<!-- Explain the changes in the pull request below: -->
  
