### PR TITLE
Add an Automatic-Module-Name entry

### DIFF
--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -71,6 +71,7 @@ jar {
     manifest {
         attributes([
             "Implementation-Version": "${project.version}",
+            "Automatic-Module-Name": "${project.group}",
             "Bundle-ManifestVersion": "2",
             "Bundle-SymbolicName": "${project.group}",
             "Bundle-Name": "Apache Thrift",


### PR DESCRIPTION
This adds an Automatic-Module-Name entry to the Thrift jar manifest
in order to provide Thrift with a stable module name when used in a
JPMS modular context. The name chosen here is "org.apache.thrift",
which matches the symbolic name used for OSGi.

See: http://branchandbound.net/blog/java/2017/12/automatic-module-name/