### PR TITLE
Fixed double newline at end of generated python service files

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1172,7 +1172,7 @@ void t_py_generator::generate_service(t_service* tservice) {
 
   // Close service file
   f_service_ << "fix_spec(all_structs)" << endl
-             << "del all_structs" << endl << endl;
+             << "del all_structs" << endl;
   f_service_.close();
 }
 


### PR DESCRIPTION
## Explain the changes in the pull request below:

Generated python files have a blank line at the end of files, except for service files where there are two blank lines, this change makes these service files consistent.

This change is trivial and thus does not require a ticket.
