### PR TITLE
THRIFT-5029: Fix Node.js lib entry point

### DIFF
--- a/lib/js/package.json
+++ b/lib/js/package.json
@@ -2,6 +2,7 @@
   "name": "thrift",
   "version": "0.14.0",
   "description": "Thrift is a software framework for scalable cross-language services development.",
+  "main": "./src/thrift",
   "author": {
     "name": "Apache Thrift Developers",
     "email": "dev@thrift.apache.org"


### PR DESCRIPTION
The latest published `thrift` version (0.13.0):
* does not contain `index.js` at the package root
* has no "main" entry point in package.json.

So module request throws an exception:
```javascript
require('thrift')
Thrown:
Error: Cannot find module 'thrift'
Require stack:
- <repl>
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:625:15)
    at Function.Module._load (internal/modules/cjs/loader.js:527:27)
```
This PR adds missed "main" field to `package.json`.
