### PR TITLE
THRIFT-5065: Fix broken links in the IDL document

### DIFF
--- a/doc/specs/idl.md
+++ b/doc/specs/idl.md
@@ -224,8 +224,8 @@ Here are some examples of Thrift definitions, using the Thrift IDL:
  [tutorial]:           /tutorial/
  [fb303.thrift]:       https://raw.githubusercontent.com/apache/thrift/master/contrib/fb303/if/fb303.thrift
  [Apache Cassandra's]: http://cassandra.apache.org/
- [cassandra.thrift]:   http://svn.apache.org/viewvc/cassandra/trunk/interface/cassandra.thrift?view=co
- [Evernote API]:       http://www.evernote.com/about/developer/api/
+ [cassandra.thrift]:   https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=interface/cassandra.thrift;hb=refs/heads/cassandra-3.0
+ [Evernote API]:       https://github.com/evernote/evernote-thrift
 
 ## To Do/Questions
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This PR fixes broken links to cassandra.thrift and Evernote API in the IDL document.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
