### PR TITLE
build/cmake/ThriftMacros.cmake: do not enforce debug suffix 'd'

### DIFF
--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -20,8 +20,8 @@
 # Uncomment this to show some basic cmake variables about platforms
 # include (NewPlatformDebug)
 
-# For Debug build types, append a "d" to the library names.
-set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
+# For Debug build types, default to "d"-suffix in library names.
+set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix")
 
 # basic options
 foreach(lang IN ITEMS C CXX)


### PR DESCRIPTION
This PR adds a minor change to the build configuration. In the current cmake implementation, the C++ library debug suffix "d" is enforced. This may be convenient for the typical installation, but removing the `FORCE` property gives more freedom to users that do not apply debug suffix naming (for example users with pure debug builds).

This PR adds a minor detail that allows users to override the debug suffix from the cmake options with `-DCMAKE_DEBUG_POSTFIX=""`. It does not change the current default behavior and should not have any adversarial side effects. Care was taken to make the change as little intrusive as possible. It adds no new lines of code and is relatively self-explanatory in its behavior.

This change is also consistent with a large number of other cmake-based projects.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.