### PR TITLE
Added TNonCopyable.h in favor of boost dependency

### DIFF
--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -143,7 +143,8 @@ include_thrift_HEADERS = \
                          src/thrift/TLogging.h \
                          src/thrift/TToString.h \
                          src/thrift/TBase.h \
-                         src/thrift/TConfiguration.h
+                         src/thrift/TConfiguration.h \
+                         src/thrift/TNonCopyable.h
 
 include_concurrencydir = $(include_thriftdir)/concurrency
 include_concurrency_HEADERS = \

--- a/lib/cpp/src/thrift/TNonCopyable.h
+++ b/lib/cpp/src/thrift/TNonCopyable.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef TNONCOPYABLE_H
+#define TNONCOPYABLE_H
+
+/**
+ * @brief A simple non-copyable base class pattern. Derive from TNonCopyable to
+ * make a class non-copyable and prohibit assignment and copy-construction.
+ */
+namespace apache {
+namespace thrift {
+
+class TNonCopyable {
+protected:
+  TNonCopyable() = default;
+  ~TNonCopyable() = default;
+
+  TNonCopyable(const TNonCopyable&) = delete;
+  TNonCopyable& operator=(const TNonCopyable&) = delete;
+};
+
+}
+}
+
+#endif

--- a/lib/cpp/src/thrift/concurrency/Monitor.h
+++ b/lib/cpp/src/thrift/concurrency/Monitor.h
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <thrift/concurrency/Exception.h>
 #include <thrift/concurrency/Mutex.h>
