### PR TITLE
THRIFT-5138: Swift - properly escape keywords

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_generator.h
@@ -42,8 +42,9 @@
  */
 class t_generator {
 public:
-  t_generator(t_program* program)
-    : keywords_(lang_keywords()){
+  t_generator(t_program* program) {
+    update_keywords();
+
     tmp_ = 0;
     indent_ = 0;
     program_ = program;
@@ -99,6 +100,7 @@ public:
 
   /**
    * Check if all identifiers are valid for the target language
+   * See update_keywords()
    */
   virtual void validate_input() const;
 
@@ -106,9 +108,16 @@ protected:
   virtual std::set<std::string> lang_keywords() const;
 
   /**
+   * Call this from constructor if you implement lang_keywords()
+   */
+  void update_keywords() {
+    keywords_ = lang_keywords();
+  }
+
+  /**
    * A list of reserved words that cannot be used as identifiers.
    */
-  const std::set<std::string> keywords_;
+  std::set<std::string> keywords_;
 
   virtual void validate_id(const std::string& id) const;
 

--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -52,6 +52,8 @@ public:
                  const std::map<std::string, std::string>& parsed_options,
                  const std::string& option_string)
     : t_generator (program) {
+    update_keywords();
+
     std::map<std::string, std::string>::const_iterator iter;
 
     gen_newstyle_ = true;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -288,6 +288,10 @@ private:
   bool gen_cocoa_;
   bool promise_kit_;
 
+protected:
+  std::set<std::string> lang_keywords() const override {
+	  return {};
+  }
 };
 
 /**

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -50,6 +50,8 @@ public:
                     const map<string, string>& parsed_options,
                     const string& option_string)
     : t_oop_generator(program) {
+    update_keywords();
+	
     (void)option_string;
     map<string, string>::const_iterator iter;
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1220,7 +1220,7 @@ void t_swift_generator::generate_swift_struct_reader(ostream& out,
         if (field_is_optional(*f_iter)) {
           continue;
         }
-        indent(out) << "try proto.validateValue(" << (*f_iter)->get_name() << ", "
+        indent(out) << "try proto.validateValue(" << maybe_escape_identifier((*f_iter)->get_name()) << ", "
                     << "named: \"" << (*f_iter)->get_name() << "\")" << endl;
       }
     }

--- a/compiler/cpp/test/CMakeLists.txt
+++ b/compiler/cpp/test/CMakeLists.txt
@@ -24,7 +24,9 @@ set(BOOST_COMPONENTS unit_test_framework)
 REQUIRE_BOOST_LIBRARIES(BOOST_COMPONENTS)
 
 file(GLOB KEYWORD_SAMPLES "${CMAKE_CURRENT_SOURCE_DIR}/keyword-samples/*.thrift")
-foreach(LANG ${thrift_compiler_LANGS})
+set(KEYWORD_LANGS ${thrift_compiler_LANGS})
+LIST(REMOVE_ITEM KEYWORD_LANGS swift) # in Swift you can escape reserved words
+foreach(LANG ${KEYWORD_LANGS})
     foreach(SAMPLE ${KEYWORD_SAMPLES})
         get_filename_component(FILENAME ${SAMPLE} NAME_WE)
         add_test(NAME "${LANG}_${FILENAME}"


### PR DESCRIPTION
Compiler: Swift, Python

- Fix one place where escaping was forgotten (Swift)
- Allow keywords to be used as identifiers in Swift
- Fix keyword mechanism (calling virtual method from base class constructor calls base class method, not the overridden one (used in Python and Swift)

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.