### PR TITLE
Fix Appveyor build

### DIFF
--- a/build/appveyor/CYGW-appveyor-build.bat
+++ b/build/appveyor/CYGW-appveyor-build.bat
@@ -31,5 +31,5 @@ SET CMAKEARGS=^
 :: -DCMAKE_CXX_STANDARD=11 ^
 
 @ECHO ON
-%BASH% -lc "mkdir -p %BUILDDIR% && cd %BUILDDIR% && cmake.exe %SRCDIR% %CMAKEARGS% && cmake --build . --config %CONFIGURATION% --target install" || EXIT /B
+%BASH% -lc "export PATH=/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/usr/bin && mkdir -p %BUILDDIR% && cd %BUILDDIR% && cmake %SRCDIR% %CMAKEARGS% && cmake --build . --config %CONFIGURATION% --target install -j `nproc`" || EXIT /B
 @ECHO OFF

--- a/build/appveyor/CYGW-appveyor-install.bat
+++ b/build/appveyor/CYGW-appveyor-install.bat
@@ -38,13 +38,3 @@ CALL cl_showenv.bat                        || EXIT /B
 %BASH% -lc "wget rawgit.com/transcode-open/apt-cyg/master/apt-cyg && install apt-cyg /bin && rm -f apt-cyg" || EXIT /B
 %BASH% -lc "apt-cyg update" || EXIT /B
 %BASH% -lc "apt-cyg install bison cmake flex gcc-g++ libboost-devel libevent-devel make openssl-devel xz zlib-devel"
-
-::
-:: We need a newer version of cmake, the one cygwin provides is too old
-:: to recognize the version of boost.  Luckily there is a pre-release
-:: one available, however cygwin's own setup program has no command line
-:: option to allow access to test packages!
-::
-
-%BASH% -lc "apt-cyg remove cmake"
-%BASH% -lc "cd / && wget http://mirror.clarkson.edu/cygwin/x86_64/release/cmake/cmake-3.14.5-1.tar.xz && tar xJf cmake-3.14.5-1.tar.xz && hash -r && cmake --version"

--- a/build/appveyor/MING-appveyor-build.bat
+++ b/build/appveyor/MING-appveyor-build.bat
@@ -30,5 +30,5 @@ SET CMAKEARGS=^
   -DWITH_PYTHON=OFF
 
 @ECHO ON
-%BASH% -lc "mkdir -p %BUILDDIR% && cd %BUILDDIR% && cmake.exe %SRCDIR% %CMAKEARGS% && cmake --build . --config %CONFIGURATION% --target install" || EXIT /B
+%BASH% -lc "mkdir -p %BUILDDIR% && cd %BUILDDIR% && cmake.exe %SRCDIR% %CMAKEARGS% && cmake --build . --config %CONFIGURATION% --target install -j `nproc`" || EXIT /B
 @ECHO OFF

--- a/build/appveyor/MSYS-appveyor-build.bat
+++ b/build/appveyor/MSYS-appveyor-build.bat
@@ -44,5 +44,5 @@ SET CMAKEARGS=-G\"%GENERATOR%\" ^
   -DWITH_SHARED_LIB=OFF ^
   -DWITH_STATIC_LIB=ON
 
-%BASH% -lc "mkdir %BUILDDIR_MSYS% && cd %BUILDDIR_MSYS% && %CMAKE% %SRCDIR_MSYS% %CMAKEARGS% && %CMAKE% --build . --config %CONFIGURATION% --target install" || EXIT /B
+%BASH% -lc "mkdir %BUILDDIR_MSYS% && cd %BUILDDIR_MSYS% && %CMAKE% %SRCDIR_MSYS% %CMAKEARGS% && %CMAKE% --build . --config %CONFIGURATION% --target install -j `nproc`" || EXIT /B
 @ECHO OFF


### PR DESCRIPTION
Use default CYGWIN cmake which is now at version `3.17.3`
Increase build speed by using all cores with -j switch

