### PR TITLE
Allow wrapping TTransportFactory into a TZlibTransportFactory

### DIFF
--- a/lib/cpp/src/thrift/transport/TZlibTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.cpp
@@ -397,6 +397,18 @@ void TZlibTransport::verifyChecksum() {
                             "verifyChecksum() called before end of "
                             "zlib stream");
 }
+
+TZlibTransportFactory::TZlibTransportFactory(std::shared_ptr<TTransportFactory> transportFactory)
+  :transportFactory_(transportFactory) {
+}
+
+std::shared_ptr<TTransport> TZlibTransportFactory::getTransport(std::shared_ptr<TTransport> trans) {
+  if (transportFactory_) {
+    return std::shared_ptr<TTransport>(new TZlibTransport(transportFactory_->getTransport(trans)));
+  } else {
+    return std::shared_ptr<TTransport>(new TZlibTransport(trans));
+  }
+}
 }
 }
 } // apache::thrift::transport

--- a/lib/cpp/src/thrift/transport/TZlibTransport.h
+++ b/lib/cpp/src/thrift/transport/TZlibTransport.h
@@ -229,12 +229,19 @@ class TZlibTransportFactory : public TTransportFactory {
 public:
   TZlibTransportFactory() = default;
 
+  /**
+   * Wraps a transport factory into a zlibbed one.
+   */
+  TZlibTransportFactory(std::shared_ptr<TTransportFactory> transportFactory);
+
   ~TZlibTransportFactory() override = default;
 
-  std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> trans) override {
-    return std::shared_ptr<TTransport>(new TZlibTransport(trans));
-  }
+  std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> trans) override;
+
+protected:
+  std::shared_ptr<TTransportFactory> transportFactory_;
 };
+
 }
 }
 } // apache::thrift::transport

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -735,8 +735,8 @@ int main(int argc, char** argv) {
   }
 
   if (zlib) {
-    // hmm.. doesn't seem to be a way to make it wrap the others...
-    transportFactory = std::make_shared<TZlibTransportFactory>();
+    // currently TZlibTransportFactory is the only factory than can wrap another:
+    transportFactory = std::make_shared<TZlibTransportFactory>(transportFactory);
   }
 
   // Server Info
@@ -816,7 +816,7 @@ int main(int argc, char** argv) {
       // if using header
       server->setOutputProtocolFactory(std::shared_ptr<TProtocolFactory>());
     }
-    
+
     apache::thrift::concurrency::ThreadFactory factory;
     factory.setDetached(false);
     std::shared_ptr<apache::thrift::concurrency::Runnable> serverThreadRunner(server);
@@ -829,7 +829,7 @@ int main(int argc, char** argv) {
 
     thread->start();
     gMonitor.waitForever();         // wait for a shutdown signal
-    
+
 #ifdef HAVE_SIGNAL_H
     signal(SIGINT, SIG_DFL);
 #endif
@@ -842,4 +842,3 @@ int main(int argc, char** argv) {
   cout << "done." << endl;
   return 0;
 }
-


### PR DESCRIPTION
This PR adds wrapping to the TZlibTransportFactory. This is very helpful so that servers can create their "normal" transport factory like before, then wrap it into a TZlibTransportFactory.

This makes the server code very consistent with the client code. It has also been a frequent request, and the lack of this wrapping was explicitly commented in `TestClient.cpp`.

I've used the wrapped TZlibTransportFactory with a large number of transports and protocols on multiple platforms successfully. Also, a similar wrapper was added recently for Go in https://issues.apache.org/jira/browse/THRIFT-4346.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.