### PR TITLE
Document Docker Build JS Versions [skip ci]

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -182,7 +182,7 @@ Last updated: October 1, 2017
 | haskell   | 7.10.3        | 8.0.2         |       |
 | haxe      | 3.2.1         | 3.4.4         | THRIFT-4352: avoid 3.4.2 |
 | java      | 1.8.0_191     | 11.0.3        |       |
-| js        |               |               | Unsure how to look for version info? |
+| js        | Node.js 6.17.1, V8 5.1.281.111, npm 3.10.10 | Node.js 10.18.0, V8 6.8.275.32, npm 6.13.4 |     |
 | lua       |               | 5.2.4         | Lua 5.3: see THRIFT-4386 |
 | netstd    | 3.1           | 3.1           | LTS version |
 | nodejs    | 6.16.0        | 10.16.0       |       |


### PR DESCRIPTION
Adding the JS versions to the Language section of the Docker build `README.md`  

I determined the version by running `node --version` in each docker container and looking up the bundled V8 and npm version in the Node.js [release log](https://nodejs.org/en/download/releases/)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.
