### PR TITLE
THRIFT-5158 Update Rust generator and Rust lib,test,tutorial to only support 2018 edition

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -192,6 +192,6 @@ Last updated: October 1, 2017
 | python    | 2.7.12        | 2.7.15        |       |
 | python3   | 3.5.2         | 3.6.8         |       |
 | ruby      | 2.3.1p112     | 2.5.1p57      |       |
-| rust      | 1.34.0        | 1.35.0        |       |
+| rust      | 1.40.0        | 1.40.0        |       |
 | smalltalk |               |               | Not in CI |
 | swift     |               | 5.1.4         |       |

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends --fix-missing \
       apt \
       apt-transport-https \
       apt-utils \
@@ -247,7 +247,7 @@ RUN apt-get install -y --no-install-recommends \
       ruby-bundler
 
 # Rust dependencies
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.36.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y
 ENV PATH /root/.cargo/bin:$PATH
 
 # Swift on Linux for cross tests

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -248,7 +248,7 @@ RUN apt-get install -y --no-install-recommends \
       ruby-bundler
 
 # Rust dependencies
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.35.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y
 ENV PATH /root/.cargo/bin:$PATH
 
 # Swift on Linux for cross tests

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -253,7 +253,7 @@ RUN apt-get install -y --no-install-recommends \
       ruby-bundler
 
 # Rust dependencies
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y
 
 # Clean up
 RUN rm -rf /var/cache/apt/* && \

--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -554,8 +554,6 @@ void t_rs_generator::render_attributes_and_includes() {
   f_gen_ << endl;
 
   // add standard includes
-  f_gen_ << "extern crate thrift;" << endl;
-  f_gen_ << endl;
   f_gen_ << "use thrift::OrderedFloat;" << endl;
   f_gen_ << "use std::cell::RefCell;" << endl;
   f_gen_ << "use std::collections::{BTreeMap, BTreeSet};" << endl;
@@ -600,7 +598,7 @@ void t_rs_generator::render_attributes_and_includes() {
   if (!referenced_modules.empty()) {
     set<string>::iterator module_iter;
     for (module_iter = referenced_modules.begin(); module_iter != referenced_modules.end(); ++module_iter) {
-      f_gen_ << "use " << rust_snake_case(*module_iter) << ";" << endl;
+      f_gen_ << "use crate::" << rust_snake_case(*module_iter) << ";" << endl;
     }
     f_gen_ << endl;
   }

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "thrift"
 description = "Rust bindings for the Apache Thrift RPC system"
+edition = "2018"
 version = "0.14.0"
 license = "Apache-2.0"
 authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]

--- a/lib/rs/README.md
+++ b/lib/rs/README.md
@@ -46,6 +46,14 @@ It does not currently use any Rust 2018 features.
 
 Breaking changes are minimized. When they are made they will be outlined below with transition guidelines.
 
+##### Thrift 0.14.0
+
+* **[THRIFT-5158]** - Rust library and generator now support Rust 2018 only
+
+    The Rust `thrift` library was updated to Rust 2018 via `cargo fix --edition`.
+    All test code in the repo was updated as well. The code generator was also updated
+    to support Rust 2018 only.
+
 ##### Thrift 0.13.0
 
 * **[THRIFT-4536]** - Use TryFrom from std, required rust 1.34.0 or higher

--- a/lib/rs/src/autogen.rs
+++ b/lib/rs/src/autogen.rs
@@ -22,7 +22,7 @@
 //! to implement required functionality. Users should never have to use code
 //! in this module directly.
 
-use protocol::{TInputProtocol, TOutputProtocol};
+use crate::protocol::{TInputProtocol, TOutputProtocol};
 
 /// Specifies the minimum functionality an auto-generated client should provide
 /// to communicate with a Thrift server.

--- a/lib/rs/src/errors.rs
+++ b/lib/rs/src/errors.rs
@@ -21,7 +21,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::{error, fmt, io, string};
 use std::convert::TryFrom;
 
-use protocol::{TFieldIdentifier, TInputProtocol, TOutputProtocol, TStructIdentifier, TType};
+use crate::protocol::{TFieldIdentifier, TInputProtocol, TOutputProtocol, TStructIdentifier, TType};
 
 // FIXME: should all my error structs impl error::Error as well?
 // FIXME: should all fields in TransportError, ProtocolError and ApplicationError be optional?
@@ -197,7 +197,7 @@ impl Error {
     /// Application code **should never** call this method directly.
     pub fn read_application_error_from_in_protocol(
         i: &mut dyn TInputProtocol,
-    ) -> ::Result<ApplicationError> {
+    ) -> crate::Result<ApplicationError> {
         let mut message = "general remote error".to_owned();
         let mut kind = ApplicationErrorKind::Unknown;
 
@@ -248,7 +248,7 @@ impl Error {
     pub fn write_application_error_to_out_protocol(
         e: &ApplicationError,
         o: &mut dyn TOutputProtocol,
-    ) -> ::Result<()> {
+    ) -> crate::Result<()> {
         o.write_struct_begin(&TStructIdentifier {
             name: "TApplicationException".to_owned(),
         })?;

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -76,10 +76,10 @@ pub mod server;
 pub mod transport;
 
 mod errors;
-pub use errors::*;
+pub use crate::errors::*;
 
 mod autogen;
-pub use autogen::*;
+pub use crate::autogen::*;
 
 /// Result type returned by all runtime library functions.
 ///

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -61,8 +61,8 @@ use std::convert::{From, TryFrom};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-use transport::{TReadTransport, TWriteTransport};
-use {ProtocolError, ProtocolErrorKind};
+use crate::transport::{TReadTransport, TWriteTransport};
+use crate::{ProtocolError, ProtocolErrorKind};
 
 #[cfg(test)]
 macro_rules! assert_eq_written_bytes {
@@ -138,54 +138,54 @@ const MAXIMUM_SKIP_DEPTH: i8 = 64;
 /// ```
 pub trait TInputProtocol {
     /// Read the beginning of a Thrift message.
-    fn read_message_begin(&mut self) -> ::Result<TMessageIdentifier>;
+    fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier>;
     /// Read the end of a Thrift message.
-    fn read_message_end(&mut self) -> ::Result<()>;
+    fn read_message_end(&mut self) -> crate::Result<()>;
     /// Read the beginning of a Thrift struct.
-    fn read_struct_begin(&mut self) -> ::Result<Option<TStructIdentifier>>;
+    fn read_struct_begin(&mut self) -> crate::Result<Option<TStructIdentifier>>;
     /// Read the end of a Thrift struct.
-    fn read_struct_end(&mut self) -> ::Result<()>;
+    fn read_struct_end(&mut self) -> crate::Result<()>;
     /// Read the beginning of a Thrift struct field.
-    fn read_field_begin(&mut self) -> ::Result<TFieldIdentifier>;
+    fn read_field_begin(&mut self) -> crate::Result<TFieldIdentifier>;
     /// Read the end of a Thrift struct field.
-    fn read_field_end(&mut self) -> ::Result<()>;
+    fn read_field_end(&mut self) -> crate::Result<()>;
     /// Read a bool.
-    fn read_bool(&mut self) -> ::Result<bool>;
+    fn read_bool(&mut self) -> crate::Result<bool>;
     /// Read a fixed-length byte array.
-    fn read_bytes(&mut self) -> ::Result<Vec<u8>>;
+    fn read_bytes(&mut self) -> crate::Result<Vec<u8>>;
     /// Read a word.
-    fn read_i8(&mut self) -> ::Result<i8>;
+    fn read_i8(&mut self) -> crate::Result<i8>;
     /// Read a 16-bit signed integer.
-    fn read_i16(&mut self) -> ::Result<i16>;
+    fn read_i16(&mut self) -> crate::Result<i16>;
     /// Read a 32-bit signed integer.
-    fn read_i32(&mut self) -> ::Result<i32>;
+    fn read_i32(&mut self) -> crate::Result<i32>;
     /// Read a 64-bit signed integer.
-    fn read_i64(&mut self) -> ::Result<i64>;
+    fn read_i64(&mut self) -> crate::Result<i64>;
     /// Read a 64-bit float.
-    fn read_double(&mut self) -> ::Result<f64>;
+    fn read_double(&mut self) -> crate::Result<f64>;
     /// Read a fixed-length string (not null terminated).
-    fn read_string(&mut self) -> ::Result<String>;
+    fn read_string(&mut self) -> crate::Result<String>;
     /// Read the beginning of a list.
-    fn read_list_begin(&mut self) -> ::Result<TListIdentifier>;
+    fn read_list_begin(&mut self) -> crate::Result<TListIdentifier>;
     /// Read the end of a list.
-    fn read_list_end(&mut self) -> ::Result<()>;
+    fn read_list_end(&mut self) -> crate::Result<()>;
     /// Read the beginning of a set.
-    fn read_set_begin(&mut self) -> ::Result<TSetIdentifier>;
+    fn read_set_begin(&mut self) -> crate::Result<TSetIdentifier>;
     /// Read the end of a set.
-    fn read_set_end(&mut self) -> ::Result<()>;
+    fn read_set_end(&mut self) -> crate::Result<()>;
     /// Read the beginning of a map.
-    fn read_map_begin(&mut self) -> ::Result<TMapIdentifier>;
+    fn read_map_begin(&mut self) -> crate::Result<TMapIdentifier>;
     /// Read the end of a map.
-    fn read_map_end(&mut self) -> ::Result<()>;
+    fn read_map_end(&mut self) -> crate::Result<()>;
     /// Skip a field with type `field_type` recursively until the default
     /// maximum skip depth is reached.
-    fn skip(&mut self, field_type: TType) -> ::Result<()> {
+    fn skip(&mut self, field_type: TType) -> crate::Result<()> {
         self.skip_till_depth(field_type, MAXIMUM_SKIP_DEPTH)
     }
     /// Skip a field with type `field_type` recursively up to `depth` levels.
-    fn skip_till_depth(&mut self, field_type: TType, depth: i8) -> ::Result<()> {
+    fn skip_till_depth(&mut self, field_type: TType, depth: i8) -> crate::Result<()> {
         if depth == 0 {
-            return Err(::Error::Protocol(ProtocolError {
+            return Err(crate::Error::Protocol(ProtocolError {
                 kind: ProtocolErrorKind::DepthLimit,
                 message: format!("cannot parse past {:?}", field_type),
             }));
@@ -238,7 +238,7 @@ pub trait TInputProtocol {
                 }
                 self.read_map_end()
             }
-            u => Err(::Error::Protocol(ProtocolError {
+            u => Err(crate::Error::Protocol(ProtocolError {
                 kind: ProtocolErrorKind::Unknown,
                 message: format!("cannot skip field type {:?}", &u),
             })),
@@ -251,7 +251,7 @@ pub trait TInputProtocol {
     /// Read an unsigned byte.
     ///
     /// This method should **never** be used in generated code.
-    fn read_byte(&mut self) -> ::Result<u8>;
+    fn read_byte(&mut self) -> crate::Result<u8>;
 }
 
 /// Converts Thrift identifiers, primitives, containers or structs into a
@@ -287,50 +287,50 @@ pub trait TInputProtocol {
 /// ```
 pub trait TOutputProtocol {
     /// Write the beginning of a Thrift message.
-    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> ::Result<()>;
+    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> crate::Result<()>;
     /// Write the end of a Thrift message.
-    fn write_message_end(&mut self) -> ::Result<()>;
+    fn write_message_end(&mut self) -> crate::Result<()>;
     /// Write the beginning of a Thrift struct.
-    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> ::Result<()>;
+    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> crate::Result<()>;
     /// Write the end of a Thrift struct.
-    fn write_struct_end(&mut self) -> ::Result<()>;
+    fn write_struct_end(&mut self) -> crate::Result<()>;
     /// Write the beginning of a Thrift field.
-    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> ::Result<()>;
+    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> crate::Result<()>;
     /// Write the end of a Thrift field.
-    fn write_field_end(&mut self) -> ::Result<()>;
+    fn write_field_end(&mut self) -> crate::Result<()>;
     /// Write a STOP field indicating that all the fields in a struct have been
     /// written.
-    fn write_field_stop(&mut self) -> ::Result<()>;
+    fn write_field_stop(&mut self) -> crate::Result<()>;
     /// Write a bool.
-    fn write_bool(&mut self, b: bool) -> ::Result<()>;
+    fn write_bool(&mut self, b: bool) -> crate::Result<()>;
     /// Write a fixed-length byte array.
-    fn write_bytes(&mut self, b: &[u8]) -> ::Result<()>;
+    fn write_bytes(&mut self, b: &[u8]) -> crate::Result<()>;
     /// Write an 8-bit signed integer.
-    fn write_i8(&mut self, i: i8) -> ::Result<()>;
+    fn write_i8(&mut self, i: i8) -> crate::Result<()>;
     /// Write a 16-bit signed integer.
-    fn write_i16(&mut self, i: i16) -> ::Result<()>;
+    fn write_i16(&mut self, i: i16) -> crate::Result<()>;
     /// Write a 32-bit signed integer.
-    fn write_i32(&mut self, i: i32) -> ::Result<()>;
+    fn write_i32(&mut self, i: i32) -> crate::Result<()>;
     /// Write a 64-bit signed integer.
-    fn write_i64(&mut self, i: i64) -> ::Result<()>;
+    fn write_i64(&mut self, i: i64) -> crate::Result<()>;
     /// Write a 64-bit float.
-    fn write_double(&mut self, d: f64) -> ::Result<()>;
+    fn write_double(&mut self, d: f64) -> crate::Result<()>;
     /// Write a fixed-length string.
-    fn write_string(&mut self, s: &str) -> ::Result<()>;
+    fn write_string(&mut self, s: &str) -> crate::Result<()>;
     /// Write the beginning of a list.
-    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> ::Result<()>;
+    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> crate::Result<()>;
     /// Write the end of a list.
-    fn write_list_end(&mut self) -> ::Result<()>;
+    fn write_list_end(&mut self) -> crate::Result<()>;
     /// Write the beginning of a set.
-    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> ::Result<()>;
+    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> crate::Result<()>;
     /// Write the end of a set.
-    fn write_set_end(&mut self) -> ::Result<()>;
+    fn write_set_end(&mut self) -> crate::Result<()>;
     /// Write the beginning of a map.
-    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> ::Result<()>;
+    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> crate::Result<()>;
     /// Write the end of a map.
-    fn write_map_end(&mut self) -> ::Result<()>;
+    fn write_map_end(&mut self) -> crate::Result<()>;
     /// Flush buffered bytes to the underlying transport.
-    fn flush(&mut self) -> ::Result<()>;
+    fn flush(&mut self) -> crate::Result<()>;
 
     // utility (DO NOT USE IN GENERATED CODE!!!!)
     //
@@ -338,94 +338,94 @@ pub trait TOutputProtocol {
     /// Write an unsigned byte.
     ///
     /// This method should **never** be used in generated code.
-    fn write_byte(&mut self, b: u8) -> ::Result<()>; // FIXME: REMOVE
+    fn write_byte(&mut self, b: u8) -> crate::Result<()>; // FIXME: REMOVE
 }
 
 impl<P> TInputProtocol for Box<P>
 where
     P: TInputProtocol + ?Sized,
 {
-    fn read_message_begin(&mut self) -> ::Result<TMessageIdentifier> {
+    fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier> {
         (**self).read_message_begin()
     }
 
-    fn read_message_end(&mut self) -> ::Result<()> {
+    fn read_message_end(&mut self) -> crate::Result<()> {
         (**self).read_message_end()
     }
 
-    fn read_struct_begin(&mut self) -> ::Result<Option<TStructIdentifier>> {
+    fn read_struct_begin(&mut self) -> crate::Result<Option<TStructIdentifier>> {
         (**self).read_struct_begin()
     }
 
-    fn read_struct_end(&mut self) -> ::Result<()> {
+    fn read_struct_end(&mut self) -> crate::Result<()> {
         (**self).read_struct_end()
     }
 
-    fn read_field_begin(&mut self) -> ::Result<TFieldIdentifier> {
+    fn read_field_begin(&mut self) -> crate::Result<TFieldIdentifier> {
         (**self).read_field_begin()
     }
 
-    fn read_field_end(&mut self) -> ::Result<()> {
+    fn read_field_end(&mut self) -> crate::Result<()> {
         (**self).read_field_end()
     }
 
-    fn read_bool(&mut self) -> ::Result<bool> {
+    fn read_bool(&mut self) -> crate::Result<bool> {
         (**self).read_bool()
     }
 
-    fn read_bytes(&mut self) -> ::Result<Vec<u8>> {
+    fn read_bytes(&mut self) -> crate::Result<Vec<u8>> {
         (**self).read_bytes()
     }
 
-    fn read_i8(&mut self) -> ::Result<i8> {
+    fn read_i8(&mut self) -> crate::Result<i8> {
         (**self).read_i8()
     }
 
-    fn read_i16(&mut self) -> ::Result<i16> {
+    fn read_i16(&mut self) -> crate::Result<i16> {
         (**self).read_i16()
     }
 
-    fn read_i32(&mut self) -> ::Result<i32> {
+    fn read_i32(&mut self) -> crate::Result<i32> {
         (**self).read_i32()
     }
 
-    fn read_i64(&mut self) -> ::Result<i64> {
+    fn read_i64(&mut self) -> crate::Result<i64> {
         (**self).read_i64()
     }
 
-    fn read_double(&mut self) -> ::Result<f64> {
+    fn read_double(&mut self) -> crate::Result<f64> {
         (**self).read_double()
     }
 
-    fn read_string(&mut self) -> ::Result<String> {
+    fn read_string(&mut self) -> crate::Result<String> {
         (**self).read_string()
     }
 
-    fn read_list_begin(&mut self) -> ::Result<TListIdentifier> {
+    fn read_list_begin(&mut self) -> crate::Result<TListIdentifier> {
         (**self).read_list_begin()
     }
 
-    fn read_list_end(&mut self) -> ::Result<()> {
+    fn read_list_end(&mut self) -> crate::Result<()> {
         (**self).read_list_end()
     }
 
-    fn read_set_begin(&mut self) -> ::Result<TSetIdentifier> {
+    fn read_set_begin(&mut self) -> crate::Result<TSetIdentifier> {
         (**self).read_set_begin()
     }
 
-    fn read_set_end(&mut self) -> ::Result<()> {
+    fn read_set_end(&mut self) -> crate::Result<()> {
         (**self).read_set_end()
     }
 
-    fn read_map_begin(&mut self) -> ::Result<TMapIdentifier> {
+    fn read_map_begin(&mut self) -> crate::Result<TMapIdentifier> {
         (**self).read_map_begin()
     }
 
-    fn read_map_end(&mut self) -> ::Result<()> {
+    fn read_map_end(&mut self) -> crate::Result<()> {
         (**self).read_map_end()
     }
 
-    fn read_byte(&mut self) -> ::Result<u8> {
+    fn read_byte(&mut self) -> crate::Result<u8> {
         (**self).read_byte()
     }
 }
@@ -434,95 +434,95 @@ impl<P> TOutputProtocol for Box<P>
 where
     P: TOutputProtocol + ?Sized,
 {
-    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> ::Result<()> {
+    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> crate::Result<()> {
         (**self).write_message_begin(identifier)
     }
 
-    fn write_message_end(&mut self) -> ::Result<()> {
+    fn write_message_end(&mut self) -> crate::Result<()> {
         (**self).write_message_end()
     }
 
-    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> ::Result<()> {
+    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> crate::Result<()> {
         (**self).write_struct_begin(identifier)
     }
 
-    fn write_struct_end(&mut self) -> ::Result<()> {
+    fn write_struct_end(&mut self) -> crate::Result<()> {
         (**self).write_struct_end()
     }
 
-    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> ::Result<()> {
+    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> crate::Result<()> {
         (**self).write_field_begin(identifier)
     }
 
-    fn write_field_end(&mut self) -> ::Result<()> {
+    fn write_field_end(&mut self) -> crate::Result<()> {
         (**self).write_field_end()
     }
 
-    fn write_field_stop(&mut self) -> ::Result<()> {
+    fn write_field_stop(&mut self) -> crate::Result<()> {
         (**self).write_field_stop()
     }
 
-    fn write_bool(&mut self, b: bool) -> ::Result<()> {
+    fn write_bool(&mut self, b: bool) -> crate::Result<()> {
         (**self).write_bool(b)
     }
 
-    fn write_bytes(&mut self, b: &[u8]) -> ::Result<()> {
+    fn write_bytes(&mut self, b: &[u8]) -> crate::Result<()> {
         (**self).write_bytes(b)
     }
 
-    fn write_i8(&mut self, i: i8) -> ::Result<()> {
+    fn write_i8(&mut self, i: i8) -> crate::Result<()> {
         (**self).write_i8(i)
     }
 
-    fn write_i16(&mut self, i: i16) -> ::Result<()> {
+    fn write_i16(&mut self, i: i16) -> crate::Result<()> {
         (**self).write_i16(i)
     }
 
-    fn write_i32(&mut self, i: i32) -> ::Result<()> {
+    fn write_i32(&mut self, i: i32) -> crate::Result<()> {
         (**self).write_i32(i)
     }
 
-    fn write_i64(&mut self, i: i64) -> ::Result<()> {
+    fn write_i64(&mut self, i: i64) -> crate::Result<()> {
         (**self).write_i64(i)
     }
 
-    fn write_double(&mut self, d: f64) -> ::Result<()> {
+    fn write_double(&mut self, d: f64) -> crate::Result<()> {
         (**self).write_double(d)
     }
 
-    fn write_string(&mut self, s: &str) -> ::Result<()> {
+    fn write_string(&mut self, s: &str) -> crate::Result<()> {
         (**self).write_string(s)
     }
 
-    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> ::Result<()> {
+    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> crate::Result<()> {
         (**self).write_list_begin(identifier)
     }
 
-    fn write_list_end(&mut self) -> ::Result<()> {
+    fn write_list_end(&mut self) -> crate::Result<()> {
         (**self).write_list_end()
     }
 
-    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> ::Result<()> {
+    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> crate::Result<()> {
         (**self).write_set_begin(identifier)
     }
 
-    fn write_set_end(&mut self) -> ::Result<()> {
+    fn write_set_end(&mut self) -> crate::Result<()> {
         (**self).write_set_end()
     }
 
-    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> ::Result<()> {
+    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> crate::Result<()> {
         (**self).write_map_begin(identifier)
     }
 
-    fn write_map_end(&mut self) -> ::Result<()> {
+    fn write_map_end(&mut self) -> crate::Result<()> {
         (**self).write_map_end()
     }
 
-    fn flush(&mut self) -> ::Result<()> {
+    fn flush(&mut self) -> crate::Result<()> {
         (**self).flush()
     }
 
-    fn write_byte(&mut self, b: u8) -> ::Result<()> {
+    fn write_byte(&mut self, b: u8) -> crate::Result<()> {
         (**self).write_byte(b)
     }
 }
@@ -769,14 +769,14 @@ impl From<TMessageType> for u8 {
 }
 
 impl TryFrom<u8> for TMessageType {
-    type Error = ::Error;
+    type Error = crate::Error;
     fn try_from(b: u8) -> Result<Self, Self::Error> {
         match b {
             0x01 => Ok(TMessageType::Call),
             0x02 => Ok(TMessageType::Reply),
             0x03 => Ok(TMessageType::Exception),
             0x04 => Ok(TMessageType::OneWay),
-            unkn => Err(::Error::Protocol(ProtocolError {
+            unkn => Err(crate::Error::Protocol(ProtocolError {
                 kind: ProtocolErrorKind::InvalidData,
                 message: format!("cannot convert {} to TMessageType", unkn),
             })),
@@ -848,12 +848,12 @@ impl Display for TType {
 /// message sequence number `actual`.
 ///
 /// Return `()` if `actual == expected`, `Err` otherwise.
-pub fn verify_expected_sequence_number(expected: i32, actual: i32) -> ::Result<()> {
+pub fn verify_expected_sequence_number(expected: i32, actual: i32) -> crate::Result<()> {
     if expected == actual {
         Ok(())
     } else {
-        Err(::Error::Application(::ApplicationError {
-            kind: ::ApplicationErrorKind::BadSequenceId,
+        Err(crate::Error::Application(crate::ApplicationError {
+            kind: crate::ApplicationErrorKind::BadSequenceId,
             message: format!("expected {} got {}", expected, actual),
         }))
     }
@@ -863,12 +863,12 @@ pub fn verify_expected_sequence_number(expected: i32, actual: i32) -> ::Result<(
 /// service-call name `actual`.
 ///
 /// Return `()` if `actual == expected`, `Err` otherwise.
-pub fn verify_expected_service_call(expected: &str, actual: &str) -> ::Result<()> {
+pub fn verify_expected_service_call(expected: &str, actual: &str) -> crate::Result<()> {
     if expected == actual {
         Ok(())
     } else {
-        Err(::Error::Application(::ApplicationError {
-            kind: ::ApplicationErrorKind::WrongMethodName,
+        Err(crate::Error::Application(crate::ApplicationError {
+            kind: crate::ApplicationErrorKind::WrongMethodName,
             message: format!("expected {} got {}", expected, actual),
         }))
     }
@@ -878,12 +878,12 @@ pub fn verify_expected_service_call(expected: &str, actual: &str) -> ::Result<()
 /// `actual`.
 ///
 /// Return `()` if `actual == expected`, `Err` otherwise.
-pub fn verify_expected_message_type(expected: TMessageType, actual: TMessageType) -> ::Result<()> {
+pub fn verify_expected_message_type(expected: TMessageType, actual: TMessageType) -> crate::Result<()> {
     if expected == actual {
         Ok(())
     } else {
-        Err(::Error::Application(::ApplicationError {
-            kind: ::ApplicationErrorKind::InvalidMessageType,
+        Err(crate::Error::Application(crate::ApplicationError {
+            kind: crate::ApplicationErrorKind::InvalidMessageType,
             message: format!("expected {} got {}", expected, actual),
         }))
     }
@@ -892,11 +892,11 @@ pub fn verify_expected_message_type(expected: TMessageType, actual: TMessageType
 /// Check if a required Thrift struct field exists.
 ///
 /// Return `()` if it does, `Err` otherwise.
-pub fn verify_required_field_exists<T>(field_name: &str, field: &Option<T>) -> ::Result<()> {
+pub fn verify_required_field_exists<T>(field_name: &str, field: &Option<T>) -> crate::Result<()> {
     match *field {
         Some(_) => Ok(()),
-        None => Err(::Error::Protocol(::ProtocolError {
-            kind: ::ProtocolErrorKind::Unknown,
+        None => Err(crate::Error::Protocol(crate::ProtocolError {
+            kind: crate::ProtocolErrorKind::Unknown,
             message: format!("missing required field {}", field_name),
         })),
     }
@@ -907,10 +907,10 @@ pub fn verify_required_field_exists<T>(field_name: &str, field: &Option<T>) -> :
 /// `field_ident` must *not* have `TFieldIdentifier.field_type` of type `TType::Stop`.
 ///
 /// Return `TFieldIdentifier.id` if an id exists, `Err` otherwise.
-pub fn field_id(field_ident: &TFieldIdentifier) -> ::Result<i16> {
+pub fn field_id(field_ident: &TFieldIdentifier) -> crate::Result<i16> {
     field_ident.id.ok_or_else(|| {
-        ::Error::Protocol(::ProtocolError {
-            kind: ::ProtocolErrorKind::Unknown,
+        crate::Error::Protocol(crate::ProtocolError {
+            kind: crate::ProtocolErrorKind::Unknown,
             message: format!("missing field in in {:?}", field_ident),
         })
     })
@@ -922,7 +922,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use transport::{TReadTransport, TWriteTransport};
+    use crate::transport::{TReadTransport, TWriteTransport};
 
     #[test]
     fn must_create_usable_input_protocol_from_concrete_input_protocol() {

--- a/lib/rs/src/protocol/multiplexed.rs
+++ b/lib/rs/src/protocol/multiplexed.rs
@@ -82,7 +82,7 @@ impl<P> TOutputProtocol for TMultiplexedOutputProtocol<P>
 where
     P: TOutputProtocol,
 {
-    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> ::Result<()> {
+    fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> crate::Result<()> {
         match identifier.message_type {
             // FIXME: is there a better way to override identifier here?
             TMessageType::Call | TMessageType::OneWay => {
@@ -96,94 +96,94 @@ where
         }
     }
 
-    fn write_message_end(&mut self) -> ::Result<()> {
+    fn write_message_end(&mut self) -> crate::Result<()> {
         self.inner.write_message_end()
     }
 
-    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> ::Result<()> {
+    fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> crate::Result<()> {
         self.inner.write_struct_begin(identifier)
     }
 
-    fn write_struct_end(&mut self) -> ::Result<()> {
+    fn write_struct_end(&mut self) -> crate::Result<()> {
         self.inner.write_struct_end()
     }
 
-    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> ::Result<()> {
+    fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> crate::Result<()> {
         self.inner.write_field_begin(identifier)
     }
 
-    fn write_field_end(&mut self) -> ::Result<()> {
+    fn write_field_end(&mut self) -> crate::Result<()> {
         self.inner.write_field_end()
     }
 
-    fn write_field_stop(&mut self) -> ::Result<()> {
+    fn write_field_stop(&mut self) -> crate::Result<()> {
         self.inner.write_field_stop()
     }
 
-    fn write_bytes(&mut self, b: &[u8]) -> ::Result<()> {
+    fn write_bytes(&mut self, b: &[u8]) -> crate::Result<()> {
         self.inner.write_bytes(b)
     }
 
-    fn write_bool(&mut self, b: bool) -> ::Result<()> {
+    fn write_bool(&mut self, b: bool) -> crate::Result<()> {
         self.inner.write_bool(b)
     }
 
-    fn write_i8(&mut self, i: i8) -> ::Result<()> {
+    fn write_i8(&mut self, i: i8) -> crate::Result<()> {
         self.inner.write_i8(i)
     }
 
-    fn write_i16(&mut self, i: i16) -> ::Result<()> {
+    fn write_i16(&mut self, i: i16) -> crate::Result<()> {
         self.inner.write_i16(i)
     }
 
-    fn write_i32(&mut self, i: i32) -> ::Result<()> {
+    fn write_i32(&mut self, i: i32) -> crate::Result<()> {
         self.inner.write_i32(i)
     }
 
-    fn write_i64(&mut self, i: i64) -> ::Result<()> {
+    fn write_i64(&mut self, i: i64) -> crate::Result<()> {
         self.inner.write_i64(i)
     }
 
-    fn write_double(&mut self, d: f64) -> ::Result<()> {
+    fn write_double(&mut self, d: f64) -> crate::Result<()> {
         self.inner.write_double(d)
     }
 
-    fn write_string(&mut self, s: &str) -> ::Result<()> {
+    fn write_string(&mut self, s: &str) -> crate::Result<()> {
         self.inner.write_string(s)
     }
 
-    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> ::Result<()> {
+    fn write_list_begin(&mut self, identifier: &TListIdentifier) -> crate::Result<()> {
         self.inner.write_list_begin(identifier)
     }
 
-    fn write_list_end(&mut self) -> ::Result<()> {
+    fn write_list_end(&mut self) -> crate::Result<()> {
         self.inner.write_list_end()
     }
 
-    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> ::Result<()> {
+    fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> crate::Result<()> {
         self.inner.write_set_begin(identifier)
     }
 
-    fn write_set_end(&mut self) -> ::Result<()> {
+    fn write_set_end(&mut self) -> crate::Result<()> {
         self.inner.write_set_end()
     }
 
-    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> ::Result<()> {
+    fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> crate::Result<()> {
         self.inner.write_map_begin(identifier)
     }
 
-    fn write_map_end(&mut self) -> ::Result<()> {
+    fn write_map_end(&mut self) -> crate::Result<()> {
         self.inner.write_map_end()
     }
 
-    fn flush(&mut self) -> ::Result<()> {
+    fn flush(&mut self) -> crate::Result<()> {
         self.inner.flush()
     }
 
     // utility
     //
 
-    fn write_byte(&mut self, b: u8) -> ::Result<()> {
+    fn write_byte(&mut self, b: u8) -> crate::Result<()> {
         self.inner.write_byte(b)
     }
 }
@@ -191,8 +191,8 @@ where
 #[cfg(test)]
 mod tests {
 
-    use protocol::{TBinaryOutputProtocol, TMessageIdentifier, TMessageType, TOutputProtocol};
-    use transport::{TBufferChannel, TIoChannel, WriteHalf};
+    use crate::protocol::{TBinaryOutputProtocol, TMessageIdentifier, TMessageType, TOutputProtocol};
+    use crate::transport::{TBufferChannel, TIoChannel, WriteHalf};
 
     use super::*;
 

--- a/lib/rs/src/protocol/stored.rs
+++ b/lib/rs/src/protocol/stored.rs
@@ -21,7 +21,7 @@ use super::{
     TFieldIdentifier, TInputProtocol, TListIdentifier, TMapIdentifier, TMessageIdentifier,
     TSetIdentifier, TStructIdentifier,
 };
-use ProtocolErrorKind;
+use crate::ProtocolErrorKind;
 
 /// `TInputProtocol` required to use a `TMultiplexedProcessor`.
 ///
@@ -101,95 +101,95 @@ impl<'a> TStoredInputProtocol<'a> {
 }
 
 impl<'a> TInputProtocol for TStoredInputProtocol<'a> {
-    fn read_message_begin(&mut self) -> ::Result<TMessageIdentifier> {
+    fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier> {
         self.message_ident.take().ok_or_else(|| {
-            ::errors::new_protocol_error(
+            crate::errors::new_protocol_error(
                 ProtocolErrorKind::Unknown,
                 "message identifier already read",
             )
         })
     }
 
-    fn read_message_end(&mut self) -> ::Result<()> {
+    fn read_message_end(&mut self) -> crate::Result<()> {
         self.inner.read_message_end()
     }
 
-    fn read_struct_begin(&mut self) -> ::Result<Option<TStructIdentifier>> {
+    fn read_struct_begin(&mut self) -> crate::Result<Option<TStructIdentifier>> {
         self.inner.read_struct_begin()
     }
 
-    fn read_struct_end(&mut self) -> ::Result<()> {
+    fn read_struct_end(&mut self) -> crate::Result<()> {
         self.inner.read_struct_end()
     }
 
-    fn read_field_begin(&mut self) -> ::Result<TFieldIdentifier> {
+    fn read_field_begin(&mut self) -> crate::Result<TFieldIdentifier> {
         self.inner.read_field_begin()
     }
 
-    fn read_field_end(&mut self) -> ::Result<()> {
+    fn read_field_end(&mut self) -> crate::Result<()> {
         self.inner.read_field_end()
     }
 
-    fn read_bytes(&mut self) -> ::Result<Vec<u8>> {
+    fn read_bytes(&mut self) -> crate::Result<Vec<u8>> {
         self.inner.read_bytes()
     }
 
-    fn read_bool(&mut self) -> ::Result<bool> {
+    fn read_bool(&mut self) -> crate::Result<bool> {
         self.inner.read_bool()
     }
 
-    fn read_i8(&mut self) -> ::Result<i8> {
+    fn read_i8(&mut self) -> crate::Result<i8> {
         self.inner.read_i8()
     }
 
-    fn read_i16(&mut self) -> ::Result<i16> {
+    fn read_i16(&mut self) -> crate::Result<i16> {
         self.inner.read_i16()
     }
 
-    fn read_i32(&mut self) -> ::Result<i32> {
+    fn read_i32(&mut self) -> crate::Result<i32> {
         self.inner.read_i32()
     }
 
-    fn read_i64(&mut self) -> ::Result<i64> {
+    fn read_i64(&mut self) -> crate::Result<i64> {
         self.inner.read_i64()
     }
 
-    fn read_double(&mut self) -> ::Result<f64> {
+    fn read_double(&mut self) -> crate::Result<f64> {
         self.inner.read_double()
     }
 
-    fn read_string(&mut self) -> ::Result<String> {
+    fn read_string(&mut self) -> crate::Result<String> {
         self.inner.read_string()
     }
 
-    fn read_list_begin(&mut self) -> ::Result<TListIdentifier> {
+    fn read_list_begin(&mut self) -> crate::Result<TListIdentifier> {
         self.inner.read_list_begin()
     }
 
-    fn read_list_end(&mut self) -> ::Result<()> {
+    fn read_list_end(&mut self) -> crate::Result<()> {
         self.inner.read_list_end()
     }
 
-    fn read_set_begin(&mut self) -> ::Result<TSetIdentifier> {
+    fn read_set_begin(&mut self) -> crate::Result<TSetIdentifier> {
         self.inner.read_set_begin()
     }
 
-    fn read_set_end(&mut self) -> ::Result<()> {
+    fn read_set_end(&mut self) -> crate::Result<()> {
         self.inner.read_set_end()
     }
 
-    fn read_map_begin(&mut self) -> ::Result<TMapIdentifier> {
+    fn read_map_begin(&mut self) -> crate::Result<TMapIdentifier> {
         self.inner.read_map_begin()
     }
 
-    fn read_map_end(&mut self) -> ::Result<()> {
+    fn read_map_end(&mut self) -> crate::Result<()> {
         self.inner.read_map_end()
     }
 
     // utility
     //
 
-    fn read_byte(&mut self) -> ::Result<u8> {
+    fn read_byte(&mut self) -> crate::Result<u8> {
         self.inner.read_byte()
     }
 }

--- a/lib/rs/src/server/mod.rs
+++ b/lib/rs/src/server/mod.rs
@@ -17,8 +17,8 @@
 
 //! Types used to implement a Thrift server.
 
-use protocol::{TInputProtocol, TMessageIdentifier, TMessageType, TOutputProtocol};
-use {ApplicationError, ApplicationErrorKind};
+use crate::protocol::{TInputProtocol, TMessageIdentifier, TMessageType, TOutputProtocol};
+use crate::{ApplicationError, ApplicationErrorKind};
 
 mod multiplexed;
 mod threaded;
@@ -91,19 +91,19 @@ pub trait TProcessor {
     /// the response to `o`.
     ///
     /// Returns `()` if the handler was executed; `Err` otherwise.
-    fn process(&self, i: &mut dyn TInputProtocol, o: &mut dyn TOutputProtocol) -> ::Result<()>;
+    fn process(&self, i: &mut dyn TInputProtocol, o: &mut dyn TOutputProtocol) -> crate::Result<()>;
 }
 
 /// Convenience function used in generated `TProcessor` implementations to
 /// return an `ApplicationError` if thrift message processing failed.
 pub fn handle_process_result(
     msg_ident: &TMessageIdentifier,
-    res: ::Result<()>,
+    res: crate::Result<()>,
     o_prot: &mut dyn TOutputProtocol,
-) -> ::Result<()> {
+) -> crate::Result<()> {
     if let Err(e) = res {
         let e = match e {
-            ::Error::Application(a) => a,
+            crate::Error::Application(a) => a,
             _ => ApplicationError::new(ApplicationErrorKind::Unknown, format!("{:?}", e)),
         };
 
@@ -114,7 +114,7 @@ pub fn handle_process_result(
         );
 
         o_prot.write_message_begin(&ident)?;
-        ::Error::write_application_error_to_out_protocol(&e, o_prot)?;
+        crate::Error::write_application_error_to_out_protocol(&e, o_prot)?;
         o_prot.write_message_end()?;
         o_prot.flush()
     } else {

--- a/lib/rs/src/server/multiplexed.rs
+++ b/lib/rs/src/server/multiplexed.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 
-use protocol::{TInputProtocol, TMessageIdentifier, TOutputProtocol, TStoredInputProtocol};
+use crate::protocol::{TInputProtocol, TMessageIdentifier, TOutputProtocol, TStoredInputProtocol};
 
 use super::{handle_process_result, TProcessor};
 
@@ -76,7 +76,7 @@ impl TMultiplexedProcessor {
         service_name: S,
         processor: Box<dyn TProcessor + Send + Sync>,
         as_default: bool,
-    ) -> ::Result<()> {
+    ) -> crate::Result<()> {
         let mut stored = self.stored.lock().unwrap();
 
         let name = service_name.into();
@@ -105,7 +105,7 @@ impl TMultiplexedProcessor {
         msg_ident: &TMessageIdentifier,
         i_prot: &mut dyn TInputProtocol,
         o_prot: &mut dyn TOutputProtocol,
-    ) -> ::Result<()> {
+    ) -> crate::Result<()> {
         let (svc_name, svc_call) = split_ident_name(&msg_ident.name);
         debug!("routing svc_name {:?} svc_call {}", &svc_name, &svc_call);
 
@@ -134,7 +134,7 @@ impl TMultiplexedProcessor {
 }
 
 impl TProcessor for TMultiplexedProcessor {
-    fn process(&self, i_prot: &mut dyn TInputProtocol, o_prot: &mut dyn TOutputProtocol) -> ::Result<()> {
+    fn process(&self, i_prot: &mut dyn TInputProtocol, o_prot: &mut dyn TOutputProtocol) -> crate::Result<()> {
         let msg_ident = i_prot.read_message_begin()?;
 
         debug!("process incoming msg id:{:?}", &msg_ident);
@@ -181,9 +181,9 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
-    use protocol::{TBinaryInputProtocol, TBinaryOutputProtocol, TMessageIdentifier, TMessageType};
-    use transport::{ReadHalf, TBufferChannel, TIoChannel, WriteHalf};
-    use {ApplicationError, ApplicationErrorKind};
+    use crate::protocol::{TBinaryInputProtocol, TBinaryOutputProtocol, TMessageIdentifier, TMessageType};
+    use crate::transport::{ReadHalf, TBufferChannel, TIoChannel, WriteHalf};
+    use crate::{ApplicationError, ApplicationErrorKind};
 
     use super::*;
 
@@ -220,7 +220,7 @@ mod tests {
         let rcvd_ident = i.read_message_begin().unwrap();
         let expected_ident = TMessageIdentifier::new("foo", TMessageType::Exception, 10);
         assert_eq!(rcvd_ident, expected_ident);
-        let rcvd_err = ::Error::read_application_error_from_in_protocol(&mut i).unwrap();
+        let rcvd_err = crate::Error::read_application_error_from_in_protocol(&mut i).unwrap();
         let expected_err = ApplicationError::new(
             ApplicationErrorKind::Unknown,
             MISSING_SEPARATOR_AND_NO_DEFAULT,
@@ -245,7 +245,7 @@ mod tests {
         let rcvd_ident = i.read_message_begin().unwrap();
         let expected_ident = TMessageIdentifier::new("missing:call", TMessageType::Exception, 10);
         assert_eq!(rcvd_ident, expected_ident);
-        let rcvd_err = ::Error::read_application_error_from_in_protocol(&mut i).unwrap();
+        let rcvd_err = crate::Error::read_application_error_from_in_protocol(&mut i).unwrap();
         let expected_err = ApplicationError::new(
             ApplicationErrorKind::Unknown,
             missing_processor_message(Some("missing")),
@@ -259,7 +259,7 @@ mod tests {
     }
 
     impl TProcessor for Service {
-        fn process(&self, _: &mut dyn TInputProtocol, _: &mut dyn TOutputProtocol) -> ::Result<()> {
+        fn process(&self, _: &mut dyn TInputProtocol, _: &mut dyn TOutputProtocol) -> crate::Result<()> {
             let res = self
                 .invoked
                 .compare_and_swap(false, true, Ordering::Relaxed);

--- a/lib/rs/src/server/threaded.rs
+++ b/lib/rs/src/server/threaded.rs
@@ -19,12 +19,12 @@ use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 use threadpool::ThreadPool;
 
-use protocol::{TInputProtocol, TInputProtocolFactory, TOutputProtocol, TOutputProtocolFactory};
-use transport::{TIoChannel, TReadTransportFactory, TTcpChannel, TWriteTransportFactory};
-use {ApplicationError, ApplicationErrorKind};
+use crate::protocol::{TInputProtocol, TInputProtocolFactory, TOutputProtocol, TOutputProtocolFactory};
+use crate::transport::{TIoChannel, TReadTransportFactory, TTcpChannel, TWriteTransportFactory};
+use crate::{ApplicationError, ApplicationErrorKind};
 
 use super::TProcessor;
-use TransportErrorKind;
+use crate::TransportErrorKind;
 
 /// Fixed-size thread-pool blocking Thrift server.
 ///
@@ -169,7 +169,7 @@ where
     ///
     /// Return `Err` when the server cannot bind to `listen_address` or there
     /// is an unrecoverable error.
-    pub fn listen<A: ToSocketAddrs>(&mut self, listen_address: A) -> ::Result<()> {
+    pub fn listen<A: ToSocketAddrs>(&mut self, listen_address: A) -> crate::Result<()> {
         let listener = TcpListener::bind(listen_address)?;
         for stream in listener.incoming() {
             match stream {
@@ -185,7 +185,7 @@ where
             }
         }
 
-        Err(::Error::Application(ApplicationError {
+        Err(crate::Error::Application(ApplicationError {
             kind: ApplicationErrorKind::Unknown,
             message: "aborted listen loop".into(),
         }))
@@ -194,7 +194,7 @@ where
     fn new_protocols_for_connection(
         &mut self,
         stream: TcpStream,
-    ) -> ::Result<(Box<dyn TInputProtocol + Send>, Box<dyn TOutputProtocol + Send>)> {
+    ) -> crate::Result<(Box<dyn TInputProtocol + Send>, Box<dyn TOutputProtocol + Send>)> {
         // create the shared tcp stream
         let channel = TTcpChannel::with_stream(stream);
 
@@ -228,7 +228,7 @@ fn handle_incoming_connection<PRC>(
             Ok(()) => {},
             Err(err) => {
                 match err {
-                    ::Error::Transport(ref transport_err) if transport_err.kind == TransportErrorKind::EndOfFile => {},
+                    crate::Error::Transport(ref transport_err) if transport_err.kind == TransportErrorKind::EndOfFile => {},
                     other => warn!("processor completed with error: {:?}", other),
                 }
                 break;

--- a/lib/rs/src/transport/buffered.rs
+++ b/lib/rs/src/transport/buffered.rs
@@ -264,7 +264,7 @@ mod tests {
     use std::io::{Read, Write};
 
     use super::*;
-    use transport::TBufferChannel;
+    use crate::transport::TBufferChannel;
 
     #[test]
     fn must_return_zero_if_read_buffer_is_empty() {

--- a/lib/rs/src/transport/framed.rs
+++ b/lib/rs/src/transport/framed.rs
@@ -239,7 +239,7 @@ impl TWriteTransportFactory for TFramedWriteTransportFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use transport::mem::TBufferChannel;
+    use crate::transport::mem::TBufferChannel;
 
     // FIXME: test a forced reserve
 

--- a/lib/rs/src/transport/mem.rs
+++ b/lib/rs/src/transport/mem.rs
@@ -139,7 +139,7 @@ impl TBufferChannel {
 }
 
 impl TIoChannel for TBufferChannel {
-    fn split(self) -> ::Result<(ReadHalf<Self>, WriteHalf<Self>)>
+    fn split(self) -> crate::Result<(ReadHalf<Self>, WriteHalf<Self>)>
     where
         Self: Sized,
     {

--- a/lib/rs/src/transport/mod.rs
+++ b/lib/rs/src/transport/mod.rs
@@ -111,7 +111,7 @@ pub trait TIoChannel: Read + Write {
     /// Returned halves may share the underlying OS channel or buffer resources.
     /// Implementations **should ensure** that these two halves can be safely
     /// used independently by concurrent threads.
-    fn split(self) -> ::Result<(::transport::ReadHalf<Self>, ::transport::WriteHalf<Self>)>
+    fn split(self) -> crate::Result<(crate::transport::ReadHalf<Self>, crate::transport::WriteHalf<Self>)>
     where
         Self: Sized;
 }

--- a/lib/rs/src/transport/socket.rs
+++ b/lib/rs/src/transport/socket.rs
@@ -21,7 +21,7 @@ use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 
 use super::{ReadHalf, TIoChannel, WriteHalf};
-use {new_transport_error, TransportErrorKind};
+use crate::{new_transport_error, TransportErrorKind};
 
 /// Bidirectional TCP/IP channel.
 ///
@@ -82,7 +82,7 @@ impl TTcpChannel {
     }
 
     /// Connect to `remote_address`, which should implement `ToSocketAddrs` trait.
-    pub fn open<A: ToSocketAddrs>(&mut self, remote_address: A) -> ::Result<()> {
+    pub fn open<A: ToSocketAddrs>(&mut self, remote_address: A) -> crate::Result<()> {
         if self.stream.is_some() {
             Err(new_transport_error(
                 TransportErrorKind::AlreadyOpen,
@@ -103,7 +103,7 @@ impl TTcpChannel {
     ///
     /// Both send and receive halves are closed, and this instance can no
     /// longer be used to communicate with another endpoint.
-    pub fn close(&mut self) -> ::Result<()> {
+    pub fn close(&mut self) -> crate::Result<()> {
         self.if_set(|s| s.shutdown(Shutdown::Both))
             .map_err(From::from)
     }
@@ -124,7 +124,7 @@ impl TTcpChannel {
 }
 
 impl TIoChannel for TTcpChannel {
-    fn split(self) -> ::Result<(ReadHalf<Self>, WriteHalf<Self>)>
+    fn split(self) -> crate::Result<(ReadHalf<Self>, WriteHalf<Self>)>
     where
         Self: Sized,
     {

--- a/lib/rs/test/Cargo.toml
+++ b/lib/rs/test/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kitchen-sink"
 version = "0.1.0"
+edition = "2018"
 license = "Apache-2.0"
 authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false

--- a/lib/rs/test/Makefile.am
+++ b/lib/rs/test/Makefile.am
@@ -41,6 +41,8 @@ clean-local:
 	-$(RM) src/base_two.rs
 	-$(RM) src/midlayer.rs
 	-$(RM) src/ultimate.rs
+	-$(RM) src/recursive.rs
+	-$(RM) src/identifiers.rs
 	-$(RM) -r bin
 
 EXTRA_DIST = \

--- a/lib/rs/test/src/bin/kitchen_sink_client.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_client.rs
@@ -69,7 +69,7 @@ fn run() -> thrift::Result<()> {
         TFramedWriteTransport::new(o_chan),
     );
 
-    let (i_prot, o_prot): (Box<TInputProtocol>, Box<TOutputProtocol>) = match protocol {
+    let (i_prot, o_prot): (Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>) = match protocol {
         "binary" => (
             Box::new(TBinaryInputProtocol::new(i_tran, true)),
             Box::new(TBinaryOutputProtocol::new(o_tran, true)),
@@ -86,8 +86,8 @@ fn run() -> thrift::Result<()> {
 
 fn run_client(
     service: &str,
-    i_prot: Box<TInputProtocol>,
-    o_prot: Box<TOutputProtocol>,
+    i_prot: Box<dyn TInputProtocol>,
+    o_prot: Box<dyn TOutputProtocol>,
 ) -> thrift::Result<()> {
     match service {
         "full" => exec_full_meal_client(i_prot, o_prot),
@@ -110,8 +110,8 @@ fn tcp_channel(
 }
 
 fn exec_meal_client(
-    i_prot: Box<TInputProtocol>,
-    o_prot: Box<TOutputProtocol>,
+    i_prot: Box<dyn TInputProtocol>,
+    o_prot: Box<dyn TOutputProtocol>,
 ) -> thrift::Result<()> {
     let mut client = MealServiceSyncClient::new(i_prot, o_prot);
 
@@ -127,8 +127,8 @@ fn exec_meal_client(
 }
 
 fn exec_full_meal_client(
-    i_prot: Box<TInputProtocol>,
-    o_prot: Box<TOutputProtocol>,
+    i_prot: Box<dyn TInputProtocol>,
+    o_prot: Box<dyn TOutputProtocol>,
 ) -> thrift::Result<()> {
     let mut client = FullMealServiceSyncClient::new(i_prot, o_prot);
 
@@ -141,8 +141,8 @@ fn exec_full_meal_client(
 }
 
 fn exec_recursive_client(
-    i_prot: Box<TInputProtocol>,
-    o_prot: Box<TOutputProtocol>,
+    i_prot: Box<dyn TInputProtocol>,
+    o_prot: Box<dyn TOutputProtocol>,
 ) -> thrift::Result<()> {
     let mut client = recursive::TestServiceSyncClient::new(i_prot, o_prot);
 

--- a/lib/rs/test/src/bin/kitchen_sink_server.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_server.rs
@@ -76,8 +76,8 @@ fn run() -> thrift::Result<()> {
     let w_transport_factory = TFramedWriteTransportFactory::new();
 
     let (i_protocol_factory, o_protocol_factory): (
-        Box<TInputProtocolFactory>,
-        Box<TOutputProtocolFactory>,
+        Box<dyn TInputProtocolFactory>,
+        Box<dyn TOutputProtocolFactory>,
     ) = match &*protocol {
         "binary" => (
             Box::new(TBinaryInputProtocolFactory::new()),

--- a/test/rs/Cargo.toml
+++ b/test/rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "thrift-test"
 version = "0.1.0"
+edition = "2018"
 license = "Apache-2.0"
 authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false

--- a/test/rs/src/bin/test_client.rs
+++ b/test/rs/src/bin/test_client.rs
@@ -110,10 +110,10 @@ fn build_protocols(
     transport: &str,
     protocol: &str,
     service_name: &str,
-) -> thrift::Result<(Box<TInputProtocol>, Box<TOutputProtocol>)> {
+) -> thrift::Result<(Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>)> {
     let (i_chan, o_chan) = tcp_channel(host, port)?;
 
-    let (i_tran, o_tran): (Box<TReadTransport>, Box<TWriteTransport>) = match transport {
+    let (i_tran, o_tran): (Box<dyn TReadTransport>, Box<dyn TWriteTransport>) = match transport {
         "buffered" => {
             (Box::new(TBufferedReadTransport::new(i_chan)),
              Box::new(TBufferedWriteTransport::new(o_chan)))
@@ -125,7 +125,7 @@ fn build_protocols(
         unmatched => return Err(format!("unsupported transport {}", unmatched).into()),
     };
 
-    let (i_prot, o_prot): (Box<TInputProtocol>, Box<TOutputProtocol>) = match protocol {
+    let (i_prot, o_prot): (Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>) = match protocol {
         "binary" => {
             (Box::new(TBinaryInputProtocol::new(i_tran, true)),
              Box::new(TBinaryOutputProtocol::new(o_tran, true)))
@@ -164,8 +164,8 @@ fn tcp_channel(
     c.split()
 }
 
-type BuildThriftTestClient = ThriftTestSyncClient<Box<TInputProtocol>, Box<TOutputProtocol>>;
-type BuiltSecondServiceClient = SecondServiceSyncClient<Box<TInputProtocol>, Box<TOutputProtocol>>;
+type BuildThriftTestClient = ThriftTestSyncClient<Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>>;
+type BuiltSecondServiceClient = SecondServiceSyncClient<Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>>;
 
 #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
 fn make_thrift_calls(

--- a/test/rs/src/bin/test_server.rs
+++ b/test/rs/src/bin/test_server.rs
@@ -80,8 +80,8 @@ fn run() -> thrift::Result<()> {
 
     info!("binding to {}", listen_address);
 
-    let (i_transport_factory, o_transport_factory): (Box<TReadTransportFactory>,
-                                                     Box<TWriteTransportFactory>) =
+    let (i_transport_factory, o_transport_factory): (Box<dyn TReadTransportFactory>,
+                                                     Box<dyn TWriteTransportFactory>) =
         match &*transport {
             "buffered" => {
                 (Box::new(TBufferedReadTransportFactory::new()),
@@ -96,8 +96,8 @@ fn run() -> thrift::Result<()> {
             }
         };
 
-    let (i_protocol_factory, o_protocol_factory): (Box<TInputProtocolFactory>,
-                                                   Box<TOutputProtocolFactory>) =
+    let (i_protocol_factory, o_protocol_factory): (Box<dyn TInputProtocolFactory>,
+                                                   Box<dyn TOutputProtocolFactory>) =
         match &*protocol {
             "binary" | "multi" | "multi:binary" => {
                 (Box::new(TBinaryInputProtocolFactory::new()),

--- a/test/rs/src/lib.rs
+++ b/test/rs/src/lib.rs
@@ -20,4 +20,4 @@ extern crate thrift;
 extern crate try_from;
 
 mod thrift_test;
-pub use thrift_test::*;
+pub use crate::thrift_test::*;

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "thrift-tutorial"
 version = "0.1.0"
+edition = "2018"
 license = "Apache-2.0"
 authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 exclude = ["Makefile*", "shared.rs", "tutorial.rs"]

--- a/tutorial/rs/src/bin/tutorial_client.rs
+++ b/tutorial/rs/src/bin/tutorial_client.rs
@@ -18,9 +18,6 @@
 #[macro_use]
 extern crate clap;
 
-extern crate thrift;
-extern crate thrift_tutorial;
-
 use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol};
 use thrift::transport::{
     ReadHalf, TFramedReadTransport, TFramedWriteTransport, TIoChannel, TTcpChannel, WriteHalf,

--- a/tutorial/rs/src/bin/tutorial_server.rs
+++ b/tutorial/rs/src/bin/tutorial_server.rs
@@ -18,9 +18,6 @@
 #[macro_use]
 extern crate clap;
 
-extern crate thrift;
-extern crate thrift_tutorial;
-
 use std::collections::HashMap;
 use std::convert::{From, Into};
 use std::default::Default;

--- a/tutorial/rs/src/lib.rs
+++ b/tutorial/rs/src/lib.rs
@@ -15,9 +15,5 @@
 // specific language governing permissions and limitations
 // under the License.
 
-extern crate ordered_float;
-extern crate thrift;
-extern crate try_from;
-
 pub mod shared;
 pub mod tutorial;


### PR DESCRIPTION
Client: rs

Updated the Rust generator and the lib,test,tutorial code to be **2018 edition only**. This is a breaking change, but makes both the generator and the rust codebase easier to reason about because we only have to support one edition.

I think this is worthwhile because the Rust community has (in general) moved fast, and it's been two years since this edition has been out.

Also moved minimum Rust compiler to 1.40.0 (last release of 2019). 

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
