### PR TITLE
lib/java/CMakeLists.txt: allow to override JAVA_INSTALL_DIR

### DIFF
--- a/lib/java/CMakeLists.txt
+++ b/lib/java/CMakeLists.txt
@@ -29,11 +29,12 @@ if(ANDROID)
     add_custom_target(thrift_aar ALL DEPENDS ${THRIFT_AAR})
 
 else()
-
-    if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
-        set(JAVA_INSTALL_DIR "${LIB_INSTALL_DIR}/java")
-    else()
-        set(JAVA_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/java")
+    if(NOT JAVA_INSTALL_DIR)
+        if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+            set(JAVA_INSTALL_DIR "${LIB_INSTALL_DIR}/java")
+        else()
+            set(JAVA_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/java")
+        endif()
     endif()
 
     if(IS_ABSOLUTE "${DOC_INSTALL_DIR}")


### PR DESCRIPTION
This PR adds a minor change to the build configuration. In the current cmake implementation, the Java install location is hard-coded. However compared to C++, Java does not have a well-defined install target directory structure.

This PR adds a minor detail that allows users to override JAVA_INSTALL_DIR from the cmake options with `-DJAVA_INSTALL_DIR="xxx"`. It does not change the current default behavior and should not have any adversarial side effects. Care was taken to make the change as little intrusive as possible. It adds only two lines of code and is relatively self-explanatory in its behavior.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.