### PR TITLE
THRIFT-5339: Add `TObject` trait to cover sync read & write methods of Struct/Union/Enum

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -565,7 +565,7 @@ void t_rs_generator::render_attributes_and_includes() {
   f_gen_ << endl;
   f_gen_ << "use thrift::OrderedFloat;" << endl;
   f_gen_ << "use thrift::{ApplicationError, ApplicationErrorKind, ProtocolError, ProtocolErrorKind, TThriftClient};" << endl;
-  f_gen_ << "use thrift::protocol::{TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TInputProtocol, TOutputProtocol, TSetIdentifier, TStructIdentifier, TType};" << endl;
+  f_gen_ << "use thrift::protocol::{TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TInputProtocol, TOutputProtocol, TSetIdentifier, TStructIdentifier, TType, TObject};" << endl;
   f_gen_ << "use thrift::protocol::field_id;" << endl;
   f_gen_ << "use thrift::protocol::verify_expected_message_type;" << endl;
   f_gen_ << "use thrift::protocol::verify_expected_sequence_number;" << endl;
@@ -898,7 +898,7 @@ void t_rs_generator::render_enum_definition(t_enum* tenum, const string& enum_na
 }
 
 void t_rs_generator::render_enum_impl(const string& enum_name) {
-  f_gen_ << "impl " << enum_name << " {" << endl;
+  f_gen_ << "impl TObject for " << enum_name << " {" << endl;
   indent_up();
 
   // taking enum as 'self' here because Thrift enums
@@ -907,16 +907,16 @@ void t_rs_generator::render_enum_impl(const string& enum_name) {
   // taking a reference to the enum
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
+    << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
-  f_gen_ << indent() << "o_prot.write_i32(self as i32)" << endl;
+  f_gen_ << indent() << "o_prot.write_i32(*self as i32)" << endl;
   indent_down();
   f_gen_ << indent() << "}" << endl;
 
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << enum_name << "> {"
+    << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << enum_name << "> {"
     << endl;
   indent_up();
 
@@ -1141,12 +1141,17 @@ void t_rs_generator::render_struct_impl(
     render_struct_constructor(struct_name, tstruct, struct_type);
   }
 
-  render_struct_sync_read(struct_name, tstruct, struct_type);
-  render_struct_sync_write(tstruct, struct_type);
-
   if (struct_type == t_rs_generator::T_RESULT) {
     render_result_struct_to_result_method(tstruct);
   }
+
+  f_gen_ << "}" << endl;
+  f_gen_ << endl;
+
+  f_gen_ << "impl TObject for " << struct_name << " {" << endl;
+
+  render_struct_sync_read(struct_name, tstruct, struct_type);
+  render_struct_sync_write(tstruct, struct_type);
 
   indent_down();
   f_gen_ << "}" << endl;
@@ -1383,7 +1388,7 @@ void t_rs_generator::render_union_definition(const string& union_name, t_struct*
 }
 
 void t_rs_generator::render_union_impl(const string& union_name, t_struct* tstruct) {
-  f_gen_ << "impl " << union_name << " {" << endl;
+  f_gen_ << "impl TObject for " << union_name << " {" << endl;
   indent_up();
 
   render_union_sync_read(union_name, tstruct);
@@ -1406,7 +1411,6 @@ void t_rs_generator::render_struct_sync_write(
 ) {
   f_gen_
     << indent()
-    << visibility_qualifier(struct_type)
     << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
@@ -1439,7 +1443,7 @@ void t_rs_generator::render_struct_sync_write(
 void t_rs_generator::render_union_sync_write(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
+    << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
 
@@ -1679,7 +1683,6 @@ void t_rs_generator::render_struct_sync_read(
 ) {
   f_gen_
     << indent()
-    << visibility_qualifier(struct_type)
     << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << struct_name << "> {"
     << endl;
 
@@ -1802,7 +1805,7 @@ void t_rs_generator::render_struct_sync_read(
 void t_rs_generator::render_union_sync_read(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << union_name << "> {"
+    << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << union_name << "> {"
     << endl;
   indent_up();
 

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -916,6 +916,16 @@ pub fn field_id(field_ident: &TFieldIdentifier) -> crate::Result<i16> {
     })
 }
 
+/// This trait declares the ability of IO with protocol.
+///
+/// It will be auto implemented for generated *struct*, *union* and *enum* types.
+pub trait TObject {
+    fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> crate::Result<Self>
+        where
+            Self: Sized;
+    fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> crate::Result<()>;
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Each Struct/Union/Enum generated by thrift-compiler will get two methods: `read_from_in_protocol` and `write_to_out_protocol`. 
Firstly, I think these two methods are representing a certain ability of serialization, so they should be put in a trait;
Moreover, if this trait is provided, we can use trait bounding in our user codes, such as
```rust
// pseudo code
fn serialize_struct<T>(s: T) -> Vec<u8> where T: TObject {
    s.write_to_out_protocol(protocol);
    // do other things..
}
```
It could also be a pretty useful marker trait as you can see.
The name of `TObject` is only a superficial opinion, but I believe that there are enough reasons to make the trait.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
