### PR TITLE
THRIFT-4600: Don't close the connection in flush for python THttpClient.py

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -141,10 +141,12 @@ class THttpClient(TTransportBase):
     def write(self, buf):
         self.__wbuf.write(buf)
 
+    def clearResponse(self):
+        if self.__http_response:
+            self.__http_response.read()
+
     def flush(self):
-        if self.isOpen():
-            self.close()
-        self.open()
+        self.clearResponse()
 
         # Pull data out of buffer
         data = self.__wbuf.getvalue()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/THRIFT-4600
Previous patch: https://github.com/apache/thrift/pull/1572

Keep Alive connection aren't currently possible in THttpClient since flush method closes and reopens the connection every time. Adding a fix to stop closing the connection. The earlier patch failed since it doesn't clear the response which leads to  ResponseNotReady errors and invalid buffer state. As per http client lib suggestion (https://docs.python.org/3/library/http.client.html) the previous response should be read and cleared before making next call. Added a block to read and clear the response while flushing. 
