### PR TITLE
Reduce the usage of Windows.h, and add macros to slim Windows.h

### DIFF
--- a/lib/cpp/src/thrift/transport/TPipeServer.cpp
+++ b/lib/cpp/src/thrift/transport/TPipeServer.cpp
@@ -26,6 +26,7 @@
 
 #ifdef _WIN32
 #include <thrift/windows/OverlappedSubmissionThread.h>
+#include <thrift/windows/Sync.h>
 #include <AccCtrl.h>
 #include <Aclapi.h>
 #include <sddl.h>

--- a/lib/cpp/src/thrift/transport/TPipeServer.h
+++ b/lib/cpp/src/thrift/transport/TPipeServer.h
@@ -25,9 +25,6 @@
 #ifndef _WIN32
 #include <thrift/transport/TServerSocket.h>
 #endif
-#ifdef _WIN32
-#include <thrift/windows/Sync.h>
-#endif
 
 #define TPIPE_SERVER_MAX_CONNS_DEFAULT PIPE_UNLIMITED_INSTANCES
 

--- a/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
+++ b/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
@@ -26,7 +26,6 @@
 
 #include <thrift/windows/Sync.h>
 #include <thrift/TNonCopyable.h>
-#include <Windows.h>
 
 /*
   *** Why does this class exist?

--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -27,7 +27,13 @@
 #include <thrift/concurrency/Exception.h>
 #include <thrift/TNonCopyable.h>
 
+// Including Windows.h can conflict with Winsock2 usage, and also
+// adds problematic macros like min() and max(). Try to work around:
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#undef NOMINMAX
+#undef WIN32_LEAN_AND_MEAN
 
 /*
   Lightweight synchronization objects that only make sense on Windows.  For cross-platform


### PR DESCRIPTION
Thrift requires the header "Windows.h" in a few places. This header can be problematic to include, i.e. when included in headers, because it can affect standard C++ code. This PR tries to reduce the effects of including Windows.h.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
