### PR TITLE
THRIFT-3840: C++ TJSONProtocol still using locale dependent formatting

### DIFF
--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -253,6 +253,13 @@ RUN cd / && \
     rm swift-5.1.4-RELEASE-ubuntu18.04.tar.gz && \
     swift --version
 
+# Locale(s) for cpp unit tests
+RUN apt-get install -y --no-install-recommends \
+`# Locale dependencies` \
+      locales && \
+    locale-gen en_US.UTF-8 && \
+    update-locale
+
 # cppcheck-1.82 has a nasty cpp parser bug, so we're using something newer
 RUN apt-get install -y --no-install-recommends \
 `# Static Code Analysis dependencies` \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -258,6 +258,7 @@ RUN apt-get install -y --no-install-recommends \
 `# Locale dependencies` \
       locales && \
     locale-gen en_US.UTF-8 && \
+    locale-gen de_DE.UTF-8 && \
     update-locale
 
 # cppcheck-1.82 has a nasty cpp parser bug, so we're using something newer

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -255,6 +255,13 @@ ENV PATH /root/.cargo/bin:$PATH
 #     rm swift-4.2.1-RELEASE-ubuntu18.04.tar.gz && \
 #     swift --version
 
+# Locale(s) for cpp unit tests
+RUN apt-get install -y --no-install-recommends \
+`# Locale dependencies` \
+      locales && \
+    locale-gen en_US.UTF-8 && \
+    update-locale
+
 # cppcheck-1.82 has a nasty cpp parser bug, so we're using something newer
 # don't need this on disco, nobody uses it
 # RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -260,6 +260,7 @@ RUN apt-get install -y --no-install-recommends \
 `# Locale dependencies` \
       locales && \
     locale-gen en_US.UTF-8 && \
+    locale-gen de_DE.UTF-8 && \
     update-locale
 
 # cppcheck-1.82 has a nasty cpp parser bug, so we're using something newer

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -240,6 +240,7 @@ RUN apt-get install -y --no-install-recommends \
 `# Locale dependencies` \
       locales && \
     locale-gen en_US.UTF-8 && \
+    locale-gen de_DE.UTF-8 && \
     update-locale
 
 # Clean up

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -235,6 +235,13 @@ RUN apt-get install -y --no-install-recommends \
 # Rust dependencies
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.40.0 -y
 
