### PR TITLE
THRIFT-5190: StringUtils haven't take `(offset + length) > bytes.length` into account

### DIFF
--- a/lib/java/src/org/apache/thrift/utils/StringUtils.java
+++ b/lib/java/src/org/apache/thrift/utils/StringUtils.java
@@ -55,6 +55,9 @@ public final class StringUtils {
     if (offset < 0) {
       throw new IndexOutOfBoundsException("Negative start offset " + offset);
     }
+    if (length > bytes.length - offset) {
+      throw new IndexOutOfBoundsException("Invalid range, bytes.length: " + bytes.length + " offset: " + offset + " length: " + length);
+    }
     char[] chars = new char[length * 2];
     for (int i = 0; i < length; i++) {
       int unsignedInt = bytes[i + offset] & 0xFF;

--- a/lib/java/test/org/apache/thrift/utils/TestStringUtils.java
+++ b/lib/java/test/org/apache/thrift/utils/TestStringUtils.java
@@ -20,6 +20,7 @@
 package org.apache.thrift.utils;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestStringUtils {
@@ -31,4 +32,28 @@ public class TestStringUtils {
     Assert.assertEquals("EFAB92", StringUtils.bytesToHexString(bytes, 2, 3));
     Assert.assertNull(StringUtils.bytesToHexString(null));
   }
+
+
+  private byte[] bytes;
+
+  @Before
+  public void setUp() throws Exception {
+    bytes = new byte[]{1, 2, 3, 4, 5};
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeLength() {
+    StringUtils.bytesToHexString(bytes, 0, -1);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testNegativeStartOffset() {
+    StringUtils.bytesToHexString(bytes, -1, 1);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testInvalidRange() {
+    StringUtils.bytesToHexString(bytes, 5, 1);
+  }
+
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  

1. StringUtils haven't take `(offset + length) > bytes.length` into account;

2. `if ((offset | length | (offset + length) | (size - (offset + length))) < 0)` will faster than `>`

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x]  [Apache Jira-THRIFT-5190](https://issues.apache.org/jira/browse/THRIFT-5190) 
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
