### PR TITLE
Fix STRERROR_R_CHAR_P cxx check (remove unused variable warning->error)

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -64,7 +64,7 @@ include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(
   "
   #include <string.h>
-  int main(){char b;char *a = strerror_r(0, &b, 0); return(0);}
+  int main(){char b;char *a = strerror_r(0, &b, 0); static_cast<void>(a); return(0);}
   "
   STRERROR_R_CHAR_P)
 


### PR DESCRIPTION
Client: cpp

<!-- Explain the changes in the pull request below: -->
If '-Werror=unused-variable' set for compiler, check for STRERROR_R_CHAR_P always fail because of 'a' is unused in test code fragment.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
