### PR TITLE
go: Fix things staticcheck complains about

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - [THRIFT-5347](https://issues.apache.org/jira/browse/THRIFT-5347) - Haskell support dropped
 - [THRIFT-5381](https://issues.apache.org/jira/browse/THRIFT-5381) - possible collisions at VOID type with some 3rd-party libraries on Haxe cpp targets
 - [THRIFT-5396](https://issues.apache.org/jira/browse/THRIFT-5396) - deprecate netstd "Async" method postfix
-- [THRIFT-5453](https://issues.apache.org/jira/browse/THRIFT-5453) - go: NewTSocketConf no longer returns an error
+- [THRIFT-5453](https://issues.apache.org/jira/browse/THRIFT-5453) - go: NewTSocketConf and NewTSSLSocketConf no longer return an error
 
 ### Go
 

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1854,7 +1854,7 @@ void t_go_generator::generate_go_struct_writer(ostream& out,
     std::string tstruct_name(publicize(tstruct->get_name()));
     out << indent() << "if c := p.CountSetFields" << tstruct_name << "(); c != 1 {" << endl
         << indent()
-        << "  return fmt.Errorf(\"%T write union: exactly one field must be set (%d set).\", p, c)"
+        << "  return fmt.Errorf(\"%T write union: exactly one field must be set (%d set)\", p, c)"
         << endl << indent() << "}" << endl;
   }
   out << indent() << "if err := oprot.WriteStructBegin(ctx, \"" << name << "\"); err != nil {" << endl;
@@ -2489,6 +2489,7 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
   f_remote << indent() << endl;
   f_remote << indent() << "cmd := flag.Arg(0)" << endl;
   f_remote << indent() << "var err error" << endl;
+  f_remote << indent() << "var cfg *thrift.TConfiguration = nil" << endl;
   f_remote << indent() << "if useHttp {" << endl;
   f_remote << indent() << "  trans, err = thrift.NewTHttpClient(parsedUrl.String())" << endl;
   f_remote << indent() << "  if len(headers) > 0 {" << endl;
@@ -2507,14 +2508,13 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
   f_remote << indent() << "                 os.Exit(1)" << endl;
   f_remote << indent() << "         }" << endl;
   f_remote << indent() << "  }" << endl;
-  f_remote << indent() << "  trans, err = thrift.NewTSocket(net.JoinHostPort(host, portStr))"
-           << endl;
+  f_remote << indent() << "  trans = thrift.NewTSocketConf(net.JoinHostPort(host, portStr), cfg)" << endl;
   f_remote << indent() << "  if err != nil {" << endl;
   f_remote << indent() << "    fmt.Fprintln(os.Stderr, \"error resolving address:\", err)" << endl;
   f_remote << indent() << "    os.Exit(1)" << endl;
   f_remote << indent() << "  }" << endl;
   f_remote << indent() << "  if framed {" << endl;
-  f_remote << indent() << "    trans = thrift.NewTFramedTransport(trans)" << endl;
+  f_remote << indent() << "    trans = thrift.NewTFramedTransportConf(trans, cfg)" << endl;
   f_remote << indent() << "  }" << endl;
   f_remote << indent() << "}" << endl;
   f_remote << indent() << "if err != nil {" << endl;
@@ -2525,16 +2525,16 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
   f_remote << indent() << "var protocolFactory thrift.TProtocolFactory" << endl;
   f_remote << indent() << "switch protocol {" << endl;
   f_remote << indent() << "case \"compact\":" << endl;
-  f_remote << indent() << "  protocolFactory = thrift.NewTCompactProtocolFactory()" << endl;
+  f_remote << indent() << "  protocolFactory = thrift.NewTCompactProtocolFactoryConf(cfg)" << endl;
   f_remote << indent() << "  break" << endl;
   f_remote << indent() << "case \"simplejson\":" << endl;
-  f_remote << indent() << "  protocolFactory = thrift.NewTSimpleJSONProtocolFactory()" << endl;
+  f_remote << indent() << "  protocolFactory = thrift.NewTSimpleJSONProtocolFactoryConf(cfg)" << endl;
   f_remote << indent() << "  break" << endl;
   f_remote << indent() << "case \"json\":" << endl;
   f_remote << indent() << "  protocolFactory = thrift.NewTJSONProtocolFactory()" << endl;
   f_remote << indent() << "  break" << endl;
   f_remote << indent() << "case \"binary\", \"\":" << endl;
-  f_remote << indent() << "  protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()" << endl;
+  f_remote << indent() << "  protocolFactory = thrift.NewTBinaryProtocolFactoryConf(cfg)" << endl;
   f_remote << indent() << "  break" << endl;
   f_remote << indent() << "default:" << endl;
   f_remote << indent() << "  fmt.Fprintln(os.Stderr, \"Invalid protocol specified: \", protocol)"

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -9,6 +10,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e h1:aZzprAO9/8oim3qStq3wc1Xuxx4QmAGriC4VU4ojemQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/lib/go/test/tests/client_error_test.go
+++ b/lib/go/test/tests/client_error_test.go
@@ -406,7 +406,9 @@ func prepareClientCallReply(protocol *MockTProtocol, failAt int, failWith error)
 	if failAt == 50 {
 		err = failWith
 	}
+	//lint:ignore SA4006 to keep it consistent with other checks above
 	last = protocol.EXPECT().ReadMessageEnd(context.Background()).Return(err).After(last)
+	//lint:ignore S1008 to keep it consistent with other checks above
 	if failAt == 50 {
 		return true
 	}
@@ -631,7 +633,9 @@ func prepareClientCallException(protocol *MockTProtocol, failAt int, failWith er
 	if failAt == 10 {
 		err = failWith
 	}
+	//lint:ignore SA4006 to keep it consistent with other checks above
 	last = protocol.EXPECT().ReadMessageEnd(context.Background()).Return(err).After(last)
+	//lint:ignore S1008 to keep it consistent with other checks above
 	if failAt == 10 {
 		return true
 	}

--- a/lib/go/test/tests/one_way_test.go
+++ b/lib/go/test/tests/one_way_test.go
@@ -66,8 +66,12 @@ func TestInitOneway(t *testing.T) {
 }
 
 func TestInitOnewayClient(t *testing.T) {
-	transport := thrift.NewTSocketFromAddrTimeout(addr, TIMEOUT, TIMEOUT)
-	protocol := thrift.NewTBinaryProtocolTransport(transport)
+	cfg := &thrift.TConfiguration{
+		ConnectTimeout: TIMEOUT,
+		SocketTimeout:  TIMEOUT,
+	}
+	transport := thrift.NewTSocketFromAddrConf(addr, cfg)
+	protocol := thrift.NewTBinaryProtocolConf(transport, cfg)
 	client = onewaytest.NewOneWayClient(thrift.NewTStandardClient(protocol, protocol))
 	err := transport.Open()
 	if err != nil {

--- a/lib/go/test/tests/protocols_test.go
+++ b/lib/go/test/tests/protocols_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
-func RunSocketTestSuite(t *testing.T, protocolFactory thrift.TProtocolFactory,
-	transportFactory thrift.TTransportFactory) {
+func RunSocketTestSuite(
+	t *testing.T,
+	protocolFactory thrift.TProtocolFactory,
+	transportFactory thrift.TTransportFactory,
+) {
 	// server
 	var err error
 	addr = FindAvailableTCPServerPort()
@@ -42,7 +45,12 @@ func RunSocketTestSuite(t *testing.T, protocolFactory thrift.TProtocolFactory,
 	go server.Serve()
 
 	// client
-	var transport thrift.TTransport = thrift.NewTSocketFromAddrTimeout(addr, TIMEOUT, TIMEOUT)
+	cfg := &thrift.TConfiguration{
+		ConnectTimeout: TIMEOUT,
+		SocketTimeout:  TIMEOUT,
+	}
+	thrift.PropagateTConfiguration(transportFactory, cfg)
+	var transport thrift.TTransport = thrift.NewTSocketFromAddrConf(addr, cfg)
 	transport, err = transportFactory.GetTransport(transport)
 	if err != nil {
 		t.Fatal(err)
@@ -60,39 +68,57 @@ func RunSocketTestSuite(t *testing.T, protocolFactory thrift.TProtocolFactory,
 
 // Run test suite using TJSONProtocol
 func TestTJSONProtocol(t *testing.T) {
-	RunSocketTestSuite(t,
+	RunSocketTestSuite(
+		t,
 		thrift.NewTJSONProtocolFactory(),
-		thrift.NewTTransportFactory())
-	RunSocketTestSuite(t,
+		thrift.NewTTransportFactory(),
+	)
+	RunSocketTestSuite(
+		t,
 		thrift.NewTJSONProtocolFactory(),
-		thrift.NewTBufferedTransportFactory(8912))
-	RunSocketTestSuite(t,
+		thrift.NewTBufferedTransportFactory(8912),
+	)
+	RunSocketTestSuite(
+		t,
 		thrift.NewTJSONProtocolFactory(),
-		thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()))
+		thrift.NewTFramedTransportFactoryConf(thrift.NewTTransportFactory(), nil),
+	)
 }
 
 // Run test suite using TBinaryProtocol
 func TestTBinaryProtocol(t *testing.T) {
-	RunSocketTestSuite(t,
-		thrift.NewTBinaryProtocolFactoryDefault(),
-		thrift.NewTTransportFactory())
-	RunSocketTestSuite(t,
-		thrift.NewTBinaryProtocolFactoryDefault(),
-		thrift.NewTBufferedTransportFactory(8912))
-	RunSocketTestSuite(t,
-		thrift.NewTBinaryProtocolFactoryDefault(),
-		thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()))
+	RunSocketTestSuite(
+		t,
+		thrift.NewTBinaryProtocolFactoryConf(nil),
+		thrift.NewTTransportFactory(),
+	)
+	RunSocketTestSuite(
+		t,
+		thrift.NewTBinaryProtocolFactoryConf(nil),
+		thrift.NewTBufferedTransportFactory(8912),
+	)
+	RunSocketTestSuite(
+		t,
+		thrift.NewTBinaryProtocolFactoryConf(nil),
+		thrift.NewTFramedTransportFactoryConf(thrift.NewTTransportFactory(), nil),
+	)
 }
 
 // Run test suite using TCompactBinaryProtocol
 func TestTCompactProtocol(t *testing.T) {
-	RunSocketTestSuite(t,
-		thrift.NewTCompactProtocolFactory(),
-		thrift.NewTTransportFactory())
-	RunSocketTestSuite(t,
-		thrift.NewTCompactProtocolFactory(),
-		thrift.NewTBufferedTransportFactory(8912))
-	RunSocketTestSuite(t,
-		thrift.NewTCompactProtocolFactory(),
-		thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()))
+	RunSocketTestSuite(
+		t,
+		thrift.NewTCompactProtocolFactoryConf(nil),
+		thrift.NewTTransportFactory(),
+	)
+	RunSocketTestSuite(
+		t,
+		thrift.NewTCompactProtocolFactoryConf(nil),
+		thrift.NewTBufferedTransportFactory(8912),
+	)
+	RunSocketTestSuite(
+		t,
+		thrift.NewTCompactProtocolFactoryConf(nil),
+		thrift.NewTFramedTransportFactoryConf(thrift.NewTTransportFactory(), nil),
+	)
 }

--- a/lib/go/test/tests/struct_args_rets_test.go
+++ b/lib/go/test/tests/struct_args_rets_test.go
@@ -23,7 +23,9 @@ import (
 	st "github.com/apache/thrift/lib/go/test/gopath/src/servicestest"
 )
 
-//this function is never called, it will fail to compile if check is failed
+// This function is never called, it will fail to compile if check is failed
+//
+//lint:ignore U1000 see above ^
 func staticCheckStructArgsResults() {
 	//Check that struct args and results are passed by reference
 	var sa *st.StructA = &st.StructA{}

--- a/lib/go/test/tests/thrifttest_driver.go
+++ b/lib/go/test/tests/thrifttest_driver.go
@@ -66,7 +66,9 @@ func (p *ThriftTestDriver) Start() {
 		"Ripoarisch, Kurdî, Коми, Kernewek, Кыргызча, Latina, Ladino, " +
 		"Lëtzebuergesch, Limburgs, Lingála, ລາວ, Lietuvių, Latviešu, Basa " +
 		"Banyumasan, Malagasy, Македонски, മലയാളം, मराठी, مازِرونی, Bahasa " +
+		//lint:ignore ST1018 intentionally use unicode characters here
 		"Melayu, Nnapulitano, Nedersaksisch, नेपाल भाषा, Nederlands, ‪" +
+		//lint:ignore ST1018 intentionally use unicode characters here
 		"Norsk (nynorsk)‬, ‪Norsk (bokmål)‬, Nouormand, Diné bizaad, " +
 		"Occitan, Иронау, Papiamentu, Deitsch, Polski, پنجابی, پښتو, " +
 		"Norfuk / Pitkern, Português, Runa Simi, Rumantsch, Romani, Română, " +
@@ -222,7 +224,7 @@ func (p *ThriftTestDriver) Start() {
 	}
 
 	err := client.TestException(defaultCtx, "Xception")
-	if e, ok := err.(*thrifttest.Xception); ok == false || e == nil {
+	if e, ok := err.(*thrifttest.Xception); !ok || e == nil {
 		t.Fatal("TestException Xception failed:", err)
 	} else if e.ErrorCode != 1001 || e.Message != "Xception" {
 		t.Fatal("TestException Xception failed:", e)

--- a/lib/go/thrift/application_exception.go
+++ b/lib/go/thrift/application_exception.go
@@ -145,6 +145,9 @@ func (p *tApplicationException) Read(ctx context.Context, iprot TProtocol) error
 
 func (p *tApplicationException) Write(ctx context.Context, oprot TProtocol) (err error) {
 	err = oprot.WriteStructBegin(ctx, "TApplicationException")
+	if err != nil {
+		return
+	}
 	if len(p.Error()) > 0 {
 		err = oprot.WriteFieldBegin(ctx, "message", STRING, 1)
 		if err != nil {

--- a/lib/go/thrift/compact_protocol.go
+++ b/lib/go/thrift/compact_protocol.go
@@ -334,7 +334,8 @@ func (p *TCompactProtocol) WriteString(ctx context.Context, value string) error 
 	if e != nil {
 		return NewTProtocolException(e)
 	}
-	if len(value) > 0 {
+	if len(value) == 0 {
+		return nil
 	}
 	_, e = p.trans.WriteString(value)
 	return e
@@ -722,23 +723,10 @@ func (p *TCompactProtocol) int32ToZigzag(n int32) int32 {
 	return (n << 1) ^ (n >> 31)
 }
 
-func (p *TCompactProtocol) fixedUint64ToBytes(n uint64, buf []byte) {
-	binary.LittleEndian.PutUint64(buf, n)
-}
-
-func (p *TCompactProtocol) fixedInt64ToBytes(n int64, buf []byte) {
-	binary.LittleEndian.PutUint64(buf, uint64(n))
-}
-
 // Writes a byte without any possibility of all that field header nonsense.
 // Used internally by other writing methods that know they need to write a byte.
 func (p *TCompactProtocol) writeByteDirect(b byte) error {
 	return p.trans.WriteByte(b)
-}
-
-// Writes a byte without any possibility of all that field header nonsense.
-func (p *TCompactProtocol) writeIntAsByteDirect(n int) (int, error) {
-	return 1, p.writeByteDirect(byte(n))
 }
 
 //
@@ -792,13 +780,6 @@ func (p *TCompactProtocol) zigzagToInt32(n int32) int32 {
 func (p *TCompactProtocol) zigzagToInt64(n int64) int64 {
 	u := uint64(n)
 	return int64(u>>1) ^ -(n & 1)
-}
-
-// Note that it's important that the mask bytes are long literals,
-// otherwise they'll default to ints, and when you shift an int left 56 bits,
-// you just get a messed up int.
-func (p *TCompactProtocol) bytesToInt64(b []byte) int64 {
-	return int64(binary.LittleEndian.Uint64(b))
 }
 
 // Note that it's important that the mask bytes are long literals,

--- a/lib/go/thrift/framed_transport.go
+++ b/lib/go/thrift/framed_transport.go
@@ -200,7 +200,7 @@ func (p *TFramedTransport) readFrame() error {
 		return err
 	}
 	size := binary.BigEndian.Uint32(buf)
-	if size < 0 || size > uint32(p.cfg.GetMaxFrameSize()) {
+	if size > uint32(p.cfg.GetMaxFrameSize()) {
 		return NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, fmt.Sprintf("Incorrect frame size (%d)", size))
 	}
 	_, err := io.CopyN(&p.readBuf, p.reader, int64(size))

--- a/lib/go/thrift/http_client.go
+++ b/lib/go/thrift/http_client.go
@@ -36,13 +36,11 @@ import (
 var DefaultHttpClient *http.Client = http.DefaultClient
 
 type THttpClient struct {
-	client             *http.Client
-	response           *http.Response
-	url                *url.URL
-	requestBuffer      *bytes.Buffer
-	header             http.Header
-	nsecConnectTimeout int64
-	nsecReadTimeout    int64
+	client        *http.Client
+	response      *http.Response
+	url           *url.URL
+	requestBuffer *bytes.Buffer
+	header        http.Header
 }
 
 type THttpClientTransportFactory struct {

--- a/lib/go/thrift/json_protocol.go
+++ b/lib/go/thrift/json_protocol.go
@@ -501,44 +501,6 @@ func (p *TJSONProtocol) ParseElemListBegin() (elemType TType, size int, e error)
 	return elemType, size, nil
 }
 
-func (p *TJSONProtocol) readElemListBegin() (elemType TType, size int, e error) {
-	if isNull, e := p.ParseListBegin(); isNull || e != nil {
-		return VOID, 0, e
-	}
-	// We don't really use the ctx in ReadString implementation,
-	// so this is safe for now.
-	// We might want to add context to ParseElemListBegin if we start to use
-	// ctx in ReadString implementation in the future.
-	sElemType, err := p.ReadString(context.Background())
-	if err != nil {
-		return VOID, size, err
-	}
-	elemType, err = p.StringToTypeId(sElemType)
-	if err != nil {
-		return elemType, size, err
-	}
-	nSize, _, err2 := p.ParseI64()
-	size = int(nSize)
-	return elemType, size, err2
-}
-
-func (p *TJSONProtocol) writeElemListBegin(elemType TType, size int) error {
-	if e := p.OutputListBegin(); e != nil {
-		return e
-	}
-	s, e1 := p.TypeIdToString(elemType)
-	if e1 != nil {
-		return e1
-	}
-	if e := p.OutputString(s); e != nil {
-		return e
-	}
-	if e := p.OutputI64(int64(size)); e != nil {
-		return e
-	}
-	return nil
-}
-
 func (p *TJSONProtocol) TypeIdToString(fieldType TType) (string, error) {
 	switch byte(fieldType) {
 	case BOOL:

--- a/lib/go/thrift/protocol.go
+++ b/lib/go/thrift/protocol.go
@@ -174,7 +174,7 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 		}
 		return self.ReadListEnd(ctx)
 	default:
-		return NewTProtocolExceptionWithType(INVALID_DATA, errors.New(fmt.Sprintf("Unknown data type %d", fieldType)))
+		return NewTProtocolExceptionWithType(INVALID_DATA, fmt.Errorf("Unknown data type %d", fieldType))
 	}
 	return nil
 }

--- a/lib/go/thrift/rich_transport_test.go
+++ b/lib/go/thrift/rich_transport_test.go
@@ -62,17 +62,17 @@ func TestReadByte(t *testing.T) {
 	}
 }
 
-var someError = errors.New("Some error")
+var errSomeError = errors.New("Some error")
 var readByteTests = []struct {
 	r   *mockReader
 	v   byte
 	err error
 }{
-	{&mockReader{0, 55, io.EOF}, 0, io.EOF},        // reader sends EOF w/o data
-	{&mockReader{0, 55, someError}, 0, someError},  // reader sends some other error
-	{&mockReader{1, 55, nil}, 55, nil},             // reader sends data w/o error
-	{&mockReader{1, 55, io.EOF}, 55, nil},          // reader sends data with EOF
-	{&mockReader{1, 55, someError}, 55, someError}, // reader sends data withsome error
+	{&mockReader{0, 55, io.EOF}, 0, io.EOF},              // reader sends EOF w/o data
+	{&mockReader{0, 55, errSomeError}, 0, errSomeError},  // reader sends some other error
+	{&mockReader{1, 55, nil}, 55, nil},                   // reader sends data w/o error
+	{&mockReader{1, 55, io.EOF}, 55, nil},                // reader sends data with EOF
+	{&mockReader{1, 55, errSomeError}, 55, errSomeError}, // reader sends data withsome error
 }
 
 type mockReader struct {

--- a/lib/go/thrift/serializer_test.go
+++ b/lib/go/thrift/serializer_test.go
@@ -213,20 +213,18 @@ func ProtocolTest2(t *testing.T, pf ProtocolFactory) {
 }
 
 func TestSerializer(t *testing.T) {
-
-	var protocol_factories map[string]ProtocolFactory
-	protocol_factories = make(map[string]ProtocolFactory)
-	protocol_factories["Binary"] = NewTBinaryProtocolFactoryDefault()
-	protocol_factories["Compact"] = NewTCompactProtocolFactory()
-	//protocol_factories["SimpleJSON"] = NewTSimpleJSONProtocolFactory() - write only, can't be read back by design
-	protocol_factories["JSON"] = NewTJSONProtocolFactory()
+	protocolFactories := make(map[string]ProtocolFactory)
+	protocolFactories["Binary"] = NewTBinaryProtocolFactoryDefault()
+	protocolFactories["Compact"] = NewTCompactProtocolFactory()
+	//protocolFactories["SimpleJSON"] = NewTSimpleJSONProtocolFactory() - write only, can't be read back by design
+	protocolFactories["JSON"] = NewTJSONProtocolFactory()
 
 	tests := make(map[string]func(*testing.T, ProtocolFactory))
 	tests["Test 1"] = ProtocolTest1
 	tests["Test 2"] = ProtocolTest2
 	//tests["Test 3"] = ProtocolTest3 // Example of how to add additional tests
 
-	for name, pf := range protocol_factories {
+	for name, pf := range protocolFactories {
 		t.Run(
 			name,
 			func(t *testing.T) {
@@ -241,7 +239,6 @@ func TestSerializer(t *testing.T) {
 			},
 		)
 	}
-
 }
 
 func TestSerializerPoolAsync(t *testing.T) {

--- a/lib/go/thrift/ssl_socket.go
+++ b/lib/go/thrift/ssl_socket.go
@@ -42,18 +42,22 @@ type TSSLSocket struct {
 //
 // Example:
 //
-//     trans, err := thrift.NewTSSLSocketConf("localhost:9090", nil, &TConfiguration{
+//     trans := thrift.NewTSSLSocketConf("localhost:9090", &TConfiguration{
 //         ConnectTimeout: time.Second, // Use 0 for no timeout
 //         SocketTimeout:  time.Second, // Use 0 for no timeout
+//
+//         TLSConfig: &tls.Config{
+//             // Fill in tls config here.
+//         }
 //     })
-func NewTSSLSocketConf(hostPort string, conf *TConfiguration) (*TSSLSocket, error) {
+func NewTSSLSocketConf(hostPort string, conf *TConfiguration) *TSSLSocket {
 	if cfg := conf.GetTLSConfig(); cfg != nil && cfg.MinVersion == 0 {
 		cfg.MinVersion = tls.VersionTLS10
 	}
 	return &TSSLSocket{
 		hostPort: hostPort,
 		cfg:      conf,
-	}, nil
+	}
 }
 
 // Deprecated: Use NewTSSLSocketConf instead.
@@ -62,7 +66,7 @@ func NewTSSLSocket(hostPort string, cfg *tls.Config) (*TSSLSocket, error) {
 		TLSConfig: cfg,
 
 		noPropagation: true,
-	})
+	}), nil
 }
 
 // Deprecated: Use NewTSSLSocketConf instead.
@@ -73,7 +77,7 @@ func NewTSSLSocketTimeout(hostPort string, cfg *tls.Config, connectTimeout, sock
 		TLSConfig:      cfg,
 
 		noPropagation: true,
-	})
+	}), nil
 }
 
 // NewTSSLSocketFromAddrConf creates a TSSLSocket from a net.Addr.

--- a/lib/go/thrift/staticcheck.conf
+++ b/lib/go/thrift/staticcheck.conf
@@ -1,0 +1,4 @@
+checks = [
+  "inherit",
+  "-ST1005", # To be consistent with other language libraries we need capitalized error messages.
+]

--- a/lib/go/thrift/transport_test.go
+++ b/lib/go/thrift/transport_test.go
@@ -166,12 +166,3 @@ func FindAvailableTCPServerPort(startPort int) (net.Addr, error) {
 	}
 	return nil, NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, "Could not find available server port")
 }
-
-func valueInSlice(value string, slice []string) bool {
-	for _, v := range slice {
-		if value == v {
-			return true
-		}
-	}
-	return false
-}

--- a/test/go/src/bin/stress/main.go
+++ b/test/go/src/bin/stress/main.go
@@ -103,14 +103,14 @@ func main() {
 	var transportFactory thrift.TTransportFactory
 
 	if *compact {
-		protocolFactory = thrift.NewTCompactProtocolFactory()
+		protocolFactory = thrift.NewTCompactProtocolFactoryConf(nil)
 	} else {
-		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
+		protocolFactory = thrift.NewTBinaryProtocolFactoryConf(nil)
 	}
 
 	if *framed {
 		transportFactory = thrift.NewTTransportFactory()
-		transportFactory = thrift.NewTFramedTransportFactory(transportFactory)
+		transportFactory = thrift.NewTFramedTransportFactoryConf(transportFactory, nil)
 	} else {
 		transportFactory = thrift.NewTBufferedTransportFactory(8192)
 	}

--- a/test/go/src/bin/testclient/main.go
+++ b/test/go/src/bin/testclient/main.go
@@ -36,7 +36,6 @@ var domain_socket = flag.String("domain-socket", "", "Domain Socket (e.g. /tmp/t
 var transport = flag.String("transport", "buffered", "Transport: buffered, framed, http, zlib")
 var protocol = flag.String("protocol", "binary", "Protocol: binary, compact, json")
 var ssl = flag.Bool("ssl", false, "Encrypted Transport using SSL")
-var zlib = flag.Bool("zlib", false, "Wrapped Transport using Zlib")
 var testloops = flag.Int("testloops", 1, "Number of Tests")
 
 func main() {
@@ -131,6 +130,9 @@ func callEverything(client *thrifttest.ThriftTestClient) {
 		binout[i] = byte(i)
 	}
 	bin, err := client.TestBinary(defaultCtx, binout)
+	if err != nil {
+		t.Fatalf("TestBinary failed with %v", err)
+	}
 	for i := 0; i < 256; i++ {
 		if binout[i] != bin[i] {
 			t.Fatalf("Unexpected TestBinary() result expected %d, got %d ", binout[i], bin[i])

--- a/test/go/src/bin/testserver/main.go
+++ b/test/go/src/bin/testserver/main.go
@@ -35,7 +35,6 @@ var domain_socket = flag.String("domain-socket", "", "Domain Socket (e.g. /tmp/T
 var transport = flag.String("transport", "buffered", "Transport: buffered, framed, http, zlib")
 var protocol = flag.String("protocol", "binary", "Protocol: binary, compact, json, header")
 var ssl = flag.Bool("ssl", false, "Encrypted Transport using SSL")
-var zlib = flag.Bool("zlib", false, "Wrapped Transport using Zlib")
 var certPath = flag.String("certPath", "keys", "Directory that contains SSL certificates")
 
 func main() {

--- a/test/go/src/common/client.go
+++ b/test/go/src/common/client.go
@@ -42,32 +42,35 @@ func StartClient(
 	domain_socket string,
 	transport string,
 	protocol string,
-	ssl bool) (client *thrifttest.ThriftTestClient, trans thrift.TTransport, err error) {
-
+	ssl bool,
+) (client *thrifttest.ThriftTestClient, trans thrift.TTransport, err error) {
 	hostPort := fmt.Sprintf("%s:%d", host, port)
+	cfg := &thrift.TConfiguration{
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
 
 	var protocolFactory thrift.TProtocolFactory
 	switch protocol {
 	case "compact":
-		protocolFactory = thrift.NewTCompactProtocolFactory()
+		protocolFactory = thrift.NewTCompactProtocolFactoryConf(cfg)
 	case "simplejson":
-		protocolFactory = thrift.NewTSimpleJSONProtocolFactory()
+		protocolFactory = thrift.NewTSimpleJSONProtocolFactoryConf(cfg)
 	case "json":
 		protocolFactory = thrift.NewTJSONProtocolFactory()
 	case "binary":
-		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
+		protocolFactory = thrift.NewTBinaryProtocolFactoryConf(cfg)
 	case "header":
-		protocolFactory = thrift.NewTHeaderProtocolFactory()
+		protocolFactory = thrift.NewTHeaderProtocolFactoryConf(cfg)
 	default:
-		return nil, nil, fmt.Errorf("Invalid protocol specified %s", protocol)
+		return nil, nil, fmt.Errorf("invalid protocol specified %s", protocol)
 	}
 	if debugClientProtocol {
 		protocolFactory = thrift.NewTDebugProtocolFactoryWithLogger(protocolFactory, "client:", thrift.StdLogger(nil))
 	}
 	if ssl {
-		trans, err = thrift.NewTSSLSocketConf(hostPort, &thrift.TConfiguration{
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
-		})
+		trans = thrift.NewTSSLSocketConf(hostPort, cfg)
 	} else {
 		if domain_socket != "" {
 			trans = thrift.NewTSocketConf(domain_socket, nil)
@@ -85,21 +88,21 @@ func StartClient(
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			client := &http.Client{Transport: tr}
-			trans, err = thrift.NewTHttpPostClientWithOptions(fmt.Sprintf("https://%s/", hostPort), thrift.THttpClientOptions{Client: client})
+			trans, err = thrift.NewTHttpClientWithOptions(fmt.Sprintf("https://%s/", hostPort), thrift.THttpClientOptions{Client: client})
 			fmt.Println(hostPort)
 		} else {
-			trans, err = thrift.NewTHttpPostClient(fmt.Sprintf("http://%s/", hostPort))
+			trans, err = thrift.NewTHttpClient(fmt.Sprintf("http://%s/", hostPort))
 		}
 	case "framed":
-		trans = thrift.NewTFramedTransport(trans)
+		trans = thrift.NewTFramedTransportConf(trans, cfg)
 	case "buffered":
 		trans = thrift.NewTBufferedTransport(trans, 8192)
 	case "zlib":
 		trans, err = thrift.NewTZlibTransport(trans, zlib.BestCompression)
 	case "":
-		trans = trans
+		// Do nothing
 	default:
-		return nil, nil, fmt.Errorf("Invalid transport specified %s", transport)
+		return nil, nil, fmt.Errorf("invalid transport specified %s", transport)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/test/go/src/common/clientserver_test.go
+++ b/test/go/src/common/clientserver_test.go
@@ -49,7 +49,6 @@ var units = []test_unit{
 }
 
 func TestAllConnection(t *testing.T) {
-	certPath = "../../../keys"
 	wg := &sync.WaitGroup{}
 	wg.Add(len(units))
 	for _, unit := range units {
@@ -67,6 +66,9 @@ func doUnit(t *testing.T, unit *test_unit) {
 	handler := NewMockThriftTest(ctrl)
 
 	processor, serverTransport, transportFactory, protocolFactory, err := GetServerParams(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl, "../../../keys", handler)
+	if err != nil {
+		t.Errorf("GetServerParams failed: %v", err)
+	}
 
 	server := thrift.NewTSimpleServer4(processor, serverTransport, transportFactory, protocolFactory)
 	if err = server.Listen(); err != nil {

--- a/test/go/src/common/context_test.go
+++ b/test/go/src/common/context_test.go
@@ -40,8 +40,6 @@ func (slowHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestHttpContextTimeout(t *testing.T) {
-	certPath = "../../../keys"
-
 	unit := test_unit{"127.0.0.1", 9096, "", "http", "binary", false}
 
 	server := &http.Server{Addr: unit.host + fmt.Sprintf(":%d", unit.port), Handler: slowHttpHandler{}}
@@ -56,6 +54,7 @@ func TestHttpContextTimeout(t *testing.T) {
 
 	unwrapErr := func(err error) error {
 		for {
+			//lint:ignore S1034 type switch is more appropriate here.
 			switch err.(type) {
 			case thrift.TTransportException:
 				err = err.(thrift.TTransportException).Err()

--- a/test/go/src/common/printing_handler.go
+++ b/test/go/src/common/printing_handler.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"time"
 
+	//lint:ignore ST1001 allow dot import here
 	. "github.com/apache/thrift/test/go/src/gen/thrifttest"
 )
 
@@ -333,6 +334,7 @@ func (p *printingHandler) TestException(ctx context.Context, arg string) (err er
 		e.Message = arg
 		return e
 	case "TException":
+		//lint:ignore ST1005 To be consistent with other language libraries.
 		return errors.New("Just TException")
 	}
 	return

--- a/test/go/src/common/simple_handler.go
+++ b/test/go/src/common/simple_handler.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"time"
 
+	//lint:ignore ST1001 allow dot import here
 	. "github.com/apache/thrift/test/go/src/gen/thrifttest"
 )
 
@@ -104,6 +105,7 @@ func (p *simpleHandler) TestMapMap(hello int32) (r map[int32]map[int32]int32, er
 }
 
 func (p *simpleHandler) TestInsanity(argument *Insanity) (r map[UserId]map[Numberz]*Insanity, err error) {
+	//lint:ignore ST1005 To be consistent with other language libraries.
 	return nil, errors.New("No Insanity")
 }
 
@@ -125,6 +127,7 @@ func (p *simpleHandler) TestException(arg string) (err error) {
 		e.Message = arg
 		return e
 	case "TException":
+		//lint:ignore ST1005 To be consistent with other language libraries.
 		return errors.New("Just TException")
 	}
 	return

--- a/tutorial/go/src/client.go
+++ b/tutorial/go/src/client.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -79,21 +78,14 @@ func handleClient(client *tutorial.CalculatorClient) (err error) {
 	return err
 }
 
-func runClient(transportFactory thrift.TTransportFactory, protocolFactory thrift.TProtocolFactory, addr string, secure bool) error {
+func runClient(transportFactory thrift.TTransportFactory, protocolFactory thrift.TProtocolFactory, addr string, secure bool, cfg *thrift.TConfiguration) error {
 	var transport thrift.TTransport
-	var err error
 	if secure {
-		cfg := new(tls.Config)
-		cfg.InsecureSkipVerify = true
-		transport, err = thrift.NewTSSLSocket(addr, cfg)
+		transport = thrift.NewTSSLSocketConf(addr, cfg)
 	} else {
-		transport, err = thrift.NewTSocket(addr)
+		transport = thrift.NewTSocketConf(addr, cfg)
 	}
-	if err != nil {
-		fmt.Println("Error opening socket:", err)
-		return err
-	}
-	transport, err = transportFactory.GetTransport(transport)
+	transport, err := transportFactory.GetTransport(transport)
 	if err != nil {
 		return err
 	}

--- a/tutorial/go/src/handler.go
+++ b/tutorial/go/src/handler.go
@@ -51,13 +51,10 @@ func (p *CalculatorHandler) Calculate(ctx context.Context, logid int32, w *tutor
 	switch w.Op {
 	case tutorial.Operation_ADD:
 		val = w.Num1 + w.Num2
-		break
 	case tutorial.Operation_SUBTRACT:
 		val = w.Num1 - w.Num2
-		break
 	case tutorial.Operation_MULTIPLY:
 		val = w.Num1 * w.Num2
-		break
 	case tutorial.Operation_DIVIDE:
 		if w.Num2 == 0 {
 			ouch := tutorial.NewInvalidOperation()
@@ -67,7 +64,6 @@ func (p *CalculatorHandler) Calculate(ctx context.Context, logid int32, w *tutor
 			return
 		}
 		val = w.Num1 / w.Num2
-		break
 	default:
 		ouch := tutorial.NewInvalidOperation()
 		ouch.WhatOp = int32(w.Op)
@@ -93,7 +89,7 @@ func (p *CalculatorHandler) Calculate(ctx context.Context, logid int32, w *tutor
 
 func (p *CalculatorHandler) GetStruct(ctx context.Context, key int32) (*shared.SharedStruct, error) {
 	fmt.Print("getStruct(", key, ")\n")
-	v, _ := p.log[int(key)]
+	v := p.log[int(key)]
 	return v, nil
 }
 

--- a/tutorial/go/src/main.go
+++ b/tutorial/go/src/main.go
@@ -20,6 +20,7 @@ package main
  */
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -47,13 +48,13 @@ func main() {
 	var protocolFactory thrift.TProtocolFactory
 	switch *protocol {
 	case "compact":
-		protocolFactory = thrift.NewTCompactProtocolFactory()
+		protocolFactory = thrift.NewTCompactProtocolFactoryConf(nil)
 	case "simplejson":
-		protocolFactory = thrift.NewTSimpleJSONProtocolFactory()
+		protocolFactory = thrift.NewTSimpleJSONProtocolFactoryConf(nil)
 	case "json":
 		protocolFactory = thrift.NewTJSONProtocolFactory()
 	case "binary", "":
-		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
+		protocolFactory = thrift.NewTBinaryProtocolFactoryConf(nil)
 	default:
 		fmt.Fprint(os.Stderr, "Invalid protocol specified", protocol, "\n")
 		Usage()
@@ -61,6 +62,11 @@ func main() {
 	}
 
 	var transportFactory thrift.TTransportFactory
+	cfg := &thrift.TConfiguration{
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
 	if *buffered {
 		transportFactory = thrift.NewTBufferedTransportFactory(8192)
 	} else {
@@ -68,7 +74,7 @@ func main() {
 	}
 
 	if *framed {
-		transportFactory = thrift.NewTFramedTransportFactory(transportFactory)
+		transportFactory = thrift.NewTFramedTransportFactoryConf(transportFactory, cfg)
 	}
 
 	if *server {
@@ -76,7 +82,7 @@ func main() {
 			fmt.Println("error running server:", err)
 		}
 	} else {
-		if err := runClient(transportFactory, protocolFactory, *addr, *secure); err != nil {
+		if err := runClient(transportFactory, protocolFactory, *addr, *secure, cfg); err != nil {
 			fmt.Println("error running client:", err)
 		}
 	}


### PR DESCRIPTION
Client: go

Staticcheck is the recommended replacement of the frozen and deprecated
official golint linter [1].

Fix the things it complained about (or add lint:ignore directive) in:

- lib/go/thrift
- lib/go/test/tests
- tutorial/go/src
- test/go/src
- compiler generated code

The majority of the fixes are in the following categories:

- Use of deprecated function (mainly the TConfiguration related ones)
- Redundant break in switch cases
- Unused and unexported variables/fields/functions

Also in the same spirit as fb539ae, remove the error return from
NewTSSLSocket as it can never be non-nil.

This change will be cherry-picked into 0.15.0 branch after merged.

[1]: https://groups.google.com/g/golang-nuts/c/rCP70Aq_tBc
