### PR TITLE
THRIFT-5078 Handle named pipe clients quickly disconnecting

### DIFF
--- a/lib/cpp/src/thrift/server/TServerFramework.cpp
+++ b/lib/cpp/src/thrift/server/TServerFramework.cpp
@@ -166,8 +166,9 @@ void TServerFramework::serve() {
       releaseOneDescriptor("inputTransport", inputTransport);
       releaseOneDescriptor("outputTransport", outputTransport);
       releaseOneDescriptor("client", client);
-      if (ttx.getType() == TTransportException::TIMED_OUT) {
-        // Accept timeout - continue processing.
+      if (ttx.getType() == TTransportException::TIMED_OUT
+          || ttx.getType() == TTransportException::CLIENT_DISCONNECT) {
+        // Accept timeout and client disconnect - continue processing.
         continue;
       } else if (ttx.getType() == TTransportException::END_OF_FILE
                  || ttx.getType() == TTransportException::INTERRUPTED) {

--- a/lib/cpp/src/thrift/transport/TTransportException.h
+++ b/lib/cpp/src/thrift/transport/TTransportException.h
@@ -49,7 +49,8 @@ public:
     INTERRUPTED = 4,
     BAD_ARGS = 5,
     CORRUPTED_DATA = 6,
-    INTERNAL_ERROR = 7
+    INTERNAL_ERROR = 7,
+    CLIENT_DISCONNECT = 8
   };
 
   TTransportException() : apache::thrift::TException(), type_(UNKNOWN) {}


### PR DESCRIPTION
When using the TPipeServer transport, if a client connects but disconnects before the acceptImpl method is able to create a TPipe instance the resulting exception causing the entire transport to stop.

You can cause this issue using the SysInternals accesschk utility (https://docs.microsoft.com/en-us/sysinternals/downloads/accesschk) to query the permissions of the named pipe.

This has also been reported in osquery https://github.com/osquery/osquery/issues/4280