### PR TITLE
CMake: Added better dependency tracking for external build tools

### DIFF
--- a/lib/java/CMakeLists.txt
+++ b/lib/java/CMakeLists.txt
@@ -48,19 +48,25 @@ else()
         set(PRELEASE "false")
     endif ()
 
-    add_custom_target(ThriftJava ALL
+    file(GLOB_RECURSE THRIFTJAVA_SOURCES LIST_DIRECTORIES false
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/build/libs/libthrift.jar"
         COMMENT "Building Java library using Gradle Wrapper"
         COMMAND ${GRADLEW_EXECUTABLE} ${GRADLE_OPTS} assemble
             --console=plain --no-daemon
             -Prelease=${PRELEASE}
             -Pthrift.version=${thrift_VERSION}
             "-Pbuild.dir=${CMAKE_CURRENT_BINARY_DIR}/build"
+        DEPENDS ${THRIFTJAVA_SOURCES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+    add_custom_target(ThriftJava ALL
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/build/libs/libthrift.jar")
 
     # Enable publishing from CMake if the publishing information is provided
     add_custom_target(MavenPublish
         COMMENT "Publishing Java Library to Apache Maven staging"
+        DEPENDS ThriftJava
         COMMAND ${GRADLEW_EXECUTABLE} ${GRADLE_OPTS} clean uploadArchives
             --console=plain --no-daemon
             -Prelease=${PRELEASE}
@@ -83,13 +89,13 @@ else()
 
     if(BUILD_TESTING)
         add_test(NAME JavaTest
-                COMMAND ${GRADLEW_EXECUTABLE} ${GRADLE_OPTS} test
-                    --console=plain --no-daemon
-                    -Prelease=${PRELEASE}
-                    -Pthrift.version=${thrift_VERSION}
-                    "-Pbuild.dir=${CMAKE_CURRENT_BINARY_DIR}/build"
-                    "-Pthrift.compiler=${THRIFT_COMPILER}"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            COMMAND ${GRADLEW_EXECUTABLE} ${GRADLE_OPTS} test
+                --console=plain --no-daemon
+                -Prelease=${PRELEASE}
+                -Pthrift.version=${thrift_VERSION}
+                "-Pbuild.dir=${CMAKE_CURRENT_BINARY_DIR}/build"
+                "-Pthrift.compiler=${THRIFT_COMPILER}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 
 endif()

--- a/lib/js/CMakeLists.txt
+++ b/lib/js/CMakeLists.txt
@@ -38,12 +38,17 @@ add_custom_target(ThriftJavascriptPreDeps ALL
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
-add_custom_target(ThriftJavascript ALL
+file(GLOB_RECURSE THRIFTJAVASCRIPT_SOURCES LIST_DIRECTORIES false
+    "${CMAKE_CURRENT_SOURCE_DIR}/*")
+list(FILTER THRIFTJAVASCRIPT_SOURCES EXCLUDE REGEX ".*/(dist|doc)/.*")
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/dist/thrift.js"
     COMMENT "Building Javascript library using npx Grunt wrapper"
-    DEPENDS ThriftJavascriptPreDeps
+    DEPENDS ThriftJavascriptPreDeps ${THRIFTJAVASCRIPT_SOURCES}
     COMMAND npx grunt
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
+add_custom_target(ThriftJavascript ALL
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/dist/thrift.js")
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dist/"
         DESTINATION "${JAVASCRIPT_INSTALL_DIR}"


### PR DESCRIPTION
When building components that use an external build tool (like Java gradle or Javascript grunt), cmake does currently not track if a rebuild is required. This PR creates a cmake-dependency between the sources and the target of these components "Java" and "Javascript". Assuming that all sources are fully contained in their respective component folder, cmake can infer if a require is required (i.e. the target is missing or one or more sources are more current). This drastically reduces build times.

However please be aware that if the dependency between sources and target should *not* be complete for some reason, then cmake may miss to rebuild a component. I could not observe this problem but it may be well advised to carefully check this PR.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
