### PR TITLE
THRIFT-5195: Handle Thrift union type sending for Swift

### DIFF
--- a/lib/swift/Sources/TStruct.swift
+++ b/lib/swift/Sources/TStruct.swift
@@ -62,7 +62,7 @@ public extension TStruct {
     for (propName, propValue) in mirror.children {
       guard let propName = propName else { continue }
 
-      if let tval = unwrap(any: propValue) as? TSerializable, let id = Self.fieldIds[propName] {
+      if let tval = unwrap(any: propValue, parent: mirror) as? TSerializable, let id = Self.fieldIds[propName] {
         try block(propName, tval, id)
       }
     }
@@ -78,10 +78,10 @@ public extension TStruct {
   /// - parameter any: Any instance to attempt to unwrap
   ///
   /// - returns: Unwrapped Any as Optional<Any>
-  private func unwrap(any: Any) -> Any? {
+  private func unwrap(any: Any, parent: Mirror) -> Any? {
     let mi = Mirror(reflecting: any)
     
-    if mi.displayStyle != .optional { return any }
+    if parent.displayStyle != .enum && mi.displayStyle != .optional { return any }
     if mi.children.count == 0 { return nil }
     
     let (_, some) = mi.children.first!


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  Swift should handle union type (enum) correctly when packing into a
struct type for sending.
 
 Note that union types are essentially structs with all optionals, so a specific check on the enum parent type is needed to expose the correct union choice/enum during Mirror reflection.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
