### PR TITLE
Added Javascript to cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ if(BUILD_JAVA)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/java)
 endif()
 
+if(BUILD_JAVASCRIPT)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/js)
+endif()
+
 if(BUILD_PYTHON)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lib/py)
     if(BUILD_TESTING)

--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -101,6 +101,11 @@ else()
                            "BUILD_LIBRARIES;WITH_JAVA;JAVA_FOUND;GRADLEW_FOUND" OFF)
 endif()
 
+# Javascript
+option(WITH_JAVASCRIPT "Build Javascript Thrift library" ON)
+CMAKE_DEPENDENT_OPTION(BUILD_JAVASCRIPT "Build Javascript library" ON
+                       "BUILD_LIBRARIES;WITH_JAVASCRIPT" OFF)
+
 # Python
 option(WITH_PYTHON "Build Python Thrift library" ON)
 find_package(PythonInterp QUIET) # for Python executable
@@ -182,6 +187,8 @@ else()
     MESSAGE_DEP(JAVA_FOUND "Java Runtime missing")
     MESSAGE_DEP(GRADLEW_FOUND "Gradle Wrapper missing")
 endif()
+message(STATUS "  Build Javascript library:                   ${BUILD_JAVASCRIPT}")
+MESSAGE_DEP(WITH_JAVASCRIPT "Disabled by WITH_JAVASCRIPT=OFF")
 message(STATUS)
 message(STATUS "  Build Python library:                       ${BUILD_PYTHON}")
 MESSAGE_DEP(WITH_PYTHON "Disabled by WITH_PYTHON=OFF")

--- a/lib/js/CMakeLists.txt
+++ b/lib/js/CMakeLists.txt
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if(NOT JAVASCRIPT_INSTALL_DIR)
+    if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+        set(JAVASCRIPT_INSTALL_DIR "${LIB_INSTALL_DIR}/js")
+    else()
+        set(JAVASCRIPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/js")
+    endif()
+endif()
+
+if(IS_ABSOLUTE "${DOC_INSTALL_DIR}")
+    set(JAVASCRIPT_DOC_INSTALL_DIR "${DOC_INSTALL_DIR}/js")
+else()
+    set(JAVASCRIPT_DOC_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${DOC_INSTALL_DIR}/js")
+endif()
+
+add_custom_target(ThriftJavascript ALL
+    COMMENT "Building Javascript library using npm + Grunt Wrapper"
+    COMMAND npm install
+    COMMAND npx grunt
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dist/
+        DESTINATION ${JAVASCRIPT_INSTALL_DIR}
+        FILES_MATCHING PATTERN "thrift*.js")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc/
+        DESTINATION ${JAVASCRIPT_DOC_INSTALL_DIR})


### PR DESCRIPTION
This PR adds Javascript to the cmake build. Not all targets of the autotools build are included. However the relevant section to build Javascript, build docs, lint, and install are included.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.