### PR TITLE
Make ~TException() virtual

### DIFF
--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -79,7 +79,7 @@ public:
 
   TException(const std::string& message) : message_(message) {}
 
-  ~TException() noexcept override = default;
+  virtual ~TException() noexcept override = default;
 
   const char* what() const noexcept override {
     if (message_.empty()) {


### PR DESCRIPTION
This is a trivial change. It makes the destructor for the class `TException` virtual because its a base class for other exceptions. Base classes generally should have virtual destructors (or am I missing something very specific to this use case here?).

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.