### PR TITLE
Update README for go library

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -24,14 +24,12 @@ under the License.
 Using Thrift with Go
 ====================
 
-Thrift supports Go 1.7+
+Thrift supports the currently officially supported Go releases (the latest 2).
 
-In following Go conventions, we recommend you use the 'go' tool to install
-Thrift for go.
+After initializing the go modules file in your project, use the following
+command to add the most recent version of the package:
 
-    $ go get github.com/apache/thrift/lib/go/thrift/...
-
-Will retrieve and install the most recent version of the package.
+    $ go get github.com/apache/thrift
 
 
 A note about optional fields


### PR DESCRIPTION
Because we briefly had go.mod file under lib/go/thrift in e27e82c46b
(it was later removed in d9fcdd3dba), using

    go get github.com/apache/thrift/lib/go/thrift/...

(as suggested by the current README) will get that particular version
instead of the latest released version. So update README to use

    go get github.com/apache/thrift

instead.

Also instead of saying we support Go 1.7+, say we support the officially
supported Go releases, as that's our new support policy.
