### PR TITLE
THRIFT-5446: Added code-gen for rust async.

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -18,3 +18,9 @@ integer-encoding = "3.0"
 log = "0.4"
 ordered-float = "1.0"
 threadpool = "1.7"
+
+async-trait = {version = "^0.1", optional = true}
+
+[features]
+default = ["async"]
+async = ["async-trait"]

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -14,13 +14,14 @@ keywords = ["thrift"]
 
 [dependencies]
 byteorder = "1.3"
-integer-encoding = "3.0"
+integer-encoding = { version = "3.0", features = ["futures_async"] }
 log = "0.4"
 ordered-float = "1.0"
 threadpool = "1.7"
 
-async-trait = {version = "^0.1", optional = true}
+async-trait = {version = "0.1", optional = true}
+futures = {version = "0.3", optional = true}
 
 [features]
 default = ["async"]
-async = ["async-trait"]
+async = ["async-trait", "futures"]

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -27,9 +27,9 @@ use super::{
 use super::{TOutputProtocol, TOutputProtocolFactory, TSetIdentifier, TStructIdentifier, TType};
 use crate::transport::{TReadTransport, TWriteTransport};
 
-const COMPACT_PROTOCOL_ID: u8 = 0x82;
-const COMPACT_VERSION: u8 = 0x01;
-const COMPACT_VERSION_MASK: u8 = 0x1F;
+pub(self) const COMPACT_PROTOCOL_ID: u8 = 0x82;
+pub(self) const COMPACT_VERSION: u8 = 0x01;
+pub(self) const COMPACT_VERSION_MASK: u8 = 0x1F;
 
 /// Read messages encoded in the Thrift compact protocol.
 ///
@@ -645,14 +645,14 @@ fn type_to_u8(field_type: TType) -> u8 {
     }
 }
 
