### PR TITLE
THRIFT-5129: Fix swift TSocketTransport on Mac

### DIFF
--- a/lib/swift/Sources/TSocketTransport.swift
+++ b/lib/swift/Sources/TSocketTransport.swift
@@ -159,7 +159,7 @@ public class TSocketTransport : TTransport {
       var addr = sockaddr_in(sin_len: UInt8(MemoryLayout<sockaddr_in>.size),
                              sin_family: sa_family_t(AF_INET),
                              sin_port: in_port_t(htons(UInt16(port))),
-                             sin_addr: in_addr(s_addr: in_addr_t(0)),
+                             sin_addr: hostAddr,
                              sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
       
     #endif


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 
Fix TSocketTransport of Swift client not working for mac.

Not sure why it was `in_addr_t(0)` in the first place. I tested locally on my mac and the client is working again. Let me know what other changes/clarifications are needed.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
