### PR TITLE
THRIFT-5061: Pin Ruby's rack version to 2.0.8

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                '~> 0.11.3'
   s.add_development_dependency 'pry-byebug',         '~> 3.6'
   s.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
-  s.add_development_dependency 'rack',               '~> 2.0'
+  s.add_development_dependency 'rack',               '=  2.0.8'
   s.add_development_dependency 'rack-test',          '~> 0.8.3'
   s.add_development_dependency 'rake',               '~> 12.3'
   s.add_development_dependency 'rspec',              '~> 3.7'


### PR DESCRIPTION
Client: ruby

<!-- Explain the changes in the pull request below: -->
Rack 2.1.0 changed its behavior in some cases and broke existing tests for the Thrift Ruby library (e.g., https://travis-ci.org/apache/thrift/builds/635520787). As a workaround, this PR pins its version to the prior 2.0.8.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
