### PR TITLE
THRIFT-5355 Do not rely on compiler and check boundaries

### DIFF
--- a/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.cpp
+++ b/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.cpp
@@ -184,7 +184,11 @@ int32_t TConcurrentClientSyncInfo::generateSeqId()
       throw apache::thrift::TApplicationException(
         TApplicationException::BAD_SEQUENCE_ID,
         "about to repeat a seqid");
-  int32_t newSeqId = nextseqid_++;
+  int32_t newSeqId = nextseqid_;
+  if (nextseqid_ == (std::numeric_limits<int32_t>::max)())
+    nextseqid_ = (std::numeric_limits<int32_t>::min)();
+  else
+    ++nextseqid_;
   seqidToMonitorMap_[newSeqId] = newMonitor_(seqidGuard);
   return newSeqId;
 }


### PR DESCRIPTION
C++ considers the overflow of a signed integer to be an undefined behavior (even with the "Signed Integers are Two’s Complement" update: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0907r1.html ).

Instead of relying on tests(1) to discover if a compiler does not handle the signed integer overflow as we expect it to, we should add an explicit check before incrementing.

(1) See https://github.com/apache/thrift/blob/c4e899a6d64aa97430ec9f7608d38db2095f6159/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.cpp#L33-L34

Quick check on https://godbolt.org/z/d7W8ds shows that Clang is able to optimize and just do the +1 so modern compilers should be able to keep the same performances where hardware permits.

In addition, some company rules might require code to do just that:
https://wiki.sei.cmu.edu/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow