### PR TITLE
Minor whitespace changes for netstd

### DIFF
--- a/test/netstd/Client/TestClient.cs
+++ b/test/netstd/Client/TestClient.cs
@@ -51,7 +51,6 @@ namespace ThriftTest
         Framed
     }
 
-
     internal enum TransportChoice
     {
         Socket,
@@ -340,7 +339,7 @@ namespace ThriftTest
                         Console.WriteLine("*** FAILED ***");
                         Console.WriteLine("Connect failed: " + ex.Message);
                         ReturnCode |= ErrorUnknown;
-                        Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                        Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                         continue;
                     }
                     catch (Exception ex)
@@ -348,7 +347,7 @@ namespace ThriftTest
                         Console.WriteLine("*** FAILED ***");
                         Console.WriteLine("Connect failed: " + ex.Message);
                         ReturnCode |= ErrorUnknown;
-                        Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                        Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                         continue;
                     }
 
@@ -359,7 +358,7 @@ namespace ThriftTest
                     catch (Exception ex)
                     {
                         Console.WriteLine("*** FAILED ***");
-                        Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                        Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                         ReturnCode |= ErrorUnknown;
                     }
                 }
@@ -370,7 +369,7 @@ namespace ThriftTest
                 catch (Exception ex)
                 {
                     Console.WriteLine("Error while closing transport");
-                    Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                    Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                 }
                 done = true;
             }
@@ -404,8 +403,8 @@ namespace ThriftTest
                 catch (Exception ex)
                 {
                     Console.WriteLine("*** FAILED ***");
-                    Console.WriteLine("Error while  parsing arguments");
-                    Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                    Console.WriteLine("Error while parsing arguments");
+                    Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                     return ErrorUnknown;
                 }
 
@@ -429,7 +428,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 Console.WriteLine("Unexpected error");
-                Console.WriteLine(outerEx.Message + " ST: " + outerEx.StackTrace);
+                Console.WriteLine(outerEx.Message + "\n" + outerEx.StackTrace);
                 return ErrorUnknown;
             }
         }
@@ -607,11 +606,11 @@ namespace ThriftTest
                 {
                     Console.WriteLine("*** FAILED ***");
                     returnCode |= ErrorBaseTypes;
-                    Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                    Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
                 }
             }
 
-            // CrazyNesting 
+            // CrazyNesting
             Console.WriteLine("Test CrazyNesting");
             var one = new CrazyNesting();
             var two = new CrazyNesting();
@@ -951,7 +950,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
             try
             {
@@ -968,7 +967,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
             try
             {
@@ -980,7 +979,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
 
             try
@@ -1002,7 +1001,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
             try
             {
@@ -1023,7 +1022,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
             try
             {
@@ -1038,7 +1037,7 @@ namespace ThriftTest
             {
                 Console.WriteLine("*** FAILED ***");
                 returnCode |= ErrorExceptions;
-                Console.WriteLine(ex.Message + " ST: " + ex.StackTrace);
+                Console.WriteLine(ex.Message + "\n" + ex.StackTrace);
             }
 
             Console.WriteLine("Test Oneway(1)");

--- a/tutorial/netstd/Client/Program.cs
+++ b/tutorial/netstd/Client/Program.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -25,14 +26,13 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using Thrift;
 using Thrift.Protocol;
 using Thrift.Transport;
 using Thrift.Transport.Client;
 using tutorial;
 using shared;
-using Microsoft.Extensions.DependencyInjection;
-using System.Diagnostics;
 
 namespace Client
 {


### PR DESCRIPTION
This PR adds a few very minor whitespace changes for C#. The printed error messages look a bit more nice with the PR in place, because the stack trace starts in a new line.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
