### PR TITLE
THRIFT-5253 using Result in result name generates wrong IAsync interface

### DIFF
--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Impl/Thrift5253/MyService.cs
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Impl/Thrift5253/MyService.cs
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift5253;
+
+namespace Thrift.PublicInterfaces.Compile.Tests.Impl.Thrift5253
+{
+    class MyServiceImpl : MyService.IAsync
+    {
+        public Task<AsyncProcessor> AsyncProcessorAsync(AsyncProcessor input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new AsyncProcessor() { Foo = input.Foo });
+        }
+
+        public Task<BrokenResult> BrokenAsync(BrokenArgs input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new BrokenResult() { Foo = input.Foo });
+        }
+
+        public Task<Client> ClientAsync(Client input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Client() { Foo = input.Foo });
+        }
+
+        public Task<IAsync> IAsyncAsync(IAsync input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new IAsync() { Foo = input.Foo });
+        }
+
+        public Task<InternalStructs> InternalStructsAsync(InternalStructs input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new InternalStructs() { Foo = input.Foo });
+        }
+
+        public Task<WorksRslt> WorksAsync(WorksArrrgs input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new WorksRslt() { Foo = input.Foo });
+        }
+    }
+}

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -52,6 +52,9 @@
     <Exec Condition="Exists('$(PathToThrift)')" Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./../../../../contrib/fb303/if/fb303.thrift" />
     <Exec Condition="Exists('thrift')" Command="thrift -gen netstd:wcf,union,serial -r ./../../../../contrib/fb303/if/fb303.thrift" />
     <Exec Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift')" Command="$(ProjectDir)/../../../../compiler/cpp/thrift -gen netstd:wcf,union,serial -r ./../../../../contrib/fb303/if/fb303.thrift" />
+    <Exec Condition="Exists('$(PathToThrift)')" Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5253.thrift" />
+    <Exec Condition="Exists('thrift')" Command="thrift -gen netstd:wcf,union,serial -r ./Thrift5253.thrift" />
+    <Exec Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift')" Command="$(ProjectDir)/../../../../compiler/cpp/thrift -gen netstd:wcf,union,serial -r ./Thrift5253.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5253.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5253.thrift
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+// Testcase for THRIFT-5253 using Result in result name generates wrong IAsync interface
+
+namespace * Thrift5253
+
+
+// this works
+struct WorksArrrgs { 1: i32 foo }
+struct WorksRslt   { 1: i32 foo }
+
+// this does not
+struct BrokenResult{ 1: i32 foo }
+struct BrokenArgs  { 1: i32 foo }
+
+struct InternalStructs { 1: optional i32 foo }
+struct AsyncProcessor  { 1: optional i32 foo }
+struct Client          { 1: optional i32 foo }
+struct IAsync          { 1: optional i32 foo }
+
+
+service MyService{
+    BrokenResult Broken( 1 : BrokenArgs  foo)
+    WorksRslt     Works( 1 : WorksArrrgs foo)
+
+	InternalStructs InternalStructs( 1: InternalStructs foo)
+	AsyncProcessor  AsyncProcessor ( 1: AsyncProcessor  foo)
+	Client          Client         ( 1: Client  foo)
+	IAsync          IAsync         ( 1: IAsync  foo)
+}
+


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer
