### PR TITLE
THRIFT-5303: Fix missing error handling in using PyUnicode_DecodeUTF8

### DIFF
--- a/lib/py/src/ext/protocol.tcc
+++ b/lib/py/src/ext/protocol.tcc
@@ -705,7 +705,7 @@ PyObject* ProtocolBase<Impl>::decodeValue(TType type, PyObject* typeargs) {
       return nullptr;
     }
     if (isUtf8(typeargs)) {
-      return PyUnicode_DecodeUTF8(buf, len, 0);
+      return PyUnicode_DecodeUTF8(buf, len, "replace");
     } else {
       return PyBytes_FromStringAndSize(buf, len);
     }


### PR DESCRIPTION
We should also use the 'replace' error handling mode in calling PyUnicode_DecodeUTF8 to align with THRIFT-2087.

<!-- Explain the changes in the pull request below: -->
 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
