### PR TITLE
THRIFT-5274: Enforce Java 8 compatibility

### DIFF
--- a/lib/java/build.gradle
+++ b/lib/java/build.gradle
@@ -19,6 +19,11 @@
 
 // Using the legacy plugin classpath for Clover so it can be loaded optionally
 buildscript {
+    // strictly enforce the minimum version of Java required to build and fail fast
+    if (JavaVersion.current() < JavaVersion.VERSION_1_8) {
+        throw new GradleException("The java version used is ${JavaVersion.current()}, but must be at least ${JavaVersion.VERSION_1_8}")
+    }
+
     repositories {
         mavenCentral()
         google()

--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -46,6 +46,9 @@ sourceSets {
 // ----------------------------------------------------------------------------
 // Compiler configuration details
 
+// These two properties are still needed on JDK8, and possibly used directly by
+// plugins. However, the '--release' option added below makes these two
+// properties redundant when building with JDK9 or later.
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
@@ -53,6 +56,10 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     options.debug = true
     options.deprecation = true
+    // the following is to build with Java 8 specifications, even when building with JDK9 or later
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        options.compilerArgs.addAll(['--release', '8'])
+    }
     // options.compilerArgs.addAll('-Xlint:unchecked')
 }
 


### PR DESCRIPTION
* Enforce Java 8 compatibility using the new `--release` flag introduced
  in JDK9, so that all generated bytecode follows Java 8 strict
  compatibility, even when building with newer JDK versions (9 or later)
  (this fixes NoSuchMethodError with ByteBuffer, and other potential
  incompatibilities in bytecode generation that would make the code
  unable to run on a Java 8 JRE)
* Also strictly enforce the JDK version used to build the project by
  ensuring it is at least version 1.8, and will fail fast when building
  the Java libraries if this condition is not met.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
