### PR TITLE
THRIFT-5092: Panic on nil buffer writes

### DIFF
--- a/lib/go/thrift/http_client.go
+++ b/lib/go/thrift/http_client.go
@@ -166,19 +166,30 @@ func (p *THttpClient) Read(buf []byte) (int, error) {
 }
 
 func (p *THttpClient) ReadByte() (c byte, err error) {
+	if p.response == nil {
+		return 0, NewTTransportException(NOT_OPEN, "Response buffer is empty, no request.")
+	}
 	return readByte(p.response.Body)
 }
 
 func (p *THttpClient) Write(buf []byte) (int, error) {
-	n, err := p.requestBuffer.Write(buf)
-	return n, err
+	if p.requestBuffer == nil {
+		return 0, NewTTransportException(NOT_OPEN, "Request buffer is nil, connection may have been closed.")
+	}
+	return p.requestBuffer.Write(buf)
 }
 
 func (p *THttpClient) WriteByte(c byte) error {
+	if p.requestBuffer == nil {
+		return NewTTransportException(NOT_OPEN, "Request buffer is nil, connection may have been closed.")
+	}
 	return p.requestBuffer.WriteByte(c)
 }
 
 func (p *THttpClient) WriteString(s string) (n int, err error) {
+	if p.requestBuffer == nil {
+		return 0, NewTTransportException(NOT_OPEN, "Request buffer is nil, connection may have been closed.")
+	}
 	return p.requestBuffer.WriteString(s)
 }
 

--- a/lib/go/thrift/http_client_test.go
+++ b/lib/go/thrift/http_client_test.go
@@ -35,6 +35,13 @@ func TestHttpClient(t *testing.T) {
 		t.Fatalf("Unable to connect to %s: %s", addr.String(), err)
 	}
 	TransportTest(t, trans, trans)
+
+	t.Run("nilBuffer", func(t *testing.T) {
+		_ = trans.Close()
+		if _, err = trans.Write([]byte{1, 2, 3, 4}); err == nil {
+			t.Fatalf("writing to a closed transport did not result in an error")
+		}
+	})
 }
 
 func TestHttpClientHeaders(t *testing.T) {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
* Returning an error when attempting to write to a connection that has been closed instead of panicking.
* Added a test to make sure an error is returned.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
