### PR TITLE
THRIFT-4926: Adding LOGGER.isDebugEnabled() conditions into TSaslTransport

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TSaslTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TSaslTransport.java
@@ -217,8 +217,8 @@ abstract class TSaslTransport extends TTransport {
      * data in the stream, possibly a TCP health check from load balancer.
      */
     boolean readSaslHeader = false;
-
-    LOGGER.debug("opening transport {}", this);
+		if (LOGGER.isDebugEnabled())
+			LOGGER.debug("opening transport {}", this);
     if (sasl != null && sasl.isComplete())
       throw new TTransportException("SASL transport already open");
 
@@ -230,7 +230,8 @@ abstract class TSaslTransport extends TTransport {
       // initial response, or an empty one.
       handleSaslStartMessage();
       readSaslHeader = true;
-      LOGGER.debug("{}: Start message handled", getRole());
+			if (LOGGER.isDebugEnabled())
+				LOGGER.debug("{}: Start message handled", getRole());
 
       SaslResponse message = null;
       while (!sasl.isComplete()) {
@@ -245,15 +246,17 @@ abstract class TSaslTransport extends TTransport {
         // If we are the client, and the server indicates COMPLETE, we don't need to
         // send back any further response.
         if (message.status == NegotiationStatus.COMPLETE &&
-            getRole() == SaslRole.CLIENT) {
-          LOGGER.debug("{}: All done!", getRole());
+            getRole() == SaslRole.CLIENT) {					
+					if (LOGGER.isDebugEnabled())		
+						LOGGER.debug("{}: All done!", getRole());
           continue;
         }
 
         sendSaslMessage(sasl.isComplete() ? NegotiationStatus.COMPLETE : NegotiationStatus.OK,
                         challenge);
-      }
-      LOGGER.debug("{}: Main negotiation loop complete", getRole());
+      }			
+			if (LOGGER.isDebugEnabled())
+				LOGGER.debug("{}: Main negotiation loop complete", getRole());
 
       // If we're the client, and we're complete, but the server isn't
       // complete yet, we need to wait for its response. This will occur
@@ -261,7 +264,8 @@ abstract class TSaslTransport extends TTransport {
       // and are immediately complete.
       if (getRole() == SaslRole.CLIENT &&
           (message == null || message.status == NegotiationStatus.OK)) {
-        LOGGER.debug("{}: SASL Client receiving last message", getRole());
+				if (LOGGER.isDebugEnabled())
+					LOGGER.debug("{}: SASL Client receiving last message", getRole());
         message = receiveSaslMessage();
         if (message.status != NegotiationStatus.COMPLETE) {
           throw new TTransportException(


### PR DESCRIPTION
Adding LOGGER.isDebugEnabled() conditional statements into org.apache.thrift.transport.thrift.transport.TSaslTransport to fix the issue 4926

In org.apache.thrift.transport.TSaslTransport in the previous approach, sensitive information about Role is leaked. Thus, the LOGGER.isDebugEnabled() conditional statements should be added in the method public void open() throws TTransportException.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
