### PR TITLE
THRIFT-5338: Remove lib/go/thrift/go.mod

### DIFF
--- a/lib/go/thrift/go.mod
+++ b/lib/go/thrift/go.mod
@@ -1,3 +1,0 @@
-module github.com/apache/thrift/lib/go/thrift
-
-go 1.14


### PR DESCRIPTION
Client: go

Having it under a subdirectory has some unexpected consequences, so
remove it for now. Another PR will be open up later to add it back to
the root directory.