### PR TITLE
THRIFT-5152: Separate timeout in TSSLSocket

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - [THRIFT-5164](https://issues.apache.org/jira/browse/THRIFT-5164) - In Go library TProcessor interface now includes ProcessorMap and AddToProcessorMap functions.
 - [THRIFT-5186](https://issues.apache.org/jira/browse/THRIFT-5186) - cpp: use all getaddrinfo() results when retrying failed bind() in T{Nonblocking,}ServerSocket
 - [THRIFT-5233](https://issues.apache.org/jira/browse/THRIFT-5233) - go: Now all Read*, Write* and Skip functions in TProtocol accept context arg
+- [THRIFT-5152](https://issues.apache.org/jira/browse/THRIFT-5152) - go: TSocket and TSSLSocket now have separated connect timeout and socket timeout
 
 ### Java
 

--- a/lib/go/thrift/socket.go
+++ b/lib/go/thrift/socket.go
@@ -57,8 +57,8 @@ func NewTSocketFromAddrTimeout(addr net.Addr, connTimeout time.Duration, soTimeo
 }
 
 // Creates a TSocket from an existing net.Conn
-func NewTSocketFromConnTimeout(conn net.Conn, connTimeout time.Duration) *TSocket {
-	return &TSocket{conn: wrapSocketConn(conn), addr: conn.RemoteAddr(), connectTimeout: connTimeout, socketTimeout: connTimeout}
+func NewTSocketFromConnTimeout(conn net.Conn, socketTimeout time.Duration) *TSocket {
+	return &TSocket{conn: wrapSocketConn(conn), addr: conn.RemoteAddr(), socketTimeout: socketTimeout}
 }
 
 // Sets the connect timeout


### PR DESCRIPTION
Client: go

We separated timeout in go's TSocket into connect timeout and socket
timeout in 81334cd, this change does the same for TSSLSocket to keep
them consistent.

Also rename the arg in NewTSocketFromConnTimeout from connTimeout to
socketTimeout, because in that function we already have a connection,
so connect timeout is never used again. The timeout passed into that
function is really for socket timeout, not connect timeout. The name of
that function actually means "New TSocket From Conn (with) Timeout", not
"New TSocket From ConnTimeout" (I guess that's where the original
confusion came from).

Also add the missing change note for the breaking change.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
