### PR TITLE
THRIFT-3356: handle undefined captureStackTrace

### DIFF
--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -284,7 +284,10 @@ Thrift.TProtocolExceptionType = {
 
 Thrift.TProtocolException = function TProtocolException(type, message) {
     Error.call(this);
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, this.constructor);
+    }
+
     this.name = this.constructor.name;
     this.type = type;
     this.message = message;

--- a/lib/nodejs/lib/thrift/header_protocol.js
+++ b/lib/nodejs/lib/thrift/header_protocol.js
@@ -29,7 +29,10 @@ module.exports = THeaderProtocol;
 
 function THeaderProtocolError(message) {
   Error.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.message = message;
 }

--- a/lib/nodejs/lib/thrift/header_transport.js
+++ b/lib/nodejs/lib/thrift/header_transport.js
@@ -24,7 +24,10 @@ var InputBufferUnderrunError = require('./input_buffer_underrun_error');
 
 function THeaderTransportError(message) {
   Error.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.message = message;
 }

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -253,7 +253,10 @@ exports.createHttpClient = createClient
 
 function THTTPException(response) {
   thrift.TApplicationException.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.statusCode = response.statusCode;
   this.response = response;

--- a/lib/nodejs/lib/thrift/input_buffer_underrun_error.js
+++ b/lib/nodejs/lib/thrift/input_buffer_underrun_error.js
@@ -22,7 +22,10 @@ module.exports = InputBufferUnderrunError;
 
 function InputBufferUnderrunError(message) {
   Error.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.message = message;
 };

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -49,7 +49,10 @@ exports.TException = TException;
 
 function TException(message) {
   Error.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.message = message;
 };
@@ -73,7 +76,10 @@ exports.TApplicationException = TApplicationException;
 
 function TApplicationException(type, message) {
   TException.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.type = type || TApplicationExceptionType.UNKNOWN;
   this.name = this.constructor.name;
   this.message = message;
@@ -149,7 +155,10 @@ exports.TProtocolException = TProtocolException;
 
 function TProtocolException(type, message) {
   Error.call(this);
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  }
+
   this.name = this.constructor.name;
   this.type = type;
   this.message = message;


### PR DESCRIPTION
Handle undefined `captureStackTrace` function when using thrift in a browser (`Firefox`) environment.

For more information see:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error