### PR TITLE
THRIFT-5127: Fix race conditions in TNonblockingServer

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -173,6 +173,9 @@ private:
   // Index of next IO Thread to be used (for round-robin)
   uint32_t nextIOThread_;
 
+  // Synchronizes access to ioThreads_ vector
+  Mutex ioThreadsMutex_;
+
   // Synchronizes access to connection stack and similar data
   Mutex connMutex_;
 


### PR DESCRIPTION
Client: cpp

Several race conditions were present in TNonblockingServer when
TNonblockingServer::stop() method was called concurrently with initialization of
the server (which takes place in TNonblockingServer::serve()).

 1. Thrift server uses a bidirectional pipe to notify its IO threads that they
    should exit.
    The pipe was created in the TNonblockingIOThread::registerEvents() method,
    which is called by the IO thread itself.
    Since the pipe was created _after_ the thread which was supposed to receive
    the message, there was a short time window, when such request could be
    undelivered.
    In that case, the thread would never exit and Thrift could prevent the whole
    application from terminating cleanly.
    To fix this issue, the call to createNotificationPipe() has been moved to
    the constructor of TNonblockingIOThread.
    Breaking change: the TNonblockingIOThread constructor may now throw an
    exception if pipe creation fails. However, the only caller of that
    method (TNonblockingServer::registerEvents()) could already throw due to
    unrelated errors.

 2. Accesses to TNonblockingServer::ioThreads_ vector were unsynchronized.
    In most cases this was irrelevant, because the vector is modified only
    during initialization and destruction of the server.
    However, in one scenario, creation of new threads (which may result in
    reallocation of the vector) could race with iteration over the container in
    TNonblockingServer::stop() method.
    This issue has been fixed by wrapping the code in a critical section.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
