### PR TITLE
THRIFT-5419: Update TThreadPoolAsyncServer.Execute to be async/await

### DIFF
--- a/lib/netstd/Thrift/Server/TThreadPoolAsyncServer.cs
+++ b/lib/netstd/Thrift/Server/TThreadPoolAsyncServer.cs
@@ -177,7 +177,7 @@ namespace Thrift.Server
                     try
                     {
                         TTransport client = await ServerTransport.AcceptAsync(cancellationToken);
-                        ThreadPool.QueueUserWorkItem(this.Execute, client);
+                        var ignore = Task.Run(() => ExecuteAsync(client));
                     }
                     catch (TaskCanceledException)
                     {
@@ -218,11 +218,11 @@ namespace Thrift.Server
         /// threadContext will be a TTransport instance
         /// </summary>
         /// <param name="threadContext"></param>
-        private void Execute(object threadContext)
+        private async void ExecuteAsync(TTransport client)
         {
             var cancellationToken = ServerCancellationToken;
 
-            using (TTransport client = (TTransport)threadContext)
+            using (client)
             {
                 ITAsyncProcessor processor = ProcessorFactory.GetAsyncProcessor(client, this);
                 TTransport inputTransport = null;
@@ -241,12 +241,12 @@ namespace Thrift.Server
 
                         //Recover event handler (if any) and fire createContext server event when a client connects
                         if (ServerEventHandler != null)
-                            connectionContext = ServerEventHandler.CreateContextAsync(inputProtocol, outputProtocol, cancellationToken).Result;
+                            connectionContext = await ServerEventHandler.CreateContextAsync(inputProtocol, outputProtocol, cancellationToken);
 
                         //Process client requests until client disconnects
                         while (!stop)
                         {
-                            if (! inputTransport.PeekAsync(cancellationToken).Result)
+                            if (! await inputTransport.PeekAsync(cancellationToken))
                                 break;
 
                             //Fire processContext server event
@@ -254,9 +254,9 @@ namespace Thrift.Server
                             //That is to say it may be many minutes between the event firing and the client request
                             //actually arriving or the client may hang up without ever makeing a request.
                             if (ServerEventHandler != null)
-                                ServerEventHandler.ProcessContextAsync(connectionContext, inputTransport, cancellationToken).Wait();
+                                await ServerEventHandler.ProcessContextAsync(connectionContext, inputTransport, cancellationToken);
                             //Process client request (blocks until transport is readable)
-                            if (!processor.ProcessAsync(inputProtocol, outputProtocol, cancellationToken).Result)
+                            if (! await processor.ProcessAsync(inputProtocol, outputProtocol, cancellationToken))
                                 break;
                         }
                     }
@@ -272,7 +272,7 @@ namespace Thrift.Server
 
                     //Fire deleteContext server event after client disconnects
                     if (ServerEventHandler != null)
-                        ServerEventHandler.DeleteContextAsync(connectionContext, inputProtocol, outputProtocol, cancellationToken).Wait();
+                        await ServerEventHandler.DeleteContextAsync(connectionContext, inputProtocol, outputProtocol, cancellationToken);
 
                 }
                 finally


### PR DESCRIPTION
Client: netstd

Do not put long-lived tasks on the thread pool, which causes deadlock and extreme slow performance.

<!-- Explain the changes in the pull request below: -->

Changes Execute() to be ExecuteAsync() using async/await. It still runs on the thread pool, but now freely among the threads without blocking.

I attempted to follow https://github.com/phxnsharp/thrift/blob/master/build/docker/README.md to build using docker on Linux but ran into errors. My changes do not add additional errors.

I did not see where the test results get put, so I do not know how to verify the tests.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

@Jens-G 