### PR TITLE
THRIFT-5187: Added Win32 support for domain sockets (AF_UNIX)

### DIFF
--- a/lib/cpp/src/thrift/transport/SocketCommon.cpp
+++ b/lib/cpp/src/thrift/transport/SocketCommon.cpp
@@ -19,31 +19,16 @@
  * @author: David Suárez <david.sephirot@gmail.com>
  */
 
-#ifndef THRIFT_SOCKETCOMMON_H
-#define THRIFT_SOCKETCOMMON_H
-
-#ifndef _WIN32
-
-#include <thrift/thrift-config.h>
-
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
-#ifdef HAVE_SYS_UN_H
-#include <sys/un.h>
-#endif
-
-#include <string>
-
+#include <thrift/transport/SocketCommon.h>
 #include <thrift/transport/PlatformSocket.h>
 #include <thrift/transport/TTransportException.h>
 #include <thrift/TOutput.h>
 
+#include <cstring>
+
 namespace apache {
 namespace thrift {
 namespace transport {
-
 
 socklen_t fillUnixSocketAddr(struct sockaddr_un& address, std::string& path)
 {
@@ -79,7 +64,3 @@ socklen_t fillUnixSocketAddr(struct sockaddr_un& address, std::string& path)
 }
 }
 } // apache::thrift::transport
-
-#endif // _WIN32
-
-#endif //THRIFT_SOCKETCOMMON_H

--- a/lib/cpp/src/thrift/transport/SocketCommon.h
+++ b/lib/cpp/src/thrift/transport/SocketCommon.h
@@ -22,16 +22,19 @@
 #ifndef THRIFT_SOCKETCOMMON_H
 #define THRIFT_SOCKETCOMMON_H
 
-#ifndef _WIN32
-
 #include <thrift/thrift-config.h>
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
+#endif
+#ifdef HAVE_AF_UNIX_H
+#include <afunix.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
 #endif
 
 #include <string>
@@ -45,7 +48,5 @@ socklen_t fillUnixSocketAddr(struct sockaddr_un& address, std::string& path);
 }
 }
 } // apache::thrift::transport
