### PR TITLE
THRIFT-5343: TTlsSocketTransport does not resolve IPv4 addresses or validate hostnames correctly

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/TTlsSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TTlsSocketTransport.cs
@@ -38,6 +38,7 @@ namespace Thrift.Transport.Client
         private readonly LocalCertificateSelectionCallback _localCertificateSelectionCallback;
         private readonly int _port;
         private readonly SslProtocols _sslProtocols;
+        private readonly string _targetHost;
         private TcpClient _client;
         private SslStream _secureStream;
         private int _timeout;
@@ -122,13 +123,13 @@ namespace Thrift.Transport.Client
         {
             try
             {
+                _targetHost = host;
+
                 var entry = Dns.GetHostEntry(host);
                 if (entry.AddressList.Length == 0)
                     throw new TTransportException(TTransportException.ExceptionType.Unknown, "unable to resolve host name");
 
-                var addr = entry.AddressList[0];
-
-                _host = new IPAddress(addr.GetAddressBytes(), addr.ScopeId);
+                _host = entry.AddressList[0];
                 _port = port;
                 _timeout = timeout;
                 _certificate = certificate;
@@ -239,7 +240,7 @@ namespace Thrift.Transport.Client
                         ? new X509CertificateCollection {_certificate}
                         : new X509CertificateCollection();
 
-                    var targetHost = _host.ToString();
+                    var targetHost = _targetHost ?? _host.ToString();
                     await _secureStream.AuthenticateAsClientAsync(targetHost, certs, _sslProtocols, true);
                 }
             }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
1. Use the first entry in the address list like TSocketTransport. No need to try to create another IPAddress object.
2. Save the host name if provided and use that when calling AuthenticateAsClientAsync().

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
