### PR TITLE
THRIFT-5282: Add IPv6 client support to Lua library

### DIFF
--- a/lib/lua/src/luasocket.c
+++ b/lib/lua/src/luasocket.c
@@ -344,11 +344,8 @@ static int l_socket_create_and_connect(lua_State *L) {
   // Create and connect loop for timeout milliseconds
   end = __gettime() + timeout/1000;
   do {
-    // Create the socket
-    err = tcp_create(&sock);
-    if (!err) {
-        // Connect
-        err = tcp_connect(&sock, host, port, timeout);
+    // Create and connect the socket
+    err = tcp_create_and_connect(&sock, host, port, timeout);
         if (err) {
           tcp_destroy(&sock);
           usleep(100000); // sleep for 100ms
@@ -360,7 +357,6 @@ static int l_socket_create_and_connect(lua_State *L) {
           tcp->timeout = timeout;
           return 1; // Return userdata
         }
-    }
   } while (err && __gettime() < end);
 
   LUA_CHECK_RETURN(L, err);

--- a/lib/lua/src/socket.h
+++ b/lib/lua/src/socket.h
@@ -75,4 +75,7 @@ const char * tcp_accept(p_socket sock, p_socket client, int timeout);
 const char * tcp_connect(p_socket sock, const char *host, unsigned short port,
                          int timeout);
 
+const char * tcp_create_and_connect(p_socket sock, const char *host,
+                                    unsigned short port, int timeout);
+
 #endif


### PR DESCRIPTION
Client: lua

The Lua library only supports TCP connections over IPv4 sockets. Add IPv6 support to the Thrift client in `l_socket_create_and_connect()` only, which is the usual code flow.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
