### PR TITLE
THRIFT-5382 Netstd default list/set enums values are generated incorrectly

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -667,7 +667,7 @@ string t_netstd_generator::render_const_value(ostream& out, string name, t_type*
     }
     else if (type->is_enum())
     {
-        render << type->get_name() << "." << value->get_identifier_name();
+        render << type_name(type) << "." << value->get_identifier_name();
     }
     else
     {

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -78,6 +78,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./../../../../contrib/fb303/if/fb303.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5253.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5320.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd -r ./Thrift5382.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5382.objs.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5382.objs.thrift
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+// Testcase for THRIFT-5382 Netstd default list/set enums values are generated incorrectly
+
+namespace * Thrift5382.objs
+
+enum FoobarEnum {
+	Val_1 = 0,
+	Val_2 = 1
+}

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5382.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5382.thrift
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+// Testcase for THRIFT-5382 Netstd default list/set enums values are generated incorrectly
+
+namespace * Thrift5382
+
+include "Thrift5382.objs.thrift"
+
+struct RequestModel {
+	// Breaks
+	1: optional set<Thrift5382.objs.FoobarEnum> data_1 = [ FoobarEnum.Val_1, FoobarEnum.Val_2 ],
+	// Breaks
+	2: optional list<Thrift5382.objs.FoobarEnum> data_2 = [ FoobarEnum.Val_1, FoobarEnum.Val_2 ],
+	// Works
+	3: optional Thrift5382.objs.FoobarEnum data_3 = FoobarEnum.Val_1
+}
+
+service Test {
+    void CallMe( 
+		1 : RequestModel foo,
+	)
+}


### PR DESCRIPTION
Client netstd

Prefix enums with the full namespace to allow default values in lists/sets to be set correctly.
Generated code before:
```
public RequestModel()    
{      
  this._data_1 = new THashSet<global::Thriftxxxx.objs.FoobarEnum>();                        
  this._data_1.Add(FoobarEnum.Val_1);
  this._data_1.Add(FoobarEnum.Val_2);
  this.__isset.data_1 = true;
  this._data_2 = new List<global::Thriftxxxx.objs.FoobarEnum>();
  this._data_2.Add(FoobarEnum.Val_1);
  this._data_2.Add(FoobarEnum.Val_2);
  this.__isset.data_2 = true;
  this._data_3 = global::Thriftxxxx.objs.FoobarEnum.Val_1; 
  this.__isset.data_3 = true;    
}
```
After:
```
public RequestModel()
{
  this._data_1 = new THashSet<global::Thrift5382.objs.FoobarEnum>();
  this._data_1.Add(global::Thrift5382.objs.FoobarEnum.Val_1);
  this._data_1.Add(global::Thrift5382.objs.FoobarEnum.Val_2);
  this.__isset.data_1 = true;
  this._data_2 = new List<global::Thrift5382.objs.FoobarEnum>();
  this._data_2.Add(global::Thrift5382.objs.FoobarEnum.Val_1);
  this._data_2.Add(global::Thrift5382.objs.FoobarEnum.Val_2);
  this.__isset.data_2 = true;
  this._data_3 = global::Thrift5382.objs.FoobarEnum.Val_1;
  this.__isset.data_3 = true;
}
```