### PR TITLE
THIRFT-5367: Fix crashes when using Ruby compaction GC

### DIFF
--- a/lib/rb/Rakefile
+++ b/lib/rb/Rakefile
@@ -54,7 +54,7 @@ namespace :'gen-rb' do
 
   task :'flat_spec' do
     dir = File.dirname(__FILE__) + '/spec'
-    mkdir_p("#{dir}/gen-rb/flat")
+    FileUtils.mkdir_p("#{dir}/gen-rb/flat")
     sh THRIFT, '--gen', 'rb', '--recurse', '-out', "#{dir}/gen-rb/flat", "#{dir}/ThriftNamespacedSpec.thrift"
   end
 

--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -567,6 +567,7 @@ VALUE rb_thrift_compact_proto_read_binary(VALUE self) {
 
 static void Init_constants() {
   thrift_compact_protocol_class = rb_const_get(thrift_module, rb_intern("CompactProtocol"));
+  rb_global_variable(&thrift_compact_protocol_class);
 
   VERSION = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION")));
   VERSION_MASK = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION_MASK")));

--- a/lib/rb/ext/struct.c
+++ b/lib/rb/ext/struct.c
@@ -698,14 +698,23 @@ void Init_struct() {
   rb_define_method(struct_module, "read", rb_thrift_struct_read, 1);
 
   thrift_union_class = rb_const_get(thrift_module, rb_intern("Union"));
+  rb_global_variable(&thrift_union_class);
 
   rb_define_method(thrift_union_class, "write", rb_thrift_union_write, 1);
   rb_define_method(thrift_union_class, "read", rb_thrift_union_read, 1);
 
   setfield_id = rb_intern("@setfield");
+  rb_global_variable(&setfield_id);
+
   setvalue_id = rb_intern("@value");
+  rb_global_variable(&setvalue_id);
 
   to_s_method_id = rb_intern("to_s");
+  rb_global_variable(&to_s_method_id);
+
   name_to_id_method_id = rb_intern("name_to_id");
+  rb_global_variable(&name_to_id_method_id);
+
   sorted_field_ids_method_id = rb_intern("sorted_field_ids");
+  rb_global_variable(&sorted_field_ids_method_id);
 }

--- a/lib/rb/ext/thrift_native.c
+++ b/lib/rb/ext/thrift_native.c
@@ -112,10 +112,19 @@ VALUE protocol_exception_class;
 void Init_thrift_native() {
   // cached classes
   thrift_module = rb_const_get(rb_cObject, rb_intern("Thrift"));
+  rb_global_variable(&thrift_module);
+
   thrift_bytes_module = rb_const_get(thrift_module, rb_intern("Bytes"));
+  rb_global_variable(&thrift_bytes_module);
+
   thrift_types_module = rb_const_get(thrift_module, rb_intern("Types"));
+  rb_global_variable(&thrift_types_module);
+
   rb_cSet = rb_const_get(rb_cObject, rb_intern("Set"));
+  rb_global_variable(&rb_cSet);
+
   protocol_exception_class = rb_const_get(thrift_module, rb_intern("ProtocolException"));
+  rb_global_variable(&protocol_exception_class);
 
   // Init ttype constants
   TTYPE_BOOL = FIX2INT(rb_const_get(thrift_types_module, rb_intern("BOOL")));
@@ -193,6 +202,14 @@ void Init_thrift_native() {
   element_sym = ID2SYM(rb_intern("element"));
   class_sym = ID2SYM(rb_intern("class"));
   binary_sym = ID2SYM(rb_intern("binary"));
+
+  rb_global_variable(&type_sym);
+  rb_global_variable(&name_sym);
+  rb_global_variable(&key_sym);
+  rb_global_variable(&value_sym);
+  rb_global_variable(&element_sym);
+  rb_global_variable(&class_sym);
+  rb_global_variable(&binary_sym);
 
   Init_struct();
   Init_binary_protocol_accelerated();

--- a/lib/rb/spec/spec_helper.rb
+++ b/lib/rb/spec/spec_helper.rb
@@ -62,3 +62,8 @@ end
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[gen-rb/flat])
 
+if defined?(GC.verify_compaction_references) == 'method'
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib ext]
 
-  s.add_development_dependency 'bundler',            '~> 1.11'
+  s.add_development_dependency 'bundler',            '>= 1.11'
   s.add_development_dependency 'pry',                '~> 0.11.3'
   s.add_development_dependency 'pry-byebug',         '~> 3.6'
   s.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test',          '~> 0.8.3'
   s.add_development_dependency 'rake',               '~> 12.3'
   s.add_development_dependency 'rspec',              '~> 3.7'
+  s.add_development_dependency 'srv',                '~> 1.0'
   s.add_development_dependency 'thin',               '~> 1.7'
 end
 


### PR DESCRIPTION
Ruby v2.7 introduced support for a compacting garbage collector
(https://bugs.ruby-lang.org/issues/15626) that can be invoked via
`GC.compact`.

The Thrift library does not mark its global constants, so seg faults
appear when using `GC.compact`.

To fix this, we mark globals with `rb_global_variable`, which should
be present in older versions of Ruby.

