### PR TITLE
THRIFT-5080: Generate async server implementation for Swift

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1507,8 +1507,10 @@ void t_swift_generator::generate_service(t_service* tservice) {
 
   generate_swift_service_protocol(f_decl_, tservice);
   generate_swift_service_client(f_decl_, tservice);
-  if (async_clients_) {
+  if (async_clients_ || async_servers_) {
     generate_swift_service_protocol_async(f_decl_, tservice);
+  }
+  if (async_clients_) { 
     generate_swift_service_client_async(f_decl_, tservice);
   }
   generate_swift_service_server(f_decl_, tservice);

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -69,7 +69,7 @@ public:
       } else if( iter->first.compare("async_clients") == 0) {
         async_clients_ = true;
       } else if( iter->first.compare("async_servers") == 0) {
-        if (gen_cocoa_ == true) {
+        if (gen_cocoa_) {
           throw "Async servers is not compatible with compatible with the Thrift/Cocoa library";
         }
         async_servers_ = true;


### PR DESCRIPTION
Adds additional flags to the compiler to generate an interface which allows swift servers to respond to client requests asynchronously.

This is based on the existing server implementation, and the async client implementation.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
