### PR TITLE
THRIFT-5447: Update supported Go versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,7 @@ project.lock.json
 /lib/erl/logs/
 /lib/go/pkg
 /lib/go/src
+/lib/go/test/fuzz/gopathfuzz
 /lib/go/test/gopath/
 /lib/go/test/ThriftTest.thrift
 /lib/nodets/test-compiled/

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -151,7 +151,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.14.14</td><td>1.15.7</td>
+<!-- Language Levels -------><td>1.16.7</td><td>1.17</td>
 <!-- Low-Level Transports --><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Protocols -------------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -140,9 +140,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.16.2
+ENV GOLANG_VERSION 1.17
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
+ENV GOLANG_DOWNLOAD_SHA256 6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
             tar -C /usr/local -xzf golang.tar.gz && \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -140,9 +140,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.16.2
+ENV GOLANG_VERSION 1.17
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
+ENV GOLANG_DOWNLOAD_SHA256 6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
             tar -C /usr/local -xzf golang.tar.gz && \

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -128,9 +128,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.15.10
+ENV GOLANG_VERSION 1.16.7
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d
+ENV GOLANG_DOWNLOAD_SHA256 7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
       tar -C /usr/local -xzf golang.tar.gz && \

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/apache/thrift
 
-go 1.15
+go 1.16
 
 require github.com/golang/mock v1.5.0

--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -21,6 +21,27 @@ specific language governing permissions and limitations
 under the License.
 
 
+Suppored Go releases
+====================
+
+Following the
+[official Go release policy](https://golang.org/doc/devel/release#policy),
+we support the latest two Go releases at the time of the Thrift release.
+
+For example, at the time of Thrift v0.14.0 release,
+the latest two Go releases are go1.15 and go1.14,
+and those are the two Go releases supported by Thrift v0.14.*
+(including v0.14.1 and v0.14.2 patch releases).
+
+Because of Go's backward compatibility guarantee,
+older Thrift libraries usually works with newer Go releases
+(e.g. Thrift v0.14.* works with go1.16, although it's not officially supported),
+but newer Thrift releases might use new APIs introduced in Go releases and no
+longer work with older Go releases.
+For example, Thrift v0.14.0 used APIs introduced in go1.13,
+and as a result no longer works on go1.12.
+
+
 Using Thrift with Go
 ====================
 

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,9 +1,15 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.15
+go 1.16
 
 replace github.com/apache/thrift => ../../../../
 
 replace shared => ./gen-go/shared
 
 replace tutorial => ./gen-go/tutorial
+
+require (
+	github.com/apache/thrift v0.0.0-00010101000000-000000000000
+	shared v0.0.0-00010101000000-000000000000
+	tutorial v0.0.0-00010101000000-000000000000
+)

--- a/lib/go/test/fuzz/go.sum
+++ b/lib/go/test/fuzz/go.sum
@@ -1,4 +1,3 @@
-github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/test/go/genmock.sh
+++ b/test/go/genmock.sh
@@ -4,7 +4,6 @@ set -e
 
 export GOPATH=$(mktemp -d -t gopath-XXXXXXXXXX)
 
-# TODO: Once we dropped support to go 1.15, add "@v1.5.0" suffix to go install
 GO111MODULE=on go install -mod=mod github.com/golang/mock/mockgen
 
 `go env GOPATH`/bin/mockgen -build_flags "-mod=mod" -destination=src/common/mock_handler.go -package=common github.com/apache/thrift/test/go/src/gen/thrifttest ThriftTest


### PR DESCRIPTION
Client: go

Update go versions used in travis to 1.16.7 and 1.17, update
LANGUAGES.md, and update go's README to clarify on support policy.

This change will be cherry-picked into 0.15.0 branch after merged.
