### PR TITLE
THRIFT-5128 Swift TFramedTransport does not work using present code

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -2433,7 +2433,8 @@ void t_swift_generator::generate_swift_service_server_implementation(ostream& ou
         if (!tfunction->is_oneway()) {
           out << indent() << "try outProtocol.writeMessageBegin(name: \"" << tfunction->get_name() << "\", type: .reply, sequenceID: sequenceID)" << endl
               << indent() << "try result.write(to: outProtocol)" << endl
-              << indent() << "try outProtocol.writeMessageEnd()" << endl;
+              << indent() << "try outProtocol.writeMessageEnd()" << endl
+              << indent() << "try outProtocol.transport.flush()" << endl;
         }
       } else {
         for (x_iter = xfields.begin(); x_iter != xfields.end(); ++x_iter) {
@@ -2486,7 +2487,8 @@ void t_swift_generator::generate_swift_service_server_implementation(ostream& ou
   if (!gen_cocoa_) {
     out << indent() << "catch let error as TApplicationError";
     block_open(out);
-    out << indent() << "try outProtocol.writeException(messageName: messageName, sequenceID: sequenceID, ex: error)" << endl;
+    out << indent() << "try outProtocol.writeException(messageName: messageName, sequenceID: sequenceID, ex: error)" << endl
+        << indent() << "try outProtocol.transport.flush()" << endl;
     block_close(out);
     block_close(out);
     out << indent() << "else";
@@ -2494,8 +2496,8 @@ void t_swift_generator::generate_swift_service_server_implementation(ostream& ou
     out << indent() << "try inProtocol.skip(type: .struct)" << endl
         << indent() << "try inProtocol.readMessageEnd()" << endl
         << indent() << "let ex = TApplicationError(error: .unknownMethod(methodName: messageName))" << endl
-        << indent() << "try outProtocol.writeException(messageName: messageName, "
-        << "sequenceID: sequenceID, ex: ex)" << endl;
+        << indent() << "try outProtocol.writeException(messageName: messageName, sequenceID: sequenceID, ex: ex)" << endl
+        << indent() << "try outProtocol.transport.flush()" << endl;
   } else {
     out << indent() << "catch let error as NSError";
     block_open(out);

--- a/lib/swift/Sources/TFramedTransport.swift
+++ b/lib/swift/Sources/TFramedTransport.swift
@@ -65,17 +65,15 @@ public class TFramedTransport: TTransport {
         throw TTransportError(error: .sizeLimit(limit: maxSize, got: toRead))
     }
 
-    return try transport.readAll(size: toRead)
+    let data = try transport.readAll(size: toRead)
+    remainingBytes -= data.count
+    return data
   }
 
   public func flush() throws {
     // copy buffer and reset
     let buff = writeBuffer
     writeBuffer = Data()
-
-    if buff.count - TFramedTransport.headerSize < 0 {
-      throw TTransportError(error: .unknown)
-    }
 
     let frameSize = encodeFrameSize(size: UInt32(buff.count))
 

--- a/lib/swift/Tests/ThriftTests/TFramedTransportTests.swift
+++ b/lib/swift/Tests/ThriftTests/TFramedTransportTests.swift
@@ -1,36 +1,47 @@
-//
-//  TBinaryProtocolTests.swift
-//  Thrift
-//
-//  Created by Christopher Simpson on 8/18/16.
-//
-//
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 import XCTest
 import Foundation
 @testable import Thrift
 
-
-/// Testing Binary protocol read/write against itself
-/// Uses separate read/write transport/protocols 
-class TBinaryProtocolTests: XCTestCase {
-  var transport: TMemoryBufferTransport = TMemoryBufferTransport(flushHandler: {
+/// Testig TFramedTransport
+/// 
+class TFramedTransportTests: XCTestCase {
+  var underlayingTransport: TMemoryBufferTransport = TMemoryBufferTransport(flushHandler: {
     $0.reset(readBuffer: $1)
   })
-  
+
   var proto: TBinaryProtocol!
-  
+  var transport: TFramedTransport!
+
   override func setUp() {
     super.setUp()
+    transport = TFramedTransport(transport:underlayingTransport)
     proto = TBinaryProtocol(on: transport)
-    transport.reset()
+    underlayingTransport.reset()
   }
-  
+
   override func tearDown() {
     super.tearDown()
-    transport.reset()
+    underlayingTransport.reset()
   }
-  
   func testInt8WriteRead() {
     let writeVal: UInt8 = 250
     try? proto.write(writeVal)
@@ -39,16 +50,17 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: UInt8 = (try? proto.read()) ?? 0
     XCTAssertEqual(writeVal, readVal, "Error with UInt8, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testInt16WriteRead() {
 
     let writeVal: Int16 = 12312
     try? proto.write(writeVal)
     try? transport.flush()
+
     let readVal: Int16 = (try? proto.read()) ?? 0
     XCTAssertEqual(writeVal, readVal, "Error with Int16, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testInt32WriteRead() {
     let writeVal: Int32 = 2029234
     try? proto.write(writeVal)
@@ -57,7 +69,7 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: Int32 = (try? proto.read()) ?? 0
     XCTAssertEqual(writeVal, readVal, "Error with Int32, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testInt64WriteRead() {
     let writeVal: Int64 = 234234981374134
     try? proto.write(writeVal)
@@ -66,7 +78,7 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: Int64 = (try? proto.read()) ?? 0
     XCTAssertEqual(writeVal, readVal, "Error with Int64, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testDoubleWriteRead() {
     let writeVal: Double = 3.1415926
     try? proto.write(writeVal)
@@ -75,7 +87,7 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: Double = (try? proto.read()) ?? 0.0
     XCTAssertEqual(writeVal, readVal, "Error with Double, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testBoolWriteRead() {
     let writeVal: Bool = true
     try? proto.write(writeVal)
@@ -84,7 +96,7 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: Bool = (try? proto.read()) ?? false
     XCTAssertEqual(writeVal, readVal, "Error with Bool, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testStringWriteRead() {
     let writeVal: String = "Hello World"
     try? proto.write(writeVal)
@@ -97,10 +109,10 @@ class TBinaryProtocolTests: XCTestCase {
       XCTAssertFalse(true, "Error reading \(error)")
       return
     }
-    
+
     XCTAssertEqual(writeVal, readVal, "Error with String, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testDataWriteRead() {
     let writeVal: Data = "Data World".data(using: .utf8)!
     try? proto.write(writeVal)
@@ -109,7 +121,7 @@ class TBinaryProtocolTests: XCTestCase {
     let readVal: Data = (try? proto.read()) ?? "Goodbye World".data(using: .utf8)!
     XCTAssertEqual(writeVal, readVal, "Error with Data, wrote \(writeVal) but read \(readVal)")
   }
-  
+
   func testStructWriteRead() {
     let msg = "Test Protocol Error"
     let writeVal = TApplicationError(error: .protocolError, message: msg)
@@ -119,7 +131,7 @@ class TBinaryProtocolTests: XCTestCase {
     } catch let error {
       XCTAssertFalse(true, "Caught Error attempting to write \(error)")
     }
-    
+
     do {
       let readVal = try TApplicationError.read(from: proto)
       XCTAssertEqual(readVal.error.thriftErrorCode, writeVal.error.thriftErrorCode, "Error case mismatch, expected \(readVal.error) got \(writeVal.error)")
@@ -133,26 +145,24 @@ class TBinaryProtocolTests: XCTestCase {
     let value: Double = 3.14159
     let val: Int64 = 31415926
     let uval: UInt64 = 31415926
-    
+
     let i64 = Int64(bitPattern: value.bitPattern)
     let ubc = unsafeBitCast(value, to: Int64.self)
-    
+
     XCTAssertEqual(i64, ubc, "Bitcast Double-> i64 Values don't match")
-    
+
     let dbl = Double(bitPattern: UInt64(val))
     let ubdb = unsafeBitCast(val, to: Double.self)
-    
+
     XCTAssertEqual(dbl, ubdb, "Bitcast i64 -> Double Values don't match")
-    
+
     let db2 = Double(bitPattern: uval)
     let usbc2 = unsafeBitCast(uval, to: Double.self)
-    
-    XCTAssertEqual(db2, usbc2, "Bitcast u64 -> Double Values don't match")
 
-    
+    XCTAssertEqual(db2, usbc2, "Bitcast u64 -> Double Values don't match")
   }
-  
-  static var allTests : [(String, (TBinaryProtocolTests) -> () throws -> Void)] {
+
+  static var allTests : [(String, (TFramedTransportTests) -> () throws -> Void)] {
     return [
       ("testInt8WriteRead", testInt8WriteRead),
       ("testInt16WriteRead", testInt16WriteRead),

--- a/lib/swift/Tests/ThriftTests/TMultiplexedProcessorTests.swift
+++ b/lib/swift/Tests/ThriftTests/TMultiplexedProcessorTests.swift
@@ -138,4 +138,17 @@ class TMultiplexedProcessorTests: XCTestCase {
     try transport.flush()
     try sut.process(on: proto, outProtocol: proto)
   }
+
+  static var allTests : [(String, (TMultiplexedProcessorTests) -> () throws -> Void)] {
+    return [
+      ("testExceptionMessageThrowsError", testExceptionMessageThrowsError),
+      ("testReplyMessageThrowsError", testReplyMessageThrowsError),
+      ("testMissingDefaultProcessorThrowsError", testMissingDefaultProcessorThrowsError),
+      ("testUsesDefaultProcessorForNonMultiplexedMessage", testUsesDefaultProcessorForNonMultiplexedMessage),
+      ("testUsesProcessorForMultiplexedMessage", testUsesProcessorForMultiplexedMessage),
+      ("testMissingProcessorForMultiplexedMessageThrowsError", testMissingProcessorForMultiplexedMessageThrowsError),
+      ("testCallMessageDoesNotThrowError", testCallMessageDoesNotThrowError),
+      ("testOneWayMessageDoesNotThrowError", testOneWayMessageDoesNotThrowError)
+    ]
+  }
 }

--- a/lib/swift/Tests/ThriftTests/ThriftTests.swift
+++ b/lib/swift/Tests/ThriftTests/ThriftTests.swift
@@ -6,10 +6,6 @@ class ThriftTests: XCTestCase {
     XCTAssertEqual(Thrift().version, "0.14.0")
   }
 
-  func test_in_addr_extension() {
-
-  }
-
   static var allTests : [(String, (ThriftTests) -> () throws -> Void)] {
     return [
       ("testVersion", testVersion),


### PR DESCRIPTION
Client: Swift
Server: Swift
Compiler: Swift

Fix problems in TFramedTransport.

- Call flush on outProtocol.transport, otherwise flush is never called and thus TFrameTransport never emits outgoing packet.
- Reset remainingBytes on underflow, so that new header and new message is read. This is just a quick fix, proper fix should be to read the entire message to a buffer, so that it is guaranteed that the whole message can be read before processing starts (as it is in other languages).

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.