### PR TITLE
build/cmake/DefineInstallationPaths.cmake: fixed the library path

### DIFF
--- a/build/cmake/DefineInstallationPaths.cmake
+++ b/build/cmake/DefineInstallationPaths.cmake
@@ -20,7 +20,11 @@
 
 # Define the default install paths
 set(BIN_INSTALL_DIR "bin" CACHE PATH "The binary install dir (default: bin)")
-set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+if(MSVC)
+    set(LIB_INSTALL_DIR "bin${LIB_SUFFIX}" CACHE PATH "The library install dir (default: bin${LIB_SUFFIX})")
+else()
+    set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+endif()
 set(INCLUDE_INSTALL_DIR "include" CACHE PATH "The library install dir (default: include)")
 set(CMAKE_INSTALL_DIR "lib/cmake" CACHE PATH "The subdirectory to install cmake config files (default: cmake)")
 set(PKGCONFIG_INSTALL_DIR "lib/pkgconfig" CACHE PATH "The subdirectory to install pkgconfig config files (default: lib/pkgconfig)")


### PR DESCRIPTION
This PR adds a minor change to the build configuration. In the current cmake implementation, libraries are always install into the `bin` directory. However this is only a standard on MSVC.

This PR sets the default library installation directory for Linux, MacOS and other Unix to `lib`. It does not change the current behavior on MSVC.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.