### PR TITLE
lib/cpp/test/ToStringTest.cpp: Disabled locale-based tests on Windows

### DIFF
--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -41,8 +41,12 @@ BOOST_AUTO_TEST_CASE(base_types_to_string) {
   BOOST_CHECK_EQUAL(to_string("abc"), "abc");
 }
 
+// NOTE: Currently (as of 2021.08.12) the locale-based tests do not work on
+// Windows in the AppVeyor Thrift CI build correctly. Therefore disabled on
+// Windows:
+#ifndef _WIN32
 BOOST_AUTO_TEST_CASE(locale_en_US_int_to_string) {
-#if _WIN32
+#ifdef _WIN32
   std::locale::global(std::locale("en-US.UTF-8"));
 #else
   std::locale::global(std::locale("en_US.UTF-8"));
@@ -51,7 +55,7 @@ BOOST_AUTO_TEST_CASE(locale_en_US_int_to_string) {
 }
 
 BOOST_AUTO_TEST_CASE(locale_de_DE_floating_point_to_string) {
-#if _WIN32
+#ifdef _WIN32
   std::locale::global(std::locale("de-DE.UTF-8"));
 #else
   std::locale::global(std::locale("de_DE.UTF-8"));
@@ -60,6 +64,7 @@ BOOST_AUTO_TEST_CASE(locale_de_DE_floating_point_to_string) {
   BOOST_CHECK_EQUAL(to_string(1.5f), "1.5");
   BOOST_CHECK_EQUAL(to_string(1.5L), "1.5");
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(empty_vector_to_string) {
   std::vector<int> l;


### PR DESCRIPTION
This PR disables the locale-based tests for string conversion on Windows, due to problems in the Thrift CI on AppVeyor.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  Not required for the trivial change.
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
