### PR TITLE
THRIFT-5026 TestClient/Server ignores first cmdline argument

### DIFF
--- a/test/netstd/Client/Program.cs
+++ b/test/netstd/Client/Program.cs
@@ -34,17 +34,9 @@ namespace Client
                 Console.WriteLine("Failed to grow scroll-back buffer");
             }
 
-            // split mode and options
-            var subArgs = new List<string>(args);
-            var firstArg = string.Empty;
-            if (subArgs.Count > 0)
-            { 
-                firstArg = subArgs[0];
-                subArgs.RemoveAt(0);
-            }
-
-            // run whatever mode is choosen
-            switch(firstArg)
+            // run whatever mode is choosen, default to test impl
+            var firstArg = args.Length > 0 ? args[0] : string.Empty;
+            switch (firstArg)
             {
                 case "client":
                     Console.WriteLine("The 'client' argument is no longer required.");
@@ -56,7 +48,7 @@ namespace Client
                     PrintHelp();
                     return 0;
                 default:
-                    return TestClient.Execute(subArgs);
+                    return TestClient.Execute(new List<string>(args));
             }
         }
 

--- a/test/netstd/Server/Program.cs
+++ b/test/netstd/Server/Program.cs
@@ -34,17 +34,9 @@ namespace Server
                 Console.WriteLine("Failed to grow scroll-back buffer");
             }
 
-            // split mode and options
-            var subArgs = new List<string>(args);
-            var firstArg = string.Empty;
-            if (subArgs.Count > 0)
-            { 
-                firstArg = subArgs[0];
-                subArgs.RemoveAt(0);
-            }
-
-            // run whatever mode is choosen
-            switch(firstArg)
+            // run whatever mode is choosen, default to test impl
+            var firstArg = args.Length > 0 ? args[0] : string.Empty;
+            switch (firstArg)
             {
                 case "server":
                     Console.WriteLine("The 'server' argument is no longer required.");
@@ -54,7 +46,7 @@ namespace Server
                     PrintHelp();
                     return 0;
                 default:
-                    return TestServer.Execute(subArgs);
+                    return TestServer.Execute(new List<string>( args));
             }
         }
 


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer
