### PR TITLE
THRIFT-5106: Fix various Lua library and compiler issues

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -197,6 +197,9 @@ void t_lua_generator::close_generator() {
  * Generate a typedef (essentially a constant)
  */
 void t_lua_generator::generate_typedef(t_typedef* ttypedef) {
+  if (ttypedef->get_type()->get_name().empty()) {
+    return;
+  }
   f_types_ << endl << endl << indent() << ttypedef->get_symbolic() << " = "
            << ttypedef->get_type()->get_name();
 }

--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -314,10 +314,10 @@ end
 
 function TCompactProtocol:readMapBegin()
   local size = self:readVarint32()
-  if size < 0 then
-    return nil,nil,nil
+  local kvtype = 0
+  if size > 0 then
+    kvtype = self:readSignByte()
   end
-  local kvtype = self:readSignByte()
   local ktype = self:getTType(libluabitwise.shiftr(kvtype, 4))
   local vtype = self:getTType(kvtype)
   return ktype, vtype, size
@@ -426,7 +426,7 @@ function TCompactProtocol:readVarint64()
   local data = result(0)
   local shiftl = 0
   while true do
-    b = self:readByte()
+    b = self:readSignByte()
     endFlag, data = libluabpack.fromVarint64(b, shiftl, data)
     shiftl = shiftl + 7
     if endFlag == 0 then


### PR DESCRIPTION
Client: lua

<!-- Explain the changes in the pull request below: -->
Fix the following issues:
* The Lua generator can emit empty typedefs, resulting in Lua syntax errors.
* TCompactProtocol: int64 fields are read incorrectly due to sign errors.
* TCompactProtocol: empty map fields are read incorrectly due to a bad size check.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
