### PR TITLE
THRIFT-5063: Introduce isort into the SCA to keep Python import statements ordered

### DIFF
--- a/build/docker/scripts/sca.sh
+++ b/build/docker/scripts/sca.sh
@@ -40,6 +40,10 @@ cppcheck --force --quiet --inline-suppr --error-exitcode=1 -j2 lib/c_glib/src li
 
 # Python code style
 flake8
+for i in $(find . -name '*.py' -type f | grep -v -E '(/gen-py|\./contrib/|\./lib/nodejs/examples/|\./lib/py/build/|\./test/py\.[^/]*/test_suite\.py|\./test/py/Test(Client|Server)\.py|\./tutorial/py)')
+do
+  isort -c $i
+done
 
 # PHP code style
 composer install --quiet

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -265,7 +265,7 @@ RUN apt-get install -y --no-install-recommends \
 `# Static Code Analysis dependencies` \
       cppcheck \
       sloccount && \
-    pip install flake8 && \
+    pip install flake8 isort && \
     wget -q "https://launchpad.net/ubuntu/+source/cppcheck/1.83-2/+build/14874703/+files/cppcheck_1.83-2_amd64.deb" && \
     dpkg -i cppcheck_1.83-2_amd64.deb && \
     rm cppcheck_1.83-2_amd64.deb

--- a/compiler/cpp/test/compiler/staleness_check.py
+++ b/compiler/cpp/test/compiler/staleness_check.py
@@ -18,6 +18,7 @@
 # under the License.
 #
 from __future__ import print_function
+
 import os
 import shutil
 import subprocess

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
@@ -19,17 +18,18 @@
 # under the License.
 #
 
+import os
 import sys
+from distutils.command.build_ext import build_ext
+from distutils.errors import (CCompilerError, DistutilsExecError,
+                              DistutilsPlatformError)
+
 try:
     from setuptools import setup, Extension
 except Exception:
     from distutils.core import setup, Extension
 
-from distutils.command.build_ext import build_ext
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
-
 # Fix to build sdist under vagrant
-import os
 if 'vagrant' in str(os.environ):
     try:
         del os.link

--- a/lib/py/src/TMultiplexedProcessor.py
+++ b/lib/py/src/TMultiplexedProcessor.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 
-from thrift.Thrift import TProcessor, TMessageType
-from thrift.protocol import TProtocolDecorator, TMultiplexedProtocol
+from thrift.protocol import TMultiplexedProtocol, TProtocolDecorator
 from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TMessageType, TProcessor
 
 
 class TMultiplexedProcessor(TProcessor):

--- a/lib/py/src/TRecursive.py
+++ b/lib/py/src/TRecursive.py
@@ -10,10 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 from thrift.Thrift import TType
 

--- a/lib/py/src/TSCons.py
+++ b/lib/py/src/TSCons.py
@@ -18,8 +18,10 @@
 #
 
 from os import path
-from SCons.Builder import Builder
+
 from six.moves import map
+
+from SCons.Builder import Builder
 
 
 def scons_env(env, add=''):

--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -18,16 +18,18 @@
 #
 
 from __future__ import absolute_import
+
 import logging
 import socket
 import struct
-
-from .transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
-
-from io import BytesIO
 from collections import deque
 from contextlib import contextmanager
-from tornado import gen, iostream, ioloop, tcpserver, concurrent
+from io import BytesIO
+
+from tornado import concurrent, gen, ioloop, iostream, tcpserver
+
+from .transport.TTransport import (TMemoryBuffer, TTransportBase,
+                                   TTransportException)
 
 __all__ = ['TTornadoServer', 'TTornadoStreamTransport']
 

--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -17,8 +17,10 @@
 # under the License.
 #
 
-from .TProtocol import TType, TProtocolBase, TProtocolException, TProtocolFactory
 from struct import pack, unpack
+
+from .TProtocol import (TProtocolBase, TProtocolException, TProtocolFactory,
+                        TType)
 
 
 class TBinaryProtocol(TProtocolBase):

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -17,10 +17,11 @@
 # under the License.
 #
 
-from .TProtocol import TType, TProtocolBase, TProtocolException, TProtocolFactory, checkIntegerLimits
 from struct import pack, unpack
 
 from ..compat import binary_to_str, str_to_binary
