### PR TITLE
Throw exception when there is no data in curl transport

### DIFF
--- a/lib/php/lib/Transport/TCurlClient.php
+++ b/lib/php/lib/Transport/TCurlClient.php
@@ -159,14 +159,24 @@ class TCurlClient extends TTransport
      */
     public function read($len)
     {
+        $len_avail = strlen($this->response_);
+        if ($len_avail === 0) {
+            throw new TTransportException(
+                'TCurlClient: Could not read ' . $len . ' bytes from ' .
+                $this->host_ . ':' . $this->port_ . $this->uri_, TTransportException::UNKNOWN);
+        }
+        $ret = null;
         if ($len >= strlen($this->response_)) {
-            return $this->response_;
+            //although we know there is not going to be enough data, we return what we have
+            //to meet the TTransport definition
+            $ret = $this->response_;
+            //this is needed make the next read call fail with TTransportException
+            $this->response_ = "";
         } else {
             $ret = substr($this->response_, 0, $len);
             $this->response_ = substr($this->response_, $len);
-
-            return $ret;
         }
+        return $ret;
     }
 
     /**


### PR DESCRIPTION
My team has been running a fork of php thrift (super old) and we had an issue parsing never terminates when body is empty. After looking open source code, current master is not vulnerable to our specific use case because curl throws an error when response is empty. However, I feel that explicitly throwing an error when there is no more data available in curl transport is beneficial in the case if caller has bugs. Let me know what you folks think. And Happy to add test and jira if that makes sense. Thxs

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
Happy to create it if we my problem/changes make sense.
- [] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
