### PR TITLE
THRIFT-4797: Go import improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@
 
 ### Go
 
-- [THRIFT-5369](https://issues.apache.org/jira/browse/THRIFT-5369) - TConfiguration.GetMaxMessageSize() now also applies to container sizes in TProtocol implementations provided
 - [THRIFT-5404](https://issues.apache.org/jira/browse/THRIFT-5404) - TTransportException.Timeout would correctly return true when it's connect timeout during TSocket.Open call
+- [THRIFT-5389](https://issues.apache.org/jira/browse/THRIFT-5389) - The compiler now generates correct go code with thrift constant defined on optional enum/typedef fields
+- [THRIFT-4797](https://issues.apache.org/jira/browse/THRIFT-4797) - The compiler now correctly auto renames import thrift namespaces when they collide with system imports
 
 
 ## 0.14.2
@@ -23,7 +24,7 @@
 
 ### Go
 
-- [THRIFT-5369](https://issues.apache.org/jira/browse/THRIFT-5369) - No longer pre-allocating the whole container (map/set/list) in compiled go code to avoid huge allocations on malformed messages
+- [THRIFT-5369](https://issues.apache.org/jira/browse/THRIFT-5369) - TConfiguration.GetMaxMessageSize() now also applies to container sizes in TProtocol implementations provided
 
 
 ## 0.14.1

--- a/lib/go/test/ConflictNamespaceTestE.thrift
+++ b/lib/go/test/ConflictNamespaceTestE.thrift
@@ -16,26 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-namespace go conflict.super
+namespace go conflicte.driver
 
-include "ConflictNamespaceTestA.thrift"
-include "ConflictNamespaceTestB.thrift"
-include "ConflictNamespaceTestC.thrift"
-include "ConflictNamespaceTestD.thrift"
-include "ConflictNamespaceTestE.thrift"
-include "ConflictNamespaceTestF.thrift"
-
-struct SuperThing {
-  1: ConflictNamespaceTestA.ThingA thing_a
-  2: ConflictNamespaceTestB.ThingB thing_b
-  3: ConflictNamespaceTestC.ThingC thing_c
-  4: ConflictNamespaceTestD.ThingD thing_d
-  5: ConflictNamespaceTestE.ThingE thing_e
-  6: ConflictNamespaceTestF.ThingF thing_f
-}
-
-// Define an enum to force the import of database/sql/driver
-enum Enum {
-  One = 1
-  Two = 2
+struct ThingE {
+  1: bool value
 }

--- a/lib/go/test/ConflictNamespaceTestF.thrift
+++ b/lib/go/test/ConflictNamespaceTestF.thrift
@@ -16,26 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-namespace go conflict.super
+namespace go conflictf.thrift
 
-include "ConflictNamespaceTestA.thrift"
-include "ConflictNamespaceTestB.thrift"
-include "ConflictNamespaceTestC.thrift"
-include "ConflictNamespaceTestD.thrift"
-include "ConflictNamespaceTestE.thrift"
-include "ConflictNamespaceTestF.thrift"
-
-struct SuperThing {
-  1: ConflictNamespaceTestA.ThingA thing_a
-  2: ConflictNamespaceTestB.ThingB thing_b
-  3: ConflictNamespaceTestC.ThingC thing_c
-  4: ConflictNamespaceTestD.ThingD thing_d
-  5: ConflictNamespaceTestE.ThingE thing_e
-  6: ConflictNamespaceTestF.ThingF thing_f
-}
-
-// Define an enum to force the import of database/sql/driver
-enum Enum {
-  One = 1
-  Two = 2
+struct ThingF {
+  1: bool value
 }

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -44,6 +44,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConflictNamespaceTestB.thrift \
 				ConflictNamespaceTestC.thrift \
 				ConflictNamespaceTestD.thrift \
+				ConflictNamespaceTestE.thrift \
+				ConflictNamespaceTestF.thrift \
 				ConflictNamespaceTestSuperThing.thrift \
 				ConflictNamespaceServiceTest.thrift \
 				DuplicateImportsTest.thrift \
@@ -74,6 +76,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestB.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestC.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestD.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestE.thrift
+	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestF.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceTestSuperThing.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictNamespaceServiceTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r DuplicateImportsTest.thrift
@@ -97,7 +101,7 @@ check: gopath
 				./gopath/src/dontexportrwtest \
 				./gopath/src/ignoreinitialismstest \
 				./gopath/src/unionbinarytest \
-				./gopath/src/conflictnamespacetestsuperthing \
+				./gopath/src/conflict/super \
 				./gopath/src/conflict/context/conflict_service-remote \
 				./gopath/src/servicestest/container_test-remote \
 				./gopath/src/duplicateimportstest \

--- a/lib/go/test/tests/conflict_namespace_test.go
+++ b/lib/go/test/tests/conflict_namespace_test.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"github.com/apache/thrift/lib/go/test/gopath/src/conflict/super"
+)
+
+// We just want to make sure that the compiler generated package compiles.
+var _ = super.GoUnusedProtection__


### PR DESCRIPTION
This change improves two problems in go code imports:

1. Always rename import the thrift package into "thrift", as we allow
   the user to use a different library to replace the official one from
   the compiler command line, this makes sure that in compiler generated
   go code we can always blindly use "thrift.*".

2. We added auto rename import dedup in d9019fc5a4, but in that change
   for system packages we always use the full import path as the dedup
   identifier, so system package "database/sql/driver" would not be
   detected as a conflict against a thrift go namespace of
   "foo.bar.driver". Use the part after the last "/" in system packages
   as the dedup identifier instead.
