### PR TITLE
THRIFT-5274 - Thrift 0.13.0 does not work with JDK8

### DIFF
--- a/lib/java/src/org/apache/thrift/TBaseHelper.java
+++ b/lib/java/src/org/apache/thrift/TBaseHelper.java
@@ -18,6 +18,7 @@
 package org.apache.thrift;
 
 import java.io.Serializable;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -213,8 +214,8 @@ public final class TBaseHelper {
     byte[] buf = bb.array();
 
     int arrayOffset = bb.arrayOffset();
-    int offset = arrayOffset + bb.position();
-    int origLimit = arrayOffset + bb.limit();
+    int offset = arrayOffset + ((Buffer)bb).position();
+    int origLimit = arrayOffset + ((Buffer)bb).limit();
     int limit = (origLimit - offset > 128) ? offset + 128 : origLimit;
 
     for (int i = offset; i < limit; i++) {
@@ -244,7 +245,7 @@ public final class TBaseHelper {
 
   public static boolean wrapsFullArray(ByteBuffer byteBuffer) {
     return byteBuffer.hasArray()
-      && byteBuffer.position() == 0
+      && ((Buffer)byteBuffer).position() == 0
       && byteBuffer.arrayOffset() == 0
       && byteBuffer.remaining() == byteBuffer.capacity();
   }
@@ -252,7 +253,7 @@ public final class TBaseHelper {
   public static int byteBufferToByteArray(ByteBuffer byteBuffer, byte[] target, int offset) {
     int remaining = byteBuffer.remaining();
     System.arraycopy(byteBuffer.array(),
-        byteBuffer.arrayOffset() + byteBuffer.position(),
+        byteBuffer.arrayOffset() + ((Buffer)byteBuffer).position(),
         target,
         offset,
         remaining);
@@ -275,7 +276,7 @@ public final class TBaseHelper {
     }
     ByteBuffer copy = ByteBuffer.wrap(new byte[orig.remaining()]);
     if (orig.hasArray()) {
-      System.arraycopy(orig.array(), orig.arrayOffset() + orig.position(), copy.array(), 0, orig.remaining());
+      System.arraycopy(orig.array(), orig.arrayOffset() + ((Buffer)orig).position(), copy.array(), 0, orig.remaining());
     } else {
       orig.slice().get(copy.array());
     }

--- a/lib/java/src/org/apache/thrift/async/TAsyncMethodCall.java
+++ b/lib/java/src/org/apache/thrift/async/TAsyncMethodCall.java
@@ -19,6 +19,7 @@
 package org.apache.thrift.async;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -260,7 +261,7 @@ public abstract class TAsyncMethodCall<T> {
         cleanUpAndFireCallback(key);
       } else {
         state = State.READING_RESPONSE_SIZE;
-        sizeBuffer.rewind();  // Prepare to read incoming frame size
+        ((Buffer)sizeBuffer).rewind();  // Prepare to read incoming frame size
         key.interestOps(SelectionKey.OP_READ);
       }
     }

--- a/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -19,6 +19,7 @@
 
 package org.apache.thrift.protocol;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -229,9 +230,9 @@ public class TBinaryProtocol extends TProtocol {
 
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
-    int length = bin.limit() - bin.position();
+    int length = ((Buffer)bin).limit() - ((Buffer)bin).position();
     writeI32(length);
-    trans_.write(bin.array(), bin.position() + bin.arrayOffset(), length);
+    trans_.write(bin.array(), ((Buffer)bin).position() + bin.arrayOffset(), length);
   }
 
   /**

--- a/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java
@@ -21,6 +21,7 @@
 package org.apache.thrift.protocol;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -369,8 +370,8 @@ public class TCompactProtocol extends TProtocol {
    * Write a byte array, using a varint for the size.
    */
   public void writeBinary(ByteBuffer bin) throws TException {
-    int length = bin.limit() - bin.position();
-    writeBinary(bin.array(), bin.position() + bin.arrayOffset(), length);
+    int length = ((Buffer)bin).limit() - ((Buffer)bin).position();
+    writeBinary(bin.array(), ((Buffer)bin).position() + bin.arrayOffset(), length);
   }
 
   private void writeBinary(byte[] buf, int offset, int length) throws TException {

--- a/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
@@ -20,6 +20,7 @@
 package org.apache.thrift.protocol;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -622,7 +623,7 @@ public class TJSONProtocol extends TProtocol {
 
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
-    writeJSONBase64(bin.array(), bin.position() + bin.arrayOffset(), bin.limit() - bin.position() - bin.arrayOffset());
+    writeJSONBase64(bin.array(), ((Buffer)bin).position() + bin.arrayOffset(), ((Buffer)bin).limit() - ((Buffer)bin).position() - bin.arrayOffset());
   }
 
   /**

--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -19,6 +19,7 @@
 
 package org.apache.thrift.protocol;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Stack;
@@ -360,8 +361,8 @@ public class TSimpleJSONProtocol extends TProtocol {
   @Override
   public void writeBinary(ByteBuffer bin) throws TException {
     // TODO(mcslee): Fix this
-    writeString(new String(bin.array(), bin.position() + bin.arrayOffset(),
-        bin.limit() - bin.position() - bin.arrayOffset(),
+    writeString(new String(bin.array(), ((Buffer)bin).position() + bin.arrayOffset(),
+        ((Buffer)bin).limit() - ((Buffer)bin).position() - bin.arrayOffset(),
         StandardCharsets.UTF_8));
   }
 

--- a/lib/java/src/org/apache/thrift/transport/TByteBuffer.java
+++ b/lib/java/src/org/apache/thrift/transport/TByteBuffer.java
@@ -1,5 +1,6 @@
 package org.apache.thrift.transport;
 
+import java.nio.Buffer;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -63,7 +64,7 @@ public final class TByteBuffer extends TTransport {
    * Convenience method to call clear() on the underlying NIO ByteBuffer.
    */
   public TByteBuffer clear() {
-    byteBuffer.clear();
+    ((Buffer)byteBuffer).clear();
     return this;
   }
 
@@ -71,7 +72,7 @@ public final class TByteBuffer extends TTransport {
    * Convenience method to call flip() on the underlying NIO ByteBuffer.
      */
   public TByteBuffer flip() {
-    byteBuffer.flip();
+    ((Buffer)byteBuffer).flip();
     return this;
   }
 

--- a/lib/java/src/org/apache/thrift/transport/sasl/FixedSizeHeaderReader.java
+++ b/lib/java/src/org/apache/thrift/transport/sasl/FixedSizeHeaderReader.java
@@ -23,6 +23,7 @@ import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.utils.StringUtils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 /**
@@ -39,13 +40,13 @@ public abstract class FixedSizeHeaderReader implements FrameHeaderReader {
 
   @Override
   public void clear() {
-    byteBuffer.clear();
+    ((Buffer)byteBuffer).clear();
   }
 
   @Override
   public byte[] toBytes() {
     if (!isComplete()) {
-      throw new IllegalStateException("Header is not yet complete " + StringUtils.bytesToHexString(byteBuffer.array(), 0, byteBuffer.position()));
+      throw new IllegalStateException("Header is not yet complete " + StringUtils.bytesToHexString(byteBuffer.array(), 0, ((Buffer)byteBuffer).position()));
     }
     return byteBuffer.array();
   }

--- a/lib/java/src/org/apache/thrift/transport/sasl/FrameReader.java
+++ b/lib/java/src/org/apache/thrift/transport/sasl/FrameReader.java
@@ -23,6 +23,7 @@ import org.apache.thrift.transport.TEOFException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 /**
@@ -144,10 +145,10 @@ public abstract class FrameReader<T extends FrameHeaderReader> {
    */
   static int readAvailable(TTransport transport, ByteBuffer recipient) throws TTransportException {
     if (!recipient.hasRemaining()) {
-      throw new IllegalStateException("Trying to fill a full recipient with " + recipient.limit()
+      throw new IllegalStateException("Trying to fill a full recipient with " + ((Buffer)recipient).limit()
           + " bytes");
     }
-    int currentPosition = recipient.position();
+    int currentPosition = ((Buffer)recipient).position();
     byte[] bytes = recipient.array();
     int offset = recipient.arrayOffset() + currentPosition;
     int expectedLength = recipient.remaining();
@@ -156,7 +157,7 @@ public abstract class FrameReader<T extends FrameHeaderReader> {
       throw new TEOFException("Transport is closed, while trying to read " + expectedLength +
           " bytes");
     }
-    recipient.position(currentPosition + got);
+    ((Buffer)recipient).position(currentPosition + got);
     return got;
   }
 }


### PR DESCRIPTION

Thrift 0.13.0 does not work with JDK8, as it is compiled with JDK11. Even though the source version is JDK8, incorrect byte code is generated for various ByteBuffer methods, e.g.:

Exception in thread "TAsyncClientManager#SelectorThread 22" java.lang.NoSuchMethodError: java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer;

The fix is to manually cast ByteBuffer to Buffer (or else switch to using the xenial docker image to create the release artifacts). See this task for more context: https://github.com/eclipse/jetty.project/issues/3244

