### PR TITLE
Use the cmake-generated thrift config also on MSVC

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -21,6 +21,9 @@ include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
+include(CheckStructHasMember)
+include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
 
 if (Inttypes_FOUND)
   # This allows the inttypes.h and stdint.h checks to succeed on platforms that
@@ -52,14 +55,24 @@ check_include_file(sched.h HAVE_SCHED_H)
 check_include_file(string.h HAVE_STRING_H)
 check_include_file(strings.h HAVE_STRINGS_H)
 
+# Check for afunix.h on Windows (since Windows 10 Insider Build 17063):
+check_cxx_source_compiles(
+  "
+  #define WIN32_LEAN_AND_MEAN
+  #include <winsock2.h>
+  #include <windows.h>
+  #include <afunix.h>
+  int main(){(void)sizeof(((struct sockaddr_un *)0)->sun_path); return 0;}
+  "
+  HAVE_AF_UNIX_H)
+
+
 check_function_exists(gethostbyname HAVE_GETHOSTBYNAME)
 check_function_exists(gethostbyname_r HAVE_GETHOSTBYNAME_R)
 check_function_exists(strerror_r HAVE_STRERROR_R)
 check_function_exists(sched_get_priority_max HAVE_SCHED_GET_PRIORITY_MAX)
 check_function_exists(sched_get_priority_min HAVE_SCHED_GET_PRIORITY_MIN)
 
-include(CheckCSourceCompiles)
-include(CheckCXXSourceCompiles)
 
 check_cxx_source_compiles(
   "

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -131,7 +131,10 @@
 #cmakedefine HAVE_SCHED_H 1
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <afunix.h> header file. */
+#cmakedefine HAVE_AF_UNIX_H 1
 
 /*************************** FUNCTIONS ***************************/
 

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -1438,7 +1438,7 @@ void TNonblockingIOThread::setCurrentThreadHighPriority(bool value) {
 #ifdef HAVE_SCHED_H
   // Start out with a standard, low-priority setup for the sched params.
   struct sched_param sp;
-  bzero((void*)&sp, sizeof(sp));
+  memset(static_cast<void*>(&sp), 0, sizeof(sp));
   int policy = SCHED_OTHER;
 
   // If desired, set up high-priority sched params structure.

--- a/lib/cpp/src/thrift/thrift-config.h
+++ b/lib/cpp/src/thrift/thrift-config.h
@@ -19,6 +19,5 @@
 
 #ifdef _WIN32
 #include <thrift/windows/config.h>
-#else
-#include <thrift/config.h>
 #endif
+#include <thrift/config.h>


### PR DESCRIPTION
Currently the cmake-generated header `config.h` is not used on MSVC. However it can be helpful to have the option to use this header, for example to detect the presence of newer Windows SDK features (like used in https://github.com/apache/thrift/pull/2327). 

I've tested this addition for over a year successfully on various combinations of Windows and did not find any issues or problems. I've also tried to make sure that previous Windows defines remain available unless overridden by cmake (which should be a good thing).

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
