### PR TITLE
Change StringBuffer to StringBuilder for more efficiency

### DIFF
--- a/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -308,7 +308,7 @@ public class TSimpleJSONProtocol extends TProtocol {
   public void writeString(String str) throws TException {
     writeContext_.write();
     int length = str.length();
-    StringBuffer escape = new StringBuffer(length + 16);
+    StringBuilder escape = new StringBuilder(length + 16);
     escape.append(QUOTE);
     for (int i = 0; i < length; ++i) {
       char c = str.charAt(i);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
In a single-threaded scenario, StringBuilder has better performance than StringBuffer.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
