### PR TITLE
compiler/cpp/CMakeLists.txt: Install thrift compiler locally after build

### DIFF
--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -116,6 +116,10 @@ set_target_properties(thrift-compiler PROPERTIES OUTPUT_NAME thrift)
 
 target_link_libraries(thrift-compiler parse)
 
+add_custom_command(TARGET thrift-compiler POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_SOURCE_DIR}/compiler/cpp"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/bin/thrift${CMAKE_EXECUTABLE_SUFFIX}" "${CMAKE_SOURCE_DIR}/compiler/cpp/")
+
 install(TARGETS thrift-compiler DESTINATION bin)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
This PR adds a minor change to the build configuration. The current cmake implementation behaves differently than the current autotools implementation. In the autotools implementation, the thrift compiler is copied to the `compiler/cpp/` directory so it can be used by other builds and tests (i.e. by the Javascript build). The cmake implementation does not have this step, so it can not perform certain additional build tasks.

This PR adds the copy-step for the thrift compiler from the build directory to the `compiler/cpp/` directory. There should be no downsides to this step.

I am aware that autotools may at some point be deprecated. However I am under the impression that this PR is still worthwhile because it helps to bridge the gap until this point in time. With little overhead, this PR enables additional build and test steps that previously worked only with autotools. When autotools are eventually deprecated, this copy step can be easily removed.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.