### PR TITLE
build/docker/*/Dockerfile: Added dotnet additional dependencies

### DIFF
--- a/build/docker/old/debian-stretch/Dockerfile
+++ b/build/docker/old/debian-stretch/Dockerfile
@@ -102,7 +102,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 # project isn't ready for this quite yet:
 # RUN apt-get install -y --no-install-recommends \
 # `# dotnet core dependencies` \
-#       dotnet-sdk-5.0
+#       dotnet-sdk-5.0 \
+#       dotnet-runtime-5.0 \
+#       aspnetcore-runtime-5.0 \
+#       dotnet-apphost-pack-5.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/old/ubuntu-artful/Dockerfile
+++ b/build/docker/old/ubuntu-artful/Dockerfile
@@ -114,13 +114,16 @@ RUN \
     rm -rf openssl-master
 
 RUN apt-get install -y --no-install-recommends \
-      `# Dart dependencies` \
+`# Dart dependencies` \
       dart=$DART_VERSION
 ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
 `# dotnet core dependencies` \
-      dotnet-sdk-5.0
+      dotnet-sdk-5.0 \
+      dotnet-runtime-5.0 \
+      aspnetcore-runtime-5.0 \
+      dotnet-apphost-pack-5.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -120,13 +120,16 @@ RUN \
 
 ENV DART_VERSION 2.7.2-1
 RUN apt-get install -y --no-install-recommends \
-      `# Dart dependencies` \
+`# Dart dependencies` \
       dart=$DART_VERSION
 ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
 `# dotnet core dependencies` \
-      dotnet-sdk-5.0
+      dotnet-sdk-5.0 \
+      dotnet-runtime-5.0 \
+      aspnetcore-runtime-5.0 \
+      dotnet-apphost-pack-5.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -120,13 +120,16 @@ RUN \
 
 ENV DART_VERSION 2.7.2-1
 RUN apt-get install -y --no-install-recommends \
-      `# Dart dependencies` \
+`# Dart dependencies` \
       dart=$DART_VERSION
 ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
 `# dotnet core dependencies` \
-      dotnet-sdk-5.0
+      dotnet-sdk-5.0 \
+      dotnet-runtime-5.0 \
+      aspnetcore-runtime-5.0 \
+      dotnet-apphost-pack-5.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -113,7 +113,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
 `# dotnet core dependencies` \
-      dotnet-sdk-5.0
+      dotnet-sdk-5.0 \
+      dotnet-runtime-5.0 \
+      aspnetcore-runtime-5.0 \
+      dotnet-apphost-pack-5.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \


### PR DESCRIPTION
This PR adds a few additional dotnet dependencies to the docker containers. This may help to resolve build issue https://app.travis-ci.com/github/apache/thrift/jobs/534147247

The additional dependencies are:
      dotnet-runtime-5.0 \
      aspnetcore-runtime-5.0 \
      dotnet-apphost-pack-5.0

- [x] No [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket for trivial changes
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
