### PR TITLE
build/cmake/DefineOptions.cmake: Fixed the logic of BUILD_SHARED_LIBS

### DIFF
--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -132,7 +132,12 @@ CMAKE_DEPENDENT_OPTION(BUILD_HASKELL "Build GHC library" ON
 # Common library options
 # https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html
 # Default on Windows is static, shared mode library support needs work...
-CMAKE_DEPENDENT_OPTION(BUILD_SHARED_LIBS "Build shared libraries" OFF "WIN32" ON)
+if(WIN32)
+    set(DEFAULT_BUILD_SHARED_LIBS ON)
+else()
+    set(DEFAULT_BUILD_SHARED_LIBS OFF)
+endif()
+option(BUILD_SHARED_LIBS "Build shared libraries" ${DEFAULT_BUILD_SHARED_LIBS})
 
 if (WITH_SHARED_LIB)
     message(WARNING "WITH_SHARED_LIB is deprecated; use -DBUILD_SHARED_LIBS=ON instead")


### PR DESCRIPTION
Currently the logic of the `CMAKE_DEPENDENT_OPTION` for `BUILD_SHARED_LIBS` does not work correctly. For this setting in particular, its better to use a standard cmake option, and set the default corresponding to the individual platforms (Windows OFF, other platforms ON).

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.