### PR TITLE
THRIFT-5116: Update NodeJS to supported version on Ubuntu Xenial

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- [THRIFT-5116](https://issues.apache.org/jira/browse/THRIFT-5116) - Upgrade NodeJS to 10.x
 - [THRIFT-4990](https://issues.apache.org/jira/browse/THRIFT-4990) - Upgrade to .NET Core 3.1 (LTS)
 - [THRIFT-4981](https://issues.apache.org/jira/browse/THRIFT-4981) - Remove deprecated netcore bindings from the code base
 - [THRIFT-4982](https://issues.apache.org/jira/browse/THRIFT-4982) - Remove deprecated csharp bindings from the code base

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -6,7 +6,7 @@ Guidance For: 0.13.0 |
 
 Thrift supports many programming languages and has an impressive test suite that
 exercises most of the languages, protocols, and transports.  Each build exercises
-a matrix of thousands of possible combinations.  Each language typically has a 
+a matrix of thousands of possible combinations.  Each language typically has a
 minimum required version as well as support libraries - some mandatory and some
 optional.  The information provided below will help you assess whether you can
 use Apache Thrift with your project.  Obviously this is a complex matrix to
@@ -237,7 +237,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/nodejs/README.md">node.js</a></td>
 <!-- Since -----------------><td>0.6.0</td>
 <!-- Build Systems ---------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>6.x</td><td>10.x</td>
+<!-- Language Levels -------><td>10.x</td><td>10.x</td>
 <!-- Low-Level Transports --><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
 <!-- Protocols -------------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -17,7 +17,7 @@
 # - dart: does not come with Ubuntu so we're installing 2.0.0-1 for coverage
 # - dotnet: does not come with Ubuntu
 # - go: Xenial comes with 1.6, but we need 1.10 or later
-# - nodejs: Xenial comes with 4.2.6 which exits LTS April 2018, so we're installing 8.x
+# - nodejs: Xenial comes with 4.2.6 which exits LTS April 2018, so we're installing 10.x
 # - ocaml: causes stack overflow error, just started March 2018 not sure why
 #
 
@@ -54,7 +54,7 @@ RUN apt-get update && \
 
 # node.js
     curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb https://deb.nodesource.com/node_8.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list &&\
+    echo "deb https://deb.nodesource.com/node_10.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list && \
 
 # ruby 2.4
     apt-add-repository ppa:brightbox/ruby-ng


### PR DESCRIPTION
This PR updates NodeJS on Ubuntu Xenial to 10.x. This is because NodeJS 6.x that was previously used does not support newer node modules. Also, since January 2020, NodeJS 8.x is EOL. Therefore 10.x is the currently oldest, supported NodeJS version.

The Dockerfile was tested locally so the docker build should work. Also, NodeJS is the currently successfully employed version on other thrift docker builds.

This PR fixes the issue https://travis-ci.org/apache/thrift/jobs/654070652 that is now solved in https://travis-ci.org/apache/thrift/jobs/654644828, so please review and merge. However note that the build still does not fully succeed with a later error about a required Ruby update. This second issue is very likely unrelated to this PR.

- [x] Apache Jira ticket THRIFT-5116
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.