### PR TITLE
THRIFT-5084: Multiplexed processor in Swift – explicit return statements

### DIFF
--- a/lib/swift/Sources/TMultiplexedProcessor.swift
+++ b/lib/swift/Sources/TMultiplexedProcessor.swift
@@ -86,6 +86,6 @@ private final class StoredMessage: TProtocolDecorator {
   }
 
   override func readMessageBegin() throws -> (String, TMessageType, Int32) {
-    message
+    return message
   }
 }

--- a/lib/swift/Sources/TProtocolDecorator.swift
+++ b/lib/swift/Sources/TProtocolDecorator.swift
@@ -34,7 +34,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readMessageBegin() throws -> (String, TMessageType, Int32) {
-    try proto.readMessageBegin()
+    return try proto.readMessageBegin()
   }
 
   func readMessageEnd() throws {
@@ -42,7 +42,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readStructBegin() throws -> String {
-    try proto.readStructBegin()
+    return try proto.readStructBegin()
   }
 
   func readStructEnd() throws {
@@ -50,7 +50,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readFieldBegin() throws -> (String, TType, Int32) {
-    try proto.readFieldBegin()
+    return try proto.readFieldBegin()
   }
 
   func readFieldEnd() throws {
@@ -58,7 +58,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readMapBegin() throws -> (TType, TType, Int32) {
-    try proto.readMapBegin()
+    return try proto.readMapBegin()
   }
 
   func readMapEnd() throws {
@@ -66,7 +66,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readSetBegin() throws -> (TType, Int32) {
-    try proto.readSetBegin()
+    return try proto.readSetBegin()
   }
 
   func readSetEnd() throws {
@@ -74,7 +74,7 @@ class TProtocolDecorator: TProtocol {
   }
 
   func readListBegin() throws -> (TType, Int32) {
-    try proto.readListBegin()
+    return try proto.readListBegin()
   }
 
   func readListEnd() throws {
@@ -82,35 +82,35 @@ class TProtocolDecorator: TProtocol {
   }
 
   func read() throws -> String {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Bool {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> UInt8 {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Int16 {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Int32 {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Int64 {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Double {
-    try proto.read()
+    return try proto.read()
   }
 
   func read() throws -> Data {
-    try proto.read()
+    return try proto.read()
   }
 
   func writeMessageBegin(name: String, type messageType: TMessageType, sequenceID: Int32) throws {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This PR contains changes to make it compatible with Swift 3. Swift 5.1 introduced implicit `return` statements, but I have added explicit ones to satisfy the build server. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
