### PR TITLE
THRIFT-3508: Map optional fields from thrift idl to optional fields i…

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -909,13 +909,9 @@ void t_js_generator::generate_js_struct_definition(ostream& out,
       out << indent() << dval << ";" << endl;
     }
     if (gen_ts_) {
-      if (gen_node_) {
-        f_types_ts_ << ts_indent() << "public " << (*m_iter)->get_name() << ": "
-                    << ts_get_type((*m_iter)->get_type()) << ";" << endl;
-      } else {
-        f_types_ts_ << ts_indent() << (*m_iter)->get_name() << ": "
-                    << ts_get_type((*m_iter)->get_type()) << ";" << endl;
-      }
+      string ts_access = gen_node_ ? "public " : "";
+      f_types_ts_ << ts_indent() << ts_access << (*m_iter)->get_name() << ts_get_req(*m_iter) << ": "
+                  << ts_get_type((*m_iter)->get_type()) << ";" << endl;
     }
   }
 


### PR DESCRIPTION
…n TypeScript.

Client: node,js

<!-- Explain the changes in the pull request below: -->
Add ? behind optional members in classes if the field is marked as optional in thrift-idl.

Closes THRIFT-3508 and makes THRIFT-3227 probably obsolete as optional class members are supported since TypeScript 2.0


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
No, I am hijacking the existing Ticket of THRIFT-3508 as it is exactly what I implemented.

- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"? 
Yes

- [x] Did you squash your changes to a single commit?  (not required, but preferred)
Yes

- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
Yes, I am not aware of braking changes, but was unable to to do the Test drive development approach from the provided documentation.
