### PR TITLE
THRIFT-5068: Force secure Maven Central in Travis CI

### DIFF
--- a/build/docker/scripts/autotools.sh
+++ b/build/docker/scripts/autotools.sh
@@ -1,6 +1,19 @@
 #!/bin/sh
 set -ev
 
+mkdir ~/.m2
+tee >~/.m2/settings.xml <<EOF
+<settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'>
+  <mirrors>
+    <mirror>
+      <id>secure-central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
+EOF
+
 ./bootstrap.sh
 ./configure $*
 make check -j3


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Modify docker build scripts used in CI test environments in order to put
in place a Maven .m2/settings.xml configuration file that overrides the
repository with the id 'central' with an equivalent "mirror" that uses
https instead of http.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
