### PR TITLE
THRIFT-5262 Fix a encoding struct bug in the compact protocol implementation to lua

### DIFF
--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -118,8 +118,8 @@ function TCompactProtocol:writeMessageEnd()
 end
 
 function TCompactProtocol:writeStructBegin(name)
-  self.lastFieldIndex = self.lastFieldIndex + 1
   self.lastField[self.lastFieldIndex] = self.lastFieldId
+  self.lastFieldIndex = self.lastFieldIndex + 1
   self.lastFieldId = 0
 end
 


### PR DESCRIPTION

Client:lua

<!-- Explain the changes in the pull request below: -->
  code in lib/lua/TCompactProtocol.lua as follow:
```lua
function TCompactProtocol:writeStructBegin(name)
self.lastFieldIndex = self.lastFieldIndex + 1
self.lastField[self.lastFieldIndex] = self.lastFieldId
self.lastFieldId = 0
end
```

the lastFieldId is saved into the new lastFieldIndex pos and then is restored mistakenly later.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
