### PR TITLE
THRIFT-5330: Strict mode switch for maven plugin

### DIFF
--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>thrift-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>thrift-maven-plugin</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/contrib/thrift-maven-plugin/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
+++ b/contrib/thrift-maven-plugin/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
@@ -98,6 +98,14 @@ abstract class AbstractThriftMojo extends AbstractMojo {
     private String generator;
 
     /**
+     * Tells the plugin whether to enable strict mode in Thrift compiler.
+     * By default, compilation is not strict.
+     *
+     * @parameter default-value="false"
+     */
+    private boolean strict;
+
+    /**
      * @parameter
      */
     private File[] additionalThriftPathElements = new File[]{};
@@ -178,6 +186,7 @@ abstract class AbstractThriftMojo extends AbstractMojo {
 
                     Thrift thrift = new Thrift.Builder(thriftExecutable, outputDirectory)
                             .setGenerator(generator)
+                            .setStrict(strict)
                             .addThriftPathElement(thriftSourceRoot)
                             .addThriftPathElements(derivedThriftPathElements)
                             .addThriftPathElements(asList(additionalThriftPathElements))
@@ -325,7 +334,7 @@ abstract class AbstractThriftMojo extends AbstractMojo {
     ImmutableSet<File> findThriftFilesInDirectory(File directory) throws IOException {
         checkNotNull(directory);
         checkArgument(directory.isDirectory(), "%s is not a directory", directory);
-        List<File> thriftFilesInDirectory = getFiles(directory, 
+        List<File> thriftFilesInDirectory = getFiles(directory,
         		Joiner.on(",").join(includes),
         		Joiner.on(",").join(excludes));
         return ImmutableSet.copyOf(thriftFilesInDirectory);

--- a/contrib/thrift-maven-plugin/src/main/java/org/apache/thrift/maven/Thrift.java
+++ b/contrib/thrift-maven-plugin/src/main/java/org/apache/thrift/maven/Thrift.java
@@ -51,6 +51,7 @@ final class Thrift {
     private final File javaOutputDirectory;
     private final CommandLineUtils.StringStreamConsumer output;
     private final CommandLineUtils.StringStreamConsumer error;
+    private final boolean strict;
 
     /**
      * Constructs a new instance. This should only be used by the {@link Builder}.
@@ -61,9 +62,12 @@ final class Thrift {
      * @param thriftFiles         The thrift source files to compile.
      * @param javaOutputDirectory The directory into which the java source files
      *                            will be generated.
+     * @param strict              Tells if the compilation is to be done in strict
+     *                            mode.
      */
     private Thrift(String executable, String generator, ImmutableSet<File> thriftPath,
-                   ImmutableSet<File> thriftFiles, File javaOutputDirectory) {
+                   ImmutableSet<File> thriftFiles, File javaOutputDirectory,
+                   boolean strict) {
         this.executable = checkNotNull(executable, "executable");
         this.generator = checkNotNull(generator, "generator");
         this.thriftPathElements = checkNotNull(thriftPath, "thriftPath");
@@ -71,6 +75,7 @@ final class Thrift {
         this.javaOutputDirectory = checkNotNull(javaOutputDirectory, "javaOutputDirectory");
         this.error = new CommandLineUtils.StringStreamConsumer();
         this.output = new CommandLineUtils.StringStreamConsumer();
+        this.strict = strict;
     }
 
     /**
@@ -112,6 +117,9 @@ final class Thrift {
             command.add("-I");
             command.add(thriftPathElement.toString());
         }
+        if (strict) {
+            command.add("-strict");
+        }
         command.add("-out");
         command.add(javaOutputDirectory.toString());
         command.add("--gen");
@@ -143,6 +151,7 @@ final class Thrift {
         private Set<File> thriftPathElements;
         private Set<File> thriftFiles;
         private String generator;
+        private boolean strict;
 
         /**
          * Constructs a new builder. The two parameters are present as they are
@@ -193,6 +202,11 @@ final class Thrift {
         public Builder setGenerator(String generator) {
             checkNotNull(generator);
             this.generator = generator;
+            return this;
+        }
+
+        public Builder setStrict(boolean strict) {
+            this.strict = strict;
             return this;
         }
 
@@ -256,7 +270,7 @@ final class Thrift {
         public Thrift build() {
             checkState(!thriftFiles.isEmpty());
             return new Thrift(executable, generator, ImmutableSet.copyOf(thriftPathElements),
-                    ImmutableSet.copyOf(thriftFiles), javaOutputDirectory);
+                    ImmutableSet.copyOf(thriftFiles), javaOutputDirectory, strict);
         }
     }
 }

--- a/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestThrift.java
+++ b/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestThrift.java
@@ -26,10 +26,7 @@ import org.junit.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class TestThrift {
 
@@ -118,6 +115,48 @@ public class TestThrift {
             new File(testRootDir, "shared/SharedService.java").exists());
         assertTrue("generated java code doesn't exist",
             new File(testRootDir, "tutorial/InvalidOperation.java").exists());
+    }
+
+    @Test
+    public void testImperfectNonStrict() throws Exception {
+        final File imperfectThrift = new File(idlDir, "imperfect.thrift");
+
+        builder.addThriftFile(imperfectThrift);
+
+        final Thrift thrift = builder.build();
+        // compilation is not strict by default
+
+        assertTrue("File not found: imperfect.thrift", imperfectThrift.exists());
+        assertFalse("gen-java directory should not exist", genJavaDir.exists());
+
+        // execute the compile
+        final int result = thrift.compile();
+        assertEquals(0, result);
+
+        assertFalse("gen-java directory was not removed", genJavaDir.exists());
+        assertTrue("generated java code doesn't exist",
+                   new File(testRootDir, "strictness/ImperfectService.java").exists());
+    }
+
+    @Test
+    public void testImperfectStrict() throws Exception {
+        final File imperfectThrift = new File(idlDir, "imperfect.thrift");
+
+        builder.addThriftFile(imperfectThrift);
+        builder.setStrict(true);
+
+        final Thrift thrift = builder.build();
+
+        assertTrue("File not found: imperfect.thrift", imperfectThrift.exists());
+        assertFalse("gen-java directory should not exist", genJavaDir.exists());
+
+        // execute the compile
+        final int result = thrift.compile();
+        assertNotEquals(0, result);
+
+        assertFalse("gen-java directory was not removed", genJavaDir.exists());
+        assertFalse("java code has been generated exist despire errors",
+                   new File(testRootDir, "strictness/ImperfectService.java").exists());
     }
 
     @Test

--- a/contrib/thrift-maven-plugin/src/test/resources/idl/imperfect.thrift
+++ b/contrib/thrift-maven-plugin/src/test/resources/idl/imperfect.thrift
@@ -1,0 +1,7 @@
+namespace java strictness
+
+exception BadSituation {}
+
+service ImperfectService {
+  void test() throws (BadSituation ouch)
+}


### PR DESCRIPTION
Client: java

An update for thrift-maven-plugin which enables strict compilation mode.

Strict compilation mode can be enabled by specifying `<strict>true</strict>` in the configuration section of the plugin.

For example:
```xml
            <plugin>
                <groupId>org.apache.thrift</groupId>
                <artifactId>thrift-maven-plugin</artifactId>
                <version>1.0.1</version>
                <configuration>
                    <thriftExecutable>/usr/bin/thrift</thriftExecutable>
                    <generator>java</generator>
                    <strict>true</strict>
                </configuration>
                <executions>
                    <execution>
                        <id>thrift-sources</id>
                        <phase>generate-sources</phase>
                        <goals>
                            <goal>compile</goal>
                        </goals>
                    </execution>
                    <execution>
                        <id>thrift-test-sources</id>
                        <phase>generate-test-sources</phase>
                        <goals>
                            <goal>testCompile</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```