### PR TITLE
THRIFT-5087: Revert PR1995 (commit f8b004081da)

### DIFF
--- a/build/docker/scripts/cross-test.sh
+++ b/build/docker/scripts/cross-test.sh
@@ -10,7 +10,12 @@ make cross$1
 
 RET=$?
 if [ $RET -ne 0 ]; then
-  cat test/log/unexpected_failures.log
+  if [ -f "test/features/log/unexpected_failures.log" ]; then 
+    cat "test/features/log/unexpected_failures.log"
+  fi
+  if [ -f "test/log/unexpected_failures.log" ]; then
+    cat "test/log/unexpected_failures.log"
+  fi
 fi
 
 exit $RET

--- a/configure.ac
+++ b/configure.ac
@@ -306,11 +306,15 @@ AM_CONDITIONAL(WITH_TWISTED_TEST, [test "$have_trial" = "yes"])
 have_py3="no"
 AX_THRIFT_LIB(py3, [Py3], yes)
 if test "$with_py3" = "yes"; then
-  if $PYTHON --version 2>&1 | grep -q "Python 3"; then
-    AC_PATH_PROGS([PYTHON3], [python3 python3.7 python37 python3.6 python36 python3.5 python35 python3.4 python34])
+  # if $PYTHON is 2.x then search for python 3. otherwise, $PYTHON is already 3.x
+  if $PYTHON --version 2>&1 | grep -q "Python 2"; then
+    AC_PATH_PROGS([PYTHON3], [python3 python3.8 python38 python3.7 python37 python3.6 python36 python3.5 python35 python3.4 python34])
     if test -n "$PYTHON3"; then
       have_py3="yes"
     fi
+  elif $PYTHON --version 2>&1 | grep -q "Python 3"; then
+    have_py3="yes"
+    PYTHON3=$PYTHON
   fi
 fi
 AM_CONDITIONAL(WITH_PY3, [test "$have_py3" = "yes"])


### PR DESCRIPTION
Fix CI problem

[my guess] The original intent of the chaned line is: if $PYTHON is 3.x, there is no need
to search for another 3.x

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.