### PR TITLE
Modified data type output

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_hs_generator.cc
@@ -307,7 +307,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
     string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     f_types_ << (first ? "" : "|");
-    f_types_ << << name;
+    f_types_ << name;
     first = false;
   }
   indent(f_types_) << "deriving (P.Show, P.Eq, G.Generic, TY.Typeable, P.Ord, P.Bounded)" << endl;

--- a/compiler/cpp/src/thrift/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_hs_generator.cc
@@ -305,9 +305,9 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
 
   bool first = true;
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     f_types_ << (first ? "" : "|");
-    f_types_ << name;
+    f_types_ << << name;
     first = false;
   }
   indent(f_types_) << "deriving (P.Show, P.Eq, G.Generic, TY.Typeable, P.Ord, P.Bounded)" << endl;
@@ -321,7 +321,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
   indent_up();
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
     int value = (*c_iter)->get_value();
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     indent(f_types_) << name << " -> " << value << endl;
   }
   indent_down();
@@ -329,7 +329,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
   indent_up();
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
     int value = (*c_iter)->get_value();
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     indent(f_types_) << value << " -> " << name << endl;
   }
   indent(f_types_) << "_ -> X.throw T.ThriftException" << endl;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When the Haskell generator generate the data type like this
```thrift
enum Sample1 {
	A = 0,
	B = 1,
	C = 2
}

enum Sample2 {
	C = 0,
	D = 1,
	E = 2
}
```
Output will be like this
```Haskell
data Sample1 = A|B|C
-- ...
data Sample2 = C|D|E
```
And this will make a compile error "Multiple declarations of ‘C’".
So I modified this to generate like this
```Haskell
data Sample1 = Sample1_A|Sample1_B|Sample1_C
-- ...
data Sample2 = Sample2_C|Sample2_D|Sample2_E
``` 


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
