### PR TITLE
THRIFT-5000 Thrift docker image publish on releases appveyor pipeline…

### DIFF
--- a/build/docker/publish/Dockerfile
+++ b/build/docker/publish/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcc:8 as build
+
+RUN apt update && apt upgrade -y && apt install flex bison cmake -y
+
+WORKDIR /usr/src/thrift
+
+COPY . /usr/src/thrift
+
+RUN mkdir cmake-build && cd cmake-build && cmake -DWITH_SHARED_LIB=off .. && make
+
+FROM ubuntu 
+COPY --from=build /usr/src/thrift/cmake-build/bin/thrift /bin/thrift
+WORKDIR /thrift
+ENTRYPOINT ["thrift"]

--- a/docker-hub.appveyor.yml
+++ b/docker-hub.appveyor.yml
@@ -11,4 +11,4 @@ environment:
 build_script:
   - sh: docker build compiler/cpp -f build/docker/publish/Dockerfile -t thrift:$APPVEYOR_REPO_BRANCH
   - sh: eval $login
-  - sh: docker push thrift:$APPVEYOR_REPO_BRANCH
+  - sh: docker push apache/thrift:$APPVEYOR_REPO_BRANCH

--- a/docker-hub.appveyor.yml
+++ b/docker-hub.appveyor.yml
@@ -1,0 +1,14 @@
+version: 1.0.{build}
+branches:
+  only:
+    - /^(release/)?\d+\.\d+\.\d+$/
+image: Ubuntu
+clone_depth: 1
+environment:
+  matrix:
+    - login:
+        secure: echo docker-hub-api-key | docker login --username thrift --password-stdin
+build_script:
+  - sh: docker build compiler/cpp -f build/docker/publish/Dockerfile -t thrift:$APPVEYOR_REPO_BRANCH
+  - sh: eval $login
+  - sh: docker push thrift:$APPVEYOR_REPO_BRANCH


### PR DESCRIPTION
THRIFT-5000 Thrift docker image publish on releases appveyor pipeline added

Added appveyor pipeline. Some additional configuration needed:
secret environment variable `login` should be set for the pipeline with content:
`echo docker-hub-api-key | docker login --username thrift --password-stdin` where `docker-hub-api-key` should be replaced with appropriate api key value.

`[skip ci]`