### PR TITLE
THRIFT-5224: Deprecated Nodejs Buffer()

### DIFF
--- a/lib/nodejs/lib/thrift/binary_protocol.js
+++ b/lib/nodejs/lib/thrift/binary_protocol.js
@@ -127,15 +127,15 @@ TBinaryProtocol.prototype.writeBool = function(bool) {
 };
 
 TBinaryProtocol.prototype.writeByte = function(b) {
-  this.trans.write(new Buffer([b]));
+  this.trans.write(Buffer.from([b]));
 };
 
 TBinaryProtocol.prototype.writeI16 = function(i16) {
-  this.trans.write(binary.writeI16(new Buffer(2), i16));
+  this.trans.write(binary.writeI16(Buffer.alloc(2), i16));
 };
 
 TBinaryProtocol.prototype.writeI32 = function(i32) {
-  this.trans.write(binary.writeI32(new Buffer(4), i32));
+  this.trans.write(binary.writeI32(Buffer.alloc(4), i32));
 };
 
 TBinaryProtocol.prototype.writeI64 = function(i64) {
@@ -147,13 +147,13 @@ TBinaryProtocol.prototype.writeI64 = function(i64) {
 };
 
 TBinaryProtocol.prototype.writeDouble = function(dub) {
-  this.trans.write(binary.writeDouble(new Buffer(8), dub));
+  this.trans.write(binary.writeDouble(Buffer.alloc(8), dub));
 };
 
 TBinaryProtocol.prototype.writeStringOrBinary = function(name, encoding, arg) {
   if (typeof(arg) === 'string') {
     this.writeI32(Buffer.byteLength(arg, encoding));
-    this.trans.write(new Buffer(arg, encoding));
+    this.trans.write(Buffer.from(arg, encoding));
   } else if ((arg instanceof Buffer) ||
              (Object.prototype.toString.call(arg) == '[object Uint8Array]')) {
     // Buffers in Node.js under Browserify may extend UInt8Array instead of
@@ -279,7 +279,7 @@ TBinaryProtocol.prototype.readDouble = function() {
 TBinaryProtocol.prototype.readBinary = function() {
   var len = this.readI32();
   if (len === 0) {
-    return new Buffer(0);
+    return Buffer.alloc(0);
   }
 
   if (len < 0) {

--- a/lib/nodejs/lib/thrift/buffered_transport.js
+++ b/lib/nodejs/lib/thrift/buffered_transport.js
@@ -26,7 +26,7 @@ module.exports = TBufferedTransport;
 function TBufferedTransport(buffer, callback) {
   this.defaultReadBufferSize = 1024;
   this.writeBufferSize = 512; // Soft Limit
-  this.inBuf = new Buffer(this.defaultReadBufferSize);
+  this.inBuf = Buffer.alloc(this.defaultReadBufferSize);
   this.readCursor = 0;
   this.writeCursor = 0; // for input buffer
   this.outBuffers = [];
@@ -37,7 +37,7 @@ function TBufferedTransport(buffer, callback) {
 TBufferedTransport.prototype = new THeaderTransport();
 
 TBufferedTransport.prototype.reset = function() {
-  this.inBuf = new Buffer(this.defaultReadBufferSize);
+  this.inBuf = Buffer.alloc(this.defaultReadBufferSize);
   this.readCursor = 0;
   this.writeCursor = 0;
   this.outBuffers = [];
@@ -49,7 +49,7 @@ TBufferedTransport.receiver = function(callback, seqid) {
 
   return function(data) {
     if (reader.writeCursor + data.length > reader.inBuf.length) {
-      var buf = new Buffer(reader.writeCursor + data.length);
+      var buf = Buffer.alloc(reader.writeCursor + data.length);
       reader.inBuf.copy(buf, 0, 0, reader.writeCursor);
       reader.inBuf = buf;
     }
@@ -65,7 +65,7 @@ TBufferedTransport.prototype.commitPosition = function(){
   var unreadSize = this.writeCursor - this.readCursor;
   var bufSize = (unreadSize * 2 > this.defaultReadBufferSize) ?
     unreadSize * 2 : this.defaultReadBufferSize;
-  var buf = new Buffer(bufSize);
+  var buf = Buffer.alloc(bufSize);
   if (unreadSize > 0) {
     this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor);
   }
@@ -103,7 +103,7 @@ TBufferedTransport.prototype.ensureAvailable = function(len) {
 
 TBufferedTransport.prototype.read = function(len) {
   this.ensureAvailable(len);
-  var buf = new Buffer(len);
+  var buf = Buffer.alloc(len);
   this.inBuf.copy(buf, 0, this.readCursor, this.readCursor + len);
   this.readCursor += len;
   return buf;
@@ -153,7 +153,7 @@ TBufferedTransport.prototype.consume = function(bytesConsumed) {
 
 TBufferedTransport.prototype.write = function(buf) {
   if (typeof(buf) === "string") {
-    buf = new Buffer(buf, 'utf8');
+    buf = Buffer.from(buf, 'utf8');
   }
   this.outBuffers.push(buf);
   this.outCount += buf.length;
@@ -169,7 +169,7 @@ TBufferedTransport.prototype.flush = function() {
     return;
   }
 
-  var msg = new Buffer(this.outCount),
+  var msg = Buffer.alloc(this.outCount),
       pos = 0;
   this.outBuffers.forEach(function(buf) {
     buf.copy(msg, pos, 0);

--- a/lib/nodejs/lib/thrift/compact_protocol.js
+++ b/lib/nodejs/lib/thrift/compact_protocol.js
@@ -350,7 +350,7 @@ TCompactProtocol.prototype.writeBool = function(value) {
 };
 
 TCompactProtocol.prototype.writeByte = function(b) {
-  this.trans.write(new Buffer([b]));
+  this.trans.write(Buffer.from([b]));
 };
 
 TCompactProtocol.prototype.writeI16 = function(i16) {
@@ -367,7 +367,7 @@ TCompactProtocol.prototype.writeI64 = function(i64) {
 
 // Little-endian, unlike TBinaryProtocol
 TCompactProtocol.prototype.writeDouble = function(v) {
-  var buff = new Buffer(8);
+  var buff = Buffer.alloc(8);
   var m, e, c;
 
   buff[7] = (v < 0 ? 0x80 : 0x00);
@@ -431,7 +431,7 @@ TCompactProtocol.prototype.writeDouble = function(v) {
 TCompactProtocol.prototype.writeStringOrBinary = function(name, encoding, arg) {
   if (typeof arg === 'string') {
     this.writeVarint32(Buffer.byteLength(arg, encoding)) ;
-    this.trans.write(new Buffer(arg, encoding));
+    this.trans.write(Buffer.from(arg, encoding));
   } else if (arg instanceof Buffer ||
              Object.prototype.toString.call(arg) == '[object Uint8Array]') {
     // Buffers in Node.js under Browserify may extend UInt8Array instead of
@@ -489,7 +489,7 @@ TCompactProtocol.prototype.writeCollectionBegin = function(elemType, size) {
  * Write an i32 as a varint. Results in 1-5 bytes on the wire.
  */
 TCompactProtocol.prototype.writeVarint32 = function(n) {
-  var buf = new Buffer(5);
+  var buf = Buffer.alloc(5);
   var wsize = 0;
   while (true) {
     if ((n & ~0x7F) === 0) {
@@ -500,7 +500,7 @@ TCompactProtocol.prototype.writeVarint32 = function(n) {
       n = n >>> 7;
     }
   }
-  var wbuf = new Buffer(wsize);
+  var wbuf = Buffer.alloc(wsize);
   buf.copy(wbuf,0,0,wsize);
   this.trans.write(wbuf);
 };
@@ -517,7 +517,7 @@ TCompactProtocol.prototype.writeVarint64 = function(n) {
     throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.INVALID_DATA, "Expected Int64 or Number, found: " + n);
   }
 
-  var buf = new Buffer(10);
+  var buf = Buffer.alloc(10);
   var wsize = 0;
   var hi = n.buffer.readUInt32BE(0, true);
   var lo = n.buffer.readUInt32BE(4, true);
@@ -534,7 +534,7 @@ TCompactProtocol.prototype.writeVarint64 = function(n) {
       lo = lo | mask;
     }
   }
-  var wbuf = new Buffer(wsize);
+  var wbuf = Buffer.alloc(wsize);
   buf.copy(wbuf,0,0,wsize);
   this.trans.write(wbuf);
 };
@@ -760,7 +760,7 @@ TCompactProtocol.prototype.readDouble = function() {
 TCompactProtocol.prototype.readBinary = function() {
   var size = this.readVarint32();
   if (size === 0) {
-    return new Buffer(0);
+    return Buffer.alloc(0);
   }
 
   if (size < 0) {

--- a/lib/nodejs/lib/thrift/framed_transport.js
+++ b/lib/nodejs/lib/thrift/framed_transport.js
@@ -24,7 +24,7 @@ var THeaderTransport = require('./header_transport');
 module.exports = TFramedTransport;
 
 function TFramedTransport(buffer, callback) {
-  this.inBuf = buffer || new Buffer(0);
+  this.inBuf = buffer || Buffer.alloc(0);
   this.outBuffers = [];
   this.outCount = 0;
   this.readPos = 0;
@@ -150,7 +150,7 @@ TFramedTransport.prototype.consume = function(bytesConsumed) {
 
 TFramedTransport.prototype.write = function(buf, encoding) {
   if (typeof(buf) === "string") {
-    buf = new Buffer(buf, encoding || 'utf8');
+    buf = Buffer.from(buf, encoding || 'utf8');
   }
   this.outBuffers.push(buf);
   this.outCount += buf.length;
@@ -162,7 +162,7 @@ TFramedTransport.prototype.flush = function() {
   var seqid = this._seqid;
   this._seqid = null;
 
-  var out = new Buffer(this.outCount),
+  var out = Buffer.alloc(this.outCount),
       pos = 0;
   this.outBuffers.forEach(function(buf) {
     buf.copy(out, pos, 0);
@@ -171,7 +171,7 @@ TFramedTransport.prototype.flush = function() {
 
   if (this.onFlush) {
     // TODO: optimize this better, allocate one buffer instead of both:
-    var msg = new Buffer(out.length + 4);
+    var msg = Buffer.alloc(out.length + 4);
     binary.writeI32(msg, out.length);
     out.copy(msg, 4, 0, out.length);
     if (this.onFlush) {

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -184,7 +184,7 @@ var HttpConnection = exports.HttpConnection = function(options) {
       if ((typeof chunk == 'string') ||
           (Object.prototype.toString.call(chunk) == '[object Uint8Array]')) {
         // Wrap ArrayBuffer/string in a Buffer so data[i].copy will work
-        data.push(new Buffer(chunk));
+        data.push(Buffer.from(chunk));
       } else {
         data.push(chunk);
       }
@@ -192,7 +192,7 @@ var HttpConnection = exports.HttpConnection = function(options) {
     });
 
     response.on('end', function(){
-      var buf = new Buffer(dataLen);
+      var buf = Buffer.alloc(dataLen);
       for (var i=0, len=data.length, pos=0; i<len; i++) {
         data[i].copy(buf, pos);
         pos += data[i].length;

--- a/lib/nodejs/lib/thrift/int64_util.js
+++ b/lib/nodejs/lib/thrift/int64_util.js
@@ -38,7 +38,7 @@ Int64Util.toDecimalString = function(i64) {
     if (negative) {
       // 2's complement
       var incremented = false;
-      var buffer = new Buffer(8);
+      var buffer = Buffer.alloc(8);
       for (var i = 7; i >= 0; --i) {
         buffer[i] = (~b[o + i] + (incremented ? 0 : 1)) & 0xff;
         incremented |= b[o + i];

--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -387,7 +387,7 @@ TJSONProtocol.prototype.writeString = function(arg) {
 /** Serializes a string */
 TJSONProtocol.prototype.writeBinary = function(arg) {
   if (typeof arg === 'string') {
-    var buf = new Buffer(arg, 'binary');
+    var buf = Buffer.from(arg, 'binary');
   } else if (arg instanceof Buffer ||
              Object.prototype.toString.call(arg) == '[object Uint8Array]')  {
     var buf = arg;
@@ -717,7 +717,7 @@ TJSONProtocol.prototype.readDouble = function() {
 };
 
 TJSONProtocol.prototype.readBinary = function() {
-  return new Buffer(this.readValue(), 'base64');
+  return Buffer.from(this.readValue(), 'base64');
 };
 
 TJSONProtocol.prototype.readString = function() {

--- a/lib/nodejs/lib/thrift/web_server.js
+++ b/lib/nodejs/lib/thrift/web_server.js
@@ -83,7 +83,7 @@ var wsFrame = {
    * @returns {Buffer} - The WebSocket frame, ready to send
    */
   encode: function(data, mask, binEncoding) {
-      var frame = new Buffer(wsFrame.frameSizeFromData(data, mask));
+      var frame = Buffer.alloc(wsFrame.frameSizeFromData(data, mask));
       //Byte 0 - FIN & OPCODE
       frame[0] = wsFrame.fin.FIN +
           (binEncoding ? wsFrame.frameOpCodes.BIN : wsFrame.frameOpCodes.TEXT);
@@ -162,19 +162,19 @@ var wsFrame = {
       }
       //MASK
       if (wsFrame.mask.TO_SERVER == (frame[1] & wsFrame.mask.TO_SERVER)) {
-        result.mask = new Buffer(4);
+        result.mask = Buffer.alloc(4);
         frame.copy(result.mask, 0, dataOffset, dataOffset + 4);
         dataOffset += 4;
       }
       //Payload
-      result.data = new Buffer(len);
+      result.data = Buffer.alloc(len);
       frame.copy(result.data, 0, dataOffset, dataOffset+len);
       if (result.mask) {
         wsFrame.applyMask(result.data, result.mask);
       }
       //Next Frame
       if (frame.length > dataOffset+len) {
-        result.nextFrame = new Buffer(frame.length - (dataOffset+len));
+        result.nextFrame = Buffer.alloc(frame.length - (dataOffset+len));
         frame.copy(result.nextFrame, 0, dataOffset+len, frame.length);
       }
       //Don't forward control frames
@@ -537,7 +537,7 @@ exports.createWebServer = function(options) {
           //Prepend any existing decoded data
           if (data) {
             if (result.data) {
-              var newData = new Buffer(data.length + result.data.length);
+              var newData = Buffer.alloc(data.length + result.data.length);
               data.copy(newData);
               result.data.copy(newData, data.length);
               result.data = newData;

--- a/lib/nodejs/lib/thrift/ws_connection.js
+++ b/lib/nodejs/lib/thrift/ws_connection.js
@@ -183,7 +183,7 @@ WSConnection.prototype.__onData = function(data) {
   if (Object.prototype.toString.call(data) === "[object ArrayBuffer]") {
     data = new Uint8Array(data);
   }
-  var buf = new Buffer(data);
+  var buf = Buffer.from(data);
   this.transport.receiver(this.__decodeCallback.bind(this))(buf);
 
 };

--- a/lib/nodejs/lib/thrift/xhr_connection.js
+++ b/lib/nodejs/lib/thrift/xhr_connection.js
@@ -134,7 +134,7 @@ XHRConnection.prototype.setRecvBuffer = function(buf) {
   if (Object.prototype.toString.call(buf) == "[object ArrayBuffer]") {
     var data = new Uint8Array(buf);
   }
-  var thing = new Buffer(data || buf);
+  var thing = Buffer.from(data || buf);
 
   this.transport.receiver(this.__decodeCallback.bind(this))(thing);
 

--- a/lib/nodejs/test/test-cases.js
+++ b/lib/nodejs/test/test-cases.js
@@ -90,10 +90,10 @@ const simple = [
   ["testI64", -5],
   ["testI64", 734359738368],
   ["testI64", -734359738368],
-  ["testI64", new Int64(new Buffer([0, 0x20, 0, 0, 0, 0, 0, 1]))], // 2^53+1
+  ["testI64", new Int64(Buffer.from([0, 0x20, 0, 0, 0, 0, 0, 1]))], // 2^53+1
   [
     "testI64",
-    new Int64(new Buffer([0xff, 0xdf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]))
+    new Int64(Buffer.from([0xff, 0xdf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]))
   ], // -2^53-1
   ["testTypedef", 69]
 ];

--- a/lib/nodejs/test/test_driver.js
+++ b/lib/nodejs/test/test_driver.js
@@ -71,13 +71,13 @@ exports.ThriftTestDriver = function(client, callback) {
       for (let i = 0; i < 256; ++i) {
         arr[i] = 255 - i;
       }
-      let buf = new Buffer(arr);
+      let buf = Buffer.from(arr);
       client.testBinary(buf, function(err, response) {
         assert.error(err, "testBinary: no callback error");
         assert.equal(response.length, 256, "testBinary");
         assert.deepEqual(response, buf, "testBinary(Buffer)");
       });
-      buf = new Buffer(arr);
+      buf = Buffer.from(arr);
       client.testBinary(buf.toString("binary"), function(err, response) {
         assert.error(err, "testBinary: no callback error");
         assert.equal(response.length, 256, "testBinary");


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  This PR fix issue THRIFT-5224.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
