### PR TITLE
THRIFT-5122: Fix memory leak on accept error in thrift_simple_server_serve()

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
+++ b/lib/c_glib/src/thrift/c_glib/server/thrift_simple_server.c
@@ -83,7 +83,10 @@ thrift_simple_server_serve (ThriftServer *server, GError **error)
         g_object_unref (input_protocol);
         g_object_unref (output_protocol);
       }
-
+      if ((*error) != NULL) {
+        g_message ("thrift_simple_server_serve : %s", (*error)->message);
+        g_clear_error (error);
+      }
       if (t != NULL)
       {
         g_object_unref (t);


### PR DESCRIPTION
Client: c_glib
Patch: wangyunjian

Signed-off-by: wangyunjian <wangyunjian@huawei.com>