### PR TITLE
THRIFT-5177: getaddrinfo() should not be used for Unix sockets

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -261,7 +261,7 @@ void TServerSocket::listen() {
     throw TTransportException(TTransportException::BAD_ARGS, "Specified port is invalid");
   }
 
-  const struct addrinfo *res;
+  const struct addrinfo *res = nullptr;
   int error;
   char port[sizeof("65535")];
   THRIFT_SNPRINTF(port, sizeof(port), "%d", port_);
@@ -275,19 +275,21 @@ void TServerSocket::listen() {
   // If address is not specified use wildcard address (NULL)
   TGetAddrInfoWrapper info(address_.empty() ? nullptr : &address_[0], port, &hints);
 
-  error = info.init();
-  if (error) {
-    GlobalOutput.printf("getaddrinfo %d: %s", error, THRIFT_GAI_STRERROR(error));
-    close();
-    throw TTransportException(TTransportException::NOT_OPEN,
-                              "Could not resolve host for server socket.");
-  }
+  if (path_.empty()) {
+    error = info.init();
+    if (error) {
+      GlobalOutput.printf("getaddrinfo %d: %s", error, THRIFT_GAI_STRERROR(error));
+      close();
+      throw TTransportException(TTransportException::NOT_OPEN,
+                                "Could not resolve host for server socket.");
+    }
 
-  // Pick the ipv6 address first since ipv4 addresses can be mapped
-  // into ipv6 space.
-  for (res = info.res(); res; res = res->ai_next) {
-    if (res->ai_family == AF_INET6 || res->ai_next == nullptr)
-      break;
+    // Pick the ipv6 address first since ipv4 addresses can be mapped
+    // into ipv6 space.
+    for (res = info.res(); res; res = res->ai_next) {
+      if (res->ai_family == AF_INET6 || res->ai_next == nullptr)
+        break;
+    }
   }
 
   if (!path_.empty()) {
@@ -372,7 +374,7 @@ void TServerSocket::listen() {
 #endif // #ifdef TCP_DEFER_ACCEPT
 
 #ifdef IPV6_V6ONLY
-  if (res->ai_family == AF_INET6 && path_.empty()) {
+  if (path_.empty() && res->ai_family == AF_INET6) {
     int zero = 0;
     if (-1 == setsockopt(serverSocket_,
                          IPPROTO_IPV6,


### PR DESCRIPTION
Client: cpp

TServerSocket::listen() should not call getaddrinfo() for Unix sockets. The results returned by getaddrinfo() are not used for Unix socket anyway.

Depending on implementation getaddrinfo() may not support Unix sockets properly. In particular, the glibc implementation treats the Unix socket as a network socket and tries to do a bunch of network related stuff with it.