### PR TITLE
THRIFT-4963: Fix deadlock in ThreadManager::Worker::run

### DIFF
--- a/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
+++ b/lib/cpp/src/thrift/concurrency/ThreadManager.cpp
@@ -319,7 +319,9 @@ public:
 
         } else if (manager_->expireCallback_) {
           // The only other state the task could have been in is TIMEDOUT (see above)
+          manager_->mutex_.unlock();
           manager_->expireCallback_(task->getRunnable());
+          manager_->mutex_.lock();
           manager_->expiredCount_++;
         }
       }


### PR DESCRIPTION
Client: cpp

This is my first open-source contribution so do let me know if any changes are required and I'll be sure to make them :)

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes) - **Ticket existed**
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"? - **No breaking changes**
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources. - **Code changes exist**

**The problem:**
A deadlock was noticed when large input to the thrift server fills the buffer that the event handler (TNonblockingServer::TConnection::workSocket) reads from and events timeout occurs.

**What causes the deadlock:**
Thread 1 (TNonblockingServer::TConnection::workSocket) is waiting for the lock to add task (addTask()) to the task queue after which it will read the next event from buffer.
Thread 2 has the lock (taken in frame 12 in apache::thrift::concurrency::ThreadManager::Worker::run()) and is waiting to notify thread 1.
Notify cannot happen if the buffer to be read by thread 1 is full and thread 1 is waiting for the lock taken by thread 2.

**Proposed changes:**
The proposed changes remove the deadlock so the buffer can be emptied and requests can be processed as expected. In the non-timeout scenario processing and notify occurs without the lock similar to what is proposed. 

Using the thrift calculator tutorial with added string param to add() to demonstrate the deadlock.

Steps to reproduce the issue:

1. Run cpp_server
2. Run cpp_client (Should take <20 sec) - This results in the server getting into deadlock.
3. Run cpp_client 1 5 (With args 1 5 - indicating 1 thread and 5 requests). If cpp_server is deadlock all requests fail with "ERROR: open() timed out". The cpp_server will also cease to present any prints on stdout. If not either "ERROR: THRIFT_EAGAIN (timed out)" or "Call successful!" is obtained (Since we are forcefully sleeping in out server on 1 in 5 calls if any call sleeps all subsequent can time out untill sleep completes. A repeated try will guarantee at least one successful call).

Deadlock can also be found by using gdb to look at the process thread stack trace.
![Screenshot 2020-03-26 at 3 46 03 PM](https://user-images.githubusercontent.com/7749969/77635749-0d1dbc80-6f79-11ea-9662-def3e017e186.png)

Tested on thrift 0.10.0 and 0.14.0 on ubuntu 18(g++ 7.5.0) and centos 7 (g++ 4.8.5) with libevent 2.1.8-stable and boost 1.72.0.

Attaching files to test and build.txt for reference on build - [thrift_test.zip](https://github.com/apache/thrift/files/4386543/thrift_test.zip)

