### PR TITLE
THRIFT-5155: Swift 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,22 +152,11 @@ jobs:
     # ------------------------- phase: swift ------------------------
     # We lint the podspec
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.3
       language: swift
       script:
         - gem update cocoapods
-        - pod lib lint --allow-warnings --swift-version=3
-      env:
-        - JOB="pod lib lint"
-
-    - os: osx
-      osx_image: xcode10.2
-      language: swift
-      script:
-        - gem update cocoapods
-        - pod lib lint --allow-warnings --swift-version=4.0
-        - pod lib lint --allow-warnings --swift-version=4.2
-        - pod lib lint --allow-warnings --swift-version=5.0
+        - pod lib lint --allow-warnings --swift-version=5.1
       env:
         - JOB="pod lib lint"
 

--- a/lib/swift/Sources/TApplicationError.swift
+++ b/lib/swift/Sources/TApplicationError.swift
@@ -146,9 +146,12 @@ extension TApplicationError : TSerializable {
     try proto.writeFieldStop()
     try proto.writeStructEnd()
   }
-  
-  public var hashValue: Int {
-    return error.thriftErrorCode &+ (message?.hashValue ?? 0)
+}
+
+extension TApplicationError: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(error.thriftErrorCode)
+    hasher.combine(message)
   }
 }
 

--- a/lib/swift/Sources/TClient.swift
+++ b/lib/swift/Sources/TClient.swift
@@ -40,16 +40,3 @@ open class TAsyncClient<Protocol: TProtocol, Factory: TAsyncTransportFactory> {
     self.factory = factory
   }
 }
-
-
-public enum TAsyncResult<T> {
-  case success(T)
-  case error(Swift.Error)
-  
-  public func value() throws -> T {
-    switch self {
-    case .success(let t): return t
-    case .error(let e): throw e
-    }
-  }
-}

--- a/lib/swift/Sources/TCompactProtocol.swift
+++ b/lib/swift/Sources/TCompactProtocol.swift
@@ -371,10 +371,7 @@ public class TCompactProtocol: TProtocol {
     try ProtocolTransportTry(error: TProtocolError(message: "Transport Read Failed")) {
       buff = try self.transport.readAll(size: 8)
     }
-    
-    let i64: UInt64 = buff.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> UInt64 in
-      return UnsafePointer<UInt64>(OpaquePointer(ptr)).pointee
-    }
+    let i64: UInt64 = buff.withUnsafeBytes { $0.load(as: UInt64.self) }
     let bits = CFSwapInt64LittleToHost(i64)
     return Double(bitPattern: bits)
   }

