### PR TITLE
THRIFT-5032 netstd: Use PascalCase for Properties.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -51,10 +51,11 @@ t_netstd_generator::t_netstd_generator(t_program* program, const map<string, str
     : t_oop_generator(program)
 {
     (void)option_string;
-
+    use_pascal_case_properties = false;
     union_ = false;
     serialize_ = false;
     wcf_ = false;
+
     wcf_namespace_.clear();
 
     map<string, string>::const_iterator iter;
@@ -75,9 +76,12 @@ t_netstd_generator::t_netstd_generator(t_program* program, const map<string, str
             wcf_ = true;
             wcf_namespace_ = iter->second;
         }
-        else
+        else if (iter->first.compare("pascal") == 0)
         {
-            throw "unknown option netstd:" + iter->first;
+          use_pascal_case_properties = true;
+        }
+        else {
+          throw "unknown option netstd:" + iter->first;
         }
     }
 
@@ -188,6 +192,7 @@ void t_netstd_generator::init_generator()
     pverbose("- union ...... %s\n", (is_union_enabled() ? "ON" : "off"));
     pverbose("- serialize .. %s\n", (is_serialize_enabled() ? "ON" : "off"));
     pverbose("- wcf ........ %s\n", (is_wcf_enabled() ? "ON" : "off"));
+    pverbose("- pascal ........ %s\n", (use_pascal_case_properties ? "ON" : "off"));
 }
 
 string t_netstd_generator::normalize_name(string name)
@@ -2673,19 +2678,40 @@ void t_netstd_generator::prepare_member_name_mapping(void* scope, const vector<t
         }
     }
 }
+string t_netstd_generator::convert_to_pascal_case(const string& str) {
+  string out;
+  bool must_capitalize = true;
+  bool first_character = true;
+  for (auto it = str.begin(); it != str.end(); ++it) {
+    if (std::isalnum(*it)) {
+      if (must_capitalize) {
+        out.append(1, (char)::toupper(*it));
+        must_capitalize = false;
+      } else {
+        out.append(1, *it);
+      }
+    } else {
+      if (first_character) //this is a private variable and should not be PascalCased
+        return str;
+      must_capitalize = true;
+    }
+    first_character = false;
+  }
+  return out;
+}
 
