### PR TITLE
THRIFT-5214: Connectivity check on go's TSocket

### DIFF
--- a/lib/go/thrift/socket_conn.go
+++ b/lib/go/thrift/socket_conn.go
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"bytes"
+	"io"
+	"net"
+)
+
+// socketConn is a wrapped net.Conn that tries to do connectivity check.
+type socketConn struct {
+	net.Conn
+
+	buf bytes.Buffer
+}
+
+var _ net.Conn = (*socketConn)(nil)
+
+// createSocketConnFromReturn is a language sugar to help create socketConn from
+// return values of functions like net.Dial, tls.Dial, net.Listener.Accept, etc.
+func createSocketConnFromReturn(conn net.Conn, err error) (*socketConn, error) {
+	if err != nil {
+		return nil, err
+	}
+	return &socketConn{
+		Conn: conn,
+	}, nil
+}
+
+// wrapSocketConn wraps an existing net.Conn into *socketConn.
+func wrapSocketConn(conn net.Conn) *socketConn {
+	// In case conn is already wrapped,
+	// return it as-is and avoid double wrapping.
+	if sc, ok := conn.(*socketConn); ok {
+		return sc
+	}
+
+	return &socketConn{
+		Conn: conn,
+	}
+}
+
+// isValid checks whether there's a valid connection.
+//
+// It's nil safe, and returns false if sc itself is nil, or if the underlying
+// connection is nil.
+//
+// It's the same as the previous implementation of TSocket.IsOpen and
+// TSSLSocket.IsOpen before we added connectivity check.
+func (sc *socketConn) isValid() bool {
+	return sc != nil && sc.Conn != nil
+}
+
+// IsOpen checks whether the connection is open.
+//
+// It's nil safe, and returns false if sc itself is nil, or if the underlying
+// connection is nil.
+//
+// Otherwise, it tries to do a connectivity check and returns the result.
+func (sc *socketConn) IsOpen() bool {
+	if !sc.isValid() {
+		return false
+	}
+	return sc.checkConn() == nil
+}
+
+// Read implements io.Reader.
+//
+// On Windows, it behaves the same as the underlying net.Conn.Read.
+//
+// On non-Windows, it treats len(p) == 0 as a connectivity check instead of
+// readability check, which means instead of blocking until there's something to
+// read (readability check), or always return (0, nil) (the default behavior of
+// go's stdlib implementation on non-Windows), it never blocks, and will return
+// an error if the connection is lost.
+func (sc *socketConn) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, sc.read0()
+	}
+
+	n, err = sc.buf.Read(p)
+	if err != nil && err != io.EOF {
+		return
+	}
+	if n == len(p) {
+		return n, nil
+	}
+	// Continue reading from the wire.
+	var newRead int
+	newRead, err = sc.Conn.Read(p[n:])
+	n += newRead
+	return
+}

