### PR TITLE
THRIFT-5219: Binding capabilities for client socket

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -64,6 +64,17 @@ public:
   TSocket(const std::string& host, int port);
 
   /**
+   * Constructs a new socket. Note that this does NOT actually connect the
+   * socket.
+   *
+   * @param host An IP address or hostname to connect to
+   * @param port The port to connect on
+   * @param local The local IP address to bind on
+   */
+  TSocket(const std::string& host, int port, const std::string& local);
+
+
+  /**
    * Constructs a new Unix domain socket.
    * Note that this does NOT actually connect the socket.
    *
@@ -150,6 +161,14 @@ public:
   int getPort();
 
   /**
+   * Get the local address that the socket is binded to
+   *
+   * @return string local address identifier
+   */
+  std::string getLocal();
+
+
+  /**
    * Set the host that socket will connect to
    *
    * @param host host identifier
@@ -162,6 +181,20 @@ public:
    * @param port port number
    */
   void setPort(int port);
+
+  /**
+   * Set the local address that socket will bind to
+   *
+   * @param local local address identifier
+   */
+  void setLocal(std::string local);
+
+  /**
+   * Set the local address address family
+   *
+   * @param addressFamily address family
+   */
+  void setLocalAddressFamily(int addressFamily);
 
   /**
    * Controls whether the linger option is set on the socket.
@@ -287,6 +320,12 @@ protected:
 
   /** Port number to connect on */
   int port_;
+
+  /** Local address to bind to */
+  std::string local_;
+
+  /** Local address IP family */
+  int localAddressFamily_;
 
   /** UNIX domain socket path */
   std::string path_;


### PR DESCRIPTION
Client: cpp

In some telco grade applications binding the source address when using a
client socket is a must to ensure strong trust relationship in some
client/server applications.

This patch has been included to provide an overloaded constructor for
TSocket which enables to define explicitly an IP address to bind to
before connecting the socket to a remote host.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [Yes] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [Yes] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [Yes] Did you squash your changes to a single commit?  (not required, but preferred)
- [N/A] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
