### PR TITLE
THRIFT-5187: Added Win32 support for domain sockets (AF_UNIX)

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -21,6 +21,9 @@ include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
+include(CheckStructHasMember)
+include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
 
 if (Inttypes_FOUND)
   # This allows the inttypes.h and stdint.h checks to succeed on platforms that
@@ -52,14 +55,24 @@ check_include_file(sched.h HAVE_SCHED_H)
 check_include_file(string.h HAVE_STRING_H)
 check_include_file(strings.h HAVE_STRINGS_H)
 
+check_cxx_source_compiles(
+  "
+  #define WIN32_LEAN_AND_MEAN
+  #include <windows.h>
+  #include <winsock2.h>
+  #include <afunix.h>
+  int main(){(void)sizeof(((struct sockaddr_un *)0)->sun_path); return 0;}
+  "
+  HAVE_AF_UNIX_H)
+#check_struct_has_member("struct sockaddr_un" sun_path "afunix.h" HAVE_AF_UNIX_H LANGUAGE CXX)
+
+
 check_function_exists(gethostbyname HAVE_GETHOSTBYNAME)
 check_function_exists(gethostbyname_r HAVE_GETHOSTBYNAME_R)
 check_function_exists(strerror_r HAVE_STRERROR_R)
 check_function_exists(sched_get_priority_max HAVE_SCHED_GET_PRIORITY_MAX)
 check_function_exists(sched_get_priority_min HAVE_SCHED_GET_PRIORITY_MIN)
 
-include(CheckCSourceCompiles)
-include(CheckCXXSourceCompiles)
 
 check_cxx_source_compiles(
   "

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -131,7 +131,10 @@
 #cmakedefine HAVE_SCHED_H 1
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <afunix.h> header file. */
+#cmakedefine HAVE_AF_UNIX_H 1
 
 /*************************** FUNCTIONS ***************************/
 

--- a/lib/cpp/src/thrift/thrift-config.h
+++ b/lib/cpp/src/thrift/thrift-config.h
@@ -19,6 +19,5 @@
 
 #ifdef _WIN32
 #include <thrift/windows/config.h>
-#else
-#include <thrift/config.h>
 #endif
+#include <thrift/config.h>

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -68,6 +68,8 @@ public:
    * Note that this does NOT actually connect the socket.
    *
    * @param path The Unix domain socket e.g. "/tmp/ThriftTest.binary.thrift"
+   * or a zero-prefixed string to create an abstract domain socket on Linux
+   * and Windows 10.
    */
   TSocket(const std::string& path);
 
@@ -150,6 +152,13 @@ public:
   int getPort();
 
   /**
+   * Get the Unix domain socket path that the socket is connected to
+   *
+   * @return std::string path
+   */
+  std::string getPath();
+
+  /**
    * Set the host that socket will connect to
    *
    * @param host host identifier
@@ -162,6 +171,13 @@ public:
    * @param port port number
    */
   void setPort(int port);
+
+  /**
+   * Set the Unix domain socket path for the socket
+   *
+   * @param path std::string path
+   */
+  void setPath(std::string path);
 
   /**
    * Controls whether the linger option is set on the socket.


### PR DESCRIPTION
This PR adds support for domain sockets for Windows.

In order to implement this change I've changed a basic property of C++ build configuration for Windows. This would not be strictly required but is quite helpful. Domain sockets are only available on recent versions of the Windows platform SDK. Therefore I've enabled the automatic configuration of `config.h` with cmake. I've checked the results and on my platform(s) the generated config header is sensible and matches the hard-coded default. However this change is not easily portable to autotools.

During the implementation I found a number of minor issues in TServerSocket and TSocket that I believe are improved in this PR. None of these changes should be a breaking change. Mostly some methods should not be called on a domain socket and have been excluded. Also, the variable `listening_` was set to `true` at the beginning of the `listen()` method but I found that this opens a small time window where `listening_` is true but the socket is not actually listening (yet).

Please review and let me know if there is anything to discuss?

I've tested this implementation successfully on MSVC 2017 and 2019, on Ubuntu 18.04 x86_64 and on MacOS 14 with XCode 11.3.

- [x] I created Apache Jira Ticket https://issues.apache.org/jira/browse/THRIFT-5187
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.
