### PR TITLE
THRIFT-5164: Add middleware framework for Go clients

### DIFF
--- a/lib/go/thrift/example_client_middleware_test.go
+++ b/lib/go/thrift/example_client_middleware_test.go
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package thrift
+
+import (
+	"context"
+	"log"
+)
+
+// BEGIN THRIFT GENERATED CODE SECTION
+//
+// In real code this section should be from thrift generated code instead,
+// but for this example we just define some placeholders here.
+
+type MyEndpointRequest struct{}
+
+type MyEndpointResponse struct{}
+
+type MyService interface {
+	MyEndpoint(ctx context.Context, req *MyEndpointRequest) (*MyEndpointResponse, error)
+}
+
+func NewMyServiceClient(_ TClient) MyService {
+	// In real code this certainly won't return nil.
+	return nil
+}
+
+// END THRIFT GENERATED CODE SECTION
+
+func simpleClientLoggingMiddleware(next TClient) TClient {
+	return WrappedTClient{
+		Wrapped: func(ctx context.Context, method string, args, result TStruct) error {
+			log.Printf("Before: %q", method)
+			log.Printf("Args: %#v", args)
+			err := next.Call(ctx, method, args, result)
+			log.Printf("After: %q", method)
+			log.Printf("Result: %#v", result)
+			if err != nil {
+				log.Printf("Error: %v", err)
+			}
+			return err
+		},
+	}
+}
+
+func ExampleClientMiddleware() {
+	var (
+		trans        TTransport
+		protoFactory TProtocolFactory
+	)
+	var client TClient
+	client = NewTStandardClient(
+		protoFactory.GetProtocol(trans),
+		protoFactory.GetProtocol(trans),
+	)
+	client = WrapClient(client, simpleClientLoggingMiddleware)
+	myServiceClient := NewMyServiceClient(client)
+	myServiceClient.MyEndpoint(context.Background(), &MyEndpointRequest{})
+}

--- a/lib/go/thrift/example_processor_middleware_test.go
+++ b/lib/go/thrift/example_processor_middleware_test.go
@@ -24,7 +24,7 @@ import (
 	"log"
 )
 
-func simpleLoggingMiddleware(name string, next TProcessorFunction) TProcessorFunction {
+func simpleProcessorLoggingMiddleware(name string, next TProcessorFunction) TProcessorFunction {
 	return WrappedTProcessorFunction{
 		Wrapped: func(ctx context.Context, seqId int32, in, out TProtocol) (bool, TException) {
 			log.Printf("Before: %q", name)
@@ -46,7 +46,7 @@ func ExampleProcessorMiddleware() {
 		transFactory TTransportFactory
 		protoFactory TProtocolFactory
 	)
-	processor = WrapProcessor(processor, simpleLoggingMiddleware)
+	processor = WrapProcessor(processor, simpleProcessorLoggingMiddleware)
 	server := NewTSimpleServer4(processor, trans, transFactory, protoFactory)
 	log.Fatal(server.Serve())
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This commit adds a simple middleware framework for Go clients.

It provides:

 * A `ClientMiddleware` function interface used to define the actual middleware
 * `WrapClient`, the function that you use to wrap a `TClient` in a list of middleware
 * A helper `WrappedTClient` struct to help with developing middleware

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
