### PR TITLE
THRIFT-5118: Fix memory leak when the handler method return a exception

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -2445,6 +2445,7 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
         f_service_ << args_indent << "\"" << (*xception_iter)->get_name() << "\", "
                    << (*xception_iter)->get_name() << "," << endl << args_indent << "NULL);" << endl
                    << endl;
+        f_service_ << indent() << "g_object_unref ("<< (*xception_iter)->get_name() <<");"<< endl;
         f_service_ << indent() << "result =" << endl;
         indent_up();
         f_service_ << indent() << "((thrift_protocol_write_message_begin (output_protocol," << endl;


### PR DESCRIPTION
Client: c_glib
Patch: wangyunjian