+from .TProtocol import (TProtocolBase, TProtocolException, TProtocolFactory,
+                        TType, checkIntegerLimits)
 
 __all__ = ['TCompactProtocol', 'TCompactProtocolFactory']
 

--- a/lib/py/src/protocol/THeaderProtocol.py
+++ b/lib/py/src/protocol/THeaderProtocol.py
@@ -19,10 +19,12 @@
 
 from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated
 from thrift.protocol.TCompactProtocol import TCompactProtocolAccelerated
-from thrift.protocol.TProtocol import TProtocolBase, TProtocolException, TProtocolFactory
+from thrift.protocol.TProtocol import (TProtocolBase, TProtocolException,
+                                       TProtocolFactory)
 from thrift.Thrift import TApplicationException, TMessageType
-from thrift.transport.THeaderTransport import THeaderTransport, THeaderSubprotocolID, THeaderClientType
-
+from thrift.transport.THeaderTransport import (THeaderClientType,
+                                               THeaderSubprotocolID,
+                                               THeaderTransport)
 
 PROTOCOLS_BY_ID = {
     THeaderSubprotocolID.BINARY: TBinaryProtocolAccelerated,

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -17,14 +17,13 @@
 # under the License.
 #
 
-from .TProtocol import (TType, TProtocolBase, TProtocolException,
-                        TProtocolFactory, checkIntegerLimits)
 import base64
 import math
 import sys
 
 from ..compat import str_to_binary
-
+from .TProtocol import (TProtocolBase, TProtocolException, TProtocolFactory,
+                        TType, checkIntegerLimits)
 
 __all__ = ['TJSONProtocol',
            'TJSONProtocolFactory',

--- a/lib/py/src/protocol/TMultiplexedProtocol.py
+++ b/lib/py/src/protocol/TMultiplexedProtocol.py
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-from thrift.Thrift import TMessageType
 from thrift.protocol import TProtocolDecorator
+from thrift.Thrift import TMessageType
 
 SEPARATOR = ":"
 

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -17,14 +17,16 @@
 # under the License.
 #
 
-from thrift.Thrift import TException, TType, TFrozenDict
-from thrift.transport.TTransport import TTransportException
-from ..compat import binary_to_str, str_to_binary
-
-import six
 import sys
 from itertools import islice
+
+import six
 from six.moves import zip
+
+from thrift.Thrift import TException, TFrozenDict, TType
+from thrift.transport.TTransport import TTransportException
+
+from ..compat import binary_to_str, str_to_binary
 
 
 class TProtocolException(TException):

--- a/lib/py/src/server/THttpServer.py
+++ b/lib/py/src/server/THttpServer.py
@@ -21,8 +21,8 @@ import ssl
 
 from six.moves import BaseHTTPServer
 
-from thrift.Thrift import TMessageType
 from thrift.server import TServer
+from thrift.Thrift import TMessageType
 from thrift.transport import TTransport
 
 

--- a/lib/py/src/server/TNonblockingServer.py
+++ b/lib/py/src/server/TNonblockingServer.py
@@ -30,12 +30,12 @@ import select
 import socket
 import struct
 import threading
-
 from collections import deque
+
 from six.moves import queue
 
-from thrift.transport import TTransport
 from thrift.protocol.TBinaryProtocol import TBinaryProtocolFactory
+from thrift.transport import TTransport
 
 __all__ = ['TNonblockingServer']
 

--- a/lib/py/src/server/TProcessPoolServer.py
+++ b/lib/py/src/server/TProcessPoolServer.py
@@ -19,11 +19,11 @@
 
 
 import logging
+from multiprocessing import Condition, Process, Value
 
-from multiprocessing import Process, Value, Condition
+from thrift.transport.TTransport import TTransportException
 
 from .TServer import TServer
-from thrift.transport.TTransport import TTransportException
 
 logger = logging.getLogger(__name__)
 

--- a/lib/py/src/server/TServer.py
+++ b/lib/py/src/server/TServer.py
@@ -17,10 +17,11 @@
 # under the License.
 #
 
-from six.moves import queue
 import logging
 import os
 import threading
+
+from six.moves import queue
 
 from thrift.protocol import TBinaryProtocol
 from thrift.protocol.THeaderProtocol import THeaderProtocolFactory

--- a/lib/py/src/transport/THeaderTransport.py
+++ b/lib/py/src/transport/THeaderTransport.py
@@ -22,15 +22,11 @@ import zlib
 
 from thrift.compat import BufferIO, byte_index
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
-from thrift.protocol.TCompactProtocol import TCompactProtocol, readVarint, writeVarint
+from thrift.protocol.TCompactProtocol import (TCompactProtocol, readVarint,
+                                              writeVarint)
 from thrift.Thrift import TApplicationException
-from thrift.transport.TTransport import (
-    CReadableTransport,
-    TMemoryBuffer,
-    TTransportBase,
-    TTransportException,
-)
-
+from thrift.transport.TTransport import (CReadableTransport, TMemoryBuffer,
+                                         TTransportBase, TTransportException)
 
 U16 = struct.Struct("!H")
 I32 = struct.Struct("!i")

--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -17,18 +17,17 @@
 # under the License.
 #
 
-from io import BytesIO
+import base64
 import os
 import ssl
 import sys
 import warnings
-import base64
+from io import BytesIO
 
-from six.moves import urllib
-from six.moves import http_client
+import six
+from six.moves import http_client, urllib
 
 from .TTransport import TTransportBase
-import six
 
 
 class THttpClient(TTransportBase):

--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -24,9 +24,10 @@ import ssl
 import sys
 import warnings
 
-from .sslcompat import _match_hostname, _match_has_ipaddress
 from thrift.transport import TSocket
 from thrift.transport.TTransport import TTransportException
+
+from .sslcompat import _match_has_ipaddress, _match_hostname
 
 logger = logging.getLogger(__name__)
 warnings.filterwarnings(

--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -23,7 +23,8 @@ import os
 import socket
 import sys
 
-from .TTransport import TTransportBase, TTransportException, TServerTransportBase
+from .TTransport import (TServerTransportBase, TTransportBase,
+                         TTransportException)
 
 logger = logging.getLogger(__name__)
 

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -18,7 +18,9 @@
 #
 
 from struct import pack, unpack
+
 from thrift.Thrift import TException
+
 from ..compat import BufferIO
 
 

--- a/lib/py/src/transport/TTwisted.py
+++ b/lib/py/src/transport/TTwisted.py
@@ -17,16 +17,16 @@
 # under the License.
 #
 
-from io import BytesIO
 import struct
+from io import BytesIO
 
-from zope.interface import implementer, Interface, Attribute
-from twisted.internet.protocol import ServerFactory, ClientFactory, \
-    connectionDone
 from twisted.internet import defer
+from twisted.internet.protocol import (ClientFactory, ServerFactory,
+                                       connectionDone)
 from twisted.internet.threads import deferToThread
 from twisted.protocols import basic
-from twisted.web import server, resource, http
+from twisted.web import http, resource, server
+from zope.interface import Attribute, Interface, implementer
 
 from thrift.transport import TTransport
 

--- a/lib/py/src/transport/TZlibTransport.py
+++ b/lib/py/src/transport/TZlibTransport.py
@@ -23,9 +23,11 @@ data compression.
 """
 
 from __future__ import division
+
 import zlib
-from .TTransport import TTransportBase, CReadableTransport
+
 from ..compat import BufferIO
+from .TTransport import CReadableTransport, TTransportBase
 
 
 class TZlibTransportFactory(object):

--- a/test/crossrunner/__init__.py
+++ b/test/crossrunner/__init__.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-from .test import test_name  # noqa
 from .collect import collect_cross_tests, collect_feature_tests  # noqa
-from .run import TestDispatcher  # noqa
 from .report import generate_known_failures, load_known_failures  # noqa
+from .run import TestDispatcher  # noqa
+from .test import test_name  # noqa

--- a/test/crossrunner/collect.py
+++ b/test/crossrunner/collect.py
@@ -21,8 +21,8 @@ import platform
 import re
 from itertools import product
 
-from .util import merge_dict
 from .test import TestEntry
+from .util import merge_dict
 
 # Those keys are passed to execution as is.
 # Note that there are keys other than these, namely:

--- a/test/crossrunner/report.py
+++ b/test/crossrunner/report.py
@@ -18,6 +18,7 @@
 #
 
 from __future__ import print_function
+
 import datetime
 import json
 import multiprocessing

--- a/test/crossrunner/test.py
+++ b/test/crossrunner/test.py
@@ -21,8 +21,9 @@ import copy
 import multiprocessing
 import os
 import sys
+
 from .compat import path_join
-from .util import merge_dict, domain_socket_path
+from .util import domain_socket_path, merge_dict
 
 
 class TestProgram(object):

--- a/test/features/container_limit.py
+++ b/test/features/container_limit.py
@@ -3,9 +3,9 @@
 import argparse
 import sys
 
-from util import add_common_args, init_protocol
 from local_thrift import thrift  # noqa
 from thrift.Thrift import TMessageType, TType
+from util import add_common_args, init_protocol
 
 
 # TODO: generate from ThriftTest.thrift

--- a/test/features/string_limit.py
+++ b/test/features/string_limit.py
@@ -3,9 +3,9 @@
 import argparse
 import sys
 
-from util import add_common_args, init_protocol
 from local_thrift import thrift  # noqa
 from thrift.Thrift import TMessageType, TType
+from util import add_common_args, init_protocol
 
 
 # TODO: generate from ThriftTest.thrift

--- a/test/features/theader_binary.py
+++ b/test/features/theader_binary.py
@@ -4,13 +4,13 @@ import argparse
 import socket
 import sys
 
-from util import add_common_args
 from local_thrift import thrift  # noqa
+from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TCompactProtocol import TCompactProtocol
 from thrift.Thrift import TMessageType, TType
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import TBufferedTransport, TFramedTransport
-from thrift.protocol.TBinaryProtocol import TBinaryProtocol
-from thrift.protocol.TCompactProtocol import TCompactProtocol
+from util import add_common_args
 
 
 def test_void(proto):

--- a/test/features/util.py
+++ b/test/features/util.py
@@ -2,12 +2,12 @@ import argparse
 import socket
 
 from local_thrift import thrift  # noqa
-from thrift.transport.TSocket import TSocket
-from thrift.transport.TTransport import TBufferedTransport, TFramedTransport
-from thrift.transport.THttpClient import THttpClient
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
 from thrift.protocol.TCompactProtocol import TCompactProtocol
 from thrift.protocol.TJSONProtocol import TJSONProtocol
+from thrift.transport.THttpClient import THttpClient
+from thrift.transport.TSocket import TSocket
+from thrift.transport.TTransport import TBufferedTransport, TFramedTransport
 
 
 def add_common_args(p):

--- a/test/py/FastbinaryTest.py
+++ b/test/py/FastbinaryTest.py
@@ -31,16 +31,17 @@ import math
 import os
 import sys
 import timeit
-
 from copy import deepcopy
 from pprint import pprint
 
-from thrift.transport import TTransport
-from thrift.protocol.TBinaryProtocol import TBinaryProtocol, TBinaryProtocolAccelerated
-from thrift.protocol.TCompactProtocol import TCompactProtocol, TCompactProtocolAccelerated
-
 from DebugProtoTest import Srv
-from DebugProtoTest.ttypes import Backwards, Bonk, Empty, HolyMoley, OneOfEach, RandomStuff, Wrapper
+from DebugProtoTest.ttypes import (Backwards, Bonk, Empty, HolyMoley,
+                                   OneOfEach, RandomStuff, Wrapper)
+from thrift.protocol.TBinaryProtocol import (TBinaryProtocol,
+                                             TBinaryProtocolAccelerated)
+from thrift.protocol.TCompactProtocol import (TCompactProtocol,
+                                              TCompactProtocolAccelerated)
+from thrift.transport import TTransport
 
 
 class TDevNullTransport(TTransport.TTransportBase):

--- a/test/py/RunClientServer.py
+++ b/test/py/RunClientServer.py
@@ -19,11 +19,11 @@
 # under the License.
 #
 
-from __future__ import division
-from __future__ import print_function
-import platform
+from __future__ import division, print_function
+
 import copy
 import os
+import platform
 import signal
 import socket
 import subprocess

--- a/test/py/SerializationTest.py
+++ b/test/py/SerializationTest.py
@@ -19,33 +19,19 @@
 # under the License.
 #
 
-from ThriftTest.ttypes import (
-    Bonk,
-    Bools,
-    LargeDeltas,
-    ListBonks,
-    NestedListsBonk,
-    NestedListsI32x2,
-    NestedListsI32x3,
-    NestedMixedx2,
-    Numberz,
-    VersioningTestV1,
-    VersioningTestV2,
-    Xtruct,
-    Xtruct2,
-)
-
-from Recursive.ttypes import RecTree
-from Recursive.ttypes import RecList
-from Recursive.ttypes import CoRec
-from Recursive.ttypes import CoRec2
-from Recursive.ttypes import VectorTest
-from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty
-from thrift.transport import TTransport
-from thrift.protocol import TBinaryProtocol, TCompactProtocol, TJSONProtocol
-from thrift.TSerialization import serialize, deserialize
 import sys
 import unittest
+
+from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty
+from Recursive.ttypes import CoRec, CoRec2, RecList, RecTree, VectorTest
+from thrift.protocol import TBinaryProtocol, TCompactProtocol, TJSONProtocol
+from thrift.transport import TTransport
+from thrift.TSerialization import deserialize, serialize
+from ThriftTest.ttypes import (Bonk, Bools, LargeDeltas, ListBonks,
+                               NestedListsBonk, NestedListsI32x2,
+                               NestedListsI32x3, NestedMixedx2, Numberz,
+                               VersioningTestV1, VersioningTestV2, Xtruct,
+                               Xtruct2)
 
 
 class AbstractTest(unittest.TestCase):

--- a/test/py/TSimpleJSONProtocolTest.py
+++ b/test/py/TSimpleJSONProtocolTest.py
@@ -19,12 +19,12 @@
 # under the License.
 #
 
-from ThriftTest.ttypes import Bonk, VersioningTestV1, VersioningTestV2
-from thrift.protocol import TJSONProtocol
-from thrift.transport import TTransport
-
 import json
 import unittest
+
+from thrift.protocol import TJSONProtocol
+from thrift.transport import TTransport
+from ThriftTest.ttypes import Bonk, VersioningTestV1, VersioningTestV2
 
 
 class SimpleJSONProtocolTest(unittest.TestCase):

--- a/test/py/TestEof.py
+++ b/test/py/TestEof.py
@@ -19,11 +19,11 @@
 # under the License.
 #
 
-from ThriftTest.ttypes import Xtruct
-from thrift.transport import TTransport
-from thrift.protocol import TBinaryProtocol
-from thrift.protocol import TCompactProtocol
 import unittest
+
+from thrift.protocol import TBinaryProtocol, TCompactProtocol
+from thrift.transport import TTransport
+from ThriftTest.ttypes import Xtruct
 
 
 class TestEof(unittest.TestCase):

--- a/test/py/TestFrozen.py
+++ b/test/py/TestFrozen.py
@@ -19,14 +19,16 @@
 # under the License.
 #
 
-from DebugProtoTest import Srv
-from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty, Wrapper
-from DebugProtoTest.ttypes import ExceptionWithAMap, MutableException
-from thrift.Thrift import TFrozenDict
-from thrift.transport import TTransport
-from thrift.protocol import TBinaryProtocol, TCompactProtocol
 import collections
 import unittest
+
+from DebugProtoTest import Srv
+from DebugProtoTest.ttypes import (CompactProtoTestStruct, Empty,
+                                   ExceptionWithAMap, MutableException,
+                                   Wrapper)
+from thrift.protocol import TBinaryProtocol, TCompactProtocol
+from thrift.Thrift import TFrozenDict
+from thrift.transport import TTransport
 
 
 class TestFrozenBase(unittest.TestCase):

--- a/test/py/TestSocket.py
+++ b/test/py/TestSocket.py
@@ -19,11 +19,12 @@
 # under the License.
 #
 
-from thrift.transport import TSocket
-import unittest
-import time
-import socket
 import random
+import socket
+import time
+import unittest
+
+from thrift.transport import TSocket
 
 
 class TimeoutTest(unittest.TestCase):

--- a/test/test.py
+++ b/test/test.py
@@ -28,13 +28,14 @@
 #
 
 from __future__ import print_function
-from itertools import chain
+
+import argparse
 import json
 import logging
 import multiprocessing
-import argparse
 import os
 import sys
+from itertools import chain
 
 import crossrunner
 from crossrunner.compat import path_join

--- a/tutorial/php/runserver.py
+++ b/tutorial/php/runserver.py
@@ -19,9 +19,9 @@
 # under the License.
 #
 
-import os
 import BaseHTTPServer
 import CGIHTTPServer
+import os
 
 # chdir(2) into the tutorial directory.
 os.chdir(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))


### PR DESCRIPTION
Client: Python

<!-- Explain the changes in the pull request below: -->
This PR introduces isort into the SCA to ensure that the Python import statements order follows PEP8. https://www.python.org/dev/peps/pep-0008/#imports

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
