### PR TITLE
Rust: Upgrade dependency integer-encoding to 3.0

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["thrift"]
 
 [dependencies]
 byteorder = "1.3"
-integer-encoding = ">=1.1.4" # https://issues.apache.org/jira/browse/THRIFT-5131
+integer-encoding = "3.0"
 log = "0.4"
 ordered-float = "1.0"
 threadpool = "1.7"


### PR DESCRIPTION
I'm the author of integer-encoding; since it was used for the first time in thrift, new major versions have been released. The use by thrift is unaffected by this: the thrift crate compiles and runs tests fine. I recommend upgrading, as the current version is more likely to see attention in case of bug fixes (which, despite the crate being simple, have unfortunately occasionally needed to take place). At the same time, unbounded versions (like `>=1.1.4`) are not good for long-term stability, in case the API will change in a major version.
