### PR TITLE
THRIFT-5117: Add unordered_map, unordered_set to to_string

### DIFF
--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -26,6 +26,8 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace apache {
@@ -102,8 +104,22 @@ std::string to_string(const std::map<K, V>& m) {
   return o.str();
 }
 
+template <typename K, typename V>
+std::string to_string(const std::unordered_map<K, V>& m) {
+  std::ostringstream o;
+  o << "{" << to_string(m.begin(), m.end()) << "}";
+  return o.str();
+}
+
 template <typename T>
 std::string to_string(const std::set<T>& s) {
+  std::ostringstream o;
+  o << "{" << to_string(s.begin(), s.end()) << "}";
+  return o.str();
+}
+
+template <typename T>
+std::string to_string(const std::unordered_set<T>& s) {
   std::ostringstream o;
   o << "{" << to_string(s.begin(), s.end()) << "}";
   return o.str();

--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -19,6 +19,8 @@
 
 #include <vector>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <boost/test/auto_unit_test.hpp>
 
@@ -76,6 +78,24 @@ BOOST_AUTO_TEST_CASE(multi_item_map_to_string) {
   BOOST_CHECK_EQUAL(to_string(m), "{12: abc, 31: xyz}");
 }
 
+BOOST_AUTO_TEST_CASE(empty_unordered_map_to_string) {
+  std::unordered_map<int, std::string> m;
+  BOOST_CHECK_EQUAL(to_string(m), "{}");
+}
+
+BOOST_AUTO_TEST_CASE(single_item_unordered_map_to_string) {
+  std::unordered_map<int, std::string> m;
+  m[12] = "abc";
+  BOOST_CHECK_EQUAL(to_string(m), "{12: abc}");
+}
+
+BOOST_AUTO_TEST_CASE(multi_item_unordered_map_to_string) {
+  std::unordered_map<int, std::string> m;
+  m[12] = "abc";
+  m[31] = "xyz";
+  BOOST_CHECK_EQUAL(to_string(m), "{12: abc, 31: xyz}");
+}
+
 BOOST_AUTO_TEST_CASE(empty_set_to_string) {
   std::set<char> s;
   BOOST_CHECK_EQUAL(to_string(s), "{}");
@@ -89,6 +109,24 @@ BOOST_AUTO_TEST_CASE(single_item_set_to_string) {
 
 BOOST_AUTO_TEST_CASE(multi_item_set_to_string) {
   std::set<char> s;
+  s.insert('a');
+  s.insert('z');
+  BOOST_CHECK_EQUAL(to_string(s), "{a, z}");
+}
+
+BOOST_AUTO_TEST_CASE(empty_unordered_set_to_string) {
+  std::unordered_set<char> s;
+  BOOST_CHECK_EQUAL(to_string(s), "{}");
+}
+
+BOOST_AUTO_TEST_CASE(single_item_unordered_set_to_string) {
+  std::unordered_set<char> s;
+  s.insert('c');
+  BOOST_CHECK_EQUAL(to_string(s), "{c}");
+}
+
+BOOST_AUTO_TEST_CASE(multi_item_unordered_set_to_string) {
+  std::unordered_set<char> s;
   s.insert('a');
   s.insert('z');
   BOOST_CHECK_EQUAL(to_string(s), "{a, z}");

--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(multi_item_unordered_set_to_string) {
   std::unordered_set<char> s;
   s.insert('a');
   s.insert('z');
-  // Because it is an ordered_map, the resulting to_string
+  // Because it is an ordered_set, the resulting to_string
   // could be one of the following
   auto p1 = "{a, z}";
   auto p2 = "{z, a}";

--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -93,7 +93,12 @@ BOOST_AUTO_TEST_CASE(multi_item_unordered_map_to_string) {
   std::unordered_map<int, std::string> m;
   m[12] = "abc";
   m[31] = "xyz";
-  BOOST_CHECK_EQUAL(to_string(m), "{12: abc, 31: xyz}");
+  // Because it is an ordered_map, the resulting to_string
+  // could be one of the following
+  auto p1 = "{12: abc, 31: xyz}";
+  auto p2 = "{31: xyz, 12: abc}";
+  bool result = (to_string(m) == p1 || to_string(m) == p2);
+  BOOST_CHECK_EQUAL(result, true);
 }
 
 BOOST_AUTO_TEST_CASE(empty_set_to_string) {
@@ -129,7 +134,12 @@ BOOST_AUTO_TEST_CASE(multi_item_unordered_set_to_string) {
   std::unordered_set<char> s;
   s.insert('a');
   s.insert('z');
-  BOOST_CHECK_EQUAL(to_string(s), "{a, z}");
+  // Because it is an ordered_map, the resulting to_string
+  // could be one of the following
+  auto p1 = "{a, z}";
+  auto p2 = "{z, a}";
+  bool result = (to_string(s) == p1 || to_string(s) == p2);
+  BOOST_CHECK_EQUAL(result, true);
 }
 
 BOOST_AUTO_TEST_CASE(generated_empty_object_to_string) {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  **unordered_map** and **unordered_set** are not template specialized for ostream generation. This causes build failure in c++, when trying to use custom_template generation for unordered_map/unordered_set

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
