### PR TITLE
THRIFT-4282: Disabled StressTestNonBlocking on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,6 @@ environment:
      PYTHON_VERSION: 3.6
      QT_VERSION: 5.10
      ZLIB_VERSION: 1.2.11
-     DISABLED_TESTS: (StressTestNonBlocking)
 
    - PROFILE: MSVC2015
      PLATFORM: x86
@@ -56,18 +55,17 @@ environment:
      PYTHON_VERSION: 3.5
      QT_VERSION: 5.8
      ZLIB_VERSION: 1.2.8
-     DISABLED_TESTS: (StressTestNonBlocking)
      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
    - PROFILE: MINGW
      PLATFORM: x64
      CONFIGURATION: RelWithDebInfo
-     DISABLED_TESTS: (StalenessCheckTest|StressTestNonBlocking)
+     DISABLED_TESTS: (StalenessCheckTest)
 
    - PROFILE: CYGWIN
      PLATFORM: x64
      CONFIGURATION: RelWithDebInfo
-     DISABLED_TESTS: (ZlibTest|OpenSSLManualInitTest|TNonblockingServerTest|StressTestNonBlocking)
+     DISABLED_TESTS: (ZlibTest|OpenSSLManualInitTest|TNonblockingServerTest)
 
 install:
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -75,12 +75,16 @@ LINK_AGAINST_THRIFT_LIBRARY(StressTest thriftnb)
 add_test(NAME StressTest COMMAND StressTest)
 add_test(NAME StressTestConcurrent COMMAND StressTest --client-type=concurrent)
 
-add_executable(StressTestNonBlocking src/StressTestNonBlocking.cpp)
-target_link_libraries(StressTestNonBlocking crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
-LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thrift)
-LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftnb)
-LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftz)
-add_test(NAME StressTestNonBlocking COMMAND StressTestNonBlocking)
+# As of https://jira.apache.org/jira/browse/THRIFT-4282, StressTestNonBlocking
+# is broken on Windows. Contributions welcome.
+if (NOT WIN32 AND NOT CYGWIN)
+    add_executable(StressTestNonBlocking src/StressTestNonBlocking.cpp)
+    target_link_libraries(StressTestNonBlocking crossstressgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+    LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thrift)
+    LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftnb)
+    LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftz)
+    add_test(NAME StressTestNonBlocking COMMAND StressTestNonBlocking)
+endif()
 
 #
 # Common thrift code generation rules


### PR DESCRIPTION
This PR disables StressTestNonBlocking on Windows, not just in AppVeyor but generally. This is required because the test is flaky.

- [x] See https://jira.apache.org/jira/browse/THRIFT-4282
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.