### PR TITLE
THRIFT-5454: add __getState__ function to TProcessPoolServer to enable correct multiprocessing behavior related to pickling

### DIFF
--- a/lib/py/src/server/TProcessPoolServer.py
+++ b/lib/py/src/server/TProcessPoolServer.py
@@ -42,6 +42,11 @@ class TProcessPoolServer(TServer):
         self.stopCondition = Condition()
         self.postForkCallback = None
 
+    def __getstate__(self):
+        state=self.__dict__.copy()
+        state['workers'] = None
+        return state
+
     def setPostForkCallback(self, callback):
         if not callable(callback):
             raise TypeError("This is not a callback!")


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Before this change, when using Python TProcessPoolServer with more than 1 workers, only one worker process will be successfully spawned and all the other processes will reach a pickling error and exit.

When [starting the worker process](https://github.com/apache/thrift/blob/82504b395e2d3e67f506a75ad51aa5734a9ad98a/lib/py/src/server/TProcessPoolServer.py#L99), the entire TProcessPoolServer is pickled and it seems that an alive `Process` contains a `weakref` which is  not picklable. 

Adding the `__getState__` function to exclude the information about all the other processes can solve this, thanks to the answer in https://stackoverflow.com/questions/62830911/typeerror-cannot-pickle-weakref-object .

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
