### PR TITLE
THRIFT-4930: Remove LOGGER.warn in org.apache.thrift.transport.TSocket

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TSocket.java
@@ -239,7 +239,7 @@ public class TSocket extends TIOStreamTransport {
       try {
         socket_.close();
       } catch (IOException iox) {				
-        //LOGGER.warn("Could not close socket.", iox);
+        //LOGGER.warn("Could not close socket.", iox); 
       }
       socket_ = null;
     }

--- a/lib/java/src/org/apache/thrift/transport/TSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TSocket.java
@@ -238,9 +238,8 @@ public class TSocket extends TIOStreamTransport {
     if (socket_ != null) {
       try {
         socket_.close();
-      } catch (IOException iox) {
-				if (LOGGER.isWarnEnabled()) 
-        LOGGER.warn("Could not close socket.", iox);
+      } catch (IOException iox) {				
+        //LOGGER.warn("Could not close socket.", iox);
       }
       socket_ = null;
     }

--- a/lib/java/src/org/apache/thrift/transport/TSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TSocket.java
@@ -239,6 +239,7 @@ public class TSocket extends TIOStreamTransport {
       try {
         socket_.close();
       } catch (IOException iox) {
+				if (LOGGER.isWarnEnabled()) 
         LOGGER.warn("Could not close socket.", iox);
       }
       socket_ = null;


### PR DESCRIPTION
Remove LOGGER.warn in org.apache.thrift.transport.TSocket to fix the issues 4930 and 4924
<!-- Explain the changes in the pull request below: -->
In org.apache.thrift.transport.TSocket in the previous approach, sensitive information about socket input stream or output stream is leaked. Thus, we can remove the LOGGER warning information.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
