### PR TITLE
THRIFT-3622: Fix deprecated uses of std::auto_ptr

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -2199,7 +2199,7 @@ void t_cpp_generator::generate_service_async_skeleton(t_service* tservice) {
              << "public " << svcname << "CobSvIf {" << endl << " public:" << endl;
   indent_up();
   f_skeleton << indent() << svcname << "AsyncHandler() {" << endl << indent()
-             << "  syncHandler_ = std::auto_ptr<" << svcname << "Handler>(new " << svcname
+             << "  syncHandler_ = std::unique_ptr<" << svcname << "Handler>(new " << svcname
              << "Handler);" << endl << indent() << "  // Your initialization goes here" << endl
              << indent() << "}" << endl;
   f_skeleton << indent() << "virtual ~" << service_name_ << "AsyncHandler();" << endl;
@@ -2223,7 +2223,7 @@ void t_cpp_generator::generate_service_async_skeleton(t_service* tservice) {
 
     scope_down(f_skeleton);
   }
-  f_skeleton << endl << " protected:" << endl << indent() << "std::auto_ptr<" << svcname
+  f_skeleton << endl << " protected:" << endl << indent() << "std::unique_ptr<" << svcname
              << "Handler> syncHandler_;" << endl;
   indent_down();
   f_skeleton << "};" << endl << endl;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This PR complete fix THRIFT-3622.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
