### PR TITLE
THRIFT-5150: Fix compilation with Swift 5.2

### DIFF
--- a/lib/swift/Sources/TSet.swift
+++ b/lib/swift/Sources/TSet.swift
@@ -30,6 +30,7 @@ public struct TSet<Element : TSerializable & Hashable> : SetAlgebra, Hashable, C
   
   /// Mark: Collection
   
+  public typealias Element = Storage.Element
   public typealias Indices = Storage.Indices
   public typealias Index = Storage.Index
   public typealias IndexDistance = Int

--- a/lib/swift/Sources/TSocketServer.swift
+++ b/lib/swift/Sources/TSocketServer.swift
@@ -56,7 +56,7 @@ class TSocketServer<InProtocol: TProtocol, OutProtocol: TProtocol, Processor: TP
       let sock = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP, 0, nil, nil)
     #endif
     if sock != nil {
-      CFSocketSetSocketFlags(sock, CFSocketGetSocketFlags(sock) & ~kCFSocketCloseOnInvalidate)
+      CFSocketSetSocketFlags(sock, CFSocketGetSocketFlags(sock) & ~CFOptionFlags(kCFSocketCloseOnInvalidate))
 
       fd = CFSocketGetNative(sock)
       var yes = 1


### PR DESCRIPTION
When compiling with swift 5.2 (Xcode 11.4):
- (OS X and Linux) type 'TSet<Element>' does not conform to protocol 'Collection'
- (Linux only) kCFSocketCloseOnInvalidate has Int type

- [x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.