### PR TITLE
THRIFT-5456: [c++] Disable SIGPIPE on TServerSocket

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -311,6 +311,17 @@ void TServerSocket::_setup_sockopts() {
     throw TTransportException(TTransportException::NOT_OPEN, "Could not set SO_LINGER", errno_copy);
   }
 
+#ifdef SO_NOSIGPIPE
+  if (-1 == setsockopt(serverSocket_, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one))) {
+    int errno_copy = THRIFT_GET_SOCKET_ERROR;
+    GlobalOutput.perror("TServerSocket::listen() setsockopt() SO_NOSIGPIPE", errno_copy);
+    close();
+    throw TTransportException(TTransportException::NOT_OPEN,
+                              "Could not set SO_NOSIGPIPE",
+                              errno_copy);
+  }
+#endif
+
   // Set NONBLOCK on the accept socket
   int flags = THRIFT_FCNTL(serverSocket_, THRIFT_F_GETFL, 0);
   if (flags == -1) {


### PR DESCRIPTION
TSocketServer sets up many socket options, but unlike TSocket, it doesn't disable SIGPIPE.

One example for how this can be triggered is the server receives a request, but takes too long to process it. The sender then times out, and potentially closes its sockets. The server then completes the request, and then attempts to write back the result. Since the socket is now closed, a SIGPIPE signal is sent to the process, and if that signal isn't ignored, the process would crash, with a potential -13 exit code.