### PR TITLE
netstd: object doesn't have ToString(StringBuilder) overload. Thrift compiler generate code that doesn't compile

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -1507,7 +1507,7 @@ void t_netstd_generator::generate_netstd_struct_tostring(ostream& out, t_struct*
             out << indent() << "sb.Append(\", " << prop_name(*f_iter) << ": \");" << endl;
         }
 
-        out << indent() << prop_name(*f_iter) << ".ToString(sb);" << endl;
+        out << indent() << "sb.Append(" << prop_name(*f_iter) << ".ToString());" << endl;
 
         generate_null_check_end(out, *f_iter);
         if (is_required) {


### PR DESCRIPTION
I may miss something but object.ToString() doesn't have and overload that accept StringBuilder as parameter: thrift compiler generate code that doesn't compile


- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

[THRIFT-5316](https://issues.apache.org/jira/browse/THRIFT-5316) - issue in the JIRA