### PR TITLE
fix isOpen return None, to be consistent with other transport

### DIFF
--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -397,6 +397,8 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
                     TTransportException.NOT_OPEN,
                     "Bad SASL negotiation status: %d (%s)"
                     % (status, challenge))
+    def isOpen(self):
+        return self.transport.isOpen()
 
     def send_sasl_msg(self, status, body):
         header = pack(">BI", status, len(body))


### PR DESCRIPTION
Client: python

<!-- Explain the changes in the pull request below: -->
  
isOpen return None,  which is equivalent to False,  fix it to be consistent with other transport

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
