### PR TITLE
THRIFT-5072: Fix data type generation.

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_hs_generator.cc
@@ -305,7 +305,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
 
   bool first = true;
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     f_types_ << (first ? "" : "|");
     f_types_ << name;
     first = false;
@@ -321,7 +321,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
   indent_up();
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
     int value = (*c_iter)->get_value();
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     indent(f_types_) << name << " -> " << value << endl;
   }
   indent_down();
@@ -329,7 +329,7 @@ void t_hs_generator::generate_enum(t_enum* tenum) {
   indent_up();
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
     int value = (*c_iter)->get_value();
-    string name = capitalize((*c_iter)->get_name());
+    string name = capitalize(tenum->get_name()) + "_" + capitalize((*c_iter)->get_name());
     indent(f_types_) << value << " -> " << name << endl;
   }
   indent(f_types_) << "_ -> X.throw T.ThriftException" << endl;

--- a/test/hs/TestClient.hs
+++ b/test/hs/TestClient.hs
@@ -193,16 +193,16 @@ runClient p = do
 
   -- Enum Test
   putStrLn "testEnum"
-  numz1 <- Client.testEnum prot ONE
-  when (numz1 /= ONE) exitFailure
+  numz1 <- Client.testEnum prot Numberz_ONE
+  when (numz1 /= Numberz_ONE) exitFailure
 
   putStrLn "testEnum"
-  numz2 <- Client.testEnum prot TWO
-  when (numz2 /= TWO) exitFailure
+  numz2 <- Client.testEnum prot Numberz_TWO
+  when (numz2 /= Numberz_TWO) exitFailure
 
   putStrLn "testEnum"
-  numz5 <- Client.testEnum prot FIVE
-  when (numz5 /= FIVE) exitFailure
+  numz5 <- Client.testEnum prot Numberz_FIVE
+  when (numz5 /= Numberz_FIVE) exitFailure
 
   -- Typedef Test
   putStrLn "testTypedef"

--- a/test/hs/TestServer.hs
+++ b/test/hs/TestServer.hs
@@ -212,10 +212,10 @@ instance ThriftTest_Iface TestHandler where
 
   testInsanity _ x = do
     System.IO.putStrLn "testInsanity()"
-    return $ Map.fromList [ (1, Map.fromList [ (TWO  , x)
-                                             , (THREE, x)
+    return $ Map.fromList [ (1, Map.fromList [ (Numberz_TWO  , x)
+                                             , (Numberz_THREE, x)
                                              ])
-                          , (2, Map.fromList [ (SIX, default_Insanity)
+                          , (2, Map.fromList [ (Numberz_SIX, default_Insanity)
                                              ])
                           ]
 

--- a/test/hs/ThriftTest_Main.hs
+++ b/test/hs/ThriftTest_Main.hs
@@ -107,7 +107,7 @@ instance Iface.ThriftTest_Iface TestHandler where
         return (Map.fromList [(1, Map.fromList [(2, 2)])])
 
     testInsanity _ x = do
-        return (Map.fromList [(1, Map.fromList [(Types.ONE, x)])])
+        return (Map.fromList [(1, Map.fromList [(Types.Numberz_ONE, x)])])
 
     testMulti _ _ _ _ _ _ _ = do
         return (Types.Xtruct "" 0 0 0)

--- a/tutorial/hs/HaskellClient.hs
+++ b/tutorial/hs/HaskellClient.hs
@@ -48,7 +48,7 @@ main = do
   printf "1+1=%d\n" sum
 
 
-  let work = Work { work_op = DIVIDE,
+  let work = Work { work_op = Operation_DIVIDE,
                     work_num1 = 1,
                     work_num2 = 0,
                     work_comment = Nothing
@@ -58,7 +58,7 @@ main = do
         (\e -> printf "InvalidOperation %s\n" (show (e :: InvalidOperation)))
 
 
-  let work = Work { work_op = SUBTRACT,
+  let work = Work { work_op = Operation_SUBTRACT,
                     work_num1 = 15,
                     work_num2 = 10,
                     work_comment = Nothing

--- a/tutorial/hs/HaskellServer.hs
+++ b/tutorial/hs/HaskellServer.hs
@@ -64,13 +64,13 @@ instance Calculator_Iface CalculatorHandler where
     printf "calculate(%d, %s)\n" logid (show work)
 
     let val = case op work of
-                ADD ->
+                Operation_ADD ->
                     num1 work + num2 work
-                SUBTRACT ->
+                Operation_SUBTRACT ->
                     num1 work - num2 work
-                MULTIPLY ->
+                Operation_MULTIPLY ->
                     num1 work * num2 work
-                DIVIDE ->
+                Operation_DIVIDE ->
                     if num2 work == 0 then
                         throw $
                               InvalidOperation {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When the Haskell generator generate the data type like this

```thrift
enum Sample1 {
	A = 0,
	B = 1,
	C = 2
}

enum Sample2 {
	C = 0,
	D = 1,
	E = 2
}
```

Output will be like this
```Haskell
data Sample1 = A|B|C
-- ...
data Sample2 = C|D|E
```
And this will make a compile error "Multiple declarations of ‘C’".
So I modified this to generate like this
```Haskell
data Sample1 = Sample1_A|Sample1_B|Sample1_C
-- ...
data Sample2 = Sample2_C|Sample2_D|Sample2_E
```
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
