### PR TITLE
Rust compiler generates invalid code when using typedef with union

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -1456,6 +1456,10 @@ void t_rs_generator::render_union_sync_write(const string &union_name, t_struct 
       t_field* member = (*members_iter);
       t_field::e_req member_req = t_field::T_REQUIRED;
       t_type* ttype = member->get_type();
+      if (ttype->is_typedef()) {
+        // get the actual type of typedef
+        ttype = ((t_typedef*)ttype)->get_type();
+      }
       string match_var((ttype->is_base_type() && !ttype->is_string()) ? "f" : "ref f");
       f_gen_
         << indent()


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
a trivial change,fix a bug in the rust compiler when using typedef with union  

explanation:
```
typedef i32 int
union Number {
    1: int a
}
```
this thrift file will generate a  rs file that contains a compile error
```

error[E0308]: mismatched types
  --> benchmark/src/main.rs:96:34
   |
96 |                 o_prot.write_i32(f)?;
   |                                  ^
   |                                  |
   |                                  expected `i32`, found `&i32`
   |                                  help: consider dereferencing the borrow: `*f`

error: aborting due to previous error; 2 warnings emitted
```
it's because `ttype` is `t_typedef`
https://github.com/apache/thrift/blob/b0d14133d5071370905a1b54b37a1a7c86d50e6d/compiler/cpp/src/thrift/generate/t_rs_generator.cc#L1456
 https://github.com/apache/thrift/blob/b0d14133d5071370905a1b54b37a1a7c86d50e6d/compiler/cpp/src/thrift/generate/t_rs_generator.cc#L1457
and `t_typedef`'s `is_base_type()` gives false, but what we need is the actual type of `typedef`

so we can fix this bug by getting the actual type of `typedef`
by 3 lines of code
```
      if (ttype->is_typedef()) {
        // get the actual type of typedef
        ttype = ((t_typedef*)ttype)->get_type();
      }
```