### PR TITLE
THRIFT-5318: Update PHP thrift_protocol extension for PHP 8

### DIFF
--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol.cpp
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol.cpp
@@ -85,17 +85,10 @@ const int8_t T_EXCEPTION = 3;
 const int INVALID_DATA = 1;
 const int BAD_VERSION = 4;
 
-static zend_function_entry thrift_protocol_functions[] = {
-  PHP_FE(thrift_protocol_write_binary, nullptr)
-  PHP_FE(thrift_protocol_read_binary, nullptr)
-  PHP_FE(thrift_protocol_read_binary_after_message_begin, nullptr)
-  {nullptr, nullptr, nullptr}
-};
-
 zend_module_entry thrift_protocol_module_entry = {
   STANDARD_MODULE_HEADER,
   "thrift_protocol",
-  thrift_protocol_functions,
+  ext_functions,
   nullptr,
   nullptr,
   nullptr,
@@ -414,7 +407,7 @@ void createObject(const char* obj_typename, zval* return_value, int nargs = 0, z
   object_and_properties_init(return_value, ce, nullptr);
   zend_function* constructor = zend_std_get_constructor(Z_OBJ_P(return_value));
   zval ctor_rv;
-  zend_call_method(return_value, ce, &constructor, nullptr, 0, &ctor_rv, nargs, arg1, arg2);
+  zend_call_method(Z4_OBJ_P(return_value), ce, &constructor, nullptr, 0, &ctor_rv, nargs, arg1, arg2);
   zval_dtor(&ctor_rv);
   if (EG(exception)) {
     zend_object *ex = EG(exception);
@@ -928,7 +921,7 @@ void validate_thrift_object(zval* object) {
 
             zval* is_required = zend_hash_str_find(fieldspec, "isRequired", sizeof("isRequired")-1);
             zval rv;
-            zval* prop = zend_read_property(object_class_entry, object, varname, strlen(varname), false, &rv);
+            zval* prop = zend_read_property(object_class_entry, Z4_OBJ_P(object), varname, strlen(varname), false, &rv);
 
             if (Z_TYPE_INFO_P(is_required) == IS_TRUE && Z_TYPE_P(prop) == IS_NULL) {
                 char errbuf[128];
@@ -969,7 +962,7 @@ void binary_deserialize_spec(zval* zthis, PHPInputTransport& transport, HashTabl
         ZVAL_UNDEF(&rv);
 
         binary_deserialize(ttype, transport, &rv, fieldspec);
-        zend_update_property(ce, zthis, varname, strlen(varname), &rv);
+        zend_update_property(ce, Z4_OBJ_P(zthis), varname, strlen(varname), &rv);
 
         zval_ptr_dtor(&rv);
       } else {
@@ -1010,7 +1003,7 @@ void binary_serialize_spec(zval* zthis, PHPOutputTransport& transport, HashTable
     int8_t ttype = Z_LVAL_P(val_ptr);
 
     zval rv;
-    zval* prop = zend_read_property(Z_OBJCE_P(zthis), zthis, varname, strlen(varname), false, &rv);
+    zval* prop = zend_read_property(Z_OBJCE_P(zthis), Z4_OBJ_P(zthis), varname, strlen(varname), false, &rv);
 
     if (Z_TYPE_P(prop) == IS_REFERENCE){
       ZVAL_DEREF(prop);

--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol.h
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol.h
@@ -19,10 +19,58 @@
 
 #pragma once
 
-PHP_FUNCTION(thrift_protocol_write_binary);
-PHP_FUNCTION(thrift_protocol_read_binary);
-PHP_FUNCTION(thrift_protocol_read_binary_after_message_begin);
+/* backward compat macros */
 
-extern zend_module_entry thrift_protocol_module_entry;
-#define phpext_thrift_protocol_ptr &thrift_protocol_module_entry
+#if PHP_VERSION_ID >= 80000
+# define Z4_OBJ_P(zval)       (Z_OBJ_P(zval))
+#else
+# define Z4_OBJ_P(zval)       (zval)
+#endif
 
+#ifndef IS_MIXED
+# define IS_MIXED 0
+#endif
+
+#ifndef ZEND_PARSE_PARAMETERS_NONE
+#define ZEND_PARSE_PARAMETERS_NONE() \
+  ZEND_PARSE_PARAMETERS_START(0, 0) \
+  ZEND_PARSE_PARAMETERS_END()
+#endif
+#ifndef ZEND_ARG_INFO_WITH_DEFAULT_VALUE
+#define ZEND_ARG_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, default_value) \
+  ZEND_ARG_INFO(pass_by_ref, name)
+#endif
+
+#if PHP_VERSION_ID < 70200
+#undef ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX
+#define ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
+  static const zend_internal_arg_info name[] = { \
+    { (const char*)(zend_uintptr_t)(required_num_args), ( #class_name ), 0, return_reference, allow_null, 0 },
+#endif
+
+#ifndef ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX
+# define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args, class_name, allow_null) \
+  ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, class_name, allow_null)
+#endif
+
+#ifndef ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX
+# define ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(name, return_reference, num_args, type) \
+  ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, num_args)
+#endif
+
+#ifndef ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX
+# define ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(name, return_reference, required_num_args, class_name, type) \
+  ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
+#endif
+
+#ifndef ZEND_ARG_TYPE_MASK
+# define ZEND_ARG_TYPE_MASK(pass_by_ref, name, type_mask, default_value) \
+  ZEND_ARG_TYPE_INFO(pass_by_ref, name, 0, 0)
+#endif
+
+#ifndef ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE
+# define ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, type_hint, allow_null, default_value) \
+  ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null)
+#endif
+
+#include "php_thrift_protocol_arginfo.h"

--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol.stub.php
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol.stub.php
@@ -1,0 +1,10 @@
+<?php
+/** @generate-function-entries */
+
+// php /path/to/php-src/build/gen_stub.php lib/php/src/ext/thrift_protocol/php_thrift_protocol.stub.php
+
+function thrift_protocol_write_binary(object $protocol, string $method_name, int $msgtype, object $request_struct, int $seqID, bool $strict_write): void {}
+
+function thrift_protocol_read_binary(object $protocol, string $obj_typename, bool $strict_read, int $buffer_size=8192): object {}
+
+function thrift_protocol_read_binary_after_message_begin(object $protocol, string $obj_typename, bool $strict_read, int $buffer_size=8192): object {}

--- a/lib/php/src/ext/thrift_protocol/php_thrift_protocol_arginfo.h
+++ b/lib/php/src/ext/thrift_protocol/php_thrift_protocol_arginfo.h
@@ -1,0 +1,33 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 3bd6e0bc99143d614ddb80ee0aec192e385c8927 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_thrift_protocol_write_binary, 0, 6, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, protocol, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, method_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, msgtype, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, request_struct, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, seqID, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, strict_write, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_thrift_protocol_read_binary, 0, 3, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, protocol, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, obj_typename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, strict_read, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, buffer_size, IS_LONG, 0, "8192")
+ZEND_END_ARG_INFO()
+
+#define arginfo_thrift_protocol_read_binary_after_message_begin arginfo_thrift_protocol_read_binary
+
+
+ZEND_FUNCTION(thrift_protocol_write_binary);
+ZEND_FUNCTION(thrift_protocol_read_binary);
+ZEND_FUNCTION(thrift_protocol_read_binary_after_message_begin);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(thrift_protocol_write_binary, arginfo_thrift_protocol_write_binary)
+	ZEND_FE(thrift_protocol_read_binary, arginfo_thrift_protocol_read_binary)
+	ZEND_FE(thrift_protocol_read_binary_after_message_begin, arginfo_thrift_protocol_read_binary_after_message_begin)
+	ZEND_FE_END
+};


### PR DESCRIPTION
See https://github.com/php/php-src/blob/PHP-8.0.0/UPGRADING.INTERNALS

<!-- Explain the changes in the pull request below: -->

Various object-related Zend methods underwent API signature changes in PHP 8, necessitating a small corresponding update in thrift_protocol extension where those methods are used.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
