### PR TITLE
THRIFT-5383 Fix misplaced capacity check

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
@@ -973,7 +973,6 @@ public class TJSONProtocol extends TProtocol {
   @Override
   public String readString() throws TException {
     String str = readJSONString(false).toString(StandardCharsets.UTF_8);
-    getTransport().checkReadBytesAvailable(str.length() * getMinSerializedSize(TType.STRING));
     return str;
   }
 

--- a/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TJSONProtocol.java
@@ -972,8 +972,7 @@ public class TJSONProtocol extends TProtocol {
 
   @Override
   public String readString() throws TException {
-    String str = readJSONString(false).toString(StandardCharsets.UTF_8);
-    return str;
+    return readJSONString(false).toString(StandardCharsets.UTF_8);
   }
 
   @Override

--- a/lib/java/test/org/apache/thrift/protocol/TestTJSONProtocol.java
+++ b/lib/java/test/org/apache/thrift/protocol/TestTJSONProtocol.java
@@ -45,4 +45,15 @@ public class TestTJSONProtocol extends ProtocolTestBase {
 
     assertEquals(expectedString, protocol.readString());
   }
+
+  public void testExactlySizedBuffer() throws TException {
+    String inputString = "yeehaw";
+    TMemoryBuffer buffer = new TMemoryBuffer(inputString.length() + 2);
+
+    TJSONProtocol protocol = new TJSONProtocol(buffer);
+    protocol.writeString(inputString);
+    String outputString = protocol.readString();
+
+    assertEquals(inputString, outputString);
+  }
 }

--- a/lib/java/test/org/apache/thrift/protocol/TestTJSONProtocol.java
+++ b/lib/java/test/org/apache/thrift/protocol/TestTJSONProtocol.java
@@ -47,7 +47,10 @@ public class TestTJSONProtocol extends ProtocolTestBase {
   }
 
   public void testExactlySizedBuffer() throws TException {
-    String inputString = "yeehaw";
+    // Regression test for https://issues.apache.org/jira/browse/THRIFT-5383.
+    // Ensures that a JSON string can be read after writing to a buffer just
+    // large enough to contain it.
+    String inputString = "abcdefg";
     TMemoryBuffer buffer = new TMemoryBuffer(inputString.length() + 2);
 
     TJSONProtocol protocol = new TJSONProtocol(buffer);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The added test passes with thrift 0.13.0 and fails on 0.14.0. The source of the error seems to be an unnecessary capacity check when reading JSON string.   

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
