### PR TITLE
THRIFT-2087 Python compiler replace non utf-8 char with default

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -2230,7 +2230,7 @@ void t_py_generator::generate_deserialize_field(ostream& out,
         } else if(!gen_utf8strings_) {
           out << "readString()";
         } else {
-          out << "readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()";
+          out << "readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()";
         }
         break;
       case t_base_type::TYPE_BOOL:


### PR DESCRIPTION
Use `mode=replace` for UTF-8 string decoding in the python compiler to align with Java implementation.