### PR TITLE
THRIFT-5199: Fix infinite loop writing to closed TSocket in PHP

### DIFF
--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -328,7 +328,8 @@ class TSocket extends TTransport
             if ($writable > 0) {
                 // write buffer to stream
                 $written = fwrite($this->handle_, $buf);
-                if ($written === -1 || $written === false) {
+                $closed_socket = $written === 0 && feof($this->handle_);
+                if ($written === -1 || $written === false || $closed_socket) {
                     throw new TTransportException(
                         'TSocket: Could not write ' . TStringFuncFactory::create()->strlen($buf) . ' bytes ' .
                         $this->host_ . ':' . $this->port_


### PR DESCRIPTION
Client: php

<!-- Explain the changes in the pull request below: -->
When you call fwrite in PHP with a handle that has been closed by peer the function will return 0 bytes written (rather than false to indicate an error).

This causes an infinite loop today because the code assumes 0 only means a temporary failure to write, rather than a permanent one. 

This change adds a check to for a closed socket when 0 bytes are written

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ X] Did you squash your changes to a single commit?  (not required, but preferred)
- [ X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
