### PR TITLE
Improve setting the domain socket path into the sockaddr_un struct in TSockets

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -329,31 +329,27 @@ void TSocket::openConnection(struct addrinfo* res) {
   if (!path_.empty()) {
 
 #ifndef _WIN32
-    size_t len = path_.size() + 1;
-    if (len > sizeof(((sockaddr_un*)nullptr)->sun_path)) {
+    if ((path_.size() + 1) > sizeof(((sockaddr_un*)nullptr)->sun_path)) {
       int errno_copy = THRIFT_GET_SOCKET_ERROR;
       GlobalOutput.perror("TSocket::open() Unix Domain socket path too long", errno_copy);
       throw TTransportException(TTransportException::NOT_OPEN, " Unix Domain socket path too long");
     }
 
     struct sockaddr_un address;
+    // Store the zero-terminated path in address.sun_path
+    memset(&address, '\0', sizeof(address));
     address.sun_family = AF_UNIX;
-    memcpy(address.sun_path, path_.c_str(), len);
-
-    auto structlen = static_cast<socklen_t>(sizeof(address));
+    memcpy(address.sun_path, path_.c_str(), path_.size());
 
     if (!address.sun_path[0]) { // abstract namespace socket
-#ifdef __linux__
-      // sun_path is not null-terminated in this case and structlen determines its length
-      structlen -= sizeof(address.sun_path) - len;
-#else
+#ifndef __linux__
       GlobalOutput.perror("TSocket::open() Abstract Namespace Domain sockets only supported on linux: ", -99);
       throw TTransportException(TTransportException::NOT_OPEN,
                                 " Abstract Namespace Domain socket path not supported");
 #endif
     }
 
-    ret = connect(socket_, (struct sockaddr*)&address, structlen);
+    ret = connect(socket_, (struct sockaddr*)&address, static_cast<socklen_t>(sizeof(struct sockaddr_un)));
 #else
     GlobalOutput.perror("TSocket::open() Unix Domain socket path not supported on windows", -99);
     throw TTransportException(TTransportException::NOT_OPEN,


### PR DESCRIPTION
The code that sets a domain socket path in `TServerSocket.cpp` and `TSocket.cpp` is currently slightly more complex than required (at least that is my understanding). Also it seems to contain a potential out-of-bounds-access.

I simplified the code in the following way:
 - Ensure that the `sockaddr_un struct` is fully set to zero before using it
   - This removes the necessity to deal with zero-termination of the path. It also removes the need for the `len` variable
 - Do not use `path_.size() + 1` length when `memcpy` the path from `path_` to the `sockaddr_un struct`
   - This may be an out-of-bounds-access in the current code, depending on whether `path_` actually contains an additional zero-terminating character (which is unlikely)

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.