-
-#endif // _WIN32
 
 #endif //THRIFT_SOCKETCOMMON_H

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -249,26 +249,28 @@ void TServerSocket::setInterruptableChildren(bool enable) {
 }
 
 void TServerSocket::_setup_sockopts() {
-
-  // Set THRIFT_NO_SOCKET_CACHING to prevent 2MSL delay on accept
-  int one = 1;
-  if (-1 == setsockopt(serverSocket_,
-                       SOL_SOCKET,
-                       THRIFT_NO_SOCKET_CACHING,
-                       cast_sockopt(&one),
-                       sizeof(one))) {
-// ignore errors coming out of this setsockopt on Windows.  This is because
-// SO_EXCLUSIVEADDRUSE requires admin privileges on WinXP, but we don't
-// want to force servers to be an admin.
-#ifndef _WIN32
-    int errno_copy = THRIFT_GET_SOCKET_ERROR;
-    GlobalOutput.perror("TServerSocket::listen() setsockopt() THRIFT_NO_SOCKET_CACHING ",
-                        errno_copy);
-    close();
-    throw TTransportException(TTransportException::NOT_OPEN,
-                              "Could not set THRIFT_NO_SOCKET_CACHING",
-                              errno_copy);
-#endif
+  if (!isUnixDomainSocket()) {
+    // Set THRIFT_NO_SOCKET_CACHING to prevent 2MSL delay on accept.
+    // This does not work with Domain sockets on most platforms. And
+    // on Windows it completely breaks the socket. Therefore do not
+    // use this on Domain sockets.
+    int one = 1;
+    if (-1 == setsockopt(serverSocket_,
+                        SOL_SOCKET,
+                        THRIFT_NO_SOCKET_CACHING,
+                        cast_sockopt(&one),
+                        sizeof(one))) {
+      // NOTE: SO_EXCLUSIVEADDRUSE socket option can only be used by members
+      // of the Administrators security group on Windows XP and earlier. But
+      // we do not target WinXP anymore so no special checks required.
+      int errno_copy = THRIFT_GET_SOCKET_ERROR;
+      GlobalOutput.perror("TServerSocket::listen() setsockopt() THRIFT_NO_SOCKET_CACHING ",
+                          errno_copy);
+      close();
+      throw TTransportException(TTransportException::NOT_OPEN,
+                                "Could not set THRIFT_NO_SOCKET_CACHING",
+                                errno_copy);
+    }
   }
 
   // Set TCP buffer sizes
@@ -437,12 +439,9 @@ void TServerSocket::listen() {
     _setup_sockopts();
     _setup_unixdomain_sockopts();
 
-/*
- * TODO: seems that windows now support unix sockets,
- *       see: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
- */
-#ifndef _WIN32
-
+    // Windows supports Unix domain sockets since it ships the header
+    // HAVE_AF_UNIX_H (see https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/)
+#if (!defined(_WIN32) || defined(HAVE_AF_UNIX_H))
     struct sockaddr_un address;
     socklen_t structlen = fillUnixSocketAddr(address, path_);
 
@@ -454,7 +453,7 @@ void TServerSocket::listen() {
       // use short circuit evaluation here to only sleep if we need to
     } while ((retries++ < retryLimit_) && (THRIFT_SLEEP_SEC(retryDelay_) == 0));
 #else
-    GlobalOutput.perror("TSocket::open() Unix Domain socket path not supported on windows", -99);
+    GlobalOutput.perror("TServerSocket::open() Unix Domain socket path not supported on this version of Windows", -99);
     throw TTransportException(TTransportException::NOT_OPEN,
                               " Unix Domain socket path not supported");
 #endif
@@ -537,9 +536,14 @@ void TServerSocket::listen() {
   if (retries > retryLimit_) {
     char errbuf[1024];
     if (isUnixDomainSocket()) {
-      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() PATH %s", path_.c_str());
+#ifdef _WIN32
+      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() Could not bind to domain socket path %s, error %d", path_.c_str(), WSAGetLastError());
+#else
+      // Fixme: This does not currently handle abstract domain sockets:
+      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() Could not bind to domain socket path %s", path_.c_str());
+#endif
     } else {
-      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() BIND %d", port_);
+      THRIFT_SNPRINTF(errbuf, sizeof(errbuf), "TServerSocket::listen() Could not bind to port %d", port_);
     }
     GlobalOutput(errbuf);
     close();
@@ -664,6 +668,7 @@ shared_ptr<TTransport> TServerSocket::acceptImpl() {
   }
 
   shared_ptr<TSocket> client = createSocket(clientSocket);
+  client->setPath(path_);
   if (sendTimeout_ > 0) {
     client->setSendTimeout(sendTimeout_);
   }

--- a/lib/cpp/src/thrift/windows/config.h
+++ b/lib/cpp/src/thrift/windows/config.h
@@ -59,6 +59,7 @@
 // windows
 #include <Winsock2.h>
 #include <ws2tcpip.h>
+
 #ifndef __MINGW32__
   #ifdef _WIN32_WCE
   #pragma comment(lib, "Ws2.lib")
@@ -71,5 +72,19 @@
   #pragma comment(lib, "Shlwapi.lib")  // For StrStrIA in TPipeServer
   #endif
 #endif // __MINGW32__
+
+// Replicate the logic of afunix.h on Windows (the header is only present on
+// newer Windows SDKs)
+#ifdef HAVE_AF_UNIX_H
+#include <afunix.h>
+#else
+#ifndef UNIX_PATH_MAX
+#define UNIX_PATH_MAX 108
+#endif
+typedef struct sockaddr_un {
+  ADDRESS_FAMILY sun_family;    // AF_UNIX
+  char sun_path[UNIX_PATH_MAX]; // pathname
+} SOCKADDR_UN, *PSOCKADDR_UN;
+#endif // HAVE_AF_UNIX_H
 
 #endif // _THRIFT_WINDOWS_CONFIG_H_


### PR DESCRIPTION
This PR adds support for domain sockets for Windows.

It is a follow-up of #2127 because the former ran into a timeout and can no be reopened (due to https://github.com/isaacs/github/issues/361).

In order to implement this change I've changed a basic property of C++ build configuration for Windows. This would not be strictly required but is quite helpful. Domain sockets are only available on recent versions of the Windows platform SDK. Therefore I've enabled the automatic configuration of `config.h` with cmake. I've checked the results and on my platform(s) the generated config header is sensible and matches the hard-coded default. However this change is not easily portable to autotools.

During the implementation I found a number of minor issues in TServerSocket and TSocket that I believe are improved in this PR. None of these changes should be a breaking change. Mostly some methods should not be called on a domain socket and have been excluded. Also, the variable `listening_` was set to `true` at the beginning of the `listen()` method but I found that this opens a small time window where `listening_` is true but the socket is not actually listening (yet).

Please review and let me know if there is anything to discuss?

I've tested this implementation successfully on MSVC 2017 and 2019, on Ubuntu 18.04 x86_64 and on MacOS 14 with XCode 11.3.

- [x] I created Apache Jira Ticket https://issues.apache.org/jira/browse/THRIFT-5187
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, add ` [skip ci]` at the end of your pull request to free up build resources.