+# Locale(s) for cpp unit tests
+RUN apt-get install -y --no-install-recommends \
+`# Locale dependencies` \
+      locales && \
+    locale-gen en_US.UTF-8 && \
+    update-locale
+
 # Clean up
 RUN rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/* && \

--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -22,6 +22,7 @@
 
 #include <cmath>
 #include <limits>
+#include <locale>
 #include <map>
 #include <set>
 #include <sstream>
@@ -34,6 +35,7 @@ namespace thrift {
 template <typename T>
 std::string to_string(const T& t) {
   std::ostringstream o;
+  o.imbue(std::locale("C"));
   o << t;
   return o.str();
 }

--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -44,6 +44,7 @@ std::string to_string(const T& t) {
 // is enabled.
 inline std::string to_string(const float& t) {
   std::ostringstream o;
+  o.imbue(std::locale("C"));
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<float>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -51,6 +52,7 @@ inline std::string to_string(const float& t) {
 
 inline std::string to_string(const double& t) {
   std::ostringstream o;
+  o.imbue(std::locale("C"));
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -58,6 +60,7 @@ inline std::string to_string(const double& t) {
 
 inline std::string to_string(const long double& t) {
   std::ostringstream o;
+  o.imbue(std::locale("C"));
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<long double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -22,7 +22,6 @@
 #include <iomanip>
 #include <sstream>
 #include <thrift/protocol/TJSONProtocol.h>
-#include <locale>
 #include <memory>
 #include <thrift/transport/TBufferTransports.h>
 #include "gen-cpp/DebugProtoTest_types.h"
@@ -350,27 +349,4 @@ BOOST_AUTO_TEST_CASE(test_json_unicode_escaped_missing_hi_surrogate) {
   OneOfEach ooe2;
   BOOST_CHECK_THROW(ooe2.read(proto.get()),
     apache::thrift::protocol::TProtocolException);
-}
-
-BOOST_AUTO_TEST_CASE(test_json_locale_with_thousands_separator_comma) {
-  testCaseSetup_1();
-
-  const std::string expected_result(
-  "{\"1\":{\"tf\":1},\"2\":{\"tf\":0},\"3\":{\"i8\":127},\"4\":{\"i16\":27000},"
-  "\"5\":{\"i32\":16777216},\"6\":{\"i64\":6000000000},\"7\":{\"dbl\":3.1415926"
-  "535897931},\"8\":{\"str\":\"JSON THIS! \\\"\\u0001\"},\"9\":{\"str\":\"\xd7\\"
-  "n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":\"AQIDrQ\"},\"12\":{\"lst\""
-  ":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2,3]},\"14\":{\"lst\":[\"i64"
-  "\",3,1,2,3]}}");
-
-#if _WIN32
-  std::locale::global(std::locale("en-US.UTF-8"));
-#else
-  std::locale::global(std::locale("en_US.UTF-8"));
-#endif
-
-  const std::string result(apache::thrift::ThriftJSONString(*ooe));
-
-  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
-    "Expected:\n" << expected_result << "\nGotten:\n" << result);
 }

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -22,6 +22,7 @@
 #include <iomanip>
 #include <sstream>
 #include <thrift/protocol/TJSONProtocol.h>
+#include <locale>
 #include <memory>
 #include <thrift/transport/TBufferTransports.h>
 #include "gen-cpp/DebugProtoTest_types.h"
@@ -349,4 +350,27 @@ BOOST_AUTO_TEST_CASE(test_json_unicode_escaped_missing_hi_surrogate) {
   OneOfEach ooe2;
   BOOST_CHECK_THROW(ooe2.read(proto.get()),
     apache::thrift::protocol::TProtocolException);
+}
+
+BOOST_AUTO_TEST_CASE(test_json_locale_with_thousands_separator_comma) {
+  testCaseSetup_1();
+
+  const std::string expected_result(
+  "{\"1\":{\"tf\":1},\"2\":{\"tf\":0},\"3\":{\"i8\":127},\"4\":{\"i16\":27000},"
+  "\"5\":{\"i32\":16777216},\"6\":{\"i64\":6000000000},\"7\":{\"dbl\":3.1415926"
+  "535897931},\"8\":{\"str\":\"JSON THIS! \\\"\\u0001\"},\"9\":{\"str\":\"\xd7\\"
+  "n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":\"AQIDrQ\"},\"12\":{\"lst\""
+  ":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2,3]},\"14\":{\"lst\":[\"i64"
+  "\",3,1,2,3]}}");
+
+#if _WIN32
+  std::locale::global(std::locale("en-US.UTF-8"));
+#else
+  std::locale::global(std::locale("en_US.UTF-8"));
+#endif
+
+  const std::string result(apache::thrift::ThriftJSONString(*ooe));
+
+  BOOST_CHECK_MESSAGE(!expected_result.compare(result),
+    "Expected:\n" << expected_result << "\nGotten:\n" << result);
 }

--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <map>
+#include <locale>
 
 #include <boost/test/unit_test.hpp>
 
@@ -38,6 +39,26 @@ BOOST_AUTO_TEST_CASE(base_types_to_string) {
   BOOST_CHECK_EQUAL(to_string('a'), "a");
   BOOST_CHECK_EQUAL(to_string(1.2), "1.2");
   BOOST_CHECK_EQUAL(to_string("abc"), "abc");
+}
+
+BOOST_AUTO_TEST_CASE(locale_en_US_int_to_string) {
+#if _WIN32
+  std::locale::global(std::locale("en-US.UTF-8"));
+#else
+  std::locale::global(std::locale("en_US.UTF-8"));
+#endif
+  BOOST_CHECK_EQUAL(to_string(1000000), "1000000");
+}
+
+BOOST_AUTO_TEST_CASE(locale_de_DE_floating_point_to_string) {
+#if _WIN32
+  std::locale::global(std::locale("de-DE.UTF-8"));
+#else
+  std::locale::global(std::locale("de_DE.UTF-8"));
+#endif
+  BOOST_CHECK_EQUAL(to_string(1.5), "1.5");
+  BOOST_CHECK_EQUAL(to_string(1.5f), "1.5");
+  BOOST_CHECK_EQUAL(to_string(1.5L), "1.5");
 }
 
 BOOST_AUTO_TEST_CASE(empty_vector_to_string) {


### PR DESCRIPTION
Add unit test for system locale with thousands separator comma
Install en_US.UTF-8 locale in Dockerfile

The global locale affects integer formatting. Some LC_NUMERIC locales specify a thousands separator "," which would break integer formatting. Add a unit test that sets the global locale to "en_US.UTF-8" (which uses a comma thousands separator). Fix the integer formatting by imbue'ing the "C" locale in ostringstream.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
