### PR TITLE
Add vcpkg installation instructions[skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ to Java, Ruby, PHP).
 Look for the README.md file in the lib/<language>/ folder for more details on the
 installation of each language library package.
 
+Package Managers
+================
+
+You can download and install thrift using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install thrift
+
+The thrift port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Testing
 =======
 


### PR DESCRIPTION
thrift is available as a port in vcpkg, a C++ library manager that simplifies installation for thrift and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build thrift, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/thrift/portfile.cmake). We try to keep the library maintained as close as possible to the original library.