### PR TITLE
Non-Required JS Dependencies

### DIFF
--- a/lib/js/package.json
+++ b/lib/js/package.json
@@ -13,7 +13,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "browserify": "~16.2",
-    "grunt": "~1.0",
     "grunt-cli": "~1.3",
     "grunt-contrib-concat": "~1.0",
     "grunt-contrib-jshint": "~2.1",
@@ -21,12 +20,11 @@
     "grunt-contrib-uglify": "~4.0",
     "grunt-jsdoc": "~2.3",
     "grunt-shell-spawn": "~0.4",
-    "jslint": "~0.12",
-    "node-int64": "~0.4.0"
-  },
-  "dependencies": {
+    "grunt": "~1.0",
     "jsdoc": "~3.5",
+    "jslint": "~0.12",
     "json-int64": "~1.0",
+    "node-int64": "~0.4.0",
     "nopt": "~4.0"
   }
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
I discovered this repo because Synk had flagged one of our dependencies as having a security vulnerability. That vulnerability is a ReDos attack that resides in the `marked` module that is part of `jsdoc`. From what I can tell all the modules listed as `dependencies` are not required at runtime and can be made `devDependencies`. This also happens to fix the security issue.

I cannot find any explicit reference to these modules in the build artifact. The builds pass and everything appears to be fine when I run the tests in Docker. So, from what I can tell this change should have zero noticeable impact on consumers of Thrift.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.