### PR TITLE
THRIFT-5184: Fix Connection header check for Firefox when establishing a WebSocket connection.

### DIFF
--- a/lib/d/src/thrift/transport/websocket.d
+++ b/lib/d/src/thrift/transport/websocket.d
@@ -121,7 +121,7 @@ protected:
       upgrade_ = sicmp(upgrade, "websocket") == 0;
     } else if (startsWith!compToLower(split[0], cast(ubyte[])"connection")) {
       auto connection = stripLeft(cast(const(char)[])split[2]);
-      connection_ = sicmp(connection, "upgrade") == 0;
+      connection_ = canFind(connection.toLower, "upgrade");
     } else if (startsWith!compToLower(split[0], cast(ubyte[])"sec-websocket-key")) {
       auto secWebSocketKey = stripLeft(cast(const(char)[])split[2]);
       auto hash = sha1Of(secWebSocketKey ~ WEBSOCKET_GUID);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When establishing a WebSocket connection, Firefox sends Connection: keep-alive, Upgrade instead of just Connection: Upgrade. Check to see if Upgrade is in the header instead of checking to see if it is the entire header value.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
