### PR TITLE
THRIFT-5050: Fix MemoryBuffer.pm to raise a proper exception if no data is available

### DIFF
--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -203,7 +203,8 @@ RUN apt-get install -y --no-install-recommends \
       libclass-accessor-class-perl \
       libcrypt-ssleay-perl \
       libio-socket-ssl-perl \
-      libnet-ssleay-perl
+      libnet-ssleay-perl \
+      libtest-exception-perl
 
 RUN apt-get install -y --no-install-recommends \
 `# Php dependencies` \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -204,7 +204,8 @@ RUN apt-get install -y --no-install-recommends \
       libclass-accessor-class-perl \
       libcrypt-ssleay-perl \
       libio-socket-ssl-perl \
-      libnet-ssleay-perl
+      libnet-ssleay-perl \
+      libtest-exception-perl
 
 RUN apt-get install -y --no-install-recommends \
 `# Php dependencies` \

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -213,7 +213,8 @@ RUN apt-get install -y --no-install-recommends \
       libclass-accessor-class-perl \
       libcrypt-ssleay-perl \
       libio-socket-ssl-perl \
-      libnet-ssleay-perl
+      libnet-ssleay-perl \
+      libtest-exception-perl
 
 RUN apt-get install -y --no-install-recommends \
 `# Php dependencies` \

--- a/lib/perl/Makefile.PL
+++ b/lib/perl/Makefile.PL
@@ -34,6 +34,9 @@ WriteMakefile( ABSTRACT => 'Apache Thrift is a software framework for scalable c
                    'Class::Accessor' => 0
                },
 #              SIGN => 1,
+               TEST_REQUIRES => {
+                   'Test::Exception' => 0,
+               },
                VERSION_FROM => 'lib/Thrift.pm' );
 
 # THRIFT-4691

--- a/lib/perl/README.md
+++ b/lib/perl/README.md
@@ -61,6 +61,12 @@ to use Thrift.
   * Bit::Vector
   * Class::Accessor
 
+## Test
+
+This is only required when running tests:
+
+  * Test::Exception
+
 ### HttpClient Transport
 
 These are only required if using Thrift::HttpClient:

--- a/lib/perl/lib/Thrift/MemoryBuffer.pm
+++ b/lib/perl/lib/Thrift/MemoryBuffer.pm
@@ -117,7 +117,7 @@ sub readAll
 
     my $avail = ($self->{wPos} - $self->{rPos});
     if ($avail < $len) {
-        die TTransportException->new("Attempt to readAll($len) found only $avail available",
+        die Thrift::TTransportException->new("Attempt to readAll($len) found only $avail available",
                                     Thrift::TTransportException::END_OF_FILE);
     }
 

--- a/lib/perl/t/memory_buffer.t
+++ b/lib/perl/t/memory_buffer.t
@@ -17,7 +17,8 @@
 # under the License.
 #
 
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Exception;
 
 use strict;
 use warnings;
@@ -32,6 +33,8 @@ use ThriftTest::Types;
 
 my $transport = Thrift::MemoryBuffer->new();
 my $protocol = Thrift::BinaryProtocol->new($transport);
+
+throws_ok { $protocol->readByte } 'Thrift::TTransportException';
 
 my $a = ThriftTest::Xtruct->new();
 $a->i32_thing(10);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
`Thrift::MemoryBuffer->readAll` is expected to throw `Thrift::TTransportException` if no data is available, but it doesn't due to a wrong package name. This PR fixes it.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
