### PR TITLE
THRIFT-5395 inconsistent treatment of methods ending in "Async"

### DIFF
--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Impl/Thrift5253/MyService.cs
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Impl/Thrift5253/MyService.cs
@@ -51,6 +51,16 @@ namespace Thrift.PublicInterfaces.Compile.Tests.Impl.Thrift5253
             return Task.FromResult(new InternalStructs() { Foo = input.Foo });
         }
 
+        public Task TestAsyncAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task TestXsyncAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task<WorksRslt> WorksAsync(WorksArrrgs input, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new WorksRslt() { Foo = input.Foo });

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5253.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5253.thrift
@@ -42,5 +42,9 @@ service MyService{
     AsyncProcessor  AsyncProcessor ( 1: AsyncProcessor  foo)
     Client          Client         ( 1: Client  foo)
     IAsync          IAsync         ( 1: IAsync  foo)
+
+    // inconsistent treatment of methods ending in "Async"
+    void TestXsync()
+    void TestAsync()
 }
 


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer
