### PR TITLE
THRIFT-5263 Fix a bug about reading a zero-size map in the compact protocol implementation to lua

### DIFF
--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -317,7 +317,10 @@ function TCompactProtocol:readMapBegin()
   if size < 0 then
     return nil,nil,nil
   end
-  local kvtype = self:readSignByte()
+  local kvtype = 0
+  if size ~= 0 then
+    kvtype = self:readSignByte()
+  end
   local ktype = self:getTType(libluabitwise.shiftr(kvtype, 4))
   local vtype = self:getTType(kvtype)
   return ktype, vtype, size


### PR DESCRIPTION
bug in lib/lua/TCompactProtocol.lua, code as follow:

```lua
function TCompactProtocol:readMapBegin()
local size = self:readVarint32()
local kvtype = 0
if size > 0 then
kvtype = self:readSignByte()
end
local ktype = self:getTType(libluabitwise.shiftr(kvtype, 4))
local vtype = self:getTType(kvtype)
return ktype, vtype, size
end
```

if the map's size is zero, it should‘t read another byte.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
