### PR TITLE
THRIFT-5425 Throw an exception when reading TSimpleJson in Java

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -368,112 +368,108 @@ public class TSimpleJSONProtocol extends TProtocol {
 
   /**
    * Reading methods.
+   *
+   * simplejson is not meant to be read back into thrift
+   * - see http://wiki.apache.org/thrift/ThriftUsageJava
+   * - use JSON instead
    */
 
   @Override
   public TMessage readMessageBegin() throws TException {
-    // TODO(mcslee): implement
-    return EMPTY_MESSAGE;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readMessageEnd() throws TException {}
+  public void readMessageEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public TStruct readStructBegin() throws TException {
-    // TODO(mcslee): implement
-    return ANONYMOUS_STRUCT;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readStructEnd() throws TException {}
+  public void readStructEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public TField readFieldBegin() throws TException {
-    // TODO(mcslee): implement
-    return ANONYMOUS_FIELD;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readFieldEnd() throws TException {}
+  public void readFieldEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public TMap readMapBegin() throws TException {
-    // TODO(mcslee): implement
-    return EMPTY_MAP;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readMapEnd() throws TException {}
+  public void readMapEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public TList readListBegin() throws TException {
-    // TODO(mcslee): implement
-    return EMPTY_LIST;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readListEnd() throws TException {}
+  public void readListEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public TSet readSetBegin() throws TException {
-    // TODO(mcslee): implement
-    return EMPTY_SET;
+    throw new TException("Not implemented");
   }
 
   @Override
-  public void readSetEnd() throws TException {}
+  public void readSetEnd() throws TException {
+    throw new TException("Not implemented");}
 
   @Override
   public boolean readBool() throws TException {
-    return (readByte() == 1);
+    throw new TException("Not implemented");
   }
 
   @Override
   public byte readByte() throws TException {
-    // TODO(mcslee): implement
-    return 0;
+    throw new TException("Not implemented");
   }
 
   @Override
   public short readI16() throws TException {
-    // TODO(mcslee): implement
-    return 0;
+    throw new TException("Not implemented");
   }
 
   @Override
   public int readI32() throws TException {
-    // TODO(mcslee): implement
-    return 0;
+    throw new TException("Not implemented");
   }
 
   @Override
   public long readI64() throws TException {
-    // TODO(mcslee): implement
-    return 0;
+    throw new TException("Not implemented");
   }
 
   @Override
   public double readDouble() throws TException {
-    // TODO(mcslee): implement
-    return 0;
+    throw new TException("Not implemented");
   }
 
   @Override
   public String readString() throws TException {
-    // TODO(mcslee): implement
-    return "";
+    throw new TException("Not implemented");
   }
 
   public String readStringBody(int size) throws TException {
-    // TODO(mcslee): implement
-    return "";
+    throw new TException("Not implemented");
   }
 
   @Override
   public ByteBuffer readBinary() throws TException {
-    // TODO(mcslee): implement
-    return ByteBuffer.wrap(new byte[0]);
+    throw new TException("Not implemented");
   }
 
   public static class CollectionMapKeyException extends TException {

--- a/lib/java/test/org/apache/thrift/protocol/TestTSimpleJSONProtocol.java
+++ b/lib/java/test/org/apache/thrift/protocol/TestTSimpleJSONProtocol.java
@@ -23,9 +23,11 @@ import java.nio.charset.StandardCharsets;
 import junit.framework.TestCase;
 
 import org.apache.thrift.Fixtures;
+import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TMemoryBuffer;
 
+import org.apache.thrift.transport.TTransportException;
 import thrift.test.CompactProtoTestStruct;
 import thrift.test.HolyMoley;
 
@@ -89,6 +91,17 @@ public class TestTSimpleJSONProtocol extends TestCase {
       fail("this should throw a CollectionMapKeyException");
     } catch (TSimpleJSONProtocol.CollectionMapKeyException e) {
       //
+    }
+  }
+
+  public void testReadingThrows() throws TTransportException {
+    String input = "{\"test\": \"value\"}";
+    TDeserializer deserializer = new TDeserializer(new TSimpleJSONProtocol.Factory());
+    try {
+      deserializer.fromString(Fixtures.oneOfEach, input);
+      fail("Was able to read SimpleJSON");
+    } catch (TException e) {
+      assertEquals("Not implemented", e.getMessage());
     }
   }
 }


### PR DESCRIPTION
Client java

Throw an exception when reading TSimpleJson and update the comment
explain why.

I'm wondering if just throwing is acceptable since this will break backwards compatibility with clients that actually try to read. Let me know if just updating the comment would be a better solution.
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
