### PR TITLE
Make TTransportException unwrappable on go1.13+

### DIFF
--- a/lib/go/thrift/transport_exception.go
+++ b/lib/go/thrift/transport_exception.go
@@ -60,6 +60,10 @@ func (p *tTransportException) Err() error {
 	return p.err
 }
 
+func (p *tTransportException) Unwrap() error {
+	return p.err
+}
+
 func NewTTransportException(t int, e string) TTransportException {
 	return &tTransportException{typeId: t, err: errors.New(e)}
 }


### PR DESCRIPTION
Client: go

Go 1.13 introduced a new, optional, hidden interface for error
implementations to make them unwrappable [1]. We currently already kind
of support that (via TTransportException.Err), so just add a new
function to make it Go 1.13+ compatible.

I know thrift go library itself hasn't dropped support for pre-go1.13
yet, but this enables users already on go1.13 to do error inspections
more easily.

I didn't implement it for PrependError, because git grep shows that it's
currently only used by test code.

[1] https://pkg.go.dev/errors@go1.13?tab=doc#pkg-overview

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
