### PR TITLE
Thrift.csproj: Stop writing AssemblyAttributes.cs to /tmp

### DIFF
--- a/lib/netstd/Thrift/Thrift.csproj
+++ b/lib/netstd/Thrift/Thrift.csproj
@@ -56,4 +56,9 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>
 
+  <Target Name="SetTFMAssemblyAttributesPath" BeforeTargets="GenerateTargetFrameworkMonikerAttribute">
+    <PropertyGroup>
+      <TargetFrameworkMonikerAssemblyAttributesPath>$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
The netstd build writes so-called `TargetFrameworkMonikerAssemblyAttributes` files to `/tmp`. These files can be left behind, and they do not feature a build-specific or user-specific name. This can be a problem in a multi-user environment, because the files block future builds by other users (that can not overwrite the files).

This PR adds a workaround by placing the files into the build directory rather than the `/tmp` directory. There should be no negative effects, other than a new, extra line in the `Thrift.csproj` settings.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.