### PR TITLE
THRIFT-5391 Named pipes transport hardening

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/TNamedPipeTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TNamedPipeTransport.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.IO.Pipes;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,7 +40,7 @@ namespace Thrift.Transport.Client
             var serverName = string.IsNullOrWhiteSpace(server) ? server : ".";
             ConnectTimeout = (timeout > 0) ? timeout : Timeout.Infinite;
 
-            PipeStream = new NamedPipeClientStream(serverName, pipe, PipeDirection.InOut, PipeOptions.None);
+            PipeStream = new NamedPipeClientStream(serverName, pipe, PipeDirection.InOut, PipeOptions.None, TokenImpersonationLevel.Anonymous);
         }
 
         public override bool IsOpen => PipeStream != null && PipeStream.IsConnected;

--- a/test/netstd/Server/TestServer.cs
+++ b/test/netstd/Server/TestServer.cs
@@ -149,7 +149,10 @@ namespace ThriftTest
 
     public class TestServer
     {
-        public static int _clientID = -1;
+        #pragma warning disable CA2211
+        public static int _clientID = -1;  // use with Interlocked only!
+        #pragma warning restore CA2211
+
         private static readonly TConfiguration Configuration = null;  // or new TConfiguration() if needed
 
         public delegate void TestLogDelegate(string msg, params object[] values);
@@ -556,7 +559,7 @@ namespace ThriftTest
                     {
                         case TransportChoice.NamedPipe:
                             Debug.Assert(param.pipe != null);
-                            trans = new TNamedPipeServerTransport(param.pipe, Configuration);
+                            trans = new TNamedPipeServerTransport(param.pipe, Configuration, NamedPipeClientFlags.OnlyLocalClients);
                             break;
 
 


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer

* added new flag to implement [PIPE_REJECT_REMOTE_CLIENTS](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea)
* CreateFile() now enforces SECURITY_SQOS_PRESENT | SECURITY_ANONYMOUS flags [according to this patch](https://github.com/dotnet/coreclr/pull/379/files)