### PR TITLE
[threadFactory] Propagate caught exception instead of rethrowing a copy

### DIFF
--- a/lib/cpp/test/concurrency/ThreadFactoryTests.h
+++ b/lib/cpp/test/concurrency/ThreadFactoryTests.h
@@ -83,7 +83,7 @@ public:
         } catch (SystemResourceException& e) {
           std::cout << "\t\t\tfailed to create " << lix* count + tix << " thread " << e.what()
                     << std::endl;
-          throw e;
+          throw;
         }
       }
 
@@ -97,7 +97,7 @@ public:
         } catch (SystemResourceException& e) {
           std::cout << "\t\t\tfailed to start  " << lix* count + tix << " thread " << e.what()
                     << std::endl;
-          throw e;
+          throw;
         }
       }
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Propagate exception instead of rethrowing -> In the catch block, use throw; instead of throw e;

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
