### PR TITLE
Deprecated WinXP and Server2003 methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - [THRIFT-5186](https://issues.apache.org/jira/browse/THRIFT-5186) - cpp: use all getaddrinfo() results when retrying failed bind() in T{Nonblocking,}ServerSocket
 - [THRIFT-5233](https://issues.apache.org/jira/browse/THRIFT-5233) - go: Now all Read*, Write* and Skip functions in TProtocol accept context arg
 - [THRIFT-5152](https://issues.apache.org/jira/browse/THRIFT-5152) - go: TSocket and TSSLSocket now have separated connect timeout and socket timeout
+- c++: dropped support for Windows XP
 
 ### Java
 

--- a/lib/cpp/src/thrift/transport/PlatformSocket.h
+++ b/lib/cpp/src/thrift/transport/PlatformSocket.h
@@ -70,16 +70,10 @@
 #  define THRIFT_SLEEP_USEC thrift_usleep
 #  define THRIFT_TIMESPEC thrift_timespec
 #  define THRIFT_CTIME_R thrift_ctime_r
-#  define THRIFT_POLL thrift_poll
-#  if WINVER <= 0x0502 //XP, Server2003
-#    define THRIFT_POLLFD  thrift_pollfd
-#    define THRIFT_POLLIN  0x0300
-#    define THRIFT_POLLOUT 0x0010
-#  else //Vista, Win7...
-#    define THRIFT_POLLFD  pollfd
-#    define THRIFT_POLLIN  POLLIN
-#    define THRIFT_POLLOUT POLLOUT
-#  endif //WINVER
+#  define THRIFT_POLL WSAPoll
+#  define THRIFT_POLLFD  pollfd
+#  define THRIFT_POLLIN  POLLIN
+#  define THRIFT_POLLOUT POLLOUT
 #  define THRIFT_SHUT_RDWR SD_BOTH
 #  if !defined(AI_ADDRCONFIG)
 #    define AI_ADDRCONFIG 0x00000400

--- a/lib/cpp/src/thrift/windows/WinFcntl.cpp
+++ b/lib/cpp/src/thrift/windows/WinFcntl.cpp
@@ -42,57 +42,6 @@ int thrift_fcntl(THRIFT_SOCKET fd, int cmd, int flags) {
   return res;
 }
 
-#if WINVER <= 0x0502 // XP, Server2003
-int thrift_poll(THRIFT_POLLFD* fdArray, ULONG nfds, INT timeout) {
-  fd_set read_fds, write_fds;
-  fd_set* read_fds_ptr = nullptr;
-  fd_set* write_fds_ptr = nullptr;
-
-  FD_ZERO(&read_fds);
-  FD_ZERO(&write_fds);
-
-  for (ULONG i = 0; i < nfds; i++) {
-    // Read (in) socket
-    if ((fdArray[i].events & THRIFT_POLLIN) == THRIFT_POLLIN) {
-      read_fds_ptr = &read_fds;
-      FD_SET(fdArray[i].fd, &read_fds);
-    }
-    // Write (out) socket
-    else if ((fdArray[i].events & THRIFT_POLLOUT) == THRIFT_POLLOUT) {
-      write_fds_ptr = &write_fds;
-      FD_SET(fdArray[i].fd, &write_fds);
-    }
-  }
-
-  timeval time_out;
-  timeval* time_out_ptr = nullptr;
-  if (timeout >= 0) {
-    time_out.tv_sec = timeout / 1000;
-    time_out.tv_usec = (timeout % 1000) * 1000;
-    time_out_ptr = &time_out;
-  } else { // to avoid compiler warnings
-    (void)time_out;
-    (void)timeout;
-  }
-
-  int sktready = select(1, read_fds_ptr, write_fds_ptr, nullptr, time_out_ptr);
-  if (sktready > 0) {
-    for (ULONG i = 0; i < nfds; i++) {
-      fdArray[i].revents = 0;
-      if (FD_ISSET(fdArray[i].fd, &read_fds))
-        fdArray[i].revents |= THRIFT_POLLIN;
-      if (FD_ISSET(fdArray[i].fd, &write_fds))
-        fdArray[i].revents |= THRIFT_POLLOUT;
-    }
-  }
-  return sktready;
-}
-#else  // Vista, Win7...
-int thrift_poll(THRIFT_POLLFD* fdArray, ULONG nfds, INT timeout) {
-  return WSAPoll(fdArray, nfds, timeout);
-}
-#endif // WINVER
-
 #ifdef _WIN32_WCE
 std::string thrift_wstr2str(std::wstring ws) {
   std::string s(ws.begin(), ws.end());

--- a/lib/cpp/src/thrift/windows/WinFcntl.h
+++ b/lib/cpp/src/thrift/windows/WinFcntl.h
@@ -36,17 +36,8 @@
 #include <Winsock2.h>
 #include <thrift/transport/PlatformSocket.h>
 
-#if WINVER <= 0x0502 // XP, Server2003
-struct thrift_pollfd {
-  THRIFT_SOCKET fd;
-  SHORT events;
-  SHORT revents;
-};
-#endif
-
 extern "C" {
 int thrift_fcntl(THRIFT_SOCKET fd, int cmd, int flags);
-int thrift_poll(THRIFT_POLLFD* fdArray, ULONG nfds, INT timeout);
 }
 
 #ifdef _WIN32_WCE


### PR DESCRIPTION
This PR adds a very minor change: it deprecates handling of WinXP and Windows Server 2003 in `lib/cpp/src/thrift/windows/WinFcntl.{h,cpp}`. This simplifies code maintenance. I'm under the impression that support for WinXP should be dropped now.

Does this require an explicit mention in a change log? I would assume that WinXP and Server 2003 are not officially supported since a while now?

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.