### PR TITLE
ThriftTHRIFT-5172  NetStd OutOfMemoryException :

### DIFF
--- a/lib/netstd/Thrift/TBaseClient.cs
+++ b/lib/netstd/Thrift/TBaseClient.cs
@@ -63,7 +63,7 @@ namespace Thrift
                 await _inputProtocol.Transport.OpenAsync(cancellationToken);
             }
 
-            if (!_inputProtocol.Transport.IsOpen)
+            if (!_outputProtocol.Transport.IsOpen)
             {
                 await _outputProtocol.Transport.OpenAsync(cancellationToken);
             }


### PR DESCRIPTION
 **check _outputProtocol.Transport.IsOpen before opening it**

In (netstd), TBaseClient abstract class, method OpenTransportAsync :
  
public virtual async Task OpenTransportAsync(CancellationToken cancellationToken)
        {
            if (!_inputProtocol.Transport.IsOpen)
            {
                await _inputProtocol.Transport.OpenAsync(cancellationToken);
            }

            if (!**_inputProtocol**.Transport.IsOpen)
            {
                await _outputProtocol.Transport.OpenAsync(cancellationToken);
            }
        }

Last if seems to be a wrong copy/paste and should probably be 
 if (!**_outputProtocol**.Transport.IsOpen)
            {
                await _outputProtocol.Transport.OpenAsync(cancellationToken);
            }

what this fix is providing,

I also opened a corresponding ticket:
https://issues.apache.org/jira/browse/THRIFT-5172