### PR TITLE
[skip ci] Make it clear that strings are not NUL-delimited

### DIFF
--- a/doc/specs/thrift-compact-protocol.md
+++ b/doc/specs/thrift-compact-protocol.md
@@ -92,7 +92,8 @@ Where:
 
 ### String encoding
 
-*String*s are first encoded to UTF-8, and then send as binary.
+*String*s are first encoded to UTF-8, and then send as binary. They do not
+include a NUL delimiter.
 
 ### Double encoding
 


### PR DESCRIPTION
It might not be obvious from the existing description. I had to run some
experiments to double-check it and this might save some time to the next
interested reader.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
