### PR TITLE
THRIFT-5214: Reset read deadline in socketConn

### DIFF
--- a/lib/go/thrift/socket_conn.go
+++ b/lib/go/thrift/socket_conn.go
@@ -23,16 +23,14 @@ import (
 	"bytes"
 	"io"
 	"net"
-	"time"
 )
 
 // socketConn is a wrapped net.Conn that tries to do connectivity check.
 type socketConn struct {
 	net.Conn
 
-	socketTimeout time.Duration
-	buf           bytes.Buffer
-	buffer        [1]byte
+	buf    bytes.Buffer
+	buffer [1]byte
 }
 
 var _ net.Conn = (*socketConn)(nil)
@@ -78,6 +76,10 @@ func (sc *socketConn) isValid() bool {
 // connection is nil.
 //
 // Otherwise, it tries to do a connectivity check and returns the result.
+//
+// It also has the side effect of resetting the previously set read deadline on
+// the socket. As a result, it shouldn't be called between setting read deadline
+// and doing actual read.
 func (sc *socketConn) IsOpen() bool {
 	if !sc.isValid() {
 		return false

--- a/lib/go/thrift/socket_unix_conn.go
+++ b/lib/go/thrift/socket_unix_conn.go
@@ -27,6 +27,11 @@ import (
 	"time"
 )
 
+// We rely on this variable to be the zero time,
+// but define it as global variable to avoid repetitive allocations.
+// Please DO NOT mutate this variable in any way.
+var zeroTime time.Time
+
 func (sc *socketConn) read0() error {
 	return sc.checkConn()
 }
@@ -38,12 +43,10 @@ func (sc *socketConn) checkConn() error {
 		return nil
 	}
 
-	// Push read deadline
-	var t time.Time
-	if sc.socketTimeout > 0 {
-		t = time.Now().Add(sc.socketTimeout)
-	}
-	sc.Conn.SetReadDeadline(t)
+	// The reading about to be done here is non-blocking so we don't really
+	// need a read deadline. We just need to clear the previously set read
+	// deadline, if any.
+	sc.Conn.SetReadDeadline(zeroTime)
 
 	rc, err := syscallConn.SyscallConn()
 	if err != nil {


### PR DESCRIPTION
Client: go

This is a slightly different, and less error-prone approach from the
fix in e382275.

The previous approach relies on passing the set socket timeout into the
underlying socketConn from TSocket and TSSLSocket. But since we have so
many different constructors for TSocket and TSSLSocket, some makes the
initial connection in the constructor and some does not, there are so
many different places we would need to remember to pass socketTimeout
into socketConn. In the future, when we add another constructor to them,
we could either forget to pass the socket timeout into socketConn, or
try to pass it while we haven't constructed socketConn yet (which will
cause panic), both are bad.

In this approach we just clear the read deadline in the connectivity
check read. Because that's a non-blocking read, it would work just fine
without a read deadline.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
