### PR TITLE
THRIFT-5131: Require >= 1.1.4 of integer-encoding dependency

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["thrift"]
 [dependencies]
 ordered-float = "1.0"
 byteorder = "1.3"
-integer-encoding = "1.0"
+integer-encoding = ">=1.1.4" # https://issues.apache.org/jira/browse/THRIFT-5131
 log = "0.4"
 threadpool = "1.7"

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -715,6 +715,31 @@ mod tests {
     }
 
     #[test]
+    fn must_round_trip_upto_i64_maxvalue() {
+        // See https://issues.apache.org/jira/browse/THRIFT-5131
+        for i in 0..64 {
+            let (mut i_prot, mut o_prot) = test_objects();
+            let val: i64 = ((1u64 << i) - 1) as i64;
+
+            o_prot
+                .write_field_begin(&TFieldIdentifier::new(
+                    "val",
+                    TType::I64,
+                    1
+                ))
+                .unwrap();
+            o_prot.write_i64(val).unwrap();
+            o_prot.write_field_end().unwrap();
+            o_prot.flush().unwrap();
+
+            copy_write_buffer_to_read_buffer!(o_prot);
+
+            i_prot.read_field_begin().unwrap();
+            assert_eq!(val, i_prot.read_i64().unwrap());
+        }
+    }
+
+    #[test]
     fn must_round_trip_message_begin() {
         let (mut i_prot, mut o_prot) = test_objects();
 


### PR DESCRIPTION
Client: Rust

Versions 1.1.0 - 1.1.3 of the integer-encoding crate had a bug where
numbers larger than 0x4000_0000_0000_0000 would cause a panic during
decoding.

Add a test to be sure that numbers up to i64::maxvalue() encode and
decode successfully.