### PR TITLE
go: Use sync.Pool for gzip in HTTP transport

### DIFF
--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 // NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function
@@ -40,14 +41,23 @@ func NewThriftHandlerFunc(processor TProcessor,
 
 // gz transparently compresses the HTTP response if the client supports it.
 func gz(handler http.HandlerFunc) http.HandlerFunc {
+	sp := &sync.Pool{
+		New: func() interface{} {
+			return gzip.NewWriter(nil)
+		}}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 			handler(w, r)
 			return
 		}
 		w.Header().Set("Content-Encoding", "gzip")
-		gz := gzip.NewWriter(w)
-		defer gz.Close()
+		gz := sp.Get().(*gzip.Writer)
+		gz.Reset(w)
+		defer func() {
+			_ = gz.Close()
+			sp.Put(gz)
+		}()
 		gzw := gzipResponseWriter{Writer: gz, ResponseWriter: w}
 		handler(gzw, r)
 	}

--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -44,7 +44,8 @@ func gz(handler http.HandlerFunc) http.HandlerFunc {
 	sp := &sync.Pool{
 		New: func() interface{} {
 			return gzip.NewWriter(nil)
-		}}
+		},
+	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {


### PR DESCRIPTION
b67cad4 introduced transparent gzip support for the HTTP transport but
calling gzip.NewWriter() with every request causes a large number of
memory allocations [1] and can create GC pressure.

Avoid this issue by using a sync.Pool for gzip writers.

[1] https://old.reddit.com/r/golang/comments/9uejp4/usage_of_syncpool_for_gzipwriter_in_http_handlers/e94jh8c/
