### PR TITLE
THRIFT-5178: Added constructor with default host localhost

### DIFF
--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -117,6 +117,10 @@ void THttpClient::flush() {
   writeBuffer_.resetBuffer();
   readHeaders_ = true;
 }
+
+void THttpClient::setPath(std::string path) {
+  path_ = path;
+}
 }
 }
 } // apache::thrift::transport

--- a/lib/cpp/src/thrift/transport/THttpClient.h
+++ b/lib/cpp/src/thrift/transport/THttpClient.h
@@ -26,15 +26,33 @@ namespace apache {
 namespace thrift {
 namespace transport {
 
+/**
+ * @brief Client transport using HTTP. The path is an optional field that is
+ * not required by Thrift HTTP server or client. It can be used i.e. with HTTP
+ * redirection, load balancing or forwarding on the server.
+ */
 class THttpClient : public THttpTransport {
 public:
-  THttpClient(std::shared_ptr<TTransport> transport, std::string host, std::string path = "");
+  /**
+   * @brief Constructor that wraps an existing transport, but also sets the
+   * host and path. The host and path are not used for the connection but are
+   * set in the HTTP header of the transport.
+   */
+  THttpClient(std::shared_ptr<TTransport> transport,
+              std::string host = "localhost",
+              std::string path = "/service");
 
+  /**
+   * @brief Constructor that will create a new socket transport using the host
+   * and port.
+   */
   THttpClient(std::string host, int port, std::string path = "");
 
   ~THttpClient() override;
 
   void flush() override;
+
+  void setPath(std::string path);
 
 protected:
   std::string host_;


### PR DESCRIPTION
The constructors for THttpClient require specifying a `host`. However not all supported socket types require a host. I.e. when using a Unix domain socket, the host is required to be localhost.

This PR adds a constructor that avoids host in the signature, and sets the value to `localhost`.

- [x] Did you create an https://issues.apache.org/jira/browse/THRIFT-5178 ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.
