### PR TITLE
TServerSocket.cpp: Ensure the server is really listening

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -167,7 +167,13 @@ TServerSocket::~TServerSocket() {
 }
 
 bool TServerSocket::isOpen() const {
-  return (serverSocket_ != THRIFT_INVALID_SOCKET);
+  if (serverSocket_ == THRIFT_INVALID_SOCKET)
+    return false;
+
+  if (!listening_)
+    return false;
+
+  return true;
 }
 
 void TServerSocket::setSendTimeout(int sendTimeout) {
@@ -324,7 +330,6 @@ void TServerSocket::_setup_tcp_sockopts() {
 }
 
 void TServerSocket::listen() {
-  listening_ = true;
 #ifdef _WIN32
   TWinsockSingleton::create();
 #endif // _WIN32
@@ -538,6 +543,7 @@ void TServerSocket::listen() {
   }
 
   // The socket is now listening!
+  listening_ = true;
 }
 
 int TServerSocket::getPort() {


### PR DESCRIPTION
Currently the C++ server does not ensure that `listening_` is `true` in `isOpen()`. I think this is incorrect because in multi-threaded environments, the socket may not be open or listening yet. Also, `listening_` should only be set to `true` when the socket is fully set up and listening.

This PR adds a minor change: it respects `listening_` for `isOpen()`, and sets `listening_` to `true` only at the end of spcket initialization. In heavy stress tests, we found this makes the server method `isOpen()` more reliable.

Thanks for consideration.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.