### PR TITLE
THRIFT-5227: Update haskell build to cabal v2-* commands

### DIFF
--- a/build/appveyor/MSVC-appveyor-install.bat
+++ b/build/appveyor/MSVC-appveyor-install.bat
@@ -56,7 +56,7 @@ pip.exe ^
             tornado ^
             twisted                       || EXIT /B
 
-cinst -y cabal --version 2.4.1.0          || EXIT /B
+cinst -y cabal --version 3.2.0.0          || EXIT /B
 cinst -y ghc --version 8.6.5              || EXIT /B
 
 :: Adobe Flex SDK 4.6 for ActionScript

--- a/lib/hs/CMakeLists.txt
+++ b/lib/hs/CMakeLists.txt
@@ -66,12 +66,9 @@ endif()
 
 add_custom_command(
     OUTPUT ${haskell_artifacts}
-    COMMAND ${CABAL} update
-    # Build dependencies first without --builddir, otherwise it fails.
-    COMMAND ${CABAL} install --only-dependencies ${hs_enable_test}
-    COMMAND ${CABAL} configure ${hs_optimize} ${hs_enable_test} --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
-    COMMAND ${CABAL} build --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
-    COMMAND ${CABAL} install --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
+    COMMAND ${CABAL} v2-update
+    COMMAND ${CABAL} v2-configure ${hs_optimize} ${hs_enable_test} --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
+    COMMAND ${CABAL} v2-build --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
     COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/thrift_cabal.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${haskell_sources}
@@ -85,9 +82,6 @@ if(BUILD_TESTING)
             COMMAND ${CABAL} check
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     add_test(NAME HaskellCabalTest
-            # Cabal fails to find built executable when --builddir is specified.
-            # So we invoke the executable directly.
-            # COMMAND ${CABAL} test --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
-            # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-            COMMAND dist/build/spec/spec)
+            COMMAND ${CABAL} v2-test --builddir=${CMAKE_CURRENT_BINARY_DIR}/dist
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/test/hs/CMakeLists.txt
+++ b/test/hs/CMakeLists.txt
@@ -56,11 +56,6 @@ set(hs_crosstest_apps
     ${CMAKE_CURRENT_BINARY_DIR}/TestServer
     ${CMAKE_CURRENT_BINARY_DIR}/TestClient
 )
-set(hs_crosstest_args
-    -igen-hs
-    -odir=${CMAKE_CURRENT_BINARY_DIR}
-    -hidir=${CMAKE_CURRENT_BINARY_DIR}
-)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(hs_optimize -O0)
@@ -70,9 +65,9 @@ endif()
 
 add_custom_command(
     OUTPUT ${hs_crosstest_apps}
-    COMMAND ${GHC} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestServer.hs -o TestServer
-    COMMAND ${GHC} ${hs_optimize} ${hs_crosstest_args} ${CMAKE_CURRENT_SOURCE_DIR}/TestClient.hs -o TestClient
-    DEPENDS ${hs_test_gen} haskell_library TestServer.hs TestClient.hs
+    COMMAND ${CABAL} v2-install --builddir=${CMAKE_CURRENT_BINARY_DIR}/test-dist ${hs_optimize} --installdir=${CMAKE_CURRENT_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${hs_test_gen} haskell_library copy-hs-test-files ${CMAKE_CURRENT_BINARY_DIR}/cabal.project ${CMAKE_CURRENT_BINARY_DIR}/thrift-test.cabal
 )
 add_custom_target(haskell_crosstest ALL
     COMMENT "Building Haskell cross test executables"
@@ -112,3 +107,10 @@ add_custom_command(OUTPUT ${hs_test_gen}
     COMMAND ${THRIFT_COMPILER} --gen hs ${PROJECT_SOURCE_DIR}/test/Include.thrift
     DEPENDS ${hs_test_gen_sources}
 )
+
+add_custom_target(copy-hs-test-files ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/test-hs/
+)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cabal.project ${CMAKE_CURRENT_BINARY_DIR}/cabal.project)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/thrift-test.cabal ${CMAKE_CURRENT_BINARY_DIR}/thrift-test.cabal)

--- a/test/hs/cabal.project
+++ b/test/hs/cabal.project
@@ -1,0 +1,2 @@
+packages:  .
+           @PROJECT_SOURCE_DIR@/lib/hs

--- a/test/hs/thrift-test.cabal
+++ b/test/hs/thrift-test.cabal
@@ -1,0 +1,46 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+Name:           thrift-test
+Version:        0.14.0
+Cabal-Version:  1.24
+License:        Apache
+Category:       Foreign
+Build-Type:     Simple
+Synopsis:       Tests for Haskell bindings for the Apache Thrift RPC system
+Homepage:       http://thrift.apache.org
+Bug-Reports:    https://issues.apache.org/jira/browse/THRIFT
+Maintainer:     dev@thrift.apache.org
+
+
+Executable TestServer
+  Hs-Source-Dirs: gen-hs test-hs
+  Ghc-Options: -Wall
+  main-is: TestServer.hs
+  Build-Depends: base, thrift, vector, unordered-containers, network, split, text, bytestring, hashable, QuickCheck
+  Default-Language: Haskell2010
+  other-modules: ThriftTest, ThriftTest_Types, ThriftTest_Iface
+
+Executable TestClient
+  Hs-Source-Dirs: gen-hs test-hs
+  Ghc-Options: -Wall
+  main-is: TestClient.hs
+  Build-Depends: base, thrift, vector, unordered-containers, network, split, text, bytestring, hashable, QuickCheck, network-uri
+  Default-Language: Haskell2010
+  other-modules: ThriftTest, ThriftTest_Types, ThriftTest_Iface, ThriftTest_Client


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Fixes the build with recent cabal versions.

I am not a cmake expert, so I just tried to get it working ...

If I do `cmake && make check` the tests pass. I do not seem to be able to call `make cross`, that target does not exist?

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
