### PR TITLE
THRIFT-5416: Allow UDP Sockets

### DIFF
--- a/lib/perl/lib/Thrift/Socket.pm
+++ b/lib/perl/lib/Thrift/Socket.pm
@@ -57,7 +57,7 @@ sub new
         port         => 9090,
         recvTimeout  => 10000,
         sendTimeout  => 10000,
-
+        proto        => 'tcp',
         handle       => undef
     };
 
@@ -260,7 +260,7 @@ sub __open
     my $self = shift;
     return IO::Socket::INET->new(PeerAddr => $self->{host},
                                  PeerPort => $self->{port},
-                                 Proto    => 'tcp',
+                                 Proto    => $self->{proto},
                                  Timeout  => $self->{sendTimeout} / 1000);
 }
 


### PR DESCRIPTION
Allows perl Socket.pm constructor to take an optional "proto" parameter which would let user's specify the socket to be of type "UDP".