### PR TITLE
THRIFT-5110 lib/cpp/src/thrift/windows/config.h: Added required static openssl libs

### DIFF
--- a/lib/cpp/src/thrift/windows/config.h
+++ b/lib/cpp/src/thrift/windows/config.h
@@ -64,6 +64,9 @@
   #pragma comment(lib, "Ws2.lib")
   #else
   #pragma comment(lib, "Ws2_32.lib")
+  #pragma comment(lib, "gdi32.lib") // For static OpenSSL
+  #pragma comment(lib, "crypt32.lib") // For static OpenSSL
+  #pragma comment(lib, "user32.lib") // For static OpenSSL
   #pragma comment(lib, "advapi32.lib") // For security APIs in TPipeServer
   #pragma comment(lib, "Shlwapi.lib")  // For StrStrIA in TPipeServer
   #endif


### PR DESCRIPTION
This PR adds a minor change to the build configuration. In the current implementation a number of libraries are missing on MSVC when linking OpenSSL static.

This PR adds three additional libraries to the set of required OpenSSL libraries on MSVC. There should be no downside to linking these system libraries.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.