### PR TITLE
THRIFT-5211: Haskell: Handle incomplete reads correctly.

### DIFF
--- a/lib/hs/src/Thrift/Transport/Framed.hs
+++ b/lib/hs/src/Thrift/Transport/Framed.hs
@@ -87,11 +87,11 @@ instance Transport t => Transport (FramedTransport t) where
 readFrame :: Transport t => FramedTransport t -> IO Int
 readFrame trans = do
   -- Read and decode the frame size.
-  szBs <- tRead (wrappedTrans trans) 4
+  szBs <- tReadAll (wrappedTrans trans) 4
   let sz = fromIntegral (B.decode szBs :: Int32)
 
   -- Read the frame and stuff it into the read buffer.
-  bs <- tRead (wrappedTrans trans) sz
+  bs <- tReadAll (wrappedTrans trans) sz
   fillBuf (readBuffer trans) bs
 
   -- Return the frame size so that the caller knows whether to expect


### PR DESCRIPTION
The read functions for handles promise to return *up* to the requested number of bytes. This means in case we read less bytes, we should try again to read some more bytes. This issue caused invalid frame sizes which caused arbitrary decoding failures.

I believe that the bug has been introduced in https://github.com/apache/thrift/commit/3c420072ab5388c2c00d15ada72aec5b061c4d4d
<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
