### PR TITLE
fix wrong thrift strict header comparing

### DIFF
--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -84,7 +84,7 @@ where
         // the thrift version header is intentionally negative
         // so the first check we'll do is see if the sign bit is set
         // and if so - assume it's the protocol-version header
-        if first_bytes[0] >= 8 {
+        if ((first_bytes[0] & 0x80) != 0) {
             // apparently we got a protocol-version header - check
             // it, and if it matches, read the rest of the fields
             if first_bytes[0..2] != [0x80, 0x01] {


### PR DESCRIPTION
Is there something wrong with the thrift strict header comparing? 

The strict header highest bit should be 1, and as u8 in rust, maybe we should compare it to 0x80 which is 0x10000000.

I didn't submit the issue on apache jira because I was unable to reset my password. Sorry for that.