### PR TITLE
Fix the problem of recursive multiple files covering each other

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_generator.h
@@ -433,7 +433,7 @@ protected:
     std::ofstream out_file;
     out_file.exceptions(out_file.exceptions() | std::ofstream::badbit | std::ofstream::failbit);
     try {
-      out_file.open(output_file_path.c_str(), std::ios::out);
+      out_file.open(output_file_path.c_str(), std::ios::out | std::ios::app);
     }
     catch (const std::ios_base::failure& e) {
       ::failure("failed to write the output to the file '%s', details: '%s'", output_file_path.c_str(), e.what());


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Fix the problem of recursive multiple files covering each other. for example : use the 'classmap' args when generating php files.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
