### PR TITLE
THRIFT-5055: Fix build-cpan-dist.sh to create a CPAN distribution correctly

### DIFF
--- a/lib/perl/build-cpan-dist.sh
+++ b/lib/perl/build-cpan-dist.sh
@@ -52,5 +52,5 @@ cp -pr ../gen-perl .
 cp -pr ../gen-perl2 .
 perl ../tools/FixupDist.pl
 cd ..
-tar cvzf --hard-dereference $DISTFILE $DISTDIR
+tar cvzf $DISTFILE --hard-dereference $DISTDIR
 rm -r $DISTDIR


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Currently, running `lib/perl/build-cpan-dist.sh` fails to create a tarball. This PR changes the option order for the tar command so that it works correctly.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
