### PR TITLE
THRIFT-5286: Fix Lua library readBool() in TCompactProtocol

### DIFF
--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -176,7 +176,6 @@ function TCompactProtocol:writeBool(bool)
   if bool then
     value = TCompactType.COMPACT_BOOLEAN_TRUE
   end
-  print(value,self.booleanFieldPending,self.booleanFieldId)
   if self.booleanFieldPending then
     self:writeFieldBeginInternal(self.booleanFieldName, TType.BOOL, self.booleanFieldId, value)
     self.booleanFieldPending = false
@@ -293,17 +292,20 @@ function TCompactProtocol:readFieldBegin()
   if ttype == TType.STOP then
     return nil, ttype, 0
   end
-  -- mask off the 4 MSB of the type header. it could contain a field id delta.
-  local modifier = libluabitwise.shiftr(libluabitwise.band(field_and_ttype, 0xf0), 4)
+  local modifier = libluabitwise.shiftr(field_and_ttype, 4)
   local id = 0
   if modifier == 0 then
     id = self:readI16()
   else
     id = self.lastFieldId + modifier
   end
-  if ttype == TType.BOOL then
-    boolValue = libluabitwise.band(field_and_ttype, 0x0f) == TCompactType.COMPACT_BOOLEAN_TRUE
-    boolValueIsNotNull = true
+  local type = libluabitwise.band(field_and_ttype, 0x0f)
+  if type == TCompactType.COMPACT_BOOLEAN_TRUE then
+    self.boolValue = true
+    self.boolValueIsNotNull = true
+  elseif type == TCompactType.COMPACT_BOOLEAN_FALSE then
+    self.boolValue = false
+    self.boolValueIsNotNull = true
   end
   self.lastFieldId = id
   return nil, ttype, id
@@ -350,9 +352,9 @@ function TCompactProtocol:readSetEnd()
 end
 
 function TCompactProtocol:readBool()
-  if boolValueIsNotNull then
-    boolValueIsNotNull = true
-    return boolValue
+  if self.boolValueIsNotNull then
+    self.boolValueIsNotNull = false
+    return self.boolValue
   end
   local val = self:readSignByte()
   if val == TCompactType.COMPACT_BOOLEAN_TRUE then


### PR DESCRIPTION
Client: Lua

`TCompactProtocol` did not read boolean fields correctly due to code bugs.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
