### PR TITLE
Removed symbolic link tutorial/cl/ensure-externals.sh

### DIFF
--- a/tutorial/cl/Makefile.am
+++ b/tutorial/cl/Makefile.am
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-setup-local-lisp-env: ensure-externals.sh
-	bash ensure-externals.sh
+setup-local-lisp-env: ../../lib/cl/ensure-externals.sh
+	bash ../../lib/cl/ensure-externals.sh
 
 gen-cl: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen cl -r $<

--- a/tutorial/cl/ensure-externals.sh
+++ b/tutorial/cl/ensure-externals.sh
@@ -1,1 +1,0 @@
-../../lib/cl/ensure-externals.sh


### PR DESCRIPTION
There is a symbolic link in the repository to point to a shell script. I'm under the impression that a relative path in the corresponding `Makefile.am` serves the same purpose. Lets see if the CI agrees.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
