### PR TITLE
THRIFT-5132 Warning in TSocket when using ssl connection

### DIFF
--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -251,8 +251,9 @@ class TSocket extends TTransport
         }
 
         if (function_exists('socket_import_stream') && function_exists('socket_set_option')) {
-            $socket = socket_import_stream($this->handle_);
-            socket_set_option($socket, SOL_TCP, TCP_NODELAY, 1);
+            // warnings silenced due to bug https://bugs.php.net/bug.php?id=70939
+            $socket = @socket_import_stream($this->handle_);
+            @socket_set_option($socket, SOL_TCP, TCP_NODELAY, 1);
         }
     }
 


### PR DESCRIPTION
Warning in TSocket when using ssl connection

When you using ssl host in

new TSocket('ssl://test.com')

you will get a warning

PHP Warning: socket_import_stream(): cannot represent a stream of type tcp_socket/ssl as a Socket Descriptor in /usr/share/php/Thrift/Transport/TSocket.php on line 254

due to the bug https://bugs.php.net/bug.php?id=70939