### PR TITLE
Added IsOpen() and GetPort() for netstd transports

### DIFF
--- a/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
@@ -44,6 +44,10 @@ namespace Thrift.Transport.Server
             _pipeAddress = pipeAddress;
         }
 
+        public override bool IsOpen() {
+            return true;
+        }
+
         public override void Listen()
         {
             // nothing to do here

--- a/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License. You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -54,6 +54,34 @@ namespace Thrift.Transport.Server
             }
         }
 
+        public override bool IsOpen()
+        {
+            if ((_server != null) && (_server.Server != null))
+            {
+                return _server.Server.IsBound;
+            }
+            return false;
+        }
+
+        public int GetPort()
+        {
+            if ((_server != null) && (_server.Server != null) && (_server.Server.LocalEndPoint != null))
+            {
+                if (_server.Server.LocalEndPoint is IPEndPoint server)
+                {
+                    return server.Port;
+                }
+                else
+                {
+                    throw new TTransportException("ServerSocket is not a network socket");
+                }
+            }
+            else
+            {
+                throw new TTransportException("ServerSocket is not open");
+            }
+        }
+
         public override void Listen()
         {
             // Make sure not to block on accept
@@ -91,7 +119,7 @@ namespace Thrift.Transport.Server
 
                 try
                 {
-                    tSocketTransport = new TSocketTransport(tcpClient,Configuration)
+                    tSocketTransport = new TSocketTransport(tcpClient, Configuration)
                     {
                         Timeout = _clientTimeout
                     };
@@ -106,7 +134,7 @@ namespace Thrift.Transport.Server
                     }
                     else //  Otherwise, clean it up ourselves.
                     {
-                        ((IDisposable) tcpClient).Dispose();
+                        ((IDisposable)tcpClient).Dispose();
                     }
 
                     throw;

--- a/lib/netstd/Thrift/Transport/Server/TServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerTransport.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License. You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,6 +30,8 @@ namespace Thrift.Transport
             Configuration = config ?? new TConfiguration();
         }
 
+        public abstract bool IsOpen();
+
         public abstract void Listen();
         public abstract void Close();
         public abstract bool IsClientPending();
@@ -41,7 +43,7 @@ namespace Thrift.Transport
 
         protected abstract ValueTask<TTransport> AcceptImplementationAsync(CancellationToken cancellationToken);
 
-        public async ValueTask<TTransport> AcceptAsync() 
+        public async ValueTask<TTransport> AcceptAsync()
         {
             return await AcceptAsync(CancellationToken.None);
         }

--- a/lib/netstd/Thrift/Transport/Server/TTlsServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TTlsServerSocketTransport.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License. You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,7 +36,7 @@ namespace Thrift.Transport.Server
         private readonly X509Certificate2 _serverCertificate;
         private readonly SslProtocols _sslProtocols;
         private TcpListener _server;
-               
+
         public TTlsServerSocketTransport(
             TcpListener listener,
             TConfiguration config,
@@ -78,6 +78,34 @@ namespace Thrift.Transport.Server
             {
                 _server = null;
                 throw new TTransportException($"Could not create ServerSocket on port {port}.");
+            }
+        }
+
+        public override bool IsOpen()
+        {
+            if ((_server != null) && (_server.Server != null))
+            {
+                return _server.Server.IsBound;
+            }
+            return false;
+        }
+
+        public int GetPort()
+        {
+            if ((_server != null) && (_server.Server != null) && (_server.Server.LocalEndPoint != null))
+            {
+                if (_server.Server.LocalEndPoint is IPEndPoint server)
+                {
+                    return server.Port;
+                }
+                else
+                {
+                    throw new TTransportException("ServerSocket is not a network socket");
+                }
+            }
+            else
+            {
+                throw new TTransportException("ServerSocket is not open");
             }
         }
 
@@ -123,7 +151,7 @@ namespace Thrift.Transport.Server
                     _localCertificateSelectionCallback, _sslProtocols);
 
                 await tTlsSocket.SetupTlsAsync();
-                
+
                 return tTlsSocket;
             }
             catch (Exception ex)


### PR DESCRIPTION
This PR adds implementations of `IsOpen()` and `GetPort()` to C# NetStd transports. The implementation is not extensively tested, but results look promising. Feedback about where (in which file) to add this in automatic testing for netstd would be welcome.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.