### PR TITLE
THRIFT-5240: Tweak the default go server connectivity check interval

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -107,4 +107,9 @@ main function:
 
     thrift.ServerConnectivityCheckInterval = 0
 
+Please be advised that due to a
+[Go runtime bug](https://github.com/golang/go/issues/27707), currently
+if this interval is set to a value too low (for example, 1ms), it might cause
+excessive cpu overhead.
+
 This feature is also only enabled on non-oneway endpoints.

--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -46,7 +46,7 @@ var ErrAbandonRequest = errors.New("request abandoned")
 // implementations can change its value to control the behavior.
 //
 // If it's changed to <=0, the feature will be disabled.
-var ServerConnectivityCheckInterval = time.Millisecond
+var ServerConnectivityCheckInterval = time.Millisecond * 5
 
 /*
  * This is not a typical TSimpleServer as it is not blocked after accept a socket.


### PR DESCRIPTION
Client: go

This is a follow up to 4db7a0af13ac9614e3e9758d42b2791040f4dc7e.

Because of the Go runtime bug [1], the previous default value of 1ms is
not a great default as it could cause excessive cpu usage. Use 5ms
instead as a balance between being useful and not causing too much cpu
overhead.
    
It's still configurable.
    
[1]: https://github.com/golang/go/issues/27707

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
