### PR TITLE
Rework the consistency between NodeJS and Javascript

### DIFF
--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -284,10 +284,9 @@ Thrift.TProtocolExceptionType = {
 
 Thrift.TProtocolException = function TProtocolException(type, message) {
     Error.call(this);
-    if (Error.captureStackTrace) {
+    if (Error.captureStackTrace !== undefined) {
         Error.captureStackTrace(this, this.constructor);
     }
-
     this.name = this.constructor.name;
     this.type = type;
     this.message = message;

--- a/lib/nodejs/lib/thrift/browser.js
+++ b/lib/nodejs/lib/thrift/browser.js
@@ -18,25 +18,32 @@
  */
 exports.Thrift = require('./thrift');
 
-var xhrConnection = require('./xhr_connection');
-exports.XHRConnection = xhrConnection.XHRConnection;
-exports.createXHRConnection = xhrConnection.createXHRConnection;
-exports.createXHRClient = xhrConnection.createXHRClient;
-
 var wsConnection = require('./ws_connection');
 exports.WSConnection = wsConnection.WSConnection;
 exports.createWSConnection = wsConnection.createWSConnection;
 exports.createWSClient = wsConnection.createWSClient;
 
-exports.Multiplexer = require('./multiplexed_protocol').Multiplexer;
+var xhrConnection = require('./xhr_connection');
+exports.XHRConnection = xhrConnection.XHRConnection;
+exports.createXHRConnection = xhrConnection.createXHRConnection;
+exports.createXHRClient = xhrConnection.createXHRClient;
 
-exports.TWebSocketTransport = require('./ws_transport');
-exports.TBufferedTransport = require('./buffered_transport');
-exports.TFramedTransport = require('./framed_transport');
-
-exports.Protocol = exports.TJSONProtocol = require('./json_protocol');
-exports.TBinaryProtocol = require('./binary_protocol');
-exports.TCompactProtocol = require('./compact_protocol');
 
 exports.Int64 = require('node-int64');
 exports.Q = require('q');
+
+var mpxProtocol = require('./multiplexed_protocol');
+exports.Multiplexer = mpxProtocol.Multiplexer;
+
+/*
+ * Export transport and protocol so they can be used outside of a
+ * cassandra/server context
+ */
+exports.TBufferedTransport = require('./buffered_transport');
+exports.TFramedTransport = require('./framed_transport');
+exports.TWebSocketTransport = require('./ws_transport');
+
+exports.Protocol = require('./json_protocol');
+exports.TJSONProtocol = require('./json_protocol');
+exports.TBinaryProtocol = require('./binary_protocol');
+exports.TCompactProtocol = require('./compact_protocol');

--- a/lib/nodejs/lib/thrift/header_protocol.js
+++ b/lib/nodejs/lib/thrift/header_protocol.js
@@ -29,10 +29,9 @@ module.exports = THeaderProtocol;
 
 function THeaderProtocolError(message) {
   Error.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
-
   this.name = this.constructor.name;
   this.message = message;
 }

--- a/lib/nodejs/lib/thrift/header_transport.js
+++ b/lib/nodejs/lib/thrift/header_transport.js
@@ -24,10 +24,9 @@ var InputBufferUnderrunError = require('./input_buffer_underrun_error');
 
 function THeaderTransportError(message) {
   Error.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
-
   this.name = this.constructor.name;
   this.message = message;
 }

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -217,7 +217,7 @@ HttpConnection.prototype.write = function(data) {
   var opts = self.nodeOptions;
   opts.headers["Content-length"] = data.length;
   if (!opts.headers["Content-Type"])
-    opts.headers["Content-Type"] = "application/x-thrift";  
+    opts.headers["Content-Type"] = "application/x-thrift";
   var req = (self.https) ?
       https.request(opts, self.responseCallback) :
       http.request(opts, self.responseCallback);
@@ -253,7 +253,7 @@ exports.createHttpClient = createClient
 
 function THTTPException(response) {
   thrift.TApplicationException.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
 

--- a/lib/nodejs/lib/thrift/index.js
+++ b/lib/nodejs/lib/thrift/index.js
@@ -58,18 +58,19 @@ exports.createWebServer = web_server.createWebServer;
 exports.Int64 = require('node-int64');
 exports.Q = require('q');
 
-var mprocessor = require('./multiplexed_processor');
-var mprotocol = require('./multiplexed_protocol');
-exports.Multiplexer = mprotocol.Multiplexer;
-exports.MultiplexedProcessor = mprocessor.MultiplexedProcessor;
+var mpxProcessor = require('./multiplexed_processor');
+var mpxProtocol = require('./multiplexed_protocol');
+exports.MultiplexedProcessor = mpxProcessor.MultiplexedProcessor;
+exports.Multiplexer = mpxProtocol.Multiplexer;
 
 /*
  * Export transport and protocol so they can be used outside of a
  * cassandra/server context
  */
-exports.TFramedTransport = require('./framed_transport');
 exports.TBufferedTransport = require('./buffered_transport');
-exports.TBinaryProtocol = require('./binary_protocol');
+exports.TFramedTransport = require('./framed_transport');
+
 exports.TJSONProtocol = require('./json_protocol');
+exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
 exports.THeaderProtocol = require('./header_protocol');

--- a/lib/nodejs/lib/thrift/input_buffer_underrun_error.js
+++ b/lib/nodejs/lib/thrift/input_buffer_underrun_error.js
@@ -22,10 +22,9 @@ module.exports = InputBufferUnderrunError;
 
 function InputBufferUnderrunError(message) {
   Error.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
-
   this.name = this.constructor.name;
   this.message = message;
 };

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -49,7 +49,7 @@ exports.TException = TException;
 
 function TException(message) {
   Error.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
 
@@ -76,7 +76,7 @@ exports.TApplicationException = TApplicationException;
 
 function TApplicationException(type, message) {
   TException.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
 
@@ -155,7 +155,7 @@ exports.TProtocolException = TProtocolException;
 
 function TProtocolException(type, message) {
   Error.call(this);
-  if (Error.captureStackTrace) {
+  if (Error.captureStackTrace !== undefined) {
     Error.captureStackTrace(this, this.constructor);
   }
 


### PR DESCRIPTION
The Thrift implementations for NodeJS and Javascript seem to have come from the same origins, and the code shares a strong resemblance. However it seems the implementations have deviated over time. The differences I could identify in this PR are mostly harmless minor syntax differences. I've also identified a number of issues where exports have been inconsistent. So the overall user experience and the maintainability should be significantly improved by this PR.

This PR contains a second, related commit. The property `Error.captureStackTrace` exists only in Node and can not be used in the browser implementation (via webpack or browserify). Therefore it must be qualified with existence checks. This is a trivial change that should not do any harm.

But in any case, it may be good if someone reviews this carefully with a second pair of eyes.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.