### PR TITLE
THRIFT-5186: Don't pass AI_ADDRCONFIG to getaddrinfo()

### DIFF
--- a/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerSocket.cpp
@@ -191,7 +191,7 @@ void TNonblockingServerSocket::listen() {
   std::memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
-  hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+  hints.ai_flags = AI_PASSIVE;
 
   // If address is not specified use wildcard address (NULL)
   TGetAddrInfoWrapper info(address_.empty() ? nullptr : &address_[0], port, &hints);

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -270,7 +270,7 @@ void TServerSocket::listen() {
   std::memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
-  hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+  hints.ai_flags = AI_PASSIVE;
 
   // If address is not specified use wildcard address (NULL)
   TGetAddrInfoWrapper info(address_.empty() ? nullptr : &address_[0], port, &hints);

--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -465,12 +465,16 @@ void TSocket::local_open() {
 
   error = getaddrinfo(host_.c_str(), port, &hints, &res0);
 
+  if (
 #ifdef _WIN32
-  if (error == WSANO_DATA) {
+      error == WSANO_DATA
+#else
+      error == EAI_NODATA
+#endif
+    ) {
     hints.ai_flags &= ~AI_ADDRCONFIG;
     error = getaddrinfo(host_.c_str(), port, &hints, &res0);
   }
-#endif
 
   if (error) {
     string errStr = "TSocket::open() getaddrinfo() " + getSocketInfo()

--- a/lib/delphi/src/Thrift.Socket.pas
+++ b/lib/delphi/src/Thrift.Socket.pas
@@ -575,7 +575,7 @@ begin
   FillChar(Hints, SizeOf(Hints), 0);
   Hints.ai_family := PF_UNSPEC;
   Hints.ai_socktype := SOCK_STREAM;
-  Hints.ai_flags := AI_PASSIVE or AI_ADDRCONFIG;
+  Hints.ai_flags := AI_PASSIVE;
   StrFmt(ThePort, '%d', [FPort]);
 
   Result := TGetAddrInfoWrapper.Create(AAddress, ThePort, @Hints);

--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -39,7 +39,7 @@ class TSocketBase(TTransportBase):
                                       self._socket_family,
                                       socket.SOCK_STREAM,
                                       0,
-                                      socket.AI_PASSIVE | socket.AI_ADDRCONFIG)
+                                      socket.AI_PASSIVE)
 
     def close(self):
         if self.handle:


### PR DESCRIPTION
Hi!

Please see the [Jira issue][THRIFT-5186] for rationale. Basically, this patch enables Thrift clients & servers to continue working in "offline mode" — when only the loopback interace `lo` (127.0.0.1) is available, nothing more.

With Thrift 0.13.0 on POSIX, C++ and Python clients/servers **crash with exception** in those conditions.

This patch is used internally in our team, to compile a *vendored* version of Thrift. We'd like to contribute this patch upstream, to relieve ourselves from the maintenance burden of vendoring.

Code review, comments, suggestions welcome!

[THRIFT-5186]: https://issues.apache.org/jira/browse/THRIFT-5186

NB: no attempt was made to cover this patch with tests. Suggestions on how to simulate "no network" environment in the test suite would be highly appreciated.

------------------------------------------------------------------------------------------

- [x] Did you create an Apache Jira ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?