### PR TITLE
THRIFT-5429: build: autotools: add foreign to AM_INIT_AUTOMAKE

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,4 +61,4 @@ autoheader
 sed '/undef VERSION/d' config.hin > config.hin2
 mv config.hin2 config.hin
 autoconf
-automake --copy --add-missing --foreign
+automake --copy --add-missing

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_INIT([thrift], [0.15.0])
 
 AC_CONFIG_AUX_DIR([.])
 
-AM_INIT_AUTOMAKE([1.13 subdir-objects tar-ustar])
+AM_INIT_AUTOMAKE([1.13 subdir-objects tar-ustar foreign])
 PKG_PROG_PKG_CONFIG
 
 AC_ARG_VAR([PY_PREFIX], [Prefix for installing Python modules.


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Add `foreign` to `AM_INIT_AUTOMAKE()` in `configure.ac` to prevent `autoreconf` complaining about "missing" files. Autotools projects have historically required these to be present, but their absense is are less critical these days.

```
$ autoreconf -vfi
...
Makefile.am: error: required file './NEWS' not found
Makefile.am: error: required file './README' not found
Makefile.am: error: required file './AUTHORS' not found
Makefile.am: error: required file './ChangeLog' not found  
...
```

Updated `bootstrap.sh` as well to remove unnecessary options from the `automake` invocation.

Fixes [THRIFT-5429](https://issues.apache.org/jira/browse/THRIFT-5429)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
