### PR TITLE
Added getter and setter for domain socket path

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -438,7 +438,7 @@ void TSocket::open() {
 
 void TSocket::unix_open() {
   if (!path_.empty()) {
-    // Unix Domain SOcket does not need addrinfo struct, so we pass nullptr
+    // Unix Domain Socket does not need addrinfo struct, so we pass NULL
     openConnection(nullptr);
   }
 }
@@ -711,12 +711,20 @@ int TSocket::getPort() {
   return port_;
 }
 
+std::string TSocket::getPath() {
+    return path_;
+}
+
 void TSocket::setHost(string host) {
   host_ = host;
 }
 
 void TSocket::setPort(int port) {
   port_ = port;
+}
+
+void TSocket::setPath(std::string path) {
+    path_ = path;
 }
 
 void TSocket::setLinger(bool on, int linger) {
@@ -828,7 +836,11 @@ string TSocket::getSocketInfo() const {
       oss << "<Host: " << host_ << " Port: " << port_ << ">";
     }
   } else {
-    oss << "<Path: " << path_ << ">";
+    std::string fmt_path_ = path_;
+    // Handle printing abstract sockets (first character is a '\0' char):
+    if (!fmt_path_.empty() && fmt_path_[0] == '\0')
+      fmt_path_[0] = '@';
+    oss << "<Path: " << fmt_path_ << ">";
   }
   return oss.str();
 }

--- a/lib/cpp/src/thrift/transport/TSocket.h
+++ b/lib/cpp/src/thrift/transport/TSocket.h
@@ -68,6 +68,7 @@ public:
    * Note that this does NOT actually connect the socket.
    *
    * @param path The Unix domain socket e.g. "/tmp/ThriftTest.binary.thrift"
+   * or a zero-prefixed string to create an abstract domain socket on Linux.
    */
   TSocket(const std::string& path, std::shared_ptr<TConfiguration> config = nullptr);
 
@@ -150,6 +151,13 @@ public:
   int getPort();
 
   /**
+   * Get the Unix domain socket path that the socket is connected to
+   *
+   * @return std::string path
+   */
+  std::string getPath();
+
+  /**
    * Set the host that socket will connect to
    *
    * @param host host identifier
@@ -162,6 +170,13 @@ public:
    * @param port port number
    */
   void setPort(int port);
+
+  /**
+   * Set the Unix domain socket path for the socket
+   *
+   * @param path std::string path
+   */
+  void setPath(std::string path);
 
   /**
    * Controls whether the linger option is set on the socket.


### PR DESCRIPTION
This PR adds a minor change to C++ domain sockets. It adds a getter and setter for the domain socket path. Also, it adds a minor bugfix when printing abstract sockets. The zero-character prefix of abstract domain sockets needs to be converted to a printable character. It is typically printed as an `@`-sign.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
