### PR TITLE
THRIFT-5086 CMake target thrift::thrift has no INTERFACE_INCLUDE_DIRE…

### DIFF
--- a/build/cmake/ThriftMacros.cmake
+++ b/build/cmake/ThriftMacros.cmake
@@ -25,6 +25,7 @@ endmacro(ADD_PKGCONFIG_THRIFT)
 
 macro(ADD_LIBRARY_THRIFT name)
     add_library(${name} ${ARGN})
+    target_include_directories(${name} INTERFACE $<INSTALL_INTERFACE:include>)
     set_target_properties(${name} PROPERTIES
         OUTPUT_NAME ${name}${THRIFT_RUNTIME_POSTFIX}   # windows link variants (/MT, /MD, /MTd, /MDd) get different names
         VERSION ${thrift_VERSION} )


### PR DESCRIPTION
…CTORIES property

Client: cpp
Patch: SmartNet Club

Entire patch taken from the JIRA ticket.