+#include <thrift/TNonCopyable.h>
 
 namespace apache {
 namespace thrift {
@@ -46,7 +47,7 @@ namespace concurrency {
  *
  * @version $Id:$
  */
-class Monitor : boost::noncopyable {
+class Monitor : apache::thrift::TNonCopyable {
 public:
   /** Creates a new mutex, and takes ownership of it. */
   Monitor();

--- a/lib/cpp/src/thrift/concurrency/Mutex.h
+++ b/lib/cpp/src/thrift/concurrency/Mutex.h
@@ -21,7 +21,7 @@
 #define _THRIFT_CONCURRENCY_MUTEX_H_ 1
 
 #include <memory>
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 
 namespace apache {
 namespace thrift {
@@ -55,7 +55,7 @@ private:
 };
 
 
-class Guard : boost::noncopyable {
+class Guard : apache::thrift::TNonCopyable {
 public:
   Guard(const Mutex& value, int64_t timeout = 0) : mutex_(&value) {
     if (timeout == 0) {

--- a/lib/cpp/src/thrift/transport/TPipe.cpp
+++ b/lib/cpp/src/thrift/transport/TPipe.cpp
@@ -40,7 +40,7 @@ void pipe_write(HANDLE pipe, const uint8_t* buf, uint32_t len);
 uint32_t pseudo_sync_read(HANDLE pipe, HANDLE event, uint8_t* buf, uint32_t len);
 void pseudo_sync_write(HANDLE pipe, HANDLE event, const uint8_t* buf, uint32_t len);
 
-class TPipeImpl : boost::noncopyable {
+class TPipeImpl : apache::thrift::TNonCopyable {
 public:
   TPipeImpl() {}
   virtual ~TPipeImpl() {}
@@ -223,7 +223,7 @@ uint32_t pseudo_sync_read(HANDLE pipe, HANDLE event, uint8_t* buf, uint32_t len)
 
 //---- Constructors ----
 TPipe::TPipe(TAutoHandle &Pipe, std::shared_ptr<TConfiguration> config)
-  : impl_(new TWaitableNamedPipeImpl(Pipe)), TimeoutSeconds_(3), 
+  : impl_(new TWaitableNamedPipeImpl(Pipe)), TimeoutSeconds_(3),
   isAnonymous_(false), TVirtualTransport(config) {
 }
 
@@ -234,12 +234,12 @@ TPipe::TPipe(HANDLE Pipe, std::shared_ptr<TConfiguration> config)
   impl_.reset(new TWaitableNamedPipeImpl(pipeHandle));
 }
 
-TPipe::TPipe(const char* pipename, std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3), 
+TPipe::TPipe(const char* pipename, std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3),
   isAnonymous_(false), TVirtualTransport(config) {
   setPipename(pipename);
 }
 
-TPipe::TPipe(const std::string& pipename, std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3), 
+TPipe::TPipe(const std::string& pipename, std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3),
   isAnonymous_(false), TVirtualTransport(config) {
   setPipename(pipename);
 }
@@ -249,7 +249,7 @@ TPipe::TPipe(HANDLE PipeRd, HANDLE PipeWrt, std::shared_ptr<TConfiguration> conf
     TVirtualTransport(config) {
 }
 
-TPipe::TPipe(std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3), isAnonymous_(false), 
+TPipe::TPipe(std::shared_ptr<TConfiguration> config) : TimeoutSeconds_(3), isAnonymous_(false),
                                                        TVirtualTransport(config) {
 }
 

--- a/lib/cpp/src/thrift/transport/TPipe.h
+++ b/lib/cpp/src/thrift/transport/TPipe.h
@@ -28,7 +28,7 @@
 #ifdef _WIN32
 #include <thrift/windows/Sync.h>
 #endif
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 #ifdef _WIN32
 #include <thrift/windows/Sync.h>
 #endif

--- a/lib/cpp/src/thrift/transport/TPipeServer.cpp
+++ b/lib/cpp/src/thrift/transport/TPipeServer.cpp
@@ -22,7 +22,7 @@
 
 #include <thrift/transport/TPipe.h>
 #include <thrift/transport/TPipeServer.h>
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 
 #ifdef _WIN32
 #include <thrift/windows/OverlappedSubmissionThread.h>
@@ -39,7 +39,7 @@ namespace transport {
 
 using std::shared_ptr;
 
-class TPipeServerImpl : boost::noncopyable {
+class TPipeServerImpl : apache::thrift::TNonCopyable {
 public:
   TPipeServerImpl() {}
   virtual ~TPipeServerImpl() {}

--- a/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.cpp
+++ b/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.cpp
@@ -19,7 +19,7 @@
 
 #include <thrift/windows/OverlappedSubmissionThread.h>
 #include <thrift/transport/TTransportException.h>
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 #include <boost/scope_exit.hpp>
 #include <process.h>
 

--- a/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
+++ b/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
@@ -25,7 +25,7 @@
 #endif
 
 #include <thrift/windows/Sync.h>
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 #include <Windows.h>
 
 /*
@@ -89,7 +89,7 @@ struct DECLSPEC_ALIGN(MEMORY_ALLOCATION_ALIGNMENT) TOverlappedWorkItem : public 
   bool process();
 };
 
-class TOverlappedSubmissionThread : boost::noncopyable {
+class TOverlappedSubmissionThread : apache::thrift::TNonCopyable {
 public:
   void addWorkItem(TOverlappedWorkItem* item);
 
@@ -117,7 +117,7 @@ private:
   HANDLE thread_;
 };
 
-class TAutoOverlapThread : boost::noncopyable {
+class TAutoOverlapThread : apache::thrift::TNonCopyable {
 private:
   TOverlappedSubmissionThread* p;
 

--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -25,7 +25,8 @@
 #endif
 
 #include <thrift/concurrency/Exception.h>
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
+
 #include <Windows.h>
 
 /*
@@ -36,13 +37,13 @@
 namespace apache {
 namespace thrift {
 
-struct TCriticalSection : boost::noncopyable {
+struct TCriticalSection : apache::thrift::TNonCopyable {
   CRITICAL_SECTION cs;
   TCriticalSection() { InitializeCriticalSection(&cs); }
   ~TCriticalSection() { DeleteCriticalSection(&cs); }
 };
 
-class TAutoCrit : boost::noncopyable {
+class TAutoCrit : apache::thrift::TNonCopyable {
 private:
   CRITICAL_SECTION* cs_;
 
@@ -51,7 +52,7 @@ public:
   ~TAutoCrit() { LeaveCriticalSection(cs_); }
 };
 
-struct TAutoResetEvent : boost::noncopyable {
+struct TAutoResetEvent : apache::thrift::TNonCopyable {
   HANDLE h;
 
   TAutoResetEvent() {
@@ -64,7 +65,7 @@ struct TAutoResetEvent : boost::noncopyable {
   ~TAutoResetEvent() { CloseHandle(h); }
 };
 
-struct TManualResetEvent : boost::noncopyable {
+struct TManualResetEvent : apache::thrift::TNonCopyable {
   HANDLE h;
 
   TManualResetEvent() {
@@ -77,7 +78,7 @@ struct TManualResetEvent : boost::noncopyable {
   ~TManualResetEvent() { CloseHandle(h); }
 };
 
-struct TAutoHandle : boost::noncopyable {
+struct TAutoHandle : apache::thrift::TNonCopyable {
   HANDLE h;
   explicit TAutoHandle(HANDLE h_ = INVALID_HANDLE_VALUE) : h(h_) {}
   ~TAutoHandle() {

--- a/lib/cpp/src/thrift/windows/TWinsockSingleton.h
+++ b/lib/cpp/src/thrift/windows/TWinsockSingleton.h
@@ -31,7 +31,7 @@
 #include <thrift/thrift-config.h>
 
 // boost
-#include <boost/noncopyable.hpp>
+#include <thrift/TNonCopyable.h>
 
 #include <memory>
 #include <mutex>
@@ -45,7 +45,7 @@ namespace transport {
  * Winsock2 must be intialised once only in order to create sockets. This class
  * performs a one time initialisation when create is called.
  */
-class TWinsockSingleton : private boost::noncopyable {
+class TWinsockSingleton : private apache::thrift::TNonCopyable {
 
 public:
   typedef std::shared_ptr<TWinsockSingleton> instance_ptr;


### PR DESCRIPTION
There is currently a thrift dependency on `boost/noncopyable.hpp`, but the design pattern of non-copyable base class is very small (only ~15 lines of code, including namespaces). To reduce the boost dependency (as discussed before), this PR adds a non-copyable base class pattern in its own header `thrift/TNonCopyable.h`.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.