### PR TITLE
THRIFT-5179:  Thrift compiler will generate wrong code if IDL struct's name is 'a' or 'b'

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -1281,8 +1281,13 @@ void t_cpp_generator::generate_struct_declaration(ostream& out,
 
   if (swap) {
     // Generate a namespace-scope swap() function
-    out << indent() << "void swap(" << tstruct->get_name() << " &a, " << tstruct->get_name()
-        << " &b);" << endl << endl;
+    if (tstruct->get_name() == "a" || tstruct->get_name() == "b") {
+      out << indent() << "void swap(" << tstruct->get_name() << " &a1, " << tstruct->get_name()
+          << " &a2);" << endl << endl;
+    } else {
+       out << indent() << "void swap(" << tstruct->get_name() << " &a, " << tstruct->get_name()
+           << " &b);" << endl << endl;
+    }
   }
 
   if (is_user_struct) {
@@ -1601,8 +1606,14 @@ void t_cpp_generator::generate_struct_result_writer(ostream& out,
  * @param tstruct The struct
  */
 void t_cpp_generator::generate_struct_swap(ostream& out, t_struct* tstruct) {
-  out << indent() << "void swap(" << tstruct->get_name() << " &a, " << tstruct->get_name()
-      << " &b) {" << endl;
+  if (tstruct->get_name() == "a" || tstruct->get_name() == "b") {
+    out << indent() << "void swap(" << tstruct->get_name() << " &a1, " << tstruct->get_name()
+        << " &a2) {" << endl; 
+  } else {
+    out << indent() << "void swap(" << tstruct->get_name() << " &a, " << tstruct->get_name()
+        << " &b) {" << endl;
+  }
+
   indent_up();
 
   // Let argument-dependent name lookup find the correct swap() function to
@@ -1617,18 +1628,32 @@ void t_cpp_generator::generate_struct_swap(ostream& out, t_struct* tstruct) {
       has_nonrequired_fields = true;
     }
 
-    out << indent() << "swap(a." << tfield->get_name() << ", b." << tfield->get_name() << ");"
-        << endl;
+    if (tstruct->get_name() == "a" || tstruct->get_name() == "b") {
+      out << indent() << "swap(a1." << tfield->get_name() << ", a2." << tfield->get_name() << ");"
+          << endl;
+    } else {
+      out << indent() << "swap(a." << tfield->get_name() << ", b." << tfield->get_name() << ");"
+          << endl;
+    }
   }
 
   if (has_nonrequired_fields) {
-    out << indent() << "swap(a.__isset, b.__isset);" << endl;
+    if (tstruct->get_name() == "a" || tstruct->get_name() == "b") {
+      out << indent() << "swap(a1.__isset, a2.__isset);" << endl; 
+    } else {
+      out << indent() << "swap(a.__isset, b.__isset);" << endl;
+    }
   }
 
   // handle empty structs
   if (fields.size() == 0) {
-    out << indent() << "(void) a;" << endl;
-    out << indent() << "(void) b;" << endl;
+    if (tstruct->get_name() == "a" || tstruct->get_name() == "b") {
+      out << indent() << "(void) a1;" << endl;
+      out << indent() << "(void) a2;" << endl;
+    } else {
+      out << indent() << "(void) a;" << endl;
+      out << indent() << "(void) b;" << endl;
+    }
   }
 
   scope_down(out);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -167,6 +167,7 @@ EXTRA_DIST = \
 	ThriftTest.thrift \
 	TypedefTest.thrift \
 	UnsafeTypes.thrift \
+	SpecificNameTest.thrift \
 	known_failures_Linux.json \
 	test.py \
 	tests.json \

--- a/test/SpecificNameTest.thrift
+++ b/test/SpecificNameTest.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp test.specificname
+
+struct a {
+  1: i32 number,
+  2: string message,
+}
+
+struct b {
+  1: i32 number,
+  2: string message,
+}
+
+service EchoService {
+  void echoA(1: a arg),
+  void echoB(2: b arg),
+}

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -56,6 +56,13 @@ set(crossstressgencpp_SOURCES
 add_library(crossstressgencpp STATIC ${crossstressgencpp_SOURCES})
 LINK_AGAINST_THRIFT_LIBRARY(crossstressgencpp thrift)
 
+set(crossspecificnamegencpp_SOURCES
+    gen-cpp/EchoService.cpp 
+    gen-cpp/SpecificNameTest_types.cpp
+)
+add_library(crossspecificnamegencpp STATIC ${crossspecificnamegencpp_SOURCES})
+LINK_AGAINST_THRIFT_LIBRARY(crossspecificnamegencpp thrift)
+
 add_executable(TestServer src/TestServer.cpp)
 target_link_libraries(TestServer crosstestgencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
 LINK_AGAINST_THRIFT_LIBRARY(TestServer thrift)
@@ -86,6 +93,12 @@ if (NOT WIN32 AND NOT CYGWIN)
     add_test(NAME StressTestNonBlocking COMMAND StressTestNonBlocking)
 endif()
 
+add_executable(SpecificNameTest src/SpecificNameTest.cpp)
+target_link_libraries(SpecificNameTest crossspecificnamegencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
+LINK_AGAINST_THRIFT_LIBRARY(SpecificNameTest thrift)
+LINK_AGAINST_THRIFT_LIBRARY(SpecificNameTest thriftnb)
+add_test(NAME SpecificNameTest COMMAND SpecificNameTest)
+
 #
 # Common thrift code generation rules
 #
@@ -96,4 +109,8 @@ add_custom_command(OUTPUT gen-cpp/SecondService.cpp gen-cpp/SecondService.h gen-
 
 add_custom_command(OUTPUT gen-cpp/Service.cpp
     COMMAND ${THRIFT_COMPILER} --gen cpp ${PROJECT_SOURCE_DIR}/test/StressTest.thrift
+)
+
+add_custom_command(OUTPUT gen-cpp/EchoService.cpp gen-cpp/SpecificNameTest_types.cpp
+    COMMAND ${THRIFT_COMPILER} --gen cpp ${PROJECT_SOURCE_DIR}/test/SpecificNameTest.thrift
 )

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -103,6 +103,9 @@ gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_constants
 gen-cpp/Service.cpp: $(top_srcdir)/test/StressTest.thrift $(THRIFT)
 	$(THRIFT) --gen cpp $<
 
+gen-cpp/SpecificNameTest_types.cpp gen-cpp/EchoService.cpp: $(top_srcdir)/test/SpecificName.thrift $(THRIFT)
+	$(THRIFT) --gen cpp $<
+
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(LIBEVENT_CPPFLAGS) -I$(top_srcdir)/lib/cpp/src -Igen-cpp -I.
 AM_CXXFLAGS = -Wall -Wextra -pedantic -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
 AM_LDFLAGS = $(BOOST_LDFLAGS) $(LIBEVENT_LDFLAGS) $(ZLIB_LIBS)

--- a/test/cpp/src/SpecificNameTest.cpp
+++ b/test/cpp/src/SpecificNameTest.cpp
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+int main(int argc, char** argv) {
+  
+  //Empty in main function, 
+  //because we just want to test  
+  //whether the generated source code
+  //(IDL file contains struct named as
+  //'a' or 'b') can be compiled.
+
+  return 0;
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
