### PR TITLE
THRIFT-5407: Minor changes in .NET to support netcoreapp3.1

### DIFF
--- a/test/netstd/Client/Client.csproj
+++ b/test/netstd/Client/Client.csproj
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
     <OutputType>Exe</OutputType>

--- a/test/netstd/Client/Program.cs
+++ b/test/netstd/Client/Program.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using ThriftTest;
 
 namespace Client
@@ -26,8 +27,8 @@ namespace Client
     {
         public static int Main(string[] args)
         {
-            if (OperatingSystem.IsWindows())
-            { 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
                 try
                 {
                     Console.SetBufferSize(Console.BufferWidth, 4096);
@@ -69,5 +70,3 @@ namespace Client
         }
     }
 }
-
-

--- a/test/netstd/Server/Program.cs
+++ b/test/netstd/Server/Program.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using ThriftTest;
 
 namespace Server
@@ -26,7 +27,7 @@ namespace Server
     {
         public static int Main(string[] args)
         {
-            if (OperatingSystem.IsWindows())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 try
                 {
@@ -65,5 +66,3 @@ namespace Server
         }
     }
 }
-
-

--- a/test/netstd/Server/Server.csproj
+++ b/test/netstd/Server/Server.csproj
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
     <OutputType>Exe</OutputType>

--- a/tutorial/netstd/Client/Client.csproj
+++ b/tutorial/netstd/Client/Client.csproj
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
     <OutputType>Exe</OutputType>

--- a/tutorial/netstd/Server/Server.csproj
+++ b/tutorial/netstd/Server/Server.csproj
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This PR re-adds support for .NET CORE 3.1. It still requires latest .NET CORE to build. Users need to manually switch the build from net5.0 to netcoreapp3.1. This can be done in DotNet or directly in the csproj files.

- [x] Apache Jira ticket https://issues.apache.org/jira/browse/THRIFT-5407
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
