### PR TITLE
Make GetResponseHeadersFromClient work with client middlewares

### DIFF
--- a/lib/go/thrift/client.go
+++ b/lib/go/thrift/client.go
@@ -9,6 +9,17 @@ type TClient interface {
 	Call(ctx context.Context, method string, args, result TStruct) error
 }
 
+// TStandardClientUnwrapper is an optional interface TClient implementations can
+// choose to implement, to unwrap the underlying *TStandardClient.
+//
+// Both TStandardClient and WrappedTClient implement it.
+type TStandardClientUnwrapper interface {
+	TClient
+
+	// Returns the underlying *TStandardClient, if any.
+	UnwrapTStandardClient() *TStandardClient
+}
+
 type TStandardClient struct {
 	seqId        int32
 	iprot, oprot TProtocol
@@ -93,3 +104,10 @@ func (p *TStandardClient) Call(ctx context.Context, method string, args, result 
 
 	return p.Recv(ctx, p.iprot, seqId, method, result)
 }
+
+// UnwrapTStandardClient implements TStandardClientUnwrapper by returning self.
+func (p *TStandardClient) UnwrapTStandardClient() *TStandardClient {
+	return p
+}
+
+var _ TStandardClientUnwrapper = (*TStandardClient)(nil)

--- a/lib/go/thrift/example_client_middleware_test.go
+++ b/lib/go/thrift/example_client_middleware_test.go
@@ -45,6 +45,7 @@ func NewMyServiceClient(_ TClient) MyService {
 
 func simpleClientLoggingMiddleware(next TClient) TClient {
 	return WrappedTClient{
+		Next: next,
 		Wrapped: func(ctx context.Context, method string, args, result TStruct) error {
 			log.Printf("Before: %q", method)
 			log.Printf("Args: %#v", args)

--- a/lib/go/thrift/header_protocol.go
+++ b/lib/go/thrift/header_protocol.go
@@ -351,7 +351,11 @@ func (p *THeaderProtocol) SetTConfiguration(cfg *TConfiguration) {
 // If the last response was not sent over THeader protocol,
 // a nil map will be returned.
 func GetResponseHeadersFromClient(c TClient) THeaderMap {
-	if sc, ok := c.(*TStandardClient); ok {
+	if u, ok := c.(TStandardClientUnwrapper); ok {
+		sc := u.UnwrapTStandardClient()
+		if sc == nil {
+			return nil
+		}
 		if hp, ok := sc.iprot.(*THeaderProtocol); ok {
 			return hp.transport.readHeaders
 		}


### PR DESCRIPTION
Client: go

When GetResponseHeadersFromClient was added we only have TStandardClient
and it rely on the TClient is actually a *TStandardClient. With client
middlewares and WrappedTClient added later, that's no longer true.

Define an optional interface, TStandardClientUnwrapper, to return the
underlying *TStandardClient, so that GetResponseHeadersFromClient can
still work with wrapped clients.
