### PR TITLE
Added isOpen() to TServerTransport

### DIFF
--- a/lib/cpp/src/thrift/transport/TPipeServer.cpp
+++ b/lib/cpp/src/thrift/transport/TPipeServer.cpp
@@ -181,6 +181,10 @@ TPipeServer::TPipeServer() : bufsize_(1024), isAnonymous_(true) {
 //---- Destructor ----
 TPipeServer::~TPipeServer() {}
 
+bool TPipeServer::isOpen() const {
+  return (impl_->getPipeHandle() != INVALID_HANDLE_VALUE);
+}
+
 //---------------------------------------------------------
 // Transport callbacks
 //---------------------------------------------------------

--- a/lib/cpp/src/thrift/transport/TPipeServer.h
+++ b/lib/cpp/src/thrift/transport/TPipeServer.h
@@ -59,6 +59,8 @@ public:
   // Destructor
   virtual ~TPipeServer();
 
+  bool isOpen() const override;
+
   // Standard transport callbacks
   void interrupt() override;
   void close() override;

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -185,6 +185,10 @@ TServerSocket::~TServerSocket() {
   close();
 }
 
+bool TServerSocket::isOpen() const {
+  return (serverSocket_ != THRIFT_INVALID_SOCKET);
+}
+
 void TServerSocket::setSendTimeout(int sendTimeout) {
   sendTimeout_ = sendTimeout;
 }

--- a/lib/cpp/src/thrift/transport/TServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TServerSocket.h
@@ -98,6 +98,9 @@ public:
 
   ~TServerSocket() override;
 
+
+  bool isOpen() const override;
+
   void setSendTimeout(int sendTimeout);
   void setRecvTimeout(int recvTimeout);
 

--- a/lib/cpp/src/thrift/transport/TServerTransport.h
+++ b/lib/cpp/src/thrift/transport/TServerTransport.h
@@ -38,6 +38,11 @@ public:
   virtual ~TServerTransport() = default;
 
   /**
+   * Whether this transport is open.
+   */
+  virtual bool isOpen() const { return false; }
+
+  /**
    * Starts the server transport listening for new connections. Prior to this
    * call most transports will not return anything when accept is called.
    *

--- a/lib/cpp/test/TServerSocketTest.cpp
+++ b/lib/cpp/test/TServerSocketTest.cpp
@@ -35,6 +35,7 @@ BOOST_AUTO_TEST_SUITE(TServerSocketTest)
 BOOST_AUTO_TEST_CASE(test_bind_to_address) {
   TServerSocket sock1("localhost", 0);
   sock1.listen();
+  BOOST_CHECK(sock1.isOpen());
   int port = sock1.getPort();
   TSocket clientSock("localhost", port);
   clientSock.open();
@@ -48,17 +49,20 @@ BOOST_AUTO_TEST_CASE(test_bind_to_address) {
   sock2.close();
 }
 
-BOOST_AUTO_TEST_CASE(test_listen_valid_port) {
+BOOST_AUTO_TEST_CASE(test_listen_invalid_port) {
   TServerSocket sock1(-1);
   TTRANSPORT_CHECK_THROW(sock1.listen(), TTransportException::BAD_ARGS);
+  BOOST_CHECK(!sock1.isOpen());
 
   TServerSocket sock2(65536);
   TTRANSPORT_CHECK_THROW(sock2.listen(), TTransportException::BAD_ARGS);
+  BOOST_CHECK(!sock1.isOpen());
 }
 
 BOOST_AUTO_TEST_CASE(test_close_before_listen) {
   TServerSocket sock1("localhost", 0);
   sock1.close();
+  BOOST_CHECK(!sock1.isOpen());
 }
 
 BOOST_AUTO_TEST_CASE(test_get_port) {

--- a/lib/cpp/test/TSocketInterruptTest.cpp
+++ b/lib/cpp/test/TSocketInterruptTest.cpp
@@ -53,6 +53,7 @@ void readerWorkerMustThrow(std::shared_ptr<TTransport> tt) {
 BOOST_AUTO_TEST_CASE(test_interruptable_child_read) {
   TServerSocket sock1("localhost", 0);
   sock1.listen();
+  BOOST_CHECK(sock1.isOpen());
   int port = sock1.getPort();
   TSocket clientSock("localhost", port);
   clientSock.open();


### PR DESCRIPTION
This PR adds a new method isOpen() to the TServerTransport and implementations TServerSocket and TPipeServer. I've added tests for TServerSocket and tested on a number of platforms. The change is rather small so I did not create a Jira ticket.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.