### PR TITLE
THRIFT-5353: Fix import dedup without explicit go namespace

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -787,14 +787,15 @@ void t_go_generator::init_generator() {
 string t_go_generator::render_included_programs(string& unused_prot) {
   const vector<t_program*>& includes = program_->get_includes();
   string result = "";
-  string local_namespace = program_->get_namespace("go");
+  string local_namespace = get_real_go_module(program_);
   std::set<std::string> included;
   for (auto include : includes) {
-    if (!local_namespace.empty() && local_namespace == include->get_namespace("go")) {
+    std::string includeModule = get_real_go_module(include);
+    if (!local_namespace.empty() && local_namespace == includeModule) {
       continue;
     }
 
-    if (!included.insert(include->get_namespace("go")).second) {
+    if (!included.insert(includeModule).second) {
         continue;
     }
 


### PR DESCRIPTION
Client: go

When a thrift file includes 2 or more other thrift files, and those
included thrift files do not have explicit go namespaces defined, the
current import dedup logic would wrongly use their empty namespace and
skip the second one, while the real import namespace should be inferred
from the filename.
