### PR TITLE
THRIFT-5171: Fix maven-ant-tasks to use HTTPS instead of HTTP

### DIFF
--- a/lib/js/test/build.xml
+++ b/lib/js/test/build.xml
@@ -235,6 +235,7 @@
       <dependency groupId="org.apache.httpcomponents" artifactId="httpclient" version="4.0.1"/>
       <dependency groupId="com.googlecode.jslint4java" artifactId="jslint4java-ant" version="1.4.6"/>
       <dependency groupId="eu.medsea.mimeutil" artifactId="mime-util" version="2.1.3"/>
+      <remoteRepository url="${mvn.repo}"/>
     </artifact:dependencies>
 
     <!-- Copy the dependencies to the build/lib dir -->

--- a/lib/json/test/build.xml
+++ b/lib/json/test/build.xml
@@ -115,6 +115,7 @@
 
     <artifact:dependencies filesetId="test.dependency.jars">
       <dependency groupId="com.github.fge" artifactId="json-schema-validator" version="${json-schema-validator.version}"/>
+      <remoteRepository url="${mvn.repo}"/>
     </artifact:dependencies>
 
     <!-- Copy the dependencies to the build/lib dir -->


### PR DESCRIPTION
Client: JavaScript, JSON

<!-- Explain the changes in the pull request below: -->
`make check` in the lib/js or lib/json directory fails because maven-ant-tasks tries to download jar files using HTTP, that is not allowed to access. This PR fixes it to use HTTPS instead.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