--- a/lib/swift/Sources/TEnum.swift
+++ b/lib/swift/Sources/TEnum.swift
@@ -24,7 +24,10 @@ public protocol TEnum : TSerializable, Hashable {
 
 extension TEnum {
   public static var thriftType: TType { return .i32 }
-  public var hashValue: Int { return rawValue.hashValue }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(rawValue)
+  }
 
   public func write(to proto: TProtocol) throws {
     try proto.write(rawValue)

--- a/lib/swift/Sources/TFileTransport.swift
+++ b/lib/swift/Sources/TFileTransport.swift
@@ -88,7 +88,7 @@ public class TFileTransport: TTransport {
   
   public func write(data: Data) throws {
     let bytesWritten = data.withUnsafeBytes {
-      fwrite($0, 1, data.count, self.fileHandle)
+      fwrite($0.baseAddress!, 1, data.count, self.fileHandle)
     }
     if bytesWritten != data.count {
       throw TTransportError(error: .unknown)

--- a/lib/swift/Sources/TList.swift
+++ b/lib/swift/Sources/TList.swift
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-public struct TList<Element : TSerializable> : RandomAccessCollection, MutableCollection, ExpressibleByArrayLiteral, TSerializable, Hashable {
+public struct TList<Element : TSerializable & Hashable> : RandomAccessCollection, MutableCollection, ExpressibleByArrayLiteral, TSerializable, Hashable {
   public typealias Storage = Array<Element>
   public typealias Indices = Storage.Indices
 
@@ -31,13 +31,8 @@ public struct TList<Element : TSerializable> : RandomAccessCollection, MutableCo
   }
 
   /// Mark: Hashable
-  public var hashValue : Int {
-    let prime = 31
-    var result = 1
-    for element in storage {
-      result = prime &* result &+ element.hashValue
-    }
-    return result
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(storage)
   }
   
   /// Mark: TSerializable

--- a/lib/swift/Sources/TMap.swift
+++ b/lib/swift/Sources/TMap.swift
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-public struct TMap<Key : TSerializable & Hashable, Value : TSerializable>: Collection, ExpressibleByDictionaryLiteral, Hashable, TSerializable {
+public struct TMap<Key : TSerializable & Hashable, Value : TSerializable & Hashable>: Collection, ExpressibleByDictionaryLiteral, Hashable, TSerializable {
   public typealias Storage = Dictionary<Key, Value>
   public typealias Element = Storage.Element
   public typealias Index = Storage.Index
@@ -111,15 +111,9 @@ public struct TMap<Key : TSerializable & Hashable, Value : TSerializable>: Colle
   }
 
   /// Mark: Hashable
-  
-  public var hashValue: Int {
-    let prime = 31
-    var result = 1
-    for (key, value) in storage {
-      result = prime &* result &+ key.hashValue
-      result = prime &* result &+ value.hashValue
-    }
-    return result
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(storage)
   }
   
   /// Mark: TSerializable

--- a/lib/swift/Sources/TSerializable.swift
+++ b/lib/swift/Sources/TSerializable.swift
@@ -21,7 +21,6 @@ import Foundation
 
 
 public protocol TSerializable {
-  var hashValue: Int { get }
 
   /// TType for instance
   static var thriftType: TType { get }
@@ -41,10 +40,6 @@ extension TSerializable {
 
   /// convenience for member access
   public var thriftType: TType { return Self.thriftType }
-}
-
-public func ==<T>(lhs: T, rhs: T) -> Bool where T : TSerializable {
-  return lhs.hashValue == rhs.hashValue
 }
 
 /// Default read/write for primitave Thrift types:

--- a/lib/swift/Sources/TSet.swift
+++ b/lib/swift/Sources/TSet.swift
@@ -126,13 +126,8 @@ public struct TSet<Element : TSerializable & Hashable> : SetAlgebra, Hashable, C
 
   
   /// Mark: Hashable
-  public var hashValue : Int {
-    let prime = 31
-    var result = 1
-    for element in storage {
-      result = prime &* result &+ element.hashValue
-    }
-    return result
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(storage)
   }
   
   /// Mark: TSerializable

--- a/lib/swift/Sources/TSocketServer.swift
+++ b/lib/swift/Sources/TSocketServer.swift
@@ -82,7 +82,7 @@ class TSocketServer<InProtocol: TProtocol, OutProtocol: TProtocol, Processor: TP
       let address = Data(bytes: ptr, count: MemoryLayout<sockaddr_in>.size)
 
       let cfaddr = address.withUnsafeBytes {
-        CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, $0, address.count, nil)
+        CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, $0.bindMemory(to: UInt8.self).baseAddress!, address.count, nil)
       }
       if CFSocketSetAddress(sock, cfaddr) != CFSocketError.success { //kCFSocketSuccess {
         CFSocketInvalidate(sock)

--- a/lib/swift/Sources/TSocketTransport.swift
+++ b/lib/swift/Sources/TSocketTransport.swift
@@ -198,7 +198,7 @@ public class TSocketTransport : TTransport {
     var writeBuffer = data
     while bytesToWrite > 0 {
       let written = writeBuffer.withUnsafeBytes {
-        Sys.write(socketDescriptor, $0, writeBuffer.count)
+        Sys.write(socketDescriptor, $0.baseAddress!, writeBuffer.count)
       }
       writeBuffer = writeBuffer.subdata(in: written ..< writeBuffer.count)
       bytesToWrite -= written

--- a/lib/swift/Sources/TStreamTransport.swift
+++ b/lib/swift/Sources/TStreamTransport.swift
@@ -104,10 +104,7 @@ fileprivate extension RunLoopMode {
       
       var bytesWritten = 0
       while bytesWritten < data.count {
-        bytesWritten = data.withUnsafeBytes {
-          return output.write($0, maxLength: data.count)
-        }
-        
+        bytesWritten = data.withUnsafeBytes { output.write($0.bindMemory(to: UInt8.self).baseAddress!, maxLength: data.count) }
         if bytesWritten == -1 {
           throw TTransportError(error: .notOpen)
         } else if bytesWritten == 0 {

--- a/lib/swift/Sources/TStruct.swift
+++ b/lib/swift/Sources/TStruct.swift
@@ -45,15 +45,6 @@ public extension TStruct {
     try proto.writeStructEnd()
   }
   
-  var hashValue: Int {
-    let prime = 31
-    var result = 1
-    self.forEach { _, value, _ in
-      result = prime &* result &+ (value.hashValue)
-    }
-    return result
-  }
-  
   /// Provides a block for handling each (available) thrift property using reflection
   /// Caveat: Skips over optional values
   


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Xcode 11.3 (Swift 5.1) generates deprecation warnings for:
* Hashable protocol conformance using new Hasher type
* Use of `withUnsafeBytes`

`TAsyncResult<T>` is also redundant with the advent of `Result<T, Error>` in the stdlib.

This PR addresses all of the above and removes old versions of Swift from the CI job.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
