### PR TITLE
THRIFT-5306: Rust code and generated code no longer has clippy warnings (Rust 1.40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,7 @@ project.lock.json
 /lib/rs/test/src/midlayer.rs
 /lib/rs/test/src/recursive.rs
 /lib/rs/test/src/ultimate.rs
+/lib/rs/test/src/identifiers.rs
 /lib/rs/*.iml
 /lib/rs/**/*.iml
 /lib/swift/.build

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -314,7 +314,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/rs/README.md">Rust</a></td>
 <!-- Since -----------------><td>0.11.0</td>
 <!-- Build Systems ---------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.35.0</td><td>1.35.0</td>
+<!-- Language Levels -------><td>1.40.0</td><td>1.xx.x</td>
 <!-- Low-Level Transports --><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
 <!-- Transport Wrappers ----><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td>
 <!-- Protocols -------------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["Makefile*", "test/**", "*.iml"]
 keywords = ["thrift"]
 
 [dependencies]
-ordered-float = "1.0"
 byteorder = "1.3"
 integer-encoding = ">=1.1.4" # https://issues.apache.org/jira/browse/THRIFT-5131
 log = "0.4"
+ordered-float = "1.0"
 threadpool = "1.7"

--- a/lib/rs/README.md
+++ b/lib/rs/README.md
@@ -48,7 +48,7 @@ Breaking changes are minimized. When they are made they will be outlined below w
 
 ##### Thrift 0.14.0
 
-* **[THRIFT-5158]** - Rust library and generator now support Rust 2018 only
+* **[THRIFT-5158]** - Rust library and generator now support Rust 2018 only. Required rust 1.40.0 or higher
 
     The Rust `thrift` library was updated to Rust 2018 via `cargo fix --edition`.
     All test code in the repo was updated as well. The code generator was also updated

--- a/lib/rs/src/errors.rs
+++ b/lib/rs/src/errors.rs
@@ -236,8 +236,8 @@ impl Error {
         i.read_struct_end()?;
 
         Ok(ApplicationError {
-            kind: kind,
-            message: message,
+            kind,
+            message,
         })
     }
 
@@ -283,7 +283,7 @@ impl error::Error for Error {
 }
 
 impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Transport(ref e) => Debug::fmt(e, f),
             Error::Protocol(ref e) => Debug::fmt(e, f),
@@ -294,7 +294,7 @@ impl Debug for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Transport(ref e) => Display::fmt(e, f),
             Error::Protocol(ref e) => Display::fmt(e, f),
@@ -362,7 +362,7 @@ impl TransportError {
     /// Create a new `TransportError`.
     pub fn new<S: Into<String>>(kind: TransportErrorKind, message: S) -> TransportError {
         TransportError {
-            kind: kind,
+            kind,
             message: message.into(),
         }
     }
@@ -404,7 +404,7 @@ impl TransportError {
 }
 
 impl Display for TransportError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
@@ -490,7 +490,7 @@ impl ProtocolError {
     /// Create a new `ProtocolError`.
     pub fn new<S: Into<String>>(kind: ProtocolErrorKind, message: S) -> ProtocolError {
         ProtocolError {
-            kind: kind,
+            kind,
             message: message.into(),
         }
     }
@@ -534,7 +534,7 @@ impl ProtocolError {
 }
 
 impl Display for ProtocolError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
@@ -581,7 +581,7 @@ impl ApplicationError {
     /// Create a new `ApplicationError`.
     pub fn new<S: Into<String>>(kind: ApplicationErrorKind, message: S) -> ApplicationError {
         ApplicationError {
-            kind: kind,
+            kind,
             message: message.into(),
         }
     }
@@ -638,7 +638,7 @@ impl ApplicationError {
 }
 
 impl Display for ApplicationError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }

--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -49,14 +49,6 @@
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![deny(bare_trait_objects)]
 
-extern crate byteorder;
-extern crate ordered_float;
-extern crate integer_encoding;
-extern crate threadpool;
-
-#[macro_use]
-extern crate log;
-
 // NOTE: this macro has to be defined before any modules. See:
 // https://danielkeep.github.io/quick-intro-to-macros.html#some-more-gotchas
 

--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -26,7 +26,7 @@ use super::{TOutputProtocol, TOutputProtocolFactory, TSetIdentifier, TStructIden
 use crate::transport::{TReadTransport, TWriteTransport};
 use crate::{ProtocolError, ProtocolErrorKind};
 
-const BINARY_PROTOCOL_VERSION_1: u32 = 0x80010000;
+const BINARY_PROTOCOL_VERSION_1: u32 = 0x8001_0000;
 
 /// Read messages encoded in the Thrift simple binary encoding.
 ///
@@ -69,8 +69,8 @@ where
     /// version number in the protocol header.
     pub fn new(transport: T, strict: bool) -> TBinaryInputProtocol<T> {
         TBinaryInputProtocol {
-            strict: strict,
-            transport: transport,
+            strict,
+            transport,
         }
     }
 }
@@ -79,7 +79,7 @@ impl<T> TInputProtocol for TBinaryInputProtocol<T>
 where
     T: TReadTransport,
 {
-    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
+    #[allow(clippy::collapsible_if)]
     fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier> {
         let mut first_bytes = vec![0; 4];
         self.transport.read_exact(&mut first_bytes[..])?;
@@ -295,8 +295,8 @@ where
     /// protocol version number in the protocol header.
     pub fn new(transport: T, strict: bool) -> TBinaryOutputProtocol<T> {
         TBinaryOutputProtocol {
-            strict: strict,
-            transport: transport,
+            strict,
+            transport,
         }
     }
 }
@@ -520,7 +520,7 @@ mod tests {
         let ident = TMessageIdentifier::new("test", TMessageType::Call, 1);
         assert!(o_prot.write_message_begin(&ident).is_ok());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 16] = [
             0x80,
             0x01,
@@ -550,7 +550,7 @@ mod tests {
         let ident = TMessageIdentifier::new("test", TMessageType::Call, 1);
         assert!(o_prot.write_message_begin(&ident).is_ok());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 13] = [
             0x00,
             0x00,
@@ -577,7 +577,7 @@ mod tests {
         let ident = TMessageIdentifier::new("test", TMessageType::Reply, 10);
         assert!(o_prot.write_message_begin(&ident).is_ok());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 16] = [
             0x80,
             0x01,
@@ -607,7 +607,7 @@ mod tests {
         let ident = TMessageIdentifier::new("test", TMessageType::Reply, 10);
         assert!(o_prot.write_message_begin(&ident).is_ok());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 13] = [
             0x00,
             0x00,
@@ -892,7 +892,7 @@ mod tests {
     fn must_round_trip_bytes() {
         let (mut i_prot, mut o_prot) = test_objects(true);
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let bytes: [u8; 25] = [
             0x20,
             0xFD,

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -76,7 +76,7 @@ where
             last_read_field_id: 0,
             read_field_id_stack: Vec::new(),
             pending_read_bool_value: None,
-            transport: transport,
+            transport,
         }
     }
 
@@ -193,7 +193,7 @@ where
 
                 Ok(TFieldIdentifier {
                     name: None,
-                    field_type: field_type,
+                    field_type,
                     id: Some(self.last_read_field_id),
                 })
             }
@@ -371,7 +371,7 @@ where
             last_write_field_id: 0,
             write_field_id_stack: Vec::new(),
             pending_write_bool_field_identifier: None,
-            transport: transport,
+            transport,
         }
     }
 
@@ -673,7 +673,7 @@ mod tests {
             431
         )));
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 8] = [
             0x82, /* protocol ID */
             0x21, /* message type | protocol version */
@@ -695,10 +695,10 @@ mod tests {
         assert_success!(o_prot.write_message_begin(&TMessageIdentifier::new(
             "bar",
             TMessageType::Reply,
-            991828
+            991_828
         )));
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 9] = [
             0x82, /* protocol ID */
             0x41, /* message type | protocol version */
@@ -743,7 +743,7 @@ mod tests {
     fn must_round_trip_message_begin() {
         let (mut i_prot, mut o_prot) = test_objects();
 
-        let ident = TMessageIdentifier::new("service_call", TMessageType::Call, 1283948);
+        let ident = TMessageIdentifier::new("service_call", TMessageType::Call, 1_283_948);
 
         assert_success!(o_prot.write_message_begin(&ident));
 
@@ -787,7 +787,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 5] = [
             0x03, /* field type */
             0x00, /* first field id */
@@ -902,7 +902,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 4] = [
             0x15, /* field delta (1) | field type */
             0x1A, /* field delta (1) | field type */
@@ -1015,7 +1015,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 8] = [
             0x05, /* field type */
             0x00, /* first field id */
@@ -1139,7 +1139,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 10] = [
             0x16, /* field delta (1) | field type */
             0x85, /* field delta (8) | field type */
@@ -1156,6 +1156,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_struct_with_mix_of_long_and_delta_fields() {
         let (mut i_prot, mut o_prot) = test_objects();
@@ -1304,7 +1305,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 7] = [
             0x16, /* field delta (1) | field type */
             0x85, /* field delta (8) | field type */
@@ -1318,6 +1319,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_nested_structs_0() {
         // last field of the containing struct is a delta
@@ -1477,7 +1479,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 7] = [
             0x16, /* field delta (1) | field type */
             0x85, /* field delta (8) | field type */
@@ -1491,6 +1493,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_nested_structs_1() {
         // last field of the containing struct is a delta
@@ -1650,7 +1653,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 7] = [
             0x16, /* field delta (1) | field type */
             0x08, /* field type */
@@ -1664,6 +1667,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_nested_structs_2() {
         let (mut i_prot, mut o_prot) = test_objects();
@@ -1820,7 +1824,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 8] = [
             0x16, /* field delta (1) | field type */
             0x08, /* field type */
@@ -1835,6 +1839,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_nested_structs_3() {
         // last field of the containing struct is a full write
@@ -1986,7 +1991,7 @@ mod tests {
         assert_success!(o_prot.write_field_stop());
         assert_success!(o_prot.write_struct_end());
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 7] = [
             0x11, /* field delta (1) | true */
             0x82, /* field delta (8) | false */
@@ -2000,6 +2005,7 @@ mod tests {
         assert_eq_written_bytes!(o_prot, expected);
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn must_round_trip_bool_field() {
         let (mut i_prot, mut o_prot) = test_objects();
@@ -2245,7 +2251,7 @@ mod tests {
     fn must_round_trip_large_sized_set_begin() {
         let (mut i_prot, mut o_prot) = test_objects();
 
-        let ident = TSetIdentifier::new(TType::Map, 3928429);
+        let ident = TSetIdentifier::new(TType::Map, 3_928_429);
 
         assert_success!(o_prot.write_set_begin(&ident));
 
@@ -2312,7 +2318,7 @@ mod tests {
     fn must_round_trip_map_begin() {
         let (mut i_prot, mut o_prot) = test_objects();
 
-        let ident = TMapIdentifier::new(TType::Map, TType::List, 1928349);
+        let ident = TMapIdentifier::new(TType::Map, TType::List, 1_928_349);
 
         assert_success!(o_prot.write_map_begin(&ident));
 
@@ -2403,11 +2409,13 @@ mod tests {
     fn must_read_write_double() {
         let (mut i_prot, mut o_prot) = test_objects();
 
-        let double = 3.141592653589793238462643;
+        #[allow(clippy::approx_constant)]
+        let double = 3.141_592_653_589_793;
         o_prot.write_double(double).unwrap();
         copy_write_buffer_to_read_buffer!(o_prot);
 
-        assert_eq!(i_prot.read_double().unwrap(), double);
+        let read_double = i_prot.read_double().unwrap();
+        assert!(read_double - double < std::f64::EPSILON);
     }
 
     #[test]
@@ -2415,11 +2423,11 @@ mod tests {
         let (_, mut o_prot) = test_objects();
         let expected = [24, 45, 68, 84, 251, 33, 9, 64];
 
-        let double = 3.141592653589793238462643;
+        #[allow(clippy::approx_constant)]
+        let double = 3.141_592_653_589_793;
         o_prot.write_double(double).unwrap();
 
         assert_eq_written_bytes!(o_prot, expected);
-
     }
 
     fn assert_no_write<F>(mut write_fn: F)

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -610,8 +610,8 @@ impl TMessageIdentifier {
     ) -> TMessageIdentifier {
         TMessageIdentifier {
             name: name.into(),
-            message_type: message_type,
-            sequence_number: sequence_number,
+            message_type,
+            sequence_number,
         }
     }
 }
@@ -660,7 +660,7 @@ impl TFieldIdentifier {
     {
         TFieldIdentifier {
             name: name.into().map(|n| n.into()),
-            field_type: field_type,
+            field_type,
             id: id.into(),
         }
     }
@@ -680,8 +680,8 @@ impl TListIdentifier {
     /// `element_type`.
     pub fn new(element_type: TType, size: i32) -> TListIdentifier {
         TListIdentifier {
-            element_type: element_type,
-            size: size,
+            element_type,
+            size,
         }
     }
 }
@@ -700,8 +700,8 @@ impl TSetIdentifier {
     /// `element_type`.
     pub fn new(element_type: TType, size: i32) -> TSetIdentifier {
         TSetIdentifier {
-            element_type: element_type,
-            size: size,
+            element_type,
+            size,
         }
     }
 }
@@ -728,7 +728,7 @@ impl TMapIdentifier {
         TMapIdentifier {
             key_type: key_type.into(),
             value_type: value_type.into(),
-            size: size,
+            size,
         }
     }
 }
@@ -747,7 +747,7 @@ pub enum TMessageType {
 }
 
 impl Display for TMessageType {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             TMessageType::Call => write!(f, "Call"),
             TMessageType::Reply => write!(f, "Reply"),
@@ -822,7 +822,7 @@ pub enum TType {
 }
 
 impl Display for TType {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             TType::Stop => write!(f, "STOP"),
             TType::Void => write!(f, "void"),

--- a/lib/rs/src/protocol/multiplexed.rs
+++ b/lib/rs/src/protocol/multiplexed.rs
@@ -203,7 +203,7 @@ mod tests {
         let ident = TMessageIdentifier::new("bar", TMessageType::Call, 2);
         assert_success!(o_prot.write_message_begin(&ident));
 
-        #[cfg_attr(rustfmt, rustfmt::skip)]
+        #[rustfmt::skip]
         let expected: [u8; 19] = [
             0x80,
             0x01, /* protocol identifier */

--- a/lib/rs/src/protocol/stored.rs
+++ b/lib/rs/src/protocol/stored.rs
@@ -92,7 +92,7 @@ impl<'a> TStoredInputProtocol<'a> {
     pub fn new(
         wrapped: &mut dyn TInputProtocol,
         message_ident: TMessageIdentifier,
-    ) -> TStoredInputProtocol {
+    ) -> TStoredInputProtocol<'_> {
         TStoredInputProtocol {
             inner: wrapped,
             message_ident: message_ident.into(),

--- a/lib/rs/src/server/multiplexed.rs
+++ b/lib/rs/src/server/multiplexed.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use log::debug;
+
 use std::collections::HashMap;
 use std::convert::Into;
 use std::fmt;
@@ -25,7 +27,7 @@ use crate::protocol::{TInputProtocol, TMessageIdentifier, TOutputProtocol, TStor
 
 use super::{handle_process_result, TProcessor};
 
-const MISSING_SEPARATOR_AND_NO_DEFAULT: &'static str =
+const MISSING_SEPARATOR_AND_NO_DEFAULT: &str =
     "missing service separator and no default processor set";
 type ThreadSafeProcessor = Box<dyn TProcessor + Send + Sync>;
 
@@ -70,7 +72,7 @@ impl TMultiplexedProcessor {
     /// Returns success if a new entry was inserted. Returns an error if:
     /// * A processor exists for `service_name`
     /// * You attempt to register a processor as default, and an existing default exists
-    #[cfg_attr(feature = "cargo-clippy", allow(map_entry))]
+    #[allow(clippy::map_entry)]
     pub fn register<S: Into<String>>(
         &mut self,
         service_name: S,
@@ -145,7 +147,7 @@ impl TProcessor for TMultiplexedProcessor {
 }
 
 impl Debug for TMultiplexedProcessor {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let stored = self.stored.lock().unwrap();
         write!(
             f,

--- a/lib/rs/src/server/threaded.rs
+++ b/lib/rs/src/server/threaded.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use log::warn;
+
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 use threadpool::ThreadPool;

--- a/lib/rs/src/transport/buffered.rs
+++ b/lib/rs/src/transport/buffered.rs
@@ -200,7 +200,7 @@ where
         TBufferedWriteTransport {
             buf: Vec::with_capacity(write_capacity),
             cap: write_capacity,
-            channel: channel,
+            channel,
         }
     }
 }
@@ -347,8 +347,8 @@ mod tests {
 
         // fill the underlying transport's byte buffer
         let mut readable_bytes = [0u8; 10];
-        for i in 0..10 {
-            readable_bytes[i] = i as u8;
+        for (i, b) in readable_bytes.iter_mut().enumerate() {
+            *b = i as u8;
         }
 
         t.chan.set_readable_bytes(&readable_bytes);
@@ -365,8 +365,8 @@ mod tests {
         assert_eq!(&buf, &[0, 1, 2, 3, 4, 5, 6, 7]);
 
         // let's clear out the buffer and try read again
-        for i in 0..8 {
-            buf[i] = 0;
+        for b in &mut buf{
+            *b = 0;
         }
         let read_result = t.read(&mut buf);
 

--- a/lib/rs/src/transport/mem.rs
+++ b/lib/rs/src/transport/mem.rs
@@ -153,7 +153,9 @@ impl TIoChannel for TBufferChannel {
             WriteHalf {
                 handle: TBufferChannel {
                     read: self.read.clone(),
-                    write: self.write.clone(),
+                    // NOTE: not cloning here, since this is the last statement
+                    // in this method and `write` can take ownership of `self.write`
+                    write: self.write,
                 },
             },
         ))

--- a/lib/rs/test/Cargo.toml
+++ b/lib/rs/test/Cargo.toml
@@ -7,9 +7,7 @@ authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false
 
 [dependencies]
-clap = "<2.28.0"
-ordered-float = "1.0"
-try_from = "0.3"
+clap = "2.33"
 
 [dependencies.thrift]
 path = "../"

--- a/lib/rs/test/src/bin/kitchen_sink_client.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_client.rs
@@ -15,11 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate clap;
-
-extern crate kitchen_sink;
-extern crate thrift;
+use clap::{clap_app, value_t};
 
 use std::convert::Into;
 
@@ -28,6 +24,8 @@ use kitchen_sink::midlayer::{MealServiceSyncClient, TMealServiceSyncClient};
 use kitchen_sink::recursive;
 use kitchen_sink::recursive::{CoRec, CoRec2, RecList, RecTree, TTestServiceSyncClient};
 use kitchen_sink::ultimate::{FullMealServiceSyncClient, TFullMealServiceSyncClient};
+
+use thrift;
 use thrift::protocol::{
     TBinaryInputProtocol, TBinaryOutputProtocol, TCompactInputProtocol, TCompactOutputProtocol,
     TInputProtocol, TOutputProtocol,

--- a/lib/rs/test/src/bin/kitchen_sink_server.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_server.rs
@@ -15,11 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate clap;
-extern crate kitchen_sink;
-extern crate thrift;
+use clap::{clap_app, value_t};
 
+use thrift;
 use thrift::protocol::{
     TBinaryInputProtocolFactory, TBinaryOutputProtocolFactory, TCompactInputProtocolFactory,
     TCompactOutputProtocolFactory, TInputProtocolFactory, TOutputProtocolFactory,

--- a/lib/rs/test/src/lib.rs
+++ b/lib/rs/test/src/lib.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-extern crate thrift;
-
 pub mod base_one;
 pub mod base_two;
 pub mod midlayer;

--- a/test/rs/Cargo.toml
+++ b/test/rs/Cargo.toml
@@ -8,10 +8,8 @@ publish = false
 
 [dependencies]
 clap = "2.33"
-env_logger = "0.4.0"
+env_logger = "0.8"
 log = "0.4"
-ordered-float = "1.0"
-try_from = "0.3"
 
 [dependencies.thrift]
 path = "../../lib/rs"

--- a/test/rs/src/bin/test_client.rs
+++ b/test/rs/src/bin/test_client.rs
@@ -15,20 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate log;
-extern crate env_logger;
+use env_logger;
+use log::*;
+use clap::{clap_app, value_t};
 
-#[macro_use]
-extern crate clap;
-extern crate ordered_float;
-extern crate thrift;
-extern crate thrift_test; // huh. I have to do this to use my lib
-
-use ordered_float::OrderedFloat;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 
+use thrift;
+use thrift::OrderedFloat;
 use thrift::protocol::{TBinaryInputProtocol, TBinaryOutputProtocol, TCompactInputProtocol,
                        TCompactOutputProtocol, TInputProtocol, TMultiplexedOutputProtocol,
                        TOutputProtocol};
@@ -38,7 +33,7 @@ use thrift::transport::{ReadHalf, TBufferedReadTransport, TBufferedWriteTranspor
 use thrift_test::*;
 
 fn main() {
-    env_logger::init().expect("logger setup failed");
+    env_logger::init();
 
     debug!("initialized logger - running cross-test client");
 
@@ -167,7 +162,7 @@ fn tcp_channel(
 type BuildThriftTestClient = ThriftTestSyncClient<Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>>;
 type BuiltSecondServiceClient = SecondServiceSyncClient<Box<dyn TInputProtocol>, Box<dyn TOutputProtocol>>;
 
-#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+#[allow(clippy::cognitive_complexity)]
 fn make_thrift_calls(
     thrift_test_client: &mut BuildThriftTestClient,
     second_service_client: &mut Option<BuiltSecondServiceClient>,
@@ -191,7 +186,7 @@ fn make_thrift_calls(
     verify_expected_result(thrift_test_client.test_byte(42), 42)?;
 
     info!("testi32");
-    verify_expected_result(thrift_test_client.test_i32(1159348374), 1159348374)?;
+    verify_expected_result(thrift_test_client.test_i32(1_159_348_374), 1_159_348_374)?;
 
     info!("testi64");
     // try!(verify_expected_result(thrift_test_client.test_i64(-8651829879438294565),
@@ -231,14 +226,14 @@ fn make_thrift_calls(
         let x_snd = Xtruct {
             string_thing: Some("foo".to_owned()),
             byte_thing: Some(12),
-            i32_thing: Some(219129),
-            i64_thing: Some(12938492818),
+            i32_thing: Some(219_129),
+            i64_thing: Some(12_938_492_818),
         };
         let x_cmp = Xtruct {
             string_thing: Some("foo".to_owned()),
             byte_thing: Some(12),
-            i32_thing: Some(219129),
-            i64_thing: Some(12938492818),
+            i32_thing: Some(219_129),
+            i64_thing: Some(12_938_492_818),
         };
         verify_expected_result(thrift_test_client.test_struct(x_snd), x_cmp)?;
     }
@@ -264,11 +259,11 @@ fn make_thrift_calls(
                 Xtruct {
                     string_thing: Some("foo".to_owned()),
                     byte_thing: Some(1),
-                    i32_thing: Some(324382098),
-                    i64_thing: Some(12938492818),
+                    i32_thing: Some(324_382_098),
+                    i64_thing: Some(12_938_492_818),
                 },
             ),
-            i32_thing: Some(293481098),
+            i32_thing: Some(293_481_098),
         };
         let x_cmp = Xtruct2 {
             byte_thing: Some(32),
@@ -276,11 +271,11 @@ fn make_thrift_calls(
                 Xtruct {
                     string_thing: Some("foo".to_owned()),
                     byte_thing: Some(1),
-                    i32_thing: Some(324382098),
-                    i64_thing: Some(12938492818),
+                    i32_thing: Some(324_382_098),
+                    i64_thing: Some(12_938_492_818),
                 },
             ),
-            i32_thing: Some(293481098),
+            i32_thing: Some(293_481_098),
         };
         verify_expected_result(thrift_test_client.test_nest(x_snd), x_cmp)?;
     }
@@ -314,12 +309,12 @@ fn make_thrift_calls(
     info!("testSet");
     {
         let mut s_snd: BTreeSet<i32> = BTreeSet::new();
-        s_snd.insert(293481);
+        s_snd.insert(293_481);
         s_snd.insert(23);
         s_snd.insert(3234);
 
         let mut s_cmp: BTreeSet<i32> = BTreeSet::new();
-        s_cmp.insert(293481);
+        s_cmp.insert(293_481);
         s_cmp.insert(23);
         s_cmp.insert(3234);
 
@@ -386,12 +381,12 @@ fn make_thrift_calls(
         let s_cmp = Xtruct {
             string_thing: Some("Hello2".to_owned()),
             byte_thing: Some(1),
-            i32_thing: Some(-123948),
-            i64_thing: Some(-19234123981),
+            i32_thing: Some(-123_948),
+            i64_thing: Some(-19_234_123_981),
         };
 
         verify_expected_result(
-            thrift_test_client.test_multi(1, -123948, -19234123981, m_snd, Numberz::Eight, 81),
+            thrift_test_client.test_multi(1, -123_948, -19_234_123_981, m_snd, Numberz::Eight, 81),
             s_cmp,
         )?;
     }
@@ -429,8 +424,8 @@ fn make_thrift_calls(
             Xtruct {
                 string_thing: Some("baz".to_owned()),
                 byte_thing: Some(0),
-                i32_thing: Some(3948539),
-                i64_thing: Some(-12938492),
+                i32_thing: Some(3_948_539),
+                i64_thing: Some(-12_938_492),
             },
         );
 
@@ -453,7 +448,7 @@ fn make_thrift_calls(
         s_cmp.insert(1 as UserId, s_cmp_nested_1);
         s_cmp.insert(2 as UserId, s_cmp_nested_2);
 
-        verify_expected_result(thrift_test_client.test_insanity(insanity.clone()), s_cmp)?;
+        verify_expected_result(thrift_test_client.test_insanity(insanity), s_cmp)?;
     }
 
     info!("testException - remote throws Xception");
@@ -583,7 +578,6 @@ fn make_thrift_calls(
     thrift_test_client.test_void()
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn verify_expected_result<T: Debug + PartialEq + Sized>(
     actual: Result<T, thrift::Error>,
     expected: T,

--- a/test/rs/src/bin/test_server.rs
+++ b/test/rs/src/bin/test_server.rs
@@ -15,21 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate log;
-extern crate env_logger;
+use env_logger;
+use log::*;
+use clap::{clap_app, value_t};
 
-#[macro_use]
-extern crate clap;
-extern crate ordered_float;
-extern crate thrift;
-extern crate thrift_test;
-
-use ordered_float::OrderedFloat;
 use std::collections::{BTreeMap, BTreeSet};
 use std::thread;
 use std::time::Duration;
 
+use thrift;
+use thrift::OrderedFloat;
 use thrift::protocol::{TBinaryInputProtocolFactory, TBinaryOutputProtocolFactory,
                        TCompactInputProtocolFactory, TCompactOutputProtocolFactory,
                        TInputProtocolFactory, TOutputProtocolFactory};
@@ -40,7 +35,7 @@ use thrift::transport::{TBufferedReadTransportFactory, TBufferedWriteTransportFa
 use thrift_test::*;
 
 fn main() {
-    env_logger::init().expect("logger setup failed");
+    env_logger::init();
 
     debug!("initialized logger - running cross-test server");
 
@@ -274,7 +269,7 @@ impl ThriftTestSyncHandler for ThriftTestSyncHandlerImpl {
         info!("testInsanity({:?})", argument);
         let mut map_0: BTreeMap<Numberz, Insanity> = BTreeMap::new();
         map_0.insert(Numberz::Two, argument.clone());
-        map_0.insert(Numberz::Three, argument.clone());
+        map_0.insert(Numberz::Three, argument);
 
         let mut map_1: BTreeMap<Numberz, Insanity> = BTreeMap::new();
         let insanity = Insanity {

--- a/test/rs/src/lib.rs
+++ b/test/rs/src/lib.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-extern crate ordered_float;
-extern crate thrift;
-extern crate try_from;
+
+
+
 
 mod thrift_test;
 pub use crate::thrift_test::*;

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -9,8 +9,6 @@ publish = false
 
 [dependencies]
 clap = "2.33"
-ordered-float = "1.0"
-try_from = "0.3"
 
 [dependencies.thrift]
 path = "../../lib/rs"

--- a/tutorial/rs/README.md
+++ b/tutorial/rs/README.md
@@ -4,37 +4,22 @@
 
 1. Get the [Thrift compiler](https://thrift.apache.org).
 
-2. Add the following crates to your `Cargo.toml`.
+2. Add the thrift crate to your `Cargo.toml`.
 
 ```toml
 thrift = "x.y.z" # x.y.z is the version of the thrift compiler
-ordered-float = "0.3.0"
-try_from = "0.2.0"
 ```
 
-3. Add the same crates to your `lib.rs` or `main.rs`.
-
-```rust
-extern crate ordered_float;
-extern crate thrift;
-extern crate try_from;
-```
-
-4. Generate Rust sources for your IDL (for example, `Tutorial.thrift`).
+3. Generate Rust sources for your IDL (for example, `Tutorial.thrift`).
 
 ```shell
 thrift -out my_rust_program/src --gen rs -r Tutorial.thrift
 ```
 
-5. Use the generated source in your code.
+4. Use the generated source in your code.
 
 ```rust
-// add extern crates here, or in your lib.rs
-extern crate ordered_float;
-extern crate thrift;
-extern crate try_from;
-
-// generated Rust module
+// generated Rust module from Thrift IDL
 mod tutorial;
 
 use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol};
@@ -120,7 +105,7 @@ each generated file.
 ### Results and Errors
 
 The Thrift runtime library defines a `thrift::Result` and a `thrift::Error` type,
-both of which are used throught the runtime library and in all generated code.
+both of which are used throughout the runtime library and in all generated code.
 Conversions are defined from `std::io::Error`, `str` and `String` into
 `thrift::Error`.
 

--- a/tutorial/rs/src/bin/tutorial_client.rs
+++ b/tutorial/rs/src/bin/tutorial_client.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate clap;
+use clap::{clap_app, value_t};
 
 use thrift::protocol::{TCompactInputProtocol, TCompactOutputProtocol};
 use thrift::transport::{

--- a/tutorial/rs/src/bin/tutorial_server.rs
+++ b/tutorial/rs/src/bin/tutorial_server.rs
@@ -15,18 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[macro_use]
-extern crate clap;
-
 use std::collections::HashMap;
 use std::convert::{From, Into};
 use std::default::Default;
 use std::sync::Mutex;
 
+use clap::{clap_app, value_t};
+
 use thrift::protocol::{TCompactInputProtocolFactory, TCompactOutputProtocolFactory};
 use thrift::server::TServer;
-
 use thrift::transport::{TFramedReadTransportFactory, TFramedWriteTransportFactory};
+
 use thrift_tutorial::shared::{SharedServiceSyncHandler, SharedStruct};
 use thrift_tutorial::tutorial::{CalculatorSyncHandler, CalculatorSyncProcessor};
 use thrift_tutorial::tutorial::{InvalidOperation, Operation, Work};


### PR DESCRIPTION
Client: rs

## Specific changes (lib/check/tutorial/cross-test)

* Update all `clippy`/`rustfmt` attributes to use new syntax
* Use new numeric literal syntax
* Use shorthand syntax for initializing structs
* Use elided lifetimes for `Formatter`
* Remove `extern crate`
* Update all `Cargo.toml` files (except `lib/rs`) to remove direct references to `ordered-float` crate (use Thrift redefinition)
* Update all `Cargo.toml` files (except `lib/rs`) to use updated, and a consistent set of crates

## Specific changes (generator)

* Remove unnecessary `()` return and `else` branch when writing fields
* Use `_f64` suffix for float literals during const initialization
* Take ownership of `self` when writing a Thrift enum (represented by a Rust enum with integers) to an output protocol
* Use shorthand syntax for initializing structs

**NOTE**: This does _not_ fix any bugs. It simply updates the Rust code and generated code so that it no longer prints clippy warnings, and uses Rust 2018 idioms.

## Specific changes (other)

* Update tutorial `README`
* Update min Rust version to reflect what we were actually testing with (Rust 1.40)