### PR TITLE
build/cmake/DefinePlatformSpecifc.cmake: Ensure ClangCl is recognized

### DIFF
--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -25,13 +25,7 @@ set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix")
 
 # basic options
 foreach(lang IN ITEMS C CXX)
-  if(CMAKE_${lang}_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wall")
-    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -ferror-limit=1")
-  elseif(CMAKE_${lang}_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wall -Wextra")
-    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -fmax-errors=1")
-  elseif(CMAKE_${lang}_COMPILER_ID STREQUAL "MSVC")
+  if("CMAKE_${lang}_COMPILER_ID" STREQUAL "MSVC" OR "${CMAKE_${lang}_SIMULATE_ID}" STREQUAL "MSVC")
     set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} /MP") # parallel build
     set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} /W3") # warning level 3
     include(CheckCXXCompilerFlag)
@@ -45,6 +39,12 @@ foreach(lang IN ITEMS C CXX)
       set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} /execution-charset:utf-8")
     endif()
     add_definitions("-DUNICODE -D_UNICODE")
+  elseif("CMAKE_${lang}_COMPILER_ID" STREQUAL "Clang")
+    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wall")
+    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -ferror-limit=1")
+  elseif("CMAKE_${lang}_COMPILER_ID" STREQUAL "GNU")
+    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -Wall -Wextra")
+    set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -fmax-errors=1")
   endif()
 endforeach()
 


### PR DESCRIPTION
The current thrift build does not work well with the clang frontend for the Visual Studio compiler (often called "ClangCl" or "clang-cl"). This is because ClangCl identifies to cmake as "MSVC" but also as "clang". ClangCl differs from "normal" clang in a few minor points. The most relevant is that it does not handle the setting `-Wall` too well, because in ClangCl `-Wall` includes a few very obscure warnings like "compatibility with c++98" (which thrift does not have). This leads to hundreds of thousands of warnings, making the build practically unusable.

The solution is quite simple: Change the order of compilers in cmake, so MSVC is detected *before* Clang.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.