### PR TITLE
TNonblockingSSLServerTest.cpp: add missing include signal.h on Linux

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -30,7 +30,7 @@
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TTransport.h>
 #include <vector>
-#ifdef __linux__
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -28,7 +28,7 @@
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TTransport.h>
 #include <vector>
-#ifdef __linux__
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
 

--- a/lib/cpp/test/TNonblockingSSLServerTest.cpp
+++ b/lib/cpp/test/TNonblockingSSLServerTest.cpp
@@ -29,6 +29,13 @@
 #include "gen-cpp/ParentService.h"
 
 #include <event.h>
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
+
+#ifdef __linux__
+#include <signal.h>
+#endif
 
 using namespace apache::thrift;
 using apache::thrift::concurrency::Guard;
@@ -158,7 +165,7 @@ private:
     void run() override {
       // When binding to explicit port, allow retrying to workaround bind failures on ports in use
       int retryCount = port ? 10 : 0;
-      pServerSocketFactory = createServerSocketFactory();  
+      pServerSocketFactory = createServerSocketFactory();
       startServer(retryCount);
     }
 

--- a/lib/cpp/test/TSSLSocketInterruptTest.cpp
+++ b/lib/cpp/test/TSSLSocketInterruptTest.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TSSLServerSocket.h>
-#ifdef __linux__
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
 


### PR DESCRIPTION
This PR adds a trivial change. On Ubuntu 18.04 x86_64 with gcc-7.2 the build can fail due to missing signal definitions in `TNonblockingSSLServerTest.cpp`. This PR adds include `signal.h` for Linux to fix this. This should be safe and required when using signal code.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.