### PR TITLE
THRIFT-4731: Replace usage of deprecated network modules in haskell library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - [THRIFT-5116](https://issues.apache.org/jira/browse/THRIFT-5116) - Upgrade NodeJS to 10.x
 - [THRIFT-5138](https://issues.apache.org/jira/browse/THRIFT-5138) - Swift generator does not escape keywords properly
 - [THRIFT-5164](https://issues.apache.org/jira/browse/THRIFT-5164) - In Go library TProcessor interface now includes ProcessorMap and AddToProcessorMap functions.
+- [THRIFT-4731](https://issues.apache.org/jira/browse/THRIFT-4731) - The Haskell library has been ported to the new network modules.
 
 ### Java
 

--- a/lib/hs/thrift.cabal
+++ b/lib/hs/thrift.cabal
@@ -32,19 +32,12 @@ License-File:   LICENSE
 Description:
   Haskell bindings for the Apache Thrift RPC system. Requires the use of the thrift code generator.
 
-flag network-uri
-   description: Get Network.URI from the network-uri package
-   default: True
-
 Library
   Hs-Source-Dirs:
     src
   Build-Depends:
-    base >= 4, base < 5, containers, ghc-prim, attoparsec, binary, bytestring >= 0.10, base64-bytestring, hashable, HTTP, text, hspec-core > 2.4.0, unordered-containers >= 0.2.6, vector >= 0.10.12.2, QuickCheck >= 2.8.2, split
-  if flag(network-uri)
-     build-depends: network-uri >= 2.6, network >= 2.6 && < 3.0
-  else
-     build-depends: network < 2.6
+    base >= 4, base < 5, containers, ghc-prim, attoparsec, binary, bytestring >= 0.10, base64-bytestring, hashable, HTTP, text, hspec-core > 2.4.0, unordered-containers >= 0.2.6, vector >= 0.10.12.2, QuickCheck >= 2.8.2, split,
+    network-uri >= 2.6, network >= 3.0.0.0
   Exposed-Modules:
     Thrift,
     Thrift.Arbitraries

--- a/test/hs/TestClient.hs
+++ b/test/hs/TestClient.hs
@@ -25,7 +25,6 @@ import Control.Monad
 import Data.Functor
 import Data.List.Split
 import Data.String
-import Network
 import Network.URI
 import System.Environment
 import System.Exit
@@ -68,11 +67,11 @@ data TransportType = Buffered IO.Handle
 
 getTransport :: String -> String -> Int -> (IO TransportType)
 getTransport "buffered" host port = do
-  h <- hOpen (host, PortNumber $ fromIntegral port)
+  h <- hOpenSocket host (show port)
   IO.hSetBuffering h $ IO.BlockBuffering Nothing
   return $ Buffered h
 getTransport "framed" host port = do
-  h <- hOpen (host, PortNumber $ fromIntegral port)
+  h <- hOpenSocket host (show port)
   t <- openFramedTransport h
   return $ Framed t
 getTransport "http" host port = let uriStr = "http://" ++ host ++ ":" ++ show port in

--- a/tutorial/hs/HaskellClient.hs
+++ b/tutorial/hs/HaskellClient.hs
@@ -34,10 +34,9 @@ import Control.Exception
 import Data.Maybe
 import Data.Text.Lazy
 import Text.Printf
-import Network
 
 main = do
-  transport  <- hOpen ("localhost", PortNumber 9090)
+  transport  <- hOpenSocket "127.0.0.1" "9090"
   let binProto = BinaryProtocol transport
   let client = (binProto, binProto)
 


### PR DESCRIPTION
Upgrade to network 3.0.0.0. Note that the `Network` module has been removed in version 3.0.0.0 and hence the thrift library no longer compiles with the current network package.

This is a breaking change, but it should be fairly easy to update call sites.

Related issues:
https://issues.apache.org/jira/browse/THRIFT-4731
https://issues.apache.org/jira/browse/THRIFT-5098
https://issues.apache.org/jira/browse/THRIFT-5193 

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
