### PR TITLE
Use io.CopyN to simplify THeaderTransport code

### DIFF
--- a/lib/go/thrift/header_transport.go
+++ b/lib/go/thrift/header_transport.go
@@ -330,10 +330,7 @@ func (t *THeaderTransport) ReadFrame() error {
 	t.reader.Discard(size32)
 
 	// Read the frame fully into frameBuffer.
-	_, err = io.Copy(
-		&t.frameBuffer,
-		io.LimitReader(t.reader, int64(frameSize)),
-	)
+	_, err = io.CopyN(&t.frameBuffer, t.reader, int64(frameSize))
 	if err != nil {
 		return err
 	}
@@ -395,7 +392,7 @@ func (t *THeaderTransport) parseHeaders(frameSize uint32) error {
 		)
 	}
 	headerBuf := NewTMemoryBuffer()
-	_, err = io.Copy(headerBuf, io.LimitReader(&t.frameBuffer, headerLength))
+	_, err = io.CopyN(headerBuf, &t.frameBuffer, headerLength)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Client: go

In THeaderTransport implementation, use io.CopyN instead of
io.Copy+io.LimitReader.

Underlying io.CopyN is actually implemented with io.Copy+io.LimitReader
[0], but it also does some extra checks we can take advantage of. It
also simplifies the code in thrift repo.

[0] https://github.com/golang/go/blob/83b181c68bf332ac7948f145f33d128377a09c42/src/io/io.go#L340

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
