### PR TITLE
THRIFT-5164: Small cleanup on the example code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 
 - [THRIFT-5069](https://issues.apache.org/jira/browse/THRIFT-5069) - Add TSerializerPool and TDeserializerPool, which are thread-safe versions of TSerializer and TDeserializer.
 - [THRIFT-5164](https://issues.apache.org/jira/browse/THRIFT-5164) - Add ProcessorMiddleware function type and WrapProcessor function to support wrapping a TProcessor with middleware functions.
+- [THRIFT-5164](https://issues.apache.org/jira/browse/THRIFT-5164) - Add ClientMiddleware function type and WrapClient function to support wrapping a TClient with middleware functions.
 
 ## 0.13.0
 

--- a/lib/go/thrift/example_client_middleware_test.go
+++ b/lib/go/thrift/example_client_middleware_test.go
@@ -59,6 +59,8 @@ func simpleClientLoggingMiddleware(next TClient) TClient {
 	}
 }
 
+// This example demonstrates how to define and use a simple logging middleware
+// to your thrift client.
 func ExampleClientMiddleware() {
 	var (
 		trans        TTransport

--- a/lib/go/thrift/example_processor_middleware_test.go
+++ b/lib/go/thrift/example_processor_middleware_test.go
@@ -24,7 +24,7 @@ import (
 	"log"
 )
 
-func simpleProcessorLoggingMiddleware(name string, next TProcessorFunction) TProcessorFunction {
+func SimpleProcessorLoggingMiddleware(name string, next TProcessorFunction) TProcessorFunction {
 	return WrappedTProcessorFunction{
 		Wrapped: func(ctx context.Context, seqId int32, in, out TProtocol) (bool, TException) {
 			log.Printf("Before: %q", name)
@@ -39,6 +39,8 @@ func simpleProcessorLoggingMiddleware(name string, next TProcessorFunction) TPro
 	}
 }
 
+// This example demonstrates how to define and use a simple logging middleware
+// to your thrift server/processor.
 func ExampleProcessorMiddleware() {
 	var (
 		processor    TProcessor
@@ -46,7 +48,7 @@ func ExampleProcessorMiddleware() {
 		transFactory TTransportFactory
 		protoFactory TProtocolFactory
 	)
-	processor = WrapProcessor(processor, simpleProcessorLoggingMiddleware)
+	processor = WrapProcessor(processor, SimpleProcessorLoggingMiddleware)
 	server := NewTSimpleServer4(processor, trans, transFactory, protoFactory)
 	log.Fatal(server.Serve())
 }


### PR DESCRIPTION
Client: go

Godoc requires at least one other exported type/function to render the
whole example file in the example, so export
simpleProcessorLoggingMiddleware to make the example of
ProcessorMiddleware more helpful.

Currently it's rendered in a not very helpful way:
https://pkg.go.dev/github.com/apache/thrift@v0.13.1-0.20200430141240-5cffef964a08/lib/go/thrift?tab=doc#example-ProcessorMiddleware

Compare to the client middleware example rendering:
https://pkg.go.dev/github.com/apache/thrift@v0.13.1-0.20200430141240-5cffef964a08/lib/go/thrift?tab=doc#example-ClientMiddleware

While I'm here, also update CHANGES.md to mention ClientMiddleware.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

[skip ci]