### PR TITLE
fix D build, with D lang openssl 2.0.3

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,12 +9,29 @@
   "dependencies": {
     "libevent": {
       "version": "~>2.0.2"
-    },
-    "openssl": {
-      "version": ">=1.1.6"
     }
   },
-  "systemDependencies": "On systems with native openssl 1.0.x use dub package openssl~>1.1, on systems with native openssl 1.1.x use dub package openssl~>2.0",
+  "systemDependencies": "On systems with native openssl 1.0.x use dub package openssl~>1.1, on systems with native openssl 1.1.x use dub package openssl~>2.0.3 (with build bug fix: https://github.com/D-Programming-Deimos/openssl/issues/63)",
+  "configurations": [
+    {
+      "name": "use_openssl_1_0",
+      "versions": ["use_openssl_1_0_x"],
+      "dependencies": {
+        "openssl": {
+          "version": "~>1.1.6"
+        }
+      }
+    },
+    {
+      "name": "use_openssl_1_1",
+      "versions": ["use_openssl_1_1_x"],
+      "dependencies": {
+        "openssl": {
+          "version": "~>2.0.3"
+        }
+      }
+    }
+  ],
   "targetType": "library",
   "sourcePaths": [
     "lib/d/src" 

--- a/lib/d/Makefile.am
+++ b/lib/d/Makefile.am
@@ -153,7 +153,7 @@ clean-local:
 #
 # Unit tests (built both in debug and release mode).
 #
-d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src
+d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src -version=use_openssl_1_0_x
 
 # There just must be some way to reassign a variable without warnings in
 # Automake...

--- a/lib/d/Makefile.am
+++ b/lib/d/Makefile.am
@@ -97,7 +97,7 @@ d_main_modules = $(filter-out $(d_libevent_dependent_modules) \
 	$(d_openssl_dependent_modules),$(d_modules))
 
 
-d_lib_flags = -w -wi -Isrc -lib
+d_lib_flags = -w -wi -Isrc -lib -version=use_openssl_1_0_x
 all_targets =
 
 #


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Fix D build failure:
https://github.com/D-Programming-Deimos/openssl/issues/63

thrift should be buildable with either openssl:
-- 1.1.6+1.0.1g
-- 2.0.3+1.1.0h

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [Y ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ Y] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
