### PR TITLE
Build fix

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,12 +9,29 @@
   "dependencies": {
     "libevent": {
       "version": "~>2.0.2"
-    },
-    "openssl": {
-      "version": ">=1.1.6"
     }
   },
-  "systemDependencies": "On systems with native openssl 1.0.x use dub package openssl~>1.1, on systems with native openssl 1.1.x use dub package openssl~>2.0",
+  "systemDependencies": "On systems with native openssl 1.0.x use dub package openssl~>1.1, on systems with native openssl 1.1.x use dub package openssl~>2.0.3 (with build bug fix: https://github.com/D-Programming-Deimos/openssl/issues/63)",
+  "configurations": [
+    {
+      "name": "use_openssl_1_0",
+      "versions": ["use_openssl_1_0_x"],
+      "dependencies": {
+        "openssl": {
+          "version": "~>1.1.6"
+        }
+      }
+    },
+    {
+      "name": "use_openssl_1_1",
+      "versions": ["use_openssl_1_1_x"],
+      "dependencies": {
+        "openssl": {
+          "version": "~>2.0.3"
+        }
+      }
+    }
+  ],
   "targetType": "library",
   "sourcePaths": [
     "lib/d/src" 

--- a/lib/d/Makefile.am
+++ b/lib/d/Makefile.am
@@ -153,7 +153,7 @@ clean-local:
 #
 # Unit tests (built both in debug and release mode).
 #
-d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src
+d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src -version=use_openssl_1_0_x
 
 # There just must be some way to reassign a variable without warnings in
 # Automake...

--- a/lib/d/Makefile.am
+++ b/lib/d/Makefile.am
@@ -97,7 +97,7 @@ d_main_modules = $(filter-out $(d_libevent_dependent_modules) \
 	$(d_openssl_dependent_modules),$(d_modules))
 
 
-d_lib_flags = -w -wi -Isrc -lib
+d_lib_flags = -w -wi -Isrc -lib -version=use_openssl_1_0_x
 all_targets =
 
 #

--- a/lib/d/src/thrift/transport/websocket.d
+++ b/lib/d/src/thrift/transport/websocket.d
@@ -163,7 +163,7 @@ private:
 
   void failConnection(CloseCode reason) {
     writeFrameHeader(Opcode.Close);
-    transport_.write(nativeToBigEndian!ushort(reason));
+    transport_.write(std.bitmanip.nativeToBigEndian!ushort(reason));
     transport_.flush();
     transport_.close();
   }
@@ -332,10 +332,10 @@ private:
       header[1] = cast(ubyte)writeBuffer_.length;
     } else if (writeBuffer_.length < 65536) {
       header[1] = 126;
-      header[2..4] = nativeToBigEndian(cast(ushort)writeBuffer_.length);
+      header[2..4] = std.bitmanip.nativeToBigEndian(cast(ushort)writeBuffer_.length);
     } else {
       header[1] = 127;
-      header[2..10] = nativeToBigEndian(cast(ulong)writeBuffer_.length);
+      header[2..10] = std.bitmanip.nativeToBigEndian(cast(ulong)writeBuffer_.length);
     }
 
     transport_.write(header);


### PR DESCRIPTION
https://github.com/ldc-developers/ldc

LDC:  The LLVM-based D Compiler. 
actually is a popular D compiler than DMD

It has build failure:

/home/./.dub/packages/apache-thrift-0.14.1/apache-thrift/lib/d/src/thrift/transport/websocket.d(335,39): Error: function `ldc.intrinsics.llvm_bswap!uint.llvm_bswap` at /home/./project/ldc2-1.26.0-linux-x86_64/bin/../import/ldc/intrinsics.di(405,7) conflicts with function `std.bitmanip.nativeToBigEndian!ushort.nativeToBigEndian` at /home/./project/ldc2-1.26.0-linux-x86_64/bin/../import/std/bitmanip.d(2998,6)

This can be easily fixed by using fully qualified names.

The new change has been tested in my local D build.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
