### PR TITLE
THRIFT-4987: Fix TBinaryProtocol support in XHRClient

### DIFF
--- a/lib/nodejs/lib/thrift/xhr_connection.js
+++ b/lib/nodejs/lib/thrift/xhr_connection.js
@@ -22,6 +22,7 @@ var thrift = require('./thrift');
 
 var TBufferedTransport = require('./buffered_transport');
 var TJSONProtocol = require('./json_protocol');
+var TBinaryProtocol = require('./binary_protocol');
 var InputBufferUnderrunError = require('./input_buffer_underrun_error');
 
 var createClient = require('./create_client');
@@ -102,13 +103,17 @@ XHRConnection.prototype.flush = function() {
 
   var xreq = this.getXmlHttpRequestObject();
 
+  if (this.protocol == TBinaryProtocol) {
+    xreq.responseType = 'arraybuffer';
+  }
+
   if (xreq.overrideMimeType) {
     xreq.overrideMimeType('application/json');
   }
 
   xreq.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
-      self.setRecvBuffer(this.responseText);
+      self.setRecvBuffer(this.response);
     }
   };
 


### PR DESCRIPTION
Client: nodejs

The XHRClient uses the XMLHttpRequest web api to do requests. To correctly interpret binary data, the `responseType` needs to be set to `arraybuffer`, and the `response` property should be used instead of `responseText` (`response` defaults to normal text when not specified). See [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest).

I'd like to add tests but am unsure what the best practice would be for this with regards to the project testing framework? It would involve bundling the `nodejs` lib into a browser for testing, or perhaps running a headless browser environment in nodejs? I'd be happy to add tests, but would greatly appreciate if someone could point me in the correct direction.

I'm succesfully using this fix with a C++ HTTP server using the binary protocol for my use case.

---
  
- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
