### PR TITLE
Adds support for building C++ codegen on Solaris

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -23,6 +23,9 @@
 #include <sstream>
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
+#ifdef __sun
+#include <sys/filio.h>
+#endif // __sun
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>


### PR DESCRIPTION
Solaris-derived systems split some functionality that is usually found
in `sys/ioctl.h` into `sys/filio.h`. In this case, the `FIONREAD`
constant is in the latter file.