-string t_netstd_generator::prop_name(t_field* tfield, bool suppress_mapping)
-{
-    string name(tfield->get_name());
-    if (suppress_mapping)
-    {
-        name[0] = toupper(name[0]);
-    }
-    else
-    {
-        name = get_mapped_member_name(name);
-    }
-    return name;
+
+string t_netstd_generator::prop_name(t_field* tfield, bool suppress_mapping) {
+  string name(tfield->get_name());
+  if (suppress_mapping) {
+    name[0] = toupper(name[0]);
+    if (use_pascal_case_properties)
+      name = t_netstd_generator::convert_to_pascal_case(name);
+  } else {
+    name = get_mapped_member_name(name);
+  }
+
+  return name;
 }
 
 string t_netstd_generator::type_name(t_type* ttype)
@@ -3020,4 +3046,5 @@ THRIFT_REGISTER_GENERATOR(
     "    wcf:             Adds bindings for WCF to generated classes.\n"
     "    serial:          Add serialization support to generated classes.\n"
     "    union:           Use new union typing, which includes a static read function for union types.\n"
+    "    pascal           Use Pascal Case property names. This follows microsoft naming convention.\n"
 )

--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.h
@@ -134,6 +134,7 @@ public:
   string argument_list(t_struct* tstruct);
   string type_to_enum(t_type* ttype);
   string prop_name(t_field* tfield, bool suppress_mapping = false);
+  string convert_to_pascal_case(const string& str);
   string get_enum_class_name(t_type* type);
 
 private:
@@ -145,6 +146,7 @@ private:
   bool hashcode_;
   bool serialize_;
   bool wcf_;
+  bool use_pascal_case_properties;
 
   string wcf_namespace_;
   map<string, int> netstd_keywords;

--- a/test/netstd/Server/Server.csproj
+++ b/test/netstd/Server/Server.csproj
@@ -47,6 +47,6 @@
     </Exec>
     <Exec Condition="Exists('$(PathToThrift)')" Command="&quot;$(PathToThrift)&quot; -out $(ProjectDir) -gen netstd:wcf,union,serial -r ./../../ThriftTest.thrift" />
     <Exec Condition="Exists('thrift')" Command="thrift -out $(ProjectDir) -gen netstd:wcf,union,serial -r ./../../ThriftTest.thrift" />
-    <Exec Condition="Exists('$(ProjectDir)/../../../compiler/cpp/thrift')" Command="$(ProjectDir)/../../../compiler/cpp/thrift -out $(ProjectDir) -gen netstd:wcf,union,serial -r ./../../ThriftTest.thrift" />
+    <Exec Condition="Exists('$(ProjectDir)/../../../compiler/cpp/thrift')" Command="$(ProjectDir)/../../../compiler/cpp/thrift -out $(ProjectDir) -gen netstd:wcf,union,serial,pascal -r ./../../ThriftTest.thrift" />
   </Target>
 </Project>

--- a/test/netstd/Server/TestServer.cs
+++ b/test/netstd/Server/TestServer.cs
@@ -254,20 +254,20 @@ namespace ThriftTest
 
             public Task<Xtruct> testStructAsync(Xtruct thing, CancellationToken cancellationToken)
             {
-                logger.Invoke("testStruct({{\"{0}\", {1}, {2}, {3}}})", thing.String_thing, thing.Byte_thing, thing.I32_thing, thing.I64_thing);
+                logger.Invoke("testStruct({{\"{0}\", {1}, {2}, {3}}})", thing.StringThing, thing.ByteThing, thing.I32Thing, thing.I64Thing);
                 return Task.FromResult(thing);
             }
 
             public Task<Xtruct2> testNestAsync(Xtruct2 nest, CancellationToken cancellationToken)
             {
-                var thing = nest.Struct_thing;
+                var thing = nest.StructThing;
                 logger.Invoke("testNest({{{0}, {{\"{1}\", {2}, {3}, {4}, {5}}}}})",
-                    nest.Byte_thing,
-                    thing.String_thing,
-                    thing.Byte_thing,
-                    thing.I32_thing,
-                    thing.I64_thing,
-                    nest.I32_thing);
+                    nest.ByteThing,
+                    thing.StringThing,
+                    thing.ByteThing,
+                    thing.I32Thing,
+                    thing.I64Thing,
+                    nest.I32Thing);
                 return Task.FromResult(nest);
             }
 
@@ -429,10 +429,10 @@ namespace ThriftTest
                 logger.Invoke("testMulti()");
 
                 var hello = new Xtruct(); ;
-                hello.String_thing = "Hello2";
-                hello.Byte_thing = arg0;
-                hello.I32_thing = arg1;
-                hello.I64_thing = arg2;
+                hello.StringThing = "Hello2";
+                hello.ByteThing = arg0;
+                hello.I32Thing = arg1;
+                hello.I64Thing = arg2;
                 return Task.FromResult(hello);
             }
 
@@ -473,12 +473,12 @@ namespace ThriftTest
                     var x = new Xception2
                     {
                         ErrorCode = 2002,
-                        Struct_thing = new Xtruct { String_thing = "This is an Xception2" }
+                        StructThing = new Xtruct { StringThing = "This is an Xception2" }
                     };
                     throw x;
                 }
 
-                var result = new Xtruct { String_thing = arg1 };
+                var result = new Xtruct { StringThing = arg1 };
                 return Task.FromResult(result);
             }
 


### PR DESCRIPTION
According to microsoft guidelines properties should be
Pascal cased. See [1].
[1] https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions