### PR TITLE
TSocketTransport.cs: Fixed a problem with initializing IPAddress

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/TSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TSocketTransport.cs
@@ -58,8 +58,7 @@ namespace Thrift.Transport.Client
                 if (entry.AddressList.Length == 0)
                     throw new TTransportException(TTransportException.ExceptionType.Unknown, "unable to resolve host name");
 
-                var addr = entry.AddressList[0];
-                Host = new IPAddress(addr.GetAddressBytes(), addr.ScopeId);
+                Host = entry.AddressList[0];
                 Port = port;
 
                 TcpClient = new TcpClient(host, port);


### PR DESCRIPTION
This PR adds a minor change to finding the host IP address in netstd. The previous code did not work for me:
```c#
Host = new IPAddress(addr.GetAddressBytes(), addr.ScopeId);
```
However I'm under the impression that the IP address can be used as is?
```c#
Host = entry.AddressList[0];
```
Please review and suggest any changes.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.