### PR TITLE
THRIFT-5052: Make the Go tutorial executable to the end

### DIFF
--- a/tutorial/go/src/client.go
+++ b/tutorial/go/src/client.go
@@ -49,7 +49,6 @@ func handleClient(client *tutorial.CalculatorClient) (err error) {
 		default:
 			fmt.Println("Error during operation:", err)
 		}
-		return err
 	} else {
 		fmt.Println("Whoa we can divide by 0 with new value:", quotient)
 	}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
For now, `make tutorialclient` for golang is interrupted due to a zero division error. But that error is an intended one and should be ignored so that users can execute a whole code example. This PR fixes it.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
