### PR TITLE
Fix c_glib implicit function declarations

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
@@ -67,6 +67,11 @@ struct _ThriftProtocolDecoratorClass
 /* used by THRIFT_TYPE_PROTOCOL_DECORATOR */
 GType thrift_protocol_decorator_get_type (void);
 
+gint32 thrift_protocol_decorator_write_message_begin (ThriftProtocol *protocol,
+                                     const gchar *name,
+                                     const ThriftMessageType message_type,
+                                     const gint32 seqid, GError **error);
+
 G_END_DECLS
 
 #endif /* _THRIFT_PROTOCOL_DECORATOR_H */

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
@@ -223,5 +223,8 @@ thrift_ssl_socket_initialize_openssl(void);
 void
 thrift_ssl_socket_finalize_openssl(void);
 
+gboolean
+thrift_ssl_socket_authorize(ThriftTransport * transport, GError **error);
+
 G_END_DECLS
 #endif


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Using Xcode 12 on macOS 10.15, any implicit function declarations are now errors rather than warnings. Some of the implicit function declarations present in thrift 0.13.0 were already addressed in 0d6a2d3. This PR fixes the ones remaining:
* usage of `thrift_protocol_decorator_write_message_begin()` from thrift_multiplexed_protocol.c: https://github.com/apache/thrift/blob/b1a5cd6542f4591563d39ed2021be9fc4690528f/lib/c_glib/src/thrift/c_glib/protocol/thrift_multiplexed_protocol.c#L60
* usage of `thrift_ssl_socket_authorize()` before its definition in thrift_ssl_socket.c: https://github.com/apache/thrift/blob/c5b9d9e69e80f8243c34d763d7b8af1c3dacbc00/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c#L432

This PR declares each of those functions in already-included header files to avoid the implicit function declarations.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] ~~Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)~~
- [ ] ~~If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?~~
No existing ticket found for this issue.
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  ~~If one was needed, did you label the Jira ticket with "Breaking-Change"?~~
- [ ] ~~If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.~~

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