--- a/lib/go/thrift/socket_conn_test.go
+++ b/lib/go/thrift/socket_conn_test.go
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type serverSocketConnCallback func(testing.TB, *socketConn)
+
+func serverSocketConn(tb testing.TB, f serverSocketConnCallback) (net.Listener, error) {
+	tb.Helper()
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		for {
+			sc, err := createSocketConnFromReturn(ln.Accept())
+			if err != nil {
+				// This is usually caused by Listener being
+				// closed, not really an error.
+				return
+			}
+			go f(tb, sc)
+		}
+	}()
+	return ln, nil
+}
+
+func writeFully(tb testing.TB, w io.Writer, s string) bool {
+	tb.Helper()
+
+	n, err := io.Copy(w, strings.NewReader(s))
+	if err != nil {
+		tb.Errorf("Failed to write %q: %v", s, err)
+		return false
+	}
+	if int(n) < len(s) {
+		tb.Errorf("Only wrote %d out of %q", n, s)
+		return false
+	}
+	return true
+}
+
+func TestSocketConn(t *testing.T) {
+	const (
+		interval = time.Millisecond * 10
+		first    = "hello"
+		second   = "world"
+	)
+
+	ln, err := serverSocketConn(
+		t,
+		func(tb testing.TB, sc *socketConn) {
+			defer sc.Close()
+
+			if !writeFully(tb, sc, first) {
+				return
+			}
+			time.Sleep(interval)
+			writeFully(tb, sc, second)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	sc, err := createSocketConnFromReturn(net.Dial("tcp", ln.Addr().String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1024)
+
+	n, err := sc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := string(buf[:n])
+	if read != first {
+		t.Errorf("Expected read %q, got %q", first, read)
+	}
+
+	n, err = sc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read = string(buf[:n])
+	if read != second {
+		t.Errorf("Expected read %q, got %q", second, read)
+	}
+}
+
+func TestSocketConnNilSafe(t *testing.T) {
+	sc := (*socketConn)(nil)
+	if sc.isValid() {
+		t.Error("Expected false for nil.isValid(), got true")
+	}
+	if sc.IsOpen() {
+		t.Error("Expected false for nil.IsOpen(), got true")
+	}
+}

--- a/lib/go/thrift/socket_unix_conn.go
+++ b/lib/go/thrift/socket_unix_conn.go
@@ -1,0 +1,73 @@
+// +build !windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"io"
+	"syscall"
+)
+
+func (sc *socketConn) read0() error {
+	return sc.checkConn()
+}
+
+func (sc *socketConn) checkConn() error {
+	syscallConn, ok := sc.Conn.(syscall.Conn)
+	if !ok {
+		// No way to check, return nil
+		return nil
+	}
+	rc, err := syscallConn.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var n int
+	var buf [1]byte
+
+	if readErr := rc.Read(func(fd uintptr) bool {
+		n, err = syscall.Read(int(fd), buf[:])
+		return true
+	}); readErr != nil {
+		return readErr
+	}
+
+	if err == syscall.EAGAIN || err == syscall.EWOULDBLOCK {
+		// This means the connection is still open but we don't have
+		// anything to read right now.
+		return nil
+	}
+
+	if n > 0 {
+		// We got 1 byte,
+		// put it to sc's buf for the next real read to use.
+		sc.buf.Write(buf[:])
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// At this point, it means the other side already closed the connection.
+	return io.EOF
+}

--- a/lib/go/thrift/socket_unix_conn_test.go
+++ b/lib/go/thrift/socket_unix_conn_test.go
@@ -1,0 +1,105 @@
+// +build !windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestSocketConnUnix(t *testing.T) {
+	const (
+		interval = time.Millisecond * 10
+		first    = "hello"
+		second   = "world"
+	)
+
+	ln, err := serverSocketConn(
+		t,
+		func(tb testing.TB, sc *socketConn) {
+			defer sc.Close()
+
+			time.Sleep(interval)
+			if !writeFully(tb, sc, first) {
+				return
+			}
+			time.Sleep(interval)
+			writeFully(tb, sc, second)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	sc, err := createSocketConnFromReturn(net.Dial("tcp", ln.Addr().String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1024)
+
+	if !sc.IsOpen() {
+		t.Error("Expected sc to report open, got false")
+	}
+	n, err := sc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := string(buf[:n])
+	if read != first {
+		t.Errorf("Expected read %q, got %q", first, read)
+	}
+
+	if !sc.IsOpen() {
+		t.Error("Expected sc to report open, got false")
+	}
+	// Do connection check again twice after server already wrote new data,
+	// make sure we correctly buffered the read bytes
+	time.Sleep(interval * 10)
+	if !sc.IsOpen() {
+		t.Error("Expected sc to report open, got false")
+	}
+	if !sc.IsOpen() {
+		t.Error("Expected sc to report open, got false")
+	}
+	if sc.buf.Len() == 0 {
+		t.Error("Expected sc to buffer read bytes, got empty buffer")
+	}
+	n, err = sc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read = string(buf[:n])
+	if read != second {
+		t.Errorf("Expected read %q, got %q", second, read)
+	}
+
+	// Now it's supposed to be closed on the server side
+	if err := sc.read0(); err != io.EOF {
+		t.Errorf("Expected to get EOF on read0, got %v", err)
+	}
+	if sc.IsOpen() {
+		t.Error("Expected sc to report not open, got true")
+	}
+}

--- a/lib/go/thrift/socket_windows_conn.go
+++ b/lib/go/thrift/socket_windows_conn.go
@@ -1,0 +1,34 @@
+// +build windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+func (sc *socketConn) read0() error {
+	// On windows, we fallback to the default behavior of reading 0 bytes.
+	var p []byte
+	_, err := sc.Conn.Read(p)
+	return err
+}
+
+func (sc *socketConn) checkConn() error {
+	// On windows, we always return nil for this check.
+	return nil
+}


### PR DESCRIPTION
Client: go

Implement connectivity check on go's TSocket and TSSLSocket for
non-Windows systems.

The implementation is inspired by
https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver//

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
