### PR TITLE
(no ticket) Public typedef of ServiceIf called IfaceType was added into generated ServiceProcessor

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -3085,8 +3085,9 @@ void ProcessorGenerator::generate_class_definition() {
     }
   }
 
-  f_header_ << " public:" << endl << indent() << class_name_ << "(::std::shared_ptr<" << if_name_
-            << "> iface) :" << endl;
+  f_header_ << " public:" << endl
+            << indent() << "typedef " << if_name_ << " IfaceType;" << endl << endl
+            << indent() << class_name_ << "(::std::shared_ptr<" << if_name_ << "> iface) :" << endl;
   if (!extends_.empty()) {
     f_header_ << indent() << "  " << extends_ << "(iface)," << endl;
   }


### PR DESCRIPTION
Public typedef of ServiceIf called IfaceType was added into generated ServiceProcessor

Client: cpp

<!-- Explain the changes in the pull request below: -->
This change might be convenient for doing some template magic,
for instance making some kind of ServiceManager or something similar.

A generated SomeServiceProcessor declaration will be look as following:
```
class SomeServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 // bla-bla-bla
 public:
  typedef SomeServiceIf IfaceType;

  SomeServiceProcessor(::std::shared_ptr<SomeServiceIf> iface) :
  // bla-bla-bla
```
instead of just
```
class SomeServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 // bla-bla-bla
 public:
  SomeServiceProcessor(::std::shared_ptr<SomeServiceIf> iface) :
  // bla-bla-bla
```
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
