### PR TITLE
THRIFT-5121: Fix inverted logic when testing message type

### DIFF
--- a/lib/swift/Sources/TMultiplexedProcessor.swift
+++ b/lib/swift/Sources/TMultiplexedProcessor.swift
@@ -58,7 +58,7 @@ public class MultiplexedProcessor: TProcessor {
 
   public func process(on inProtocol: TProtocol, outProtocol: TProtocol) throws {
     let message = try inProtocol.readMessageBegin()
-    guard message.1 != .call && message.1 != .oneway else { throw Error.incompatibleMessageType(message.1) }
+    guard message.1 == .call || message.1 == .oneway else { throw Error.incompatibleMessageType(message.1) }
     if let separatorIndex = message.0.firstIndex(of: Character(.multiplexSeparator)) {
       let serviceName = String(message.0.prefix(upTo: separatorIndex))
       let messageName = String(message.0.suffix(from: message.0.index(after: separatorIndex)))


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The previous PR added multiplexing support but contained a logic error when checking the message type. It should allow `oneway` and `call` message types and reject all others, but it rejected `oneway` and `call` messages and accepted all others.

I've fixed the bug and updated the unit tests.

https://issues.apache.org/jira/browse/THRIFT-5121

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
