### PR TITLE
Move ConflictingNamesTest to lib/go/test

### DIFF
--- a/lib/go/test/ConflictArgNamesTest.thrift
+++ b/lib/go/test/ConflictArgNamesTest.thrift
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+service ConflictArgNamesTest {
+  /**
+   * Use some names that could conflict with the compiler code as args
+   * to make sure that the compiler handled them correctly.
+   */
+  void testNameConflicts(
+    // 1: string args, // args is already a reserved keyword in thrift compiler
+    2: string result,
+    3: string meta,
+    4: string r,
+    5: string err,
+  )
+}

--- a/lib/go/test/EqualsTest.thrift
+++ b/lib/go/test/EqualsTest.thrift
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 typedef i8 mybyte
 typedef string mystr
 typedef binary mybin

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -46,7 +46,9 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConflictNamespaceTestD.thrift \
 				ConflictNamespaceTestSuperThing.thrift \
 				ConflictNamespaceServiceTest.thrift \
-				DuplicateImportsTest.thrift
+				DuplicateImportsTest.thrift \
+				EqualsTest.thrift \
+				ConflictArgNamesTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -74,6 +76,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceServiceTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r DuplicateImportsTest.thrift
 	$(THRIFT) $(THRIFTARGS) EqualsTest.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictArgNamesTest.thrift
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock || true
 	sed -i 's/\"context\"/\"golang.org\/x\/net\/context\"/g' gopath/src/github.com/golang/mock/gomock/controller.go || true
 	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
@@ -99,7 +102,8 @@ check: gopath
 				conflict/context/conflict_service-remote \
 				servicestest/container_test-remote \
 				duplicateimportstest \
-				equalstest
+				equalstest \
+				conflictargnamestest
 	GOPATH=`pwd`/gopath $(GO) test thrift tests dontexportrwtest
 
 clean-local:
@@ -113,6 +117,7 @@ EXTRA_DIST = \
 	tests \
 	common \
 	BinaryKeyTest.thrift \
+	ConflictArgNamesTest.thrift \
 	ConflictNamespaceServiceTest.thrift \
 	ConflictNamespaceTestA.thrift \
 	ConflictNamespaceTestB.thrift \

--- a/lib/go/test/tests/conflict_arg_names_test.go
+++ b/lib/go/test/tests/conflict_arg_names_test.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"conflictargnamestest"
+)
+
+// We just want to make sure that the conflictargnamestest package compiles.
+var _ = conflictargnamestest.GoUnusedProtection__

--- a/lib/go/test/tests/equals_test.go
+++ b/lib/go/test/tests/equals_test.go
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package tests
 
 import (

--- a/test/ThriftTest.thrift
+++ b/test/ThriftTest.thrift
@@ -411,17 +411,3 @@ struct StructB {
 struct OptionalSetDefaultTest {
   1: optional set<string> with_default = [ "test" ]
 }
-
-service ConflictingNamesTest {
-  /**
-   * Use some names that could conflict with the compiler code as args
-   * to make sure that the compiler handled them correctly.
-   */
-  void testNameConflicts(
-    // 1: string args,   // args is already a reserved keyword in thrift compiler
-    // 2: string result, // result will cause problems in compiled netstd code
-    3: string meta,
-    4: string r,
-    5: string err,
-  )
-}


### PR DESCRIPTION
Client: go

Also add missing copyright header for files added in
https://github.com/apache/thrift/pull/2307.
