### PR TITLE
THRIFT-5163 NodeJS: adds Q to exports for browserify

### DIFF
--- a/lib/nodejs/lib/thrift/browser.js
+++ b/lib/nodejs/lib/thrift/browser.js
@@ -39,3 +39,4 @@ exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
 
 exports.Int64 = require('node-int64');
+exports.Q = require('q');


### PR DESCRIPTION
When using the *Node.js* libs in the browser (via `browser.js`) `Q` isn't
exposed the same way as it is in a *Node* environment. If I try to call
an API function without a callback function it will throw the following
exception: `TypeError: Cannot read property 'defer' of undefined`. This
just adds `Q` to the exports in `browser.js` to make consuming the libs
more consistent with how we do in an actual *Node* environment.