### PR TITLE
THRIFT-5417: Fix Lua compiler omitting default values in Lua service functions

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -593,7 +593,21 @@ void t_lua_generator::generate_service_client(ostream& out, t_service* tservice)
     vector<t_field*>::const_iterator fld_iter;
     for (fld_iter = args.begin(); fld_iter != args.end(); ++fld_iter) {
       std::string argname = (*fld_iter)->get_name();
-      indent(out) << "args." << argname << " = " << argname << endl;
+      if ((*fld_iter)->get_value() != nullptr) {
+        // Insert default value for nil arguments
+        t_type* type = get_true_type((*fld_iter)->get_type());
+        indent(out) << "if " << argname << " ~= nil then" << endl;
+        indent_up();
+        indent(out) << "args." << argname << " = " << argname << endl;
+        indent_down();
+        indent(out) << "else" << endl;
+        indent_up();
+        indent(out) << "args." << argname << " = " << render_const_value(type, (*fld_iter)->get_value()) << endl;
+        indent_down();
+        indent(out) << "end" << endl;
+      } else {
+        indent(out) << "args." << argname << " = " << argname << endl;
+      }
     }
 
     indent(out) << "args:write(self.oprot)" << endl;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Add missing default argument values for service client functions in generated Lua code.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