-fn collection_u8_to_type(b: u8) -> crate::Result<TType> {
+pub(super) fn collection_u8_to_type(b: u8) -> crate::Result<TType> {
     match b {
         0x01 => Ok(TType::Bool),
         o => u8_to_type(o),
     }
 }
 
-fn u8_to_type(b: u8) -> crate::Result<TType> {
+pub(super) fn u8_to_type(b: u8) -> crate::Result<TType> {
     match b {
         0x00 => Ok(TType::Stop),
         0x03 => Ok(TType::I08), // equivalent to TType::Byte

--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -27,9 +27,9 @@ use super::{
 use super::{TOutputProtocol, TOutputProtocolFactory, TSetIdentifier, TStructIdentifier, TType};
 use crate::transport::{TReadTransport, TWriteTransport};
 
-pub(self) const COMPACT_PROTOCOL_ID: u8 = 0x82;
-pub(self) const COMPACT_VERSION: u8 = 0x01;
-pub(self) const COMPACT_VERSION_MASK: u8 = 0x1F;
+pub(super) const COMPACT_PROTOCOL_ID: u8 = 0x82;
+pub(super) const COMPACT_VERSION: u8 = 0x01;
+pub(super) const COMPACT_VERSION_MASK: u8 = 0x1F;
 
 /// Read messages encoded in the Thrift compact protocol.
 ///
@@ -618,14 +618,14 @@ impl TOutputProtocolFactory for TCompactOutputProtocolFactory {
     }
 }
 
-fn collection_type_to_u8(field_type: TType) -> u8 {
+pub(super) fn collection_type_to_u8(field_type: TType) -> u8 {
     match field_type {
         TType::Bool => 0x01,
         f => type_to_u8(f),
     }
 }
 
-fn type_to_u8(field_type: TType) -> u8 {
+pub(super) fn type_to_u8(field_type: TType) -> u8 {
     match field_type {
         TType::Stop => 0x00,
         TType::I08 => 0x03, // equivalent to TType::Byte

--- a/lib/rs/src/protocol/compact_stream.rs
+++ b/lib/rs/src/protocol/compact_stream.rs
@@ -1,0 +1,306 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::convert::{From, TryFrom};
+use std::io;
+
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncReadExt, AsyncSeek};
+use integer_encoding::VarIntAsyncReader;
+
+use super::compact::{
+    collection_u8_to_type, u8_to_type, COMPACT_PROTOCOL_ID, COMPACT_VERSION, COMPACT_VERSION_MASK,
+};
+use super::{
+    TFieldIdentifier, TInputStreamProtocol, TListIdentifier, TMapIdentifier, TMessageIdentifier,
+    TMessageType,
+};
+use super::{TSetIdentifier, TStructIdentifier, TType};
+
+#[derive(Debug)]
+pub struct TCompactInputStreamProtocol<T: Send> {
+    // Identifier of the last field deserialized for a struct.
+    last_read_field_id: i16,
+    // Stack of the last read field ids (a new entry is added each time a nested struct is read).
+    read_field_id_stack: Vec<i16>,
+    // Boolean value for a field.
+    // Saved because boolean fields and their value are encoded in a single byte,
+    // and reading the field only occurs after the field id is read.
+    pending_read_bool_value: Option<bool>,
+    // Underlying transport used for byte-level operations.
+    transport: T,
+}
+
+impl<T: VarIntAsyncReader + AsyncRead + Unpin + Send> TCompactInputStreamProtocol<T> {
+    /// Create a `TCompactInputProtocol` that reads bytes from `transport`.
+    pub fn new(transport: T) -> Self {
+        Self {
+            last_read_field_id: 0,
+            read_field_id_stack: Vec::new(),
+            pending_read_bool_value: None,
+            transport,
+        }
+    }
+
+    async fn read_list_set_begin(&mut self) -> crate::Result<(TType, i32)> {
+        let header = self.read_byte().await?;
+        let element_type = collection_u8_to_type(header & 0x0F)?;
+
+        let element_count;
+        let possible_element_count = (header & 0xF0) >> 4;
+        if possible_element_count != 15 {
+            // high bits set high if count and type encoded separately
+            element_count = possible_element_count as i32;
+        } else {
+            element_count = self.transport.read_varint_async::<u32>().await? as i32;
+        }
+
+        Ok((element_type, element_count))
+    }
+}
+
+#[async_trait]
+impl<T: VarIntAsyncReader + AsyncRead + Unpin + Send> TInputStreamProtocol
+    for TCompactInputStreamProtocol<T>
+{
+    async fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier> {
+        let compact_id = self.read_byte().await?;
+        if compact_id != COMPACT_PROTOCOL_ID {
+            Err(crate::Error::Protocol(crate::ProtocolError {
+                kind: crate::ProtocolErrorKind::BadVersion,
+                message: format!("invalid compact protocol header {:?}", compact_id),
+            }))
+        } else {
+            Ok(())
+        }?;
+
+        let type_and_byte = self.read_byte().await?;
+        let received_version = type_and_byte & COMPACT_VERSION_MASK;
+        if received_version != COMPACT_VERSION {
+            Err(crate::Error::Protocol(crate::ProtocolError {
+                kind: crate::ProtocolErrorKind::BadVersion,
+                message: format!(
+                    "cannot process compact protocol version {:?}",
+                    received_version
+                ),
+            }))
+        } else {
+            Ok(())
+        }?;
+
+        // NOTE: unsigned right shift will pad with 0s
+        let message_type: TMessageType = TMessageType::try_from(type_and_byte >> 5)?;
+        // writing side wrote signed sequence number as u32 to avoid zigzag encoding
+        let sequence_number = self.transport.read_varint_async::<u32>().await? as i32;
+        let service_call_name = self.read_string().await?;
+
+        self.last_read_field_id = 0;
+
+        Ok(TMessageIdentifier::new(
+            service_call_name,
+            message_type,
+            sequence_number,
+        ))
+    }
+
+    async fn read_message_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn read_struct_begin(&mut self) -> crate::Result<Option<TStructIdentifier>> {
+        self.read_field_id_stack.push(self.last_read_field_id);
+        self.last_read_field_id = 0;
+        Ok(None)
+    }
+
+    async fn read_struct_end(&mut self) -> crate::Result<()> {
+        self.last_read_field_id = self
+            .read_field_id_stack
+            .pop()
+            .expect("should have previous field ids");
+        Ok(())
+    }
+
+    async fn read_field_begin(&mut self) -> crate::Result<TFieldIdentifier> {
+        // we can read at least one byte, which is:
+        // - the type
+        // - the field delta and the type
+        let field_type = self.read_byte().await?;
+        let field_delta = (field_type & 0xF0) >> 4;
+        let field_type = match field_type & 0x0F {
+            0x01 => {
+                self.pending_read_bool_value = Some(true);
+                Ok(TType::Bool)
+            }
+            0x02 => {
+                self.pending_read_bool_value = Some(false);
+                Ok(TType::Bool)
+            }
+            ttu8 => u8_to_type(ttu8),
+        }?;
+
+        match field_type {
+            TType::Stop => Ok(
+                TFieldIdentifier::new::<Option<String>, String, Option<i16>>(
+                    None,
+                    TType::Stop,
+                    None,
+                ),
+            ),
+            _ => {
+                if field_delta != 0 {
+                    self.last_read_field_id += field_delta as i16;
+                } else {
+                    self.last_read_field_id = self.read_i16().await?;
+                };
+
+                Ok(TFieldIdentifier {
+                    name: None,
+                    field_type,
+                    id: Some(self.last_read_field_id),
+                })
+            }
+        }
+    }
+
+    async fn read_field_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn read_bool(&mut self) -> crate::Result<bool> {
+        match self.pending_read_bool_value.take() {
+            Some(b) => Ok(b),
+            None => {
+                let b = self.read_byte().await?;
+                match b {
+                    0x01 => Ok(true),
+                    0x02 => Ok(false),
+                    unkn => Err(crate::Error::Protocol(crate::ProtocolError {
+                        kind: crate::ProtocolErrorKind::InvalidData,
+                        message: format!("cannot convert {} into bool", unkn),
+                    })),
+                }
+            }
+        }
+    }
+
+    async fn read_bytes(&mut self) -> crate::Result<Vec<u8>> {
+        let len = self.transport.read_varint_async::<u32>().await?;
+        let mut buf = vec![0u8; len as usize];
+        self.transport
+            .read_exact(&mut buf)
+            .await
+            .map_err(From::from)
+            .map(|_| buf)
+    }
+
+    async fn read_i8(&mut self) -> crate::Result<i8> {
+        self.read_byte().await.map(|i| i as i8)
+    }
+
+    async fn read_i16(&mut self) -> crate::Result<i16> {
+        self.transport
+            .read_varint_async::<i16>()
+            .await
+            .map_err(From::from)
+    }
+
+    async fn read_i32(&mut self) -> crate::Result<i32> {
+        self.transport
+            .read_varint_async::<i32>()
+            .await
+            .map_err(From::from)
+    }
+
+    async fn read_i64(&mut self) -> crate::Result<i64> {
+        self.transport
+            .read_varint_async::<i64>()
+            .await
+            .map_err(From::from)
+    }
+
+    async fn read_double(&mut self) -> crate::Result<f64> {
+        let mut buf = [0; 8];
+        self.transport.read_exact(&mut buf).await?;
+        let r = f64::from_le_bytes(buf);
+        Ok(r)
+    }
+
+    async fn read_string(&mut self) -> crate::Result<String> {
+        let bytes = self.read_bytes().await?;
+        String::from_utf8(bytes).map_err(From::from)
+    }
+
+    async fn read_list_begin(&mut self) -> crate::Result<TListIdentifier> {
+        let (element_type, element_count) = self.read_list_set_begin().await?;
+        Ok(TListIdentifier::new(element_type, element_count))
+    }
+
+    async fn read_list_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn read_set_begin(&mut self) -> crate::Result<TSetIdentifier> {
+        let (element_type, element_count) = self.read_list_set_begin().await?;
+        Ok(TSetIdentifier::new(element_type, element_count))
+    }
+
+    async fn read_set_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn read_map_begin(&mut self) -> crate::Result<TMapIdentifier> {
+        let element_count = self.transport.read_varint_async::<u32>().await? as i32;
+        if element_count == 0 {
+            Ok(TMapIdentifier::new(None, None, 0))
+        } else {
+            let type_header = self.read_byte().await?;
+            let key_type = collection_u8_to_type((type_header & 0xF0) >> 4)?;
+            let val_type = collection_u8_to_type(type_header & 0x0F)?;
+            Ok(TMapIdentifier::new(key_type, val_type, element_count))
+        }
+    }
+
+    async fn read_map_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    // utility
+    //
+
+    async fn read_byte(&mut self) -> crate::Result<u8> {
+        let mut buf = [0u8; 1];
+        self.transport
+            .read_exact(&mut buf)
+            .await
+            .map_err(From::from)
+            .map(|_| buf[0])
+    }
+}
+
+impl<T> AsyncSeek for TCompactInputStreamProtocol<T>
+where
+    T: AsyncSeek + Unpin + Send,
+{
+    fn poll_seek(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        pos: io::SeekFrom,
+    ) -> std::task::Poll<io::Result<u64>> {
+        std::pin::Pin::new(&mut self.transport).poll_seek(cx, pos)
+    }
+}

--- a/lib/rs/src/protocol/compact_stream_write.rs
+++ b/lib/rs/src/protocol/compact_stream_write.rs
@@ -1,0 +1,297 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::convert::{From, TryFrom};
+use std::io;
+
+use async_trait::async_trait;
+use futures::{AsyncWrite, AsyncWriteExt};
+use integer_encoding::VarIntAsyncWriter;
+
+use super::compact::{
+    collection_type_to_u8, type_to_u8, COMPACT_PROTOCOL_ID, COMPACT_VERSION, COMPACT_VERSION_MASK,
+};
+use super::{
+    TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType,
+    TOutputStreamProtocol, TSetIdentifier, TStructIdentifier, TType,
+};
+
+/// Write messages asyncronously using the Thrift compact protocol.
+#[derive(Debug)]
+pub struct TCompactOutputStreamProtocol<T>
+where
+    T: AsyncWrite + Unpin + Send,
+{
+    // Identifier of the last field serialized for a struct.
+    last_write_field_id: i16,
+    // Stack of the last written field ids (new entry added each time a nested struct is written).
+    write_field_id_stack: Vec<i16>,
+    // Field identifier of the boolean field to be written.
+    // Saved because boolean fields and their value are encoded in a single byte
+    pending_write_bool_field_identifier: Option<TFieldIdentifier>,
+    // Underlying transport used for byte-level operations.
+    transport: T,
+}
+
+impl<T> TCompactOutputStreamProtocol<T>
+where
+    T: VarIntAsyncWriter + AsyncWrite + Unpin + Send,
+{
+    /// Create a `TCompactOutputProtocol` that writes bytes to `transport`.
+    pub fn new(transport: T) -> Self {
+        Self {
+            last_write_field_id: 0,
+            write_field_id_stack: Vec::new(),
+            pending_write_bool_field_identifier: None,
+            transport,
+        }
+    }
+
+    // FIXME: field_type as unconstrained u8 is bad
+    async fn write_field_header(&mut self, field_type: u8, field_id: i16) -> crate::Result<()> {
+        let field_delta = field_id - self.last_write_field_id;
+        if field_delta > 0 && field_delta < 15 {
+            self.write_byte(((field_delta as u8) << 4) | field_type)
+                .await?;
+        } else {
+            self.write_byte(field_type).await?;
+            self.write_i16(field_id).await?;
+        }
+        self.last_write_field_id = field_id;
+        Ok(())
+    }
+
+    async fn write_list_set_begin(
+        &mut self,
+        element_type: TType,
+        element_count: i32,
+    ) -> crate::Result<()> {
+        let elem_identifier = collection_type_to_u8(element_type);
+        if element_count <= 14 {
+            let header = (element_count as u8) << 4 | elem_identifier;
+            self.write_byte(header).await
+        } else {
+            let header = 0xF0 | elem_identifier;
+            self.write_byte(header).await?;
+            // element count is strictly positive as per the spec, so
+            // cast i32 as u32 so that varint writing won't use zigzag encoding
+            self.transport
+                .write_varint_async(element_count as u32)
+                .await
+                .map_err(From::from)
+                .map(|_| ())
+        }
+    }
+
+    fn assert_no_pending_bool_write(&self) {
+        if let Some(ref f) = self.pending_write_bool_field_identifier {
+            panic!("pending bool field {:?} not written", f)
+        }
+    }
+}
+
+#[async_trait]
+impl<T> TOutputStreamProtocol for TCompactOutputStreamProtocol<T>
+where
+    T: VarIntAsyncWriter + AsyncWrite + Unpin + Send,
+{
+    async fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> crate::Result<()> {
+        self.write_byte(COMPACT_PROTOCOL_ID).await?;
+        self.write_byte((u8::from(identifier.message_type) << 5) | COMPACT_VERSION)
+            .await?;
+        // cast i32 as u32 so that varint writing won't use zigzag encoding
+        self.transport
+            .write_varint_async(identifier.sequence_number as u32)
+            .await?;
+        self.write_string(&identifier.name).await?;
+        Ok(())
+    }
+
+    async fn write_message_end(&mut self) -> crate::Result<()> {
+        self.assert_no_pending_bool_write();
+        Ok(())
+    }
+
+    async fn write_struct_begin(&mut self, _: &TStructIdentifier) -> crate::Result<()> {
+        self.write_field_id_stack.push(self.last_write_field_id);
+        self.last_write_field_id = 0;
+        Ok(())
+    }
+
+    fn write_struct_end(&mut self) -> crate::Result<()> {
+        self.assert_no_pending_bool_write();
+        self.last_write_field_id = self
+            .write_field_id_stack
+            .pop()
+            .expect("should have previous field ids");
+        Ok(())
+    }
+
+    async fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> crate::Result<()> {
+        match identifier.field_type {
+            TType::Bool => {
+                if self.pending_write_bool_field_identifier.is_some() {
+                    panic!(
+                        "should not have a pending bool while writing another bool with id: \
+                         {:?}",
+                        identifier
+                    )
+                }
+                self.pending_write_bool_field_identifier = Some(identifier.clone());
+                Ok(())
+            }
+            _ => {
+                let field_type = type_to_u8(identifier.field_type);
+                let field_id = identifier.id.expect("non-stop field should have field id");
+                self.write_field_header(field_type, field_id).await
+            }
+        }
+    }
+
+    fn write_field_end(&mut self) -> crate::Result<()> {
+        self.assert_no_pending_bool_write();
+        Ok(())
+    }
+
+    async fn write_field_stop(&mut self) -> crate::Result<()> {
+        self.assert_no_pending_bool_write();
+        self.write_byte(type_to_u8(TType::Stop)).await
+    }
+
+    async fn write_bool(&mut self, b: bool) -> crate::Result<()> {
+        match self.pending_write_bool_field_identifier.take() {
+            Some(pending) => {
+                let field_id = pending.id.expect("bool field should have a field id");
+                let field_type_as_u8 = if b { 0x01 } else { 0x02 };
+                self.write_field_header(field_type_as_u8, field_id).await
+            }
+            None => {
+                if b {
+                    self.write_byte(0x01).await
+                } else {
+                    self.write_byte(0x02).await
+                }
+            }
+        }
+    }
+
+    async fn write_bytes(&mut self, b: &[u8]) -> crate::Result<()> {
+        // length is strictly positive as per the spec, so
+        // cast i32 as u32 so that varint writing won't use zigzag encoding
+        self.transport.write_varint_async(b.len() as u32).await?;
+        self.transport.write_all(b).await.map_err(From::from)
+    }
+
+    async fn write_i8(&mut self, i: i8) -> crate::Result<()> {
+        self.write_byte(i as u8).await
+    }
+
+    async fn write_i16(&mut self, i: i16) -> crate::Result<()> {
+        self.transport
+            .write_varint_async(i)
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+
+    async fn write_i32(&mut self, i: i32) -> crate::Result<()> {
+        self.transport
+            .write_varint_async(i)
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+
+    async fn write_i64(&mut self, i: i64) -> crate::Result<()> {
+        self.transport
+            .write_varint_async(i)
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+
+    async fn write_double(&mut self, d: f64) -> crate::Result<()> {
+        let r = d.to_le_bytes();
+        self.transport.write_all(&r).await.map_err(From::from)
+    }
+
+    async fn write_string(&mut self, s: &str) -> crate::Result<()> {
+        self.write_bytes(s.as_bytes()).await
+    }
+
+    async fn write_list_begin(&mut self, identifier: &TListIdentifier) -> crate::Result<()> {
+        self.write_list_set_begin(identifier.element_type, identifier.size)
+            .await
+    }
+
+    async fn write_list_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> crate::Result<()> {
+        self.write_list_set_begin(identifier.element_type, identifier.size)
+            .await
+    }
+
+    async fn write_set_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> crate::Result<()> {
+        if identifier.size == 0 {
+            self.write_byte(0).await
+        } else {
+            // element count is strictly positive as per the spec, so
+            // cast i32 as u32 so that varint writing won't use zigzag encoding
+            self.transport
+                .write_varint_async(identifier.size as u32)
+                .await?;
+
+            let key_type = identifier
+                .key_type
+                .expect("map identifier to write should contain key type");
+            let key_type_byte = collection_type_to_u8(key_type) << 4;
+
+            let val_type = identifier
+                .value_type
+                .expect("map identifier to write should contain value type");
+            let val_type_byte = collection_type_to_u8(val_type);
+
+            let map_type_header = key_type_byte | val_type_byte;
+            self.write_byte(map_type_header).await
+        }
+    }
+
+    async fn write_map_end(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> crate::Result<()> {
+        self.transport.flush().await.map_err(From::from)
+    }
+
+    // utility
+    //
+
+    async fn write_byte(&mut self, b: u8) -> crate::Result<()> {
+        self.transport
+            .write(&[b])
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+}

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -88,6 +88,8 @@ macro_rules! set_readable_bytes {
 
 mod binary;
 mod compact;
+mod compact_stream;
+pub use compact_stream::TCompactInputStreamProtocol;
 mod multiplexed;
 mod stored;
 mod stream;

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -90,10 +90,12 @@ mod binary;
 mod compact;
 mod compact_stream;
 pub use compact_stream::TCompactInputStreamProtocol;
+mod compact_stream_write;
+pub use compact_stream_write::TCompactOutputStreamProtocol;
 mod multiplexed;
 mod stored;
 mod stream;
-pub use stream::TInputStreamProtocol;
+pub use stream::{TInputStreamProtocol, TOutputStreamProtocol};
 
 pub use self::binary::{
     TBinaryInputProtocol, TBinaryInputProtocolFactory, TBinaryOutputProtocol,

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -90,6 +90,8 @@ mod binary;
 mod compact;
 mod multiplexed;
 mod stored;
+mod stream;
+pub use stream::TInputStreamProtocol;
 
 pub use self::binary::{
     TBinaryInputProtocol, TBinaryInputProtocolFactory, TBinaryOutputProtocol,

--- a/lib/rs/src/protocol/stream.rs
+++ b/lib/rs/src/protocol/stream.rs
@@ -1,0 +1,129 @@
+use async_trait::async_trait;
+
+use crate::{ProtocolError, ProtocolErrorKind};
+
+use super::*;
+
+#[async_trait]
+pub trait TInputStreamProtocol: Send + Sync {
+    /// Read the beginning of a Thrift message.
+    async fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier>;
+    /// Read the end of a Thrift message.
+    async fn read_message_end(&mut self) -> crate::Result<()>;
+    /// Read the beginning of a Thrift struct.
+    async fn read_struct_begin(&mut self) -> crate::Result<Option<TStructIdentifier>>;
+    /// Read the end of a Thrift struct.
+    async fn read_struct_end(&mut self) -> crate::Result<()>;
+    /// Read the beginning of a Thrift struct field.
+    async fn read_field_begin(&mut self) -> crate::Result<TFieldIdentifier>;
+    /// Read the end of a Thrift struct field.
+    async fn read_field_end(&mut self) -> crate::Result<()>;
+    /// Read a bool.
+    async fn read_bool(&mut self) -> crate::Result<bool>;
+    /// Read a fixed-length byte array.
+    async fn read_bytes(&mut self) -> crate::Result<Vec<u8>>;
+    /// Read a word.
+    async fn read_i8(&mut self) -> crate::Result<i8>;
+    /// Read a 16-bit signed integer.
+    async fn read_i16(&mut self) -> crate::Result<i16>;
+    /// Read a 32-bit signed integer.
+    async fn read_i32(&mut self) -> crate::Result<i32>;
+    /// Read a 64-bit signed integer.
+    async fn read_i64(&mut self) -> crate::Result<i64>;
+    /// Read a 64-bit float.
+    async fn read_double(&mut self) -> crate::Result<f64>;
+    /// Read a fixed-length string (not null terminated).
+    async fn read_string(&mut self) -> crate::Result<String>;
+    /// Read the beginning of a list.
+    async fn read_list_begin(&mut self) -> crate::Result<TListIdentifier>;
+    /// Read the end of a list.
+    async fn read_list_end(&mut self) -> crate::Result<()>;
+    /// Read the beginning of a set.
+    async fn read_set_begin(&mut self) -> crate::Result<TSetIdentifier>;
+    /// Read the end of a set.
+    async fn read_set_end(&mut self) -> crate::Result<()>;
+    /// Read the beginning of a map.
+    async fn read_map_begin(&mut self) -> crate::Result<TMapIdentifier>;
+    /// Read the end of a map.
+    async fn read_map_end(&mut self) -> crate::Result<()>;
+
+    /// Skip a field with type `field_type` recursively until the default
+    /// maximum skip depth is reached.
+    async fn skip(&mut self, field_type: TType) -> crate::Result<()> {
+        self.skip_till_depth(field_type, MAXIMUM_SKIP_DEPTH).await
+    }
+
+    /// Skip a field with type `field_type` recursively up to `depth` levels.
+    async fn skip_till_depth(&mut self, field_type: TType, depth: i8) -> crate::Result<()> {
+        if depth == 0 {
+            return Err(crate::Error::Protocol(ProtocolError {
+                kind: ProtocolErrorKind::DepthLimit,
+                message: format!("cannot parse past {:?}", field_type),
+            }));
+        }
+
+        match field_type {
+            TType::Bool => self.read_bool().await.map(|_| ()),
+            TType::I08 => self.read_i8().await.map(|_| ()),
+            TType::I16 => self.read_i16().await.map(|_| ()),
+            TType::I32 => self.read_i32().await.map(|_| ()),
+            TType::I64 => self.read_i64().await.map(|_| ()),
+            TType::Double => self.read_double().await.map(|_| ()),
+            TType::String => self.read_string().await.map(|_| ()),
+            TType::Struct => {
+                self.read_struct_begin().await?;
+                loop {
+                    let field_ident = self.read_field_begin().await?;
+                    if field_ident.field_type == TType::Stop {
+                        break;
+                    }
+                    self.skip_till_depth(field_ident.field_type, depth - 1)
+                        .await?;
+                }
+                self.read_struct_end().await
+            }
+            TType::List => {
+                let list_ident = self.read_list_begin().await?;
+                for _ in 0..list_ident.size {
+                    self.skip_till_depth(list_ident.element_type, depth - 1)
+                        .await?;
+                }
+                self.read_list_end().await
+            }
+            TType::Set => {
+                let set_ident = self.read_set_begin().await?;
+                for _ in 0..set_ident.size {
+                    self.skip_till_depth(set_ident.element_type, depth - 1)
+                        .await?;
+                }
+                self.read_set_end().await
+            }
+            TType::Map => {
+                let map_ident = self.read_map_begin().await?;
+                for _ in 0..map_ident.size {
+                    let key_type = map_ident
+                        .key_type
+                        .expect("non-zero sized map should contain key type");
+                    let val_type = map_ident
+                        .value_type
+                        .expect("non-zero sized map should contain value type");
+                    self.skip_till_depth(key_type, depth - 1).await?;
+                    self.skip_till_depth(val_type, depth - 1).await?;
+                }
+                self.read_map_end().await
+            }
+            u => Err(crate::Error::Protocol(ProtocolError {
+                kind: ProtocolErrorKind::Unknown,
+                message: format!("cannot skip field type {:?}", &u),
+            })),
+        }
+    }
+
+    // utility (DO NOT USE IN GENERATED CODE!!!!)
+    //
+
+    /// Read an unsigned byte.
+    ///
+    /// This method should **never** be used in generated code.
+    async fn read_byte(&mut self) -> crate::Result<u8>;
+}

--- a/lib/rs/src/protocol/stream.rs
+++ b/lib/rs/src/protocol/stream.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use async_trait::async_trait;
 
 use crate::{ProtocolError, ProtocolErrorKind};
@@ -5,7 +22,7 @@ use crate::{ProtocolError, ProtocolErrorKind};
 use super::*;
 
 #[async_trait]
-pub trait TInputStreamProtocol: Send + Sync {
+pub trait TInputStreamProtocol: Send {
     /// Read the beginning of a Thrift message.
     async fn read_message_begin(&mut self) -> crate::Result<TMessageIdentifier>;
     /// Read the end of a Thrift message.

--- a/lib/rs/src/protocol/stream.rs
+++ b/lib/rs/src/protocol/stream.rs
@@ -144,3 +144,60 @@ pub trait TInputStreamProtocol: Send {
     /// This method should **never** be used in generated code.
     async fn read_byte(&mut self) -> crate::Result<u8>;
 }
+
+#[async_trait]
+pub trait TOutputStreamProtocol: Send {
+    /// Write the beginning of a Thrift message.
+    async fn write_message_begin(&mut self, identifier: &TMessageIdentifier) -> crate::Result<()>;
+    /// Write the end of a Thrift message.
+    async fn write_message_end(&mut self) -> crate::Result<()>;
+    /// Write the beginning of a Thrift struct.
+    async fn write_struct_begin(&mut self, identifier: &TStructIdentifier) -> crate::Result<()>;
+    /// Write the end of a Thrift struct.
+    fn write_struct_end(&mut self) -> crate::Result<()>;
+    /// Write the beginning of a Thrift field.
+    async fn write_field_begin(&mut self, identifier: &TFieldIdentifier) -> crate::Result<()>;
+    /// Write the end of a Thrift field.
+    fn write_field_end(&mut self) -> crate::Result<()>;
+    /// Write a STOP field indicating that all the fields in a struct have been
+    /// written.
+    async fn write_field_stop(&mut self) -> crate::Result<()>;
+    /// Write a bool.
+    async fn write_bool(&mut self, b: bool) -> crate::Result<()>;
+    /// Write a fixed-length byte array.
+    async fn write_bytes(&mut self, b: &[u8]) -> crate::Result<()>;
+    /// Write an 8-bit signed integer.
+    async fn write_i8(&mut self, i: i8) -> crate::Result<()>;
+    /// Write a 16-bit signed integer.
+    async fn write_i16(&mut self, i: i16) -> crate::Result<()>;
+    /// Write a 32-bit signed integer.
+    async fn write_i32(&mut self, i: i32) -> crate::Result<()>;
+    /// Write a 64-bit signed integer.
+    async fn write_i64(&mut self, i: i64) -> crate::Result<()>;
+    /// Write a 64-bit float.
+    async fn write_double(&mut self, d: f64) -> crate::Result<()>;
+    /// Write a fixed-length string.
+    async fn write_string(&mut self, s: &str) -> crate::Result<()>;
+    /// Write the beginning of a list.
+    async fn write_list_begin(&mut self, identifier: &TListIdentifier) -> crate::Result<()>;
+    /// Write the end of a list.
+    async fn write_list_end(&mut self) -> crate::Result<()>;
+    /// Write the beginning of a set.
+    async fn write_set_begin(&mut self, identifier: &TSetIdentifier) -> crate::Result<()>;
+    /// Write the end of a set.
+    async fn write_set_end(&mut self) -> crate::Result<()>;
+    /// Write the beginning of a map.
+    async fn write_map_begin(&mut self, identifier: &TMapIdentifier) -> crate::Result<()>;
+    /// Write the end of a map.
+    async fn write_map_end(&mut self) -> crate::Result<()>;
+    /// Flush buffered bytes to the underlying transport.
+    async fn flush(&mut self) -> crate::Result<()>;
+
+    // utility (DO NOT USE IN GENERATED CODE!!!!)
+    //
+
+    /// Write an unsigned byte.
+    ///
+    /// This method should **never** be used in generated code.
+    async fn write_byte(&mut self, b: u8) -> crate::Result<()>; // FIXME: REMOVE
+}


### PR DESCRIPTION
This draft PR adds support to generate the async version for Rust. Note that when it comes to async, Rust is effectively colored, and thus we need both versions.

It introduces:

* a small generalization of the compiler to generate async next to the sync version
* two traits in the library, `TInputStreamProtocol` and `TOutputStreamProtocol` used to consume the stream
* an implementation of `TInputStreamProtocol` and `TOutputStreamProtocol` for compact

I verified that this code generates a valid implementation for `parquet.thrift`, from which a diff can be seen [here](https://github.com/jorgecarleitao/parquet-format-rs/pull/1/files).

NOTE: this PR introduces two dependencies to the rust library, `async-trait` and `futures`.

The first is a macro to enable support for traits with `async` (which `TInputStreamProtocol` is).
The second is a very common set of traits useful for declaring `async` interfaces without committing to a particular runtime (e.g. tokyo).