### PR TITLE
[THRIFT-5089] Add UnmarshalJSON function to decode ENUM value

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -917,7 +917,7 @@ string t_go_generator::go_imports_begin(bool consts) {
   if (!consts && get_program()->get_enums().size() > 0) {
     system_packages.push_back("database/sql/driver");
     system_packages.push_back("errors");
-    system_packages.push_back("encoding/json");
+    system_packages.push_back("strconv");
   }
   system_packages.push_back("fmt");
   system_packages.push_back(gen_thrift_import_);
@@ -1052,15 +1052,12 @@ void t_go_generator::generate_enum(t_enum* tenum) {
 
   // Generate UnmarshalJSON
   f_types_ << "func (p *" << tenum_name << ") UnmarshalJSON(value []byte) error {" << endl;
-  f_types_ << "q, err := " << tenum_name << "FromString(string(value))" << endl;
+  f_types_ << "unquotedValue, err := strconv.Unquote(string(value))" << endl;
+  f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
+  f_types_ << "q, err := " << tenum_name << "FromString(unquotedValue)" << endl;
   f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
   f_types_ << "*p = q" << endl;
   f_types_ << "return nil" << endl;
-  f_types_ << "}" << endl << endl;
-
-  // Generate MarshalJSON
-  f_types_ << "func (p *" << tenum_name << ") MarshalJSON() ([]byte, error) {" << endl;
-  f_types_ << "return json.Marshal(p.String())" << endl;
   f_types_ << "}" << endl << endl;
 
   // Generate Scan for sql.Scanner interface

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -917,6 +917,7 @@ string t_go_generator::go_imports_begin(bool consts) {
   if (!consts && get_program()->get_enums().size() > 0) {
     system_packages.push_back("database/sql/driver");
     system_packages.push_back("errors");
+    system_packages.push_back("strconv");
   }
   system_packages.push_back("fmt");
   system_packages.push_back(gen_thrift_import_);
@@ -1044,6 +1045,16 @@ void t_go_generator::generate_enum(t_enum* tenum) {
   // Generate UnmarshalText
   f_types_ << "func (p *" << tenum_name << ") UnmarshalText(text []byte) error {" << endl;
   f_types_ << "q, err := " << tenum_name << "FromString(string(text))" << endl;
+  f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
+  f_types_ << "*p = q" << endl;
+  f_types_ << "return nil" << endl;
+  f_types_ << "}" << endl << endl;
+
+  // Generate UnmarshalJSON
+  f_types_ << "func (p *" << tenum_name << ") UnmarshalJSON(value []byte) error {" << endl;
+  f_types_ << "unquotedValue, err := strconv.Unquote(string(value))" << endl;
+  f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
+  f_types_ << "q, err := " << tenum_name << "FromString(unquotedValue)" << endl;
   f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
   f_types_ << "*p = q" << endl;
   f_types_ << "return nil" << endl;

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -917,6 +917,7 @@ string t_go_generator::go_imports_begin(bool consts) {
   if (!consts && get_program()->get_enums().size() > 0) {
     system_packages.push_back("database/sql/driver");
     system_packages.push_back("errors");
+    system_packages.push_back("encoding/json");
     system_packages.push_back("strconv");
   }
   system_packages.push_back("fmt");
@@ -1058,6 +1059,11 @@ void t_go_generator::generate_enum(t_enum* tenum) {
   f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
   f_types_ << "*p = q" << endl;
   f_types_ << "return nil" << endl;
+  f_types_ << "}" << endl << endl;
+
+  // Generate MarshalJSON
+  f_types_ << "func (p *" << tenum_name << ") MarshalJSON() ([]byte, error) {" << endl;
+  f_types_ << "return json.Marshal(p.String())" << endl;
   f_types_ << "}" << endl << endl;
 
   // Generate Scan for sql.Scanner interface

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -917,7 +917,7 @@ string t_go_generator::go_imports_begin(bool consts) {
   if (!consts && get_program()->get_enums().size() > 0) {
     system_packages.push_back("database/sql/driver");
     system_packages.push_back("errors");
-    system_packages.push_back("strconv");
+    system_packages.push_back("encoding/json");
   }
   system_packages.push_back("fmt");
   system_packages.push_back(gen_thrift_import_);
@@ -1052,12 +1052,15 @@ void t_go_generator::generate_enum(t_enum* tenum) {
 
   // Generate UnmarshalJSON
   f_types_ << "func (p *" << tenum_name << ") UnmarshalJSON(value []byte) error {" << endl;
-  f_types_ << "unquotedValue, err := strconv.Unquote(string(value))" << endl;
-  f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
-  f_types_ << "q, err := " << tenum_name << "FromString(unquotedValue)" << endl;
+  f_types_ << "q, err := " << tenum_name << "FromString(string(value))" << endl;
   f_types_ << "if (err != nil) {" << endl << "return err" << endl << "}" << endl;
   f_types_ << "*p = q" << endl;
   f_types_ << "return nil" << endl;
+  f_types_ << "}" << endl << endl;
+
+  // Generate MarshalJSON
+  f_types_ << "func (p *" << tenum_name << ") MarshalJSON() ([]byte, error) {" << endl;
+  f_types_ << "return json.Marshal(p.String())" << endl;
   f_types_ << "}" << endl << endl;
 
   // Generate Scan for sql.Scanner interface

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -46,7 +46,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConflictNamespaceTestD.thrift \
 				ConflictNamespaceTestSuperThing.thrift \
 				ConflictNamespaceServiceTest.thrift \
-				DuplicateImportsTest.thrift
+				DuplicateImportsTest.thrift \
+				StructEnumMarshallingTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -73,6 +74,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestSuperThing.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceServiceTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r DuplicateImportsTest.thrift
+	$(THRIFT) $(THRIFTARGS) StructEnumMarshallingTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock || true
 	sed -i 's/\"context\"/\"golang.org\/x\/net\/context\"/g' gopath/src/github.com/golang/mock/gomock/controller.go || true
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
@@ -97,7 +99,8 @@ check: gopath
 				conflictnamespacetestsuperthing \
 				conflict/context/conflict_service-remote \
 				servicestest/container_test-remote \
-				duplicateimportstest
+				duplicateimportstest \
+				structenummarshallingtest
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:
@@ -132,4 +135,5 @@ EXTRA_DIST = \
 	ConflictNamespaceTestC.thrift \
 	ConflictNamespaceTestD.thrift \
 	ConflictNamespaceTestSuperThing.thrift \
-	ConflictNamespaceServiceTest.thrift
+	ConflictNamespaceServiceTest.thrift \
+	StructEnumMarshallingTest.thrift

--- a/lib/go/test/StructEnumMarshallingTest.thrift
+++ b/lib/go/test/StructEnumMarshallingTest.thrift
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+enum DummyEnum {
+    FIRST = 1
+}
+
+struct Dummy {
+    1: DummyEnum dummyEnum
+}

--- a/lib/go/test/tests/struct_enum_marshalling_test.go
+++ b/lib/go/test/tests/struct_enum_marshalling_test.go
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package tests
 
 import (

--- a/lib/go/test/tests/struct_enum_marshalling_test.go
+++ b/lib/go/test/tests/struct_enum_marshalling_test.go
@@ -52,7 +52,7 @@ func TestMarshaling(t *testing.T) {
 		t.Error(err)
 	}
 
-	expectedJson := `{"dummyEnum": "FIRST"}`
+	expectedJson := `{"dummyEnum":"FIRST"}`
 	actualJson := string(jsonBytes)
 
 	if actualJson != expectedJson {

--- a/lib/go/test/tests/struct_enum_marshalling_test.go
+++ b/lib/go/test/tests/struct_enum_marshalling_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+	"structenummarshallingtest"
+)
+
+func TestUnmarshaling(t* testing.T) {
+	dummyStruct := &structenummarshallingtest.DummyEnum{}
+
+	err := json.Unmarshal([]byte(`{"dummyEnum": "FIRST"}`), dummyStruct)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if dummyStruct.DummyEnum != structenummarshallingtest.DummyEnum_FIRST {
+		t.Errorf(
+			"enums are not equals. actual: %d. expected: %d",
+			dummyStruct.DummyEnum,
+			structenummarshallingtest.DummyEnum_FIRST,
+		)
+	}
+}
+
+func TestMarshaling(t* testing.T) {
+	dummyStruct := &structenummarshallingtest.DummyEnum{
+		DummyEnum: structenummarshallingtest.DummyEnum_FIRST,
+	}
+
+	jsonBytes, err := json.Marshal(dummyStruct)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedJson := `{"dummyEnum": "FIRST"}`
+	actualJson := string(jsonBytes)
+
+	if actualJson != expectedJson {
+		t.Errorf(
+			`json strings are not equal. expected: "%s". actual: "%s"`,
+			expectedJson,
+			actualJson,
+		)
+	}
+}

--- a/lib/go/test/tests/struct_enum_marshalling_test.go
+++ b/lib/go/test/tests/struct_enum_marshalling_test.go
@@ -6,8 +6,8 @@ import (
 	"structenummarshallingtest"
 )
 
-func TestUnmarshaling(t* testing.T) {
-	dummyStruct := &structenummarshallingtest.DummyEnum{}
+func TestUnmarshaling(t *testing.T) {
+	dummyStruct := &structenummarshallingtest.Dummy{}
 
 	err := json.Unmarshal([]byte(`{"dummyEnum": "FIRST"}`), dummyStruct)
 	if err != nil {
@@ -23,8 +23,8 @@ func TestUnmarshaling(t* testing.T) {
 	}
 }
 
-func TestMarshaling(t* testing.T) {
-	dummyStruct := &structenummarshallingtest.DummyEnum{
+func TestMarshaling(t *testing.T) {
+	dummyStruct := &structenummarshallingtest.Dummy{
 		DummyEnum: structenummarshallingtest.DummyEnum_FIRST,
 	}
 


### PR DESCRIPTION
Hello.

This feature provides functionality to use json.Unmarshal() function on structs with fields which are thrift ENUMs. 
