### PR TITLE
THRIFT-5046: Better struct tag overrides

### DIFF
--- a/lib/go/test/GoTagTest.thrift
+++ b/lib/go/test/GoTagTest.thrift
@@ -19,7 +19,7 @@
 
 struct tagged {
     1: string string_thing,
-    2: i64 int_thing (go.tag = "json:\"int_thing,string\""),
+    2: i64 int_thing (go.tag = "json:\"custom_thing\" mykey:\"myvalue\""),
     3: optional i64 optional_int_thing
     4: optional bool optional_bool_thing = false
 }

--- a/lib/go/test/tests/gotag_test.go
+++ b/lib/go/test/tests/gotag_test.go
@@ -38,8 +38,16 @@ func TestCustomTag(t *testing.T) {
 	s := gotagtest.Tagged{}
 	st := reflect.TypeOf(s)
 	field, ok := st.FieldByName("IntThing")
-	if !ok || field.Tag.Get("json") != "int_thing,string" {
-		t.Error("Unexpected custom tag value")
+	if !ok {
+		t.Error("Missing field IntThing")
+		return
+	}
+
+	if v := field.Tag.Get("json"); v != "custom_thing" {
+		t.Errorf("Expected custom_thing for tag json, got %s", v)
+	}
+	if v := field.Tag.Get("mykey"); v != "myvalue" {
+		t.Errorf("Expected myvalue for tag mykey, got %s", v)
 	}
 }
 


### PR DESCRIPTION
Custom go.tag in an IDL no longer removes the existing "db" and "json"
tags but can override them.

This allows us to change default tags in the future without affecting
user defined ones.

Client: go

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.
