### PR TITLE
Removed boost from compiler test, and deleted unused bincat.sh

### DIFF
--- a/compiler/cpp/test/CMakeLists.txt
+++ b/compiler/cpp/test/CMakeLists.txt
@@ -17,12 +17,6 @@
 # under the License.
 #
 
-# Unit tests for the compiler still require boost
-include(BoostMacros)
-REQUIRE_BOOST_HEADERS()
-set(BOOST_COMPONENTS unit_test_framework)
-REQUIRE_BOOST_LIBRARIES(BOOST_COMPONENTS)
-
 file(GLOB KEYWORD_SAMPLES "${CMAKE_CURRENT_SOURCE_DIR}/keyword-samples/*.thrift")
 foreach(LANG ${thrift_compiler_LANGS})
     foreach(SAMPLE ${KEYWORD_SAMPLES})
@@ -33,7 +27,6 @@ foreach(LANG ${thrift_compiler_LANGS})
             PASS_REGULAR_EXPRESSION "Cannot use reserved language keyword")
     endforeach()
 endforeach()
-
 
 find_package(PythonInterp QUIET)
 if(PYTHONINTERP_FOUND)

--- a/compiler/cpp/test/Makefile.am
+++ b/compiler/cpp/test/Makefile.am
@@ -23,6 +23,5 @@
 
 AUTOMAKE_OPTIONS = subdir-objects serial-tests nostdinc
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) -I$(top_srcdir)/compiler/cpp/src
-AM_LDFLAGS = $(BOOST_LDFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir)/compiler/cpp/src
 AM_CXXFLAGS = -Wall -Wextra -pedantic

--- a/compiler/cpp/test/bincat.sh
+++ b/compiler/cpp/test/bincat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /bin/cat


### PR DESCRIPTION
This is a minor PR that removes the (now deprecated) boost dependency from the tests of Thrift compiler, and removes the (unused) script `bincat.sh`. I'm curious if the CI finds any problems...

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.