### PR TITLE
Move java dependency tomcat-embed to the crossTest configuration...

### DIFF
--- a/lib/java/gradle.properties
+++ b/lib/java/gradle.properties
@@ -28,9 +28,8 @@ maven-repository-id=apache.releases.https
 httpclient.version=4.5.10
 httpcore.version=4.4.12
 slf4j.version=1.7.28
-#servlet.version=2.5
-#It contains servlet3
-tomcat.embed.version=8.5.46
+servlet.version=4.0.1
+tomcat.embed.version=9.0.43
 junit.version=4.12
 mockito.version=1.10.19
 javax.annotation.version=1.3.2

--- a/lib/java/gradle/environment.gradle
+++ b/lib/java/gradle/environment.gradle
@@ -44,7 +44,7 @@ ext.mavenRepositoryUrl = property('maven-repository-url')
 // Versions used in this project
 ext.httpclientVersion = property('httpclient.version')
 ext.httpcoreVersion = property('httpcore.version')
-//ext.servletVersion = property('servlet.version')
+ext.servletVersion = property('servlet.version')
 ext.tomcatEmbedVersion = property('tomcat.embed.version')
 ext.slf4jVersion = property('slf4j.version')
 ext.junitVersion = property('junit.version')
@@ -67,8 +67,7 @@ dependencies {
     compile "org.slf4j:slf4j-api:${slf4jVersion}"
     compile "org.apache.httpcomponents:httpclient:${httpclientVersion}"
     compile "org.apache.httpcomponents:httpcore:${httpcoreVersion}"
-    //compile "javax.servlet:servlet-api:${servletVersion}"
-    compile "org.apache.tomcat.embed:tomcat-embed-core:${tomcatEmbedVersion}"
+    compile "javax.servlet:javax.servlet-api:${servletVersion}"
     compile "javax.annotation:javax.annotation-api:${javaxAnnotationVersion}"
 
     testCompile "junit:junit:${junitVersion}"

--- a/lib/java/gradle/functionalTests.gradle
+++ b/lib/java/gradle/functionalTests.gradle
@@ -45,6 +45,7 @@ configurations {
 }
 
 dependencies {
+    crossTestCompile "org.apache.tomcat.embed:tomcat-embed-core:${tomcatEmbedVersion}"
     crossTestCompile sourceSets.main.output
     crossTestCompile sourceSets.test.output
 }

--- a/lib/java/gradle/publishing.gradle
+++ b/lib/java/gradle/publishing.gradle
@@ -85,7 +85,7 @@ def configurePom(pom) {
 
     pom.whenConfigured {
         // Fixup the scope for servlet-api to be 'provided' instead of 'compile'
-        dependencies.find { dep -> dep.groupId == 'javax.servlet' && dep.artifactId == 'servlet-api' }.with {
+        dependencies.find { dep -> dep.groupId == 'javax.servlet' && dep.artifactId == 'javax.servlet-api' }.with {
             if(it != null) {
               // it.optional = true
               it.scope = 'provided'


### PR DESCRIPTION
…to remove outdated unnecessary compile time dependency.

When using java package libthrift 0.14.0, I've noticed a new compile time dependency for the package to tomcat-embedded-core. Upon reviewing, this package is quite old and is a security risk. When I looked at where and how this package is being used, I noticed that it's only refered to by crossTest and to provide access to the javax.servlet classes.

Since tomcat-embedded is only used in crossTests, I have moved it to crossTest configuration so the libthrift java package does not require this unnecessary dependency for compilation. Instead, the java-servlet dependency has been reintroduced in compile time. I've also taken this opportunity to update both dependenciesto a later version.