### PR TITLE
set pos_ = 0 and endPos_ = 0 when invoke clear() in TMemoryInputTransport.java

### DIFF
--- a/lib/java/src/org/apache/thrift/transport/TMemoryInputTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TMemoryInputTransport.java
@@ -47,6 +47,8 @@ public final class TMemoryInputTransport extends TTransport {
 
   public void clear() {
     buf_ = null;
+    pos_ = 0;
+    endPos_ = 0;
   }
 
   @Override


### PR DESCRIPTION
set `pos_ = 0` and `endPos_ = 0` when invoke `clear()` in TMemoryInputTransport.java