### PR TITLE
THRIFT-5245: Fix NullPointerException in the implements of Protocol.java

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -222,13 +222,17 @@ public class TBinaryProtocol extends TProtocol {
 
   @Override
   public void writeString(String str) throws TException {
-    byte[] dat = str.getBytes(StandardCharsets.UTF_8);
+    byte[] dat = str == null ? new byte[0] : str.getBytes(StandardCharsets.UTF_8);
     writeI32(dat.length);
     trans_.write(dat, 0, dat.length);
   }
 
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
+    if (bin == null) {
+      bin = ByteBuffer.wrap(new byte[0]);
+    }
+
     int length = bin.limit() - bin.position();
     writeI32(length);
     trans_.write(bin.array(), bin.position() + bin.arrayOffset(), length);

--- a/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java
@@ -361,7 +361,7 @@ public class TCompactProtocol extends TProtocol {
    * Write a string to the wire with a varint size preceding.
    */
   public void writeString(String str) throws TException {
-    byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+    byte[] bytes = str == null ? new byte[0] : str.getBytes(StandardCharsets.UTF_8);
     writeBinary(bytes, 0, bytes.length);
   }
 
@@ -369,6 +369,10 @@ public class TCompactProtocol extends TProtocol {
    * Write a byte array, using a varint for the size.
    */
   public void writeBinary(ByteBuffer bin) throws TException {
+    if (bin == null) {
+      bin = ByteBuffer.wrap(new byte[0]);
+    }
+
     int length = bin.limit() - bin.position();
     writeBinary(bin.array(), bin.position() + bin.arrayOffset(), length);
   }

--- a/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
@@ -616,12 +616,16 @@ public class TJSONProtocol extends TProtocol {
 
   @Override
   public void writeString(String str) throws TException {
-    byte[] b = str.getBytes(StandardCharsets.UTF_8);
+    byte[] b = str == null ? new byte[0] : str.getBytes(StandardCharsets.UTF_8);
     writeJSONString(b);
   }
 
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
+    if (bin == null) {
+      bin = ByteBuffer.wrap(new byte[0]);
+    }
+
     writeJSONBase64(bin.array(), bin.position() + bin.arrayOffset(), bin.limit() - bin.position() - bin.arrayOffset());
   }
 

--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -305,6 +305,10 @@ public class TSimpleJSONProtocol extends TProtocol {
 
   @Override
   public void writeString(String str) throws TException {
+    if (str == null) {
+      str = "";
+    }
+
     writeContext_.write();
     int length = str.length();
     StringBuffer escape = new StringBuffer(length + 16);
@@ -359,6 +363,10 @@ public class TSimpleJSONProtocol extends TProtocol {
 
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
+    if (bin == null) {
+      bin = ByteBuffer.wrap(new byte[0]);
+    }
+
     // TODO(mcslee): Fix this
     writeString(new String(bin.array(), bin.position() + bin.arrayOffset(),
         bin.limit() - bin.position() - bin.arrayOffset(),


### PR DESCRIPTION
It seems that, when the element type of map/list is String/ByteBuffer, and the value of element is null, there will always be a NPE.

- [x] [Apache Jira](https://issues.apache.org/jira/browse/THRIFT-5245) 
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)


