### PR TITLE
THRIFT-5352: Fix construction of Py exceptions with no fields

### DIFF
--- a/lib/py/src/Thrift.py
+++ b/lib/py/src/Thrift.py
@@ -90,7 +90,7 @@ class TException(Exception):
 
     def __init__(self, message=None):
         Exception.__init__(self, message)
-        self.message = message
+        super(TException, self).__setattr__("message", message)
 
 
 class TApplicationException(TException):

--- a/test/DebugProtoTest.thrift
+++ b/test/DebugProtoTest.thrift
@@ -245,6 +245,8 @@ exception MutableException {
   1: string msg;
 } (python.immutable = "false")
 
+exception ExceptionWithoutFields {}
+
 service ServiceForExceptionWithAMap {
   void methodThatThrowsAnException() throws (1: ExceptionWithAMap xwamap);
 }

--- a/test/py/TestFrozen.py
+++ b/test/py/TestFrozen.py
@@ -21,7 +21,7 @@
 
 from DebugProtoTest import Srv
 from DebugProtoTest.ttypes import CompactProtoTestStruct, Empty, Wrapper
-from DebugProtoTest.ttypes import ExceptionWithAMap, MutableException
+from DebugProtoTest.ttypes import ExceptionWithAMap, MutableException, ExceptionWithoutFields
 from thrift.Thrift import TFrozenDict
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TCompactProtocol
@@ -103,6 +103,9 @@ class TestFrozenBase(unittest.TestCase):
         mutexc = MutableException(msg='foo')
         mutexc.msg = 'bar'
         self.assertEqual(mutexc.msg, 'bar')
+
+    def test_frozen_exception_with_no_fields(self):
+        ExceptionWithoutFields()
 
     def test_frozen_exception_serialization(self):
         result = Srv.declaredExceptionMethod_result(


### PR DESCRIPTION
Client: py

When no fields are present, we don't get the special constructor that
uses `__setattr__` to avoid these checks. So the default constructor sets
message normally and triggers the anti-mutation tripwires.

Before:

```console
$ thrift --version
Thrift version 0.14.0

$ pip freeze | grep thrift
thrift==0.14.0

$ cat test.thrift
exception LookMaNoFields {}

$ thrift -out . -gen py test.thrift

$ python
>>> from test.ttypes import LookMaNoFields
>>> LookMaNoFields()
Traceback (most recent call last):
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/src/thrift/lib/py/thrift/Thrift.py", line 93, in __init__
    super(TException, self).__setattr__("message", message)
  File "/src/example/test/ttypes.py", line 23, in __setattr__
    raise TypeError("can't modify immutable instance")
TypeError: can't modify immutable instance
```

After:

```
$ python
>>> from test.ttypes import LookMaNoFields
>>> LookMaNoFields()
LookMaNoFields(message=None)
```


- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
