### PR TITLE
Fix specification to match implementation

### DIFF
--- a/doc/specs/thrift-binary-protocol.md
+++ b/doc/specs/thrift-binary-protocol.md
@@ -1,4 +1,4 @@
-Thrift Binary protocol encoding 
+Thrift Binary protocol encoding
 ===============================
 
 <!--
@@ -182,12 +182,12 @@ Where:
 The following field-types are used:
 
 * `BOOL`, encoded as `2`
-* `BYTE`, encoded as `3`
+* `I8`, encoded as `3`
 * `DOUBLE`, encoded as `4`
 * `I16`, encoded as `6`
 * `I32`, encoded as `8`
 * `I64`, encoded as `10`
-* `STRING`, used for binary and string fields, encoded as `11`
+* `BINARY`, used for binary and string fields, encoded as `11`
 * `STRUCT`, used for structs and union fields, encoded as `12`
 * `MAP`, encoded as `13`
 * `SET`, encoded as `14`

--- a/doc/specs/thrift-compact-protocol.md
+++ b/doc/specs/thrift-compact-protocol.md
@@ -205,7 +205,7 @@ The following field-types can be encoded:
 
 * `BOOLEAN_TRUE`, encoded as `1`
 * `BOOLEAN_FALSE`, encoded as `2`
-* `BYTE`, encoded as `3`
+* `I8`, encoded as `3`
 * `I16`, encoded as `4`
 * `I32`, encoded as `5`
 * `I64`, encoded as `6`
@@ -245,20 +245,22 @@ Where:
 
 The short form should be used when the length is in the range 0 - 14 (inclusive).
 
-The following element-types are used (note that these are _different_ from the field-types):
+The following element-types are used (see note below):
 
 * `BOOL`, encoded as `2`
-* `BYTE`, encoded as `3`
-* `DOUBLE`, encoded as `4`
-* `I16`, encoded as `6`
-* `I32`, encoded as `8`
-* `I64`, encoded as `10`
-* `STRING`, used for binary and string fields, encoded as `11`
+* `I8`, encoded as `3`
+* `I16`, encoded as `4`
+* `I32`, encoded as `5`
+* `I64`, encoded as `6`
+* `DOUBLE`, encoded as `7`
+* `BINARY`, used for binary and string fields, encoded as `8`
+* `LIST`, encoded as `9`
+* `SET`, encoded as `10`
+* `MAP`, encoded as `11`
 * `STRUCT`, used for structs and union fields, encoded as `12`
-* `MAP`, encoded as `13`
-* `SET`, encoded as `14`
-* `LIST`, encoded as `15`
 
+*Note*: Although field-types and element-types lists are currently very similar, there is _no guarantee_ that this will
+remain true after new types are added.
 
 The maximum list/set size is configurable. By default there is no limit (meaning the limit is the maximum int32 value:
 2147483647).


### PR DESCRIPTION
As stated in THRIFT-5300, the specification was wrong and type identifiers for collections DO match the field types (except for the obvious boolean type which is then represented as only `BOOL_TRUE`).

Also replaced `BYTE` name with `I8` as the former is documented as a compatibility name only (especially since some languages have an unsigned byte type).

[skip ci] Trivial documentation changes only.