### PR TITLE
THRIFT-5082: Add a Class reference for PHP enum $_TSPEC

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_php_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_php_generator.cc
@@ -746,9 +746,9 @@ void t_php_generator::generate_php_type_spec(ostream& out, t_type* t) {
   t = get_true_type(t);
   indent(out) << "'type' => " << type_to_enum(t) << "," << endl;
 
-  if (t->is_base_type() || t->is_enum()) {
+  if (t->is_base_type()) {
     // Noop, type is all we need
-  } else if (t->is_struct() || t->is_xception()) {
+  } else if (t->is_struct() || t->is_xception() || t->is_enum()) {
     indent(out) << "'class' => '" << php_namespace(t->get_program()) << t->get_name() << "',"
                 << endl;
   } else if (t->is_map()) {


### PR DESCRIPTION
Issue described in the ticket: https://issues.apache.org/jira/browse/THRIFT-5082

This adds the class reference to PHP `$_TSPEC`

**BEFORE**
```
5 => array(
  'var' => 'group_type',
  'isRequired' => true,
  'type' => TType::I32,
  ),
```

**AFTER**
```
5 => array(
  'var' => 'group_type',
  'isRequired' => true,
  'type' => TType::I32,
  'class' => '\thrift\groups\GroupType',
  ),
```