### PR TITLE
THRIFT-5325: Fix Lua library writeStructEnd() in TCompactProtocol

### DIFF
--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -124,8 +124,8 @@ function TCompactProtocol:writeStructBegin(name)
 end
 
 function TCompactProtocol:writeStructEnd()
-  self.lastFieldId = self.lastField[self.lastFieldIndex]
   self.lastFieldIndex = self.lastFieldIndex - 1
+  self.lastFieldId = self.lastField[self.lastFieldIndex]
 end
 
 function TCompactProtocol:writeFieldBegin(name, ttype, id)


### PR DESCRIPTION
In 0.13.0, two changes were made to the Lua library's TCompactProtocol for writing structs: THRIFT-4992 (writeStructEnd) and THRIFT-5262 (writeStructBegin). Unfortunately these addressed the same issue, so the two changes together just recreated the original problem of corrupt field indices in nested structs.

Revert the change in THRIFT-4992 (and keep the one in THRIFT-5262).

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
