### PR TITLE
THRIFT-5102: Fix memory leak in thrift_simple_server_serve()

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
+++ b/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
@@ -78,6 +78,15 @@ thrift_simple_server_serve (ThriftServer *server, GError **error)
                                                              NULL);
         THRIFT_TRANSPORT_GET_CLASS (output_transport)->close (output_transport,
                                                               NULL);
+        g_object_unref (input_transport);
+        g_object_unref (output_transport);
+        g_object_unref (input_protocol);
+        g_object_unref (output_protocol);
+      }
+
+      if (t != NULL)
+      {
+        g_object_unref (t);
       }
     }
 


### PR DESCRIPTION
Client: c_glib
Patch: wangyunjian

Signed-off-by: wangyunjian <wangyunjian@huawei.com>