### PR TITLE
THRIFT-5404: Allow other types of TTransportException to be timeouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@
 
 ### Go
 
-- [THRIFT-5369](https://issues.apache.org/jira/browse/THRIFT-5369) - No longer pre-allocating the whole container (map/set/list) in compiled go code to avoid huge allocations on malformed messages
+- [THRIFT-5369](https://issues.apache.org/jira/browse/THRIFT-5369) - TConfiguration.GetMaxMessageSize() now also applies to container sizes in TProtocol implementations provided
+- [THRIFT-5404](https://issues.apache.org/jira/browse/THRIFT-5404) - TTransportException.Timeout would correctly return true when it's connect timeout during TSocket.Open call
 
 
 ## 0.14.1

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -179,7 +179,8 @@ RUN apt-get install -y --no-install-recommends \
 # Test dependencies for running puppeteer
 RUN apt-get install -y --no-install-recommends \
 `# JS dependencies` \
-      libxss1
+      libxss1 \
+      libxtst6
 
 RUN apt-get install -y --no-install-recommends \
 `# OCaml dependencies` \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -179,7 +179,8 @@ RUN apt-get install -y --no-install-recommends \
 # Test dependencies for running puppeteer
 RUN apt-get install -y --no-install-recommends \
 `# JS dependencies` \
-      libxss1
+      libxss1 \
+      libxtst6
 
 # does not work on disco?
 # RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -170,6 +170,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN apt-get install -y --no-install-recommends \
 `# JS dependencies` \
       libxss1 \
+      libxtst6 \
       libatk-bridge2.0-0 \
       libgtk-3-0
 

--- a/lib/go/thrift/socket.go
+++ b/lib/go/thrift/socket.go
@@ -166,7 +166,11 @@ func (p *TSocket) Open() error {
 		p.addr.String(),
 		p.cfg.GetConnectTimeout(),
 	)); err != nil {
-		return NewTTransportException(NOT_OPEN, err.Error())
+		return &tTransportException{
+			typeId: NOT_OPEN,
+			err:    err,
+			msg:    err.Error(),
+		}
 	}
 	return nil
 }

--- a/lib/go/thrift/ssl_socket.go
+++ b/lib/go/thrift/ssl_socket.go
@@ -167,7 +167,11 @@ func (p *TSSLSocket) Open() error {
 			p.hostPort,
 			p.cfg.GetTLSConfig(),
 		)); err != nil {
-			return NewTTransportException(NOT_OPEN, err.Error())
+			return &tTransportException{
+				typeId: NOT_OPEN,
+				err:    err,
+				msg:    err.Error(),
+			}
 		}
 	} else {
 		if p.conn.isValid() {
@@ -190,7 +194,11 @@ func (p *TSSLSocket) Open() error {
 			p.addr.String(),
 			p.cfg.GetTLSConfig(),
 		)); err != nil {
-			return NewTTransportException(NOT_OPEN, err.Error())
+			return &tTransportException{
+				typeId: NOT_OPEN,
+				err:    err,
+				msg:    err.Error(),
+			}
 		}
 	}
 	return nil

--- a/lib/go/thrift/transport_exception.go
+++ b/lib/go/thrift/transport_exception.go
@@ -72,7 +72,7 @@ func (p *tTransportException) Unwrap() error {
 }
 
 func (p *tTransportException) Timeout() bool {
-	return p.typeId == TIMED_OUT
+	return p.typeId == TIMED_OUT || isTimeoutError(p.err)
 }
 
 func NewTTransportException(t int, e string) TTransportException {


### PR DESCRIPTION
Client: go

Currently we only treat TTransportException with typeId == TIMED_OUT as
timeout (return true in Timeout function). When opening a new socket, if
we got a connect timeout from net.Dial, we wrap the error as
TTransportException with typeId == NOT_OPEN, thus it's no longer treated
as a timeout error.

Change the error to be directly wrapping the original error (instead of
recreate a new error with the same error message), and change
tTransportException.Exception to also return true if the wrapped error
is a timeout error. This way we don't have to break anything (if code
rely on TTransportException.TypeId being NOT_OPEN in this case, that's
still true).

While I'm here, also update CHANGES.md from #2359.
