### PR TITLE
THRIFT-5043 Make TBufferChannel clonable

### DIFF
--- a/lib/rs/src/transport/mem.rs
+++ b/lib/rs/src/transport/mem.rs
@@ -31,7 +31,7 @@ use super::{ReadHalf, TIoChannel, WriteHalf};
 /// `set_readable_bytes(...)`. Callers can then read until the buffer is
 /// depleted. No further reads are accepted until the internal read buffer is
 /// replenished again.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TBufferChannel {
     read: Arc<Mutex<ReadData>>,
     write: Arc<Mutex<WriteData>>,


### PR DESCRIPTION
It is useful for `TBufferChannel` to be `Clone` so that you can use it to read bytes that were written by a client for use cases like testing or sending over alternative transports like UDP.