### PR TITLE
THRIFT-4928: Adding LOGGER.isInfoEnabled() condition into TTransport 

### DIFF
--- a/lib/javame/src/org/apache/thrift/transport/TTransport.java
+++ b/lib/javame/src/org/apache/thrift/transport/TTransport.java
@@ -19,6 +19,8 @@
 
 package org.apache.thrift.transport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
  * Generic class that encapsulates the I/O layer. This is basically a thin
  * wrapper around the combined functionality of Java input/output streams.
@@ -26,6 +28,8 @@ package org.apache.thrift.transport;
  */
 public abstract class TTransport {
 
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(TTransport.class);
   /**
    * Queries whether the transport is open.
    *
@@ -83,8 +87,12 @@ public abstract class TTransport {
     while (got < len) {
       ret = read(buf, off+got, len-got);
       if (ret <= 0) {
-        throw new TTransportException("Cannot read. Remote side has closed. Tried to read " + len + " bytes, but only got " + got + " bytes.");
-      }
+				if (LOGGER.isInfoEnabled())  {
+				throw new TTransportException("Cannot read. Remote side has closed. Tried to read " + len + " bytes, but only got " + got + " bytes.");
+			}
+			else 
+				throw new TTransportException("Cannot read. Remote side has closed. ");
+			}
       got += ret;
     }
     return got;


### PR DESCRIPTION
  Adding LOGGER.isInfoEnabled() conditional statement into org.apache.thrift.transport.thrift.transport.TTransport to fix the issue 4928

<!-- Explain the changes in the pull request below: -->
In org.apache.thrift.transport.TTransport in the previous approach, sensitive information about expected and actual reading lengths (len, got) is leaked. Thus, the LOGGER.isInfoEnabled()() conditional statements should be added in the method readAll(byte[] buf, int off, int len).

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
