### PR TITLE
THRIFT-5214: Use peek to implement socket connectivity check

### DIFF
--- a/lib/go/thrift/socket_conn.go
+++ b/lib/go/thrift/socket_conn.go
@@ -20,8 +20,6 @@
 package thrift
 
 import (
-	"bytes"
-	"io"
 	"net"
 )
 
@@ -29,7 +27,6 @@ import (
 type socketConn struct {
 	net.Conn
 
-	buf    bytes.Buffer
 	buffer [1]byte
 }
 
@@ -101,16 +98,5 @@ func (sc *socketConn) Read(p []byte) (n int, err error) {
 		return 0, sc.read0()
 	}
 
-	n, err = sc.buf.Read(p)
-	if err != nil && err != io.EOF {
-		return
-	}
-	if n == len(p) {
-		return n, nil
-	}
-	// Continue reading from the wire.
-	var newRead int
-	newRead, err = sc.Conn.Read(p[n:])
-	n += newRead
-	return
+	return sc.Conn.Read(p)
 }

--- a/lib/go/thrift/socket_unix_conn_test.go
+++ b/lib/go/thrift/socket_unix_conn_test.go
@@ -75,16 +75,13 @@ func TestSocketConnUnix(t *testing.T) {
 		t.Error("Expected sc to report open, got false")
 	}
 	// Do connection check again twice after server already wrote new data,
-	// make sure we correctly buffered the read bytes
+	// make sure we don't cause any data loss with the check.
 	time.Sleep(interval * 10)
 	if !sc.IsOpen() {
 		t.Error("Expected sc to report open, got false")
 	}
 	if !sc.IsOpen() {
 		t.Error("Expected sc to report open, got false")
-	}
-	if sc.buf.Len() == 0 {
-		t.Error("Expected sc to buffer read bytes, got empty buffer")
 	}
 	n, err = sc.Read(buf)
 	if err != nil {


### PR DESCRIPTION
Client: go

In previous implementation of socket connectivity check, we try to read
1 byte and put it into buffer when succeeded. The buffer complicates
the implementation of Read function. Change to use syscall.Recvfrom with
MSG_PEEK flag instead so that the buffer is no longer needed.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
