### PR TITLE
FIX python CI errors 

### DIFF
--- a/test/crossrunner/compat.py
+++ b/test/crossrunner/compat.py
@@ -8,9 +8,9 @@ if sys.version_info[0] == 2:
         bin_args = map(lambda a: a.decode(_ENCODE), args)
         return os.path.join(*bin_args).encode(_ENCODE)
 
-    def str_join(s, l):
-        bin_args = map(lambda a: a.decode(_ENCODE), l)
-        b = s.decode(_ENCODE)
+    def str_join(left, right):
+        bin_args = map(lambda a: a.decode(_ENCODE), right)
+        b = left.decode(_ENCODE)
         return b.join(bin_args).encode(_ENCODE)
 
     logfile_open = open

--- a/test/py/TestServer.py
+++ b/test/py/TestServer.py
@@ -175,7 +175,7 @@ class TestHandler(object):
 
     def testMulti(self, arg0, arg1, arg2, arg3, arg4, arg5):
         if options.verbose > 1:
-            logging.info('testMulti(%s)' % [arg0, arg1, arg2, arg3, arg4, arg5])
+            logging.info('testMulti(%s, %s, %s, %s, %s, %s)' % (arg0, arg1, arg2, arg3, arg4, arg5))
         return Xtruct(string_thing='Hello2',
                       byte_thing=arg0, i32_thing=arg1, i64_thing=arg2)
 


### PR DESCRIPTION
a) CI error at ./test/py/TestServer.py:178:26: F507 '...' % ... has 1 placeholder(s) but 6 substitution(s)
b) CI error at ./test/crossrunner/compat.py:11:21: E741 ambiguous variable name 'l'

