### PR TITLE
Minor cmake cleanup

### DIFF
--- a/build/cmake/ThriftMacros.cmake
+++ b/build/cmake/ThriftMacros.cmake
@@ -28,7 +28,8 @@ macro(ADD_LIBRARY_THRIFT name)
     target_include_directories(${name} INTERFACE $<INSTALL_INTERFACE:include>)
     set_target_properties(${name} PROPERTIES
         OUTPUT_NAME ${name}${THRIFT_RUNTIME_POSTFIX}   # windows link variants (/MT, /MD, /MTd, /MDd) get different names
-        VERSION ${thrift_VERSION} )
+        VERSION ${thrift_VERSION})
+
     # set_target_properties(${name} PROPERTIES PUBLIC_HEADER "${thriftcpp_HEADERS}")
     install(TARGETS ${name} EXPORT "${name}Targets"
         RUNTIME DESTINATION "${BIN_INSTALL_DIR}"
@@ -44,20 +45,4 @@ macro(ADD_LIBRARY_THRIFT name)
 		FILE "${name}Targets.cmake"
 		NAMESPACE "${name}::"
 		DESTINATION "${CMAKE_INSTALL_DIR}/thrift")
-endmacro()
-
-macro(TARGET_INCLUDE_DIRECTORIES_THRIFT name)
-    target_include_directories(${name} ${ARGN})
-endmacro()
-
-macro(TARGET_LINK_LIBRARIES_THRIFT name)
-    target_link_libraries(${name} ${ARGN})
-endmacro()
-
-macro(LINK_AGAINST_THRIFT_LIBRARY target)
-    target_link_libraries(${target} ${ARGN})
-endmacro()
-
-macro(TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY target libname)
-    target_link_libraries(${target} ${ARGN} ${libname})
 endmacro()

--- a/lib/c_glib/CMakeLists.txt
+++ b/lib/c_glib/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${GLIB_INCLUDE_DIRS})
 include_directories(src)
 
 # SYSLIBS contains libraries that need to be linked to all lib targets
-set(SYSLIBS ${GLIB_LIBRARIES} ${GLIB_GOBJECT_LIBRARIES})
+list(APPEND SYSLIBS ${GLIB_LIBRARIES} ${GLIB_GOBJECT_LIBRARIES})
 
 # Create the thrift C glib library
 set(thrift_c_glib_SOURCES
@@ -67,31 +67,40 @@ set(thrift_c_glib_zlib_SOURCES
     src/thrift/c_glib/transport/thrift_transport.c
     src/thrift/c_glib/transport/thrift_transport_factory.c
     src/thrift/c_glib/transport/thrift_zlib_transport.c
-    src/thrift/c_glib/transport/thrift_zlib_transport_factory.c   
+    src/thrift/c_glib/transport/thrift_zlib_transport_factory.c
 )
 
 # If OpenSSL is not found just ignore the OpenSSL stuff
-if(WITH_OPENSSL)
+if(OPENSSL_FOUND AND WITH_OPENSSL)
     list(APPEND thrift_c_glib_SOURCES
 	    src/thrift/c_glib/transport/thrift_ssl_socket.c
     )
-    include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
-    list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+    if(TARGET OpenSSL::SSL OR TARGET OpenSSL::Crypto)
+        if(TARGET OpenSSL::SSL)
+            list(APPEND SYSLIBS OpenSSL::SSL)
+        endif()
+        if(TARGET OpenSSL::Crypto)
+            list(APPEND SYSLIBS OpenSSL::Crypto)
+        endif()
+    else()
+        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+    endif()
 endif()
 
 
-# Contains the thrift specific ADD_LIBRARY_THRIFT and TARGET_LINK_LIBRARIES_THRIFT
+# Contains the thrift specific ADD_LIBRARY_THRIFT macro
 include(ThriftMacros)
 
 ADD_LIBRARY_THRIFT(thrift_c_glib ${thrift_c_glib_SOURCES})
-TARGET_LINK_LIBRARIES_THRIFT(thrift_c_glib PUBLIC ${SYSLIBS})
+target_link_libraries(thrift_c_glib PUBLIC ${SYSLIBS})
 
 # If Zlib is not found just ignore the Zlib stuff
 if(WITH_ZLIB)
     include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
     ADD_LIBRARY_THRIFT(thrift_c_glib_zlib ${thrift_c_glib_zlib_SOURCES})
-    TARGET_LINK_LIBRARIES_THRIFT(thrift_c_glib_zlib ${SYSLIBS} ${ZLIB_LIBRARIES})
-    TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY(thrift_c_glib_zlib thrift_c_glib)
+    target_link_libraries(thrift_c_glib_zlib ${SYSLIBS} ${ZLIB_LIBRARIES})
+    target_link_libraries(thrift_c_glib_zlib thrift_c_glib)
 endif()
 
 # Install the headers

--- a/lib/c_glib/test/CMakeLists.txt
+++ b/lib/c_glib/test/CMakeLists.txt
@@ -52,48 +52,48 @@ set(testgenc_SOURCES
 )
 
 add_library(testgenc STATIC ${testgenc_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(testgenc thrift_c_glib)
+target_link_libraries(testgenc thrift_c_glib)
 
 
 add_executable(testserialization testserialization.c)
 target_link_libraries(testserialization testgenc)
-LINK_AGAINST_THRIFT_LIBRARY(testserialization thrift_c_glib)
+target_link_libraries(testserialization thrift_c_glib)
 add_test(NAME testserialization COMMAND testserialization)
 
 add_executable(testapplicationexception testapplicationexception.c)
-LINK_AGAINST_THRIFT_LIBRARY(testapplicationexception thrift_c_glib)
+target_link_libraries(testapplicationexception thrift_c_glib)
 add_test(NAME testapplicationexception COMMAND testapplicationexception)
 
 add_executable(testtransportsocket testtransportsocket.c)
-LINK_AGAINST_THRIFT_LIBRARY(testtransportsocket thrift_c_glib)
+target_link_libraries(testtransportsocket thrift_c_glib)
 add_test(NAME testtransportsocket COMMAND testtransportsocket)
 
 add_executable(testbinaryprotocol testbinaryprotocol.c)
-LINK_AGAINST_THRIFT_LIBRARY(testbinaryprotocol thrift_c_glib)
+target_link_libraries(testbinaryprotocol thrift_c_glib)
 add_test(NAME testbinaryprotocol COMMAND testbinaryprotocol)
 
 add_executable(testcompactprotocol testcompactprotocol.c)
-LINK_AGAINST_THRIFT_LIBRARY(testcompactprotocol thrift_c_glib)
+target_link_libraries(testcompactprotocol thrift_c_glib)
 add_test(NAME testcompactprotocol COMMAND testcompactprotocol)
 
 add_executable(testbufferedtransport testbufferedtransport.c)
-LINK_AGAINST_THRIFT_LIBRARY(testbufferedtransport thrift_c_glib)
+target_link_libraries(testbufferedtransport thrift_c_glib)
 add_test(NAME testbufferedtransport COMMAND testbufferedtransport)
 
 add_executable(testframedtransport testframedtransport.c)
-LINK_AGAINST_THRIFT_LIBRARY(testframedtransport thrift_c_glib)
+target_link_libraries(testframedtransport thrift_c_glib)
 add_test(NAME testframedtransport COMMAND testframedtransport)
 
 add_executable(testfdtransport testfdtransport.c)
-LINK_AGAINST_THRIFT_LIBRARY(testfdtransport thrift_c_glib)
+target_link_libraries(testfdtransport thrift_c_glib)
 add_test(NAME testfdtransport COMMAND testfdtransport)
 
 add_executable(testmemorybuffer testmemorybuffer.c)
-LINK_AGAINST_THRIFT_LIBRARY(testmemorybuffer thrift_c_glib)
+target_link_libraries(testmemorybuffer thrift_c_glib)
 add_test(NAME testmemorybuffer COMMAND testmemorybuffer)
 
 add_executable(testsimpleserver testsimpleserver.c)
-LINK_AGAINST_THRIFT_LIBRARY(testsimpleserver thrift_c_glib)
+target_link_libraries(testsimpleserver thrift_c_glib)
 add_test(NAME testsimpleserver COMMAND testsimpleserver)
 
 add_executable(testdebugproto testdebugproto.c)
@@ -132,7 +132,7 @@ if(WITH_ZLIB)
   include_directories(SYSTEM "${ZLIB_INCLUDE_DIRS}")
   add_executable(testzlibtransport testzlibtransport.c)
   target_link_libraries(testzlibtransport testgenc ${ZLIB_LIBRARIES})
-  LINK_AGAINST_THRIFT_LIBRARY(testzlibtransport thrift_c_glib_zlib)
+  target_link_libraries(testzlibtransport thrift_c_glib_zlib)
   add_test(NAME testzlibtransport COMMAND testzlibtransport)
 endif(WITH_ZLIB)
 
@@ -162,7 +162,7 @@ if(BUILD_CPP)
     )
 
     add_library(testgenc_cpp STATIC ${testgenc_cpp_SOURCES})
-    LINK_AGAINST_THRIFT_LIBRARY(testgenc_cpp thrift)
+    target_link_libraries(testgenc_cpp thrift)
 
     #HACK: testthrifttestclient.cpp includes ThriftTest.h without gen-*/ prefixes
     # so we include it here

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -27,11 +27,8 @@ if(NOT BUILD_SHARED_LIBS)
   add_definitions("-DTHRIFT_STATIC_DEFINE")
 endif()
 
-# SYSLIBS contains libraries that need to be linked to all lib targets
-set(SYSLIBS "")
-
 # Create the thrift C++ library
-set( thriftcpp_SOURCES
+set(thriftcpp_SOURCES
    src/thrift/TApplicationException.cpp
    src/thrift/TOutput.cpp
    src/thrift/async/TAsyncChannel.cpp
@@ -102,12 +99,21 @@ endif()
 
 # If OpenSSL is not found or disabled just ignore the OpenSSL stuff
 if(OPENSSL_FOUND AND WITH_OPENSSL)
-    list( APPEND thriftcpp_SOURCES
+    list(APPEND thriftcpp_SOURCES
        src/thrift/transport/TSSLSocket.cpp
        src/thrift/transport/TSSLServerSocket.cpp
     )
-    include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
-    list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+    if(TARGET OpenSSL::SSL OR TARGET OpenSSL::Crypto)
+        if(TARGET OpenSSL::SSL)
+            list(APPEND SYSLIBS OpenSSL::SSL)
+        endif()
+        if(TARGET OpenSSL::Crypto)
+            list(APPEND SYSLIBS OpenSSL::Crypto)
+        endif()
+    else()
+        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
+    endif()
 endif()
 
 if(UNIX)
@@ -117,7 +123,8 @@ if(UNIX)
         list(APPEND SYSLIBS pthread)
     endif()
 endif()
-set( thriftcpp_threads_SOURCES
+
+set(thriftcpp_threads_SOURCES
     src/thrift/concurrency/ThreadFactory.cpp
     src/thrift/concurrency/Thread.cpp
     src/thrift/concurrency/Monitor.cpp
@@ -125,7 +132,7 @@ set( thriftcpp_threads_SOURCES
 )
 
 # Thrift non blocking server
-set( thriftcppnb_SOURCES
+set(thriftcppnb_SOURCES
     src/thrift/server/TNonblockingServer.cpp
     src/thrift/transport/TNonblockingServerSocket.cpp
     src/thrift/async/TEvhttpServer.cpp
@@ -134,13 +141,13 @@ set( thriftcppnb_SOURCES
 
 # If OpenSSL is not found or disabled just ignore the OpenSSL stuff
 if(OPENSSL_FOUND AND WITH_OPENSSL)
-    list( APPEND thriftcppnb_SOURCES
+    list(APPEND thriftcppnb_SOURCES
     src/thrift/transport/TNonblockingSSLServerSocket.cpp
     )
 endif()
 
 # Thrift zlib transport
-set( thriftcppz_SOURCES
+set(thriftcppz_SOURCES
     src/thrift/transport/TZlibTransport.cpp
     src/thrift/protocol/THeaderProtocol.cpp
     src/thrift/transport/THeaderTransport.cpp
@@ -148,14 +155,13 @@ set( thriftcppz_SOURCES
     src/thrift/transport/THeaderTransport.cpp
 )
 
-# Contains the thrift specific ADD_LIBRARY_THRIFT and TARGET_LINK_LIBRARIES_THRIFT
+# Contains the thrift specific ADD_LIBRARY_THRIFT macro
 include(ThriftMacros)
 
 ADD_LIBRARY_THRIFT(thrift ${thriftcpp_SOURCES} ${thriftcpp_threads_SOURCES})
+target_link_libraries(thrift PUBLIC ${SYSLIBS})
 if(WIN32)
-    TARGET_LINK_LIBRARIES_THRIFT(thrift PUBLIC ${SYSLIBS} ws2_32)
-else()
-    TARGET_LINK_LIBRARIES_THRIFT(thrift PUBLIC ${SYSLIBS})
+    target_link_libraries(thrift PUBLIC ws2_32)
 endif()
 ADD_PKGCONFIG_THRIFT(thrift)
 
@@ -164,12 +170,12 @@ if(WITH_LIBEVENT)
     include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftnb ${thriftcppnb_SOURCES})
-    LINK_AGAINST_THRIFT_LIBRARY(thriftnb PUBLIC thrift)
+    target_link_libraries(thriftnb PUBLIC thrift)
     if(TARGET libevent::core AND TARGET libevent::extra)
         # libevent was found via its cmake config, use modern style targets
-        TARGET_LINK_LIBRARIES_THRIFT(thriftnb PUBLIC libevent::core libevent::extra)
+        target_link_libraries(thriftnb PUBLIC libevent::core libevent::extra)
     else()
-        TARGET_LINK_LIBRARIES_THRIFT(thriftnb PUBLIC ${LIBEVENT_LIBRARIES})
+        target_link_libraries(thriftnb PUBLIC ${LIBEVENT_LIBRARIES})
     endif()
     ADD_PKGCONFIG_THRIFT(thrift-nb)
 endif()
@@ -179,8 +185,8 @@ if(WITH_ZLIB)
     include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftz ${thriftcppz_SOURCES})
-    LINK_AGAINST_THRIFT_LIBRARY(thriftz PUBLIC thrift)
-    TARGET_LINK_LIBRARIES_THRIFT(thriftz PUBLIC ${ZLIB_LIBRARIES})
+    target_link_libraries(thriftz PUBLIC thrift)
+    target_link_libraries(thriftz PUBLIC ${ZLIB_LIBRARIES})
     ADD_PKGCONFIG_THRIFT(thrift-z)
 endif()
 

--- a/lib/cpp/src/thrift/qt/CMakeLists.txt
+++ b/lib/cpp/src/thrift/qt/CMakeLists.txt
@@ -24,5 +24,5 @@ set( thriftcppqt5_SOURCES
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5 REQUIRED COMPONENTS Core Network)
 ADD_LIBRARY_THRIFT(thriftqt5 ${thriftcppqt5_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(thriftqt5 PUBLIC thrift)
-TARGET_LINK_LIBRARIES_THRIFT(thriftqt5 PUBLIC Qt5::Core Qt5::Network)
+target_link_libraries(thriftqt5 PUBLIC thrift)
+target_link_libraries(thriftqt5 PUBLIC Qt5::Core Qt5::Network)

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -67,7 +67,7 @@ add_library(testgencpp_cob STATIC ${testgencpp_cob_SOURCES})
 
 add_executable(Benchmark Benchmark.cpp)
 target_link_libraries(Benchmark testgencpp)
-LINK_AGAINST_THRIFT_LIBRARY(Benchmark thrift)
+target_link_libraries(Benchmark thrift)
 add_test(NAME Benchmark COMMAND Benchmark)
 target_link_libraries(Benchmark testgencpp)
 
@@ -86,7 +86,7 @@ set(UnitTest_SOURCES
 
 add_executable(UnitTests ${UnitTest_SOURCES})
 target_link_libraries(UnitTests testgencpp ${Boost_LIBRARIES})
-LINK_AGAINST_THRIFT_LIBRARY(UnitTests thrift)
+target_link_libraries(UnitTests thrift)
 add_test(NAME UnitTests COMMAND UnitTests)
 if(MSVC)
     # Disable C4503: decorated name length exceeded, name was truncated
@@ -109,7 +109,7 @@ target_link_libraries(TInterruptTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TInterruptTest thrift)
+target_link_libraries(TInterruptTest thrift)
 if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT MINGW)
     target_link_libraries(TInterruptTest -lrt)
 endif ()
@@ -120,7 +120,7 @@ target_link_libraries(TServerIntegrationTest
     testgencpp_cob
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TServerIntegrationTest thrift)
+target_link_libraries(TServerIntegrationTest thrift)
 if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT MINGW)
     target_link_libraries(TServerIntegrationTest -lrt)
 endif ()
@@ -134,8 +134,8 @@ target_link_libraries(TransportTest
     ${Boost_LIBRARIES}
     ${ZLIB_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TransportTest thrift)
-LINK_AGAINST_THRIFT_LIBRARY(TransportTest thriftz)
+target_link_libraries(TransportTest thrift)
+target_link_libraries(TransportTest thriftz)
 add_test(NAME TransportTest COMMAND TransportTest)
 
 add_executable(ZlibTest ZlibTest.cpp)
@@ -144,8 +144,8 @@ target_link_libraries(ZlibTest
     ${Boost_LIBRARIES}
     ${ZLIB_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(ZlibTest thrift)
-LINK_AGAINST_THRIFT_LIBRARY(ZlibTest thriftz)
+target_link_libraries(ZlibTest thrift)
+target_link_libraries(ZlibTest thriftz)
 add_test(NAME ZlibTest COMMAND ZlibTest)
 endif(WITH_ZLIB)
 
@@ -154,7 +154,7 @@ target_link_libraries(AnnotationTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(AnnotationTest thrift)
+target_link_libraries(AnnotationTest thrift)
 add_test(NAME AnnotationTest COMMAND AnnotationTest)
 
 add_executable(EnumTest EnumTest.cpp)
@@ -162,7 +162,7 @@ target_link_libraries(EnumTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(EnumTest thrift)
+target_link_libraries(EnumTest thrift)
 add_test(NAME EnumTest COMMAND EnumTest)
 
 if(HAVE_GETOPT_H)
@@ -171,7 +171,7 @@ target_link_libraries(TFileTransportTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TFileTransportTest thrift)
+target_link_libraries(TFileTransportTest thrift)
 add_test(NAME TFileTransportTest COMMAND TFileTransportTest)
 endif()
 
@@ -179,14 +179,14 @@ add_executable(TFDTransportTest TFDTransportTest.cpp)
 target_link_libraries(TFDTransportTest
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TFDTransportTest thrift)
+target_link_libraries(TFDTransportTest thrift)
 add_test(NAME TFDTransportTest COMMAND TFDTransportTest)
 
 add_executable(TPipedTransportTest TPipedTransportTest.cpp)
 target_link_libraries(TPipedTransportTest
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(TPipedTransportTest thrift)
+target_link_libraries(TPipedTransportTest thrift)
 add_test(NAME TPipedTransportTest COMMAND TPipedTransportTest)
 
 set(AllProtocolsTest_SOURCES
@@ -200,7 +200,7 @@ target_link_libraries(AllProtocolsTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(AllProtocolsTest thrift)
+target_link_libraries(AllProtocolsTest thrift)
 add_test(NAME AllProtocolsTest COMMAND AllProtocolsTest)
 
 # The debug run-time in Windows asserts on isprint() with negative inputs
@@ -210,7 +210,7 @@ if (NOT MSVC OR (MSVC AND CMAKE_BUILD_TYPE EQUAL "DEBUG"))
         testgencpp
         ${Boost_LIBRARIES}
     )
-    LINK_AGAINST_THRIFT_LIBRARY(DebugProtoTest thrift)
+    target_link_libraries(DebugProtoTest thrift)
     add_test(NAME DebugProtoTest COMMAND DebugProtoTest)
 endif()
 
@@ -219,7 +219,7 @@ target_link_libraries(JSONProtoTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(JSONProtoTest thrift)
+target_link_libraries(JSONProtoTest thrift)
 add_test(NAME JSONProtoTest COMMAND JSONProtoTest)
 
 add_executable(OptionalRequiredTest OptionalRequiredTest.cpp)
@@ -227,7 +227,7 @@ target_link_libraries(OptionalRequiredTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(OptionalRequiredTest thrift)
+target_link_libraries(OptionalRequiredTest thrift)
 add_test(NAME OptionalRequiredTest COMMAND OptionalRequiredTest)
 
 add_executable(RecursiveTest RecursiveTest.cpp)
@@ -235,7 +235,7 @@ target_link_libraries(RecursiveTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(RecursiveTest thrift)
+target_link_libraries(RecursiveTest thrift)
 add_test(NAME RecursiveTest COMMAND RecursiveTest)
 
 add_executable(SpecializationTest SpecializationTest.cpp)
@@ -243,7 +243,7 @@ target_link_libraries(SpecializationTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(SpecializationTest thrift)
+target_link_libraries(SpecializationTest thrift)
 add_test(NAME SpecializationTest COMMAND SpecializationTest)
 
 set(concurrency_test_SOURCES
@@ -253,7 +253,7 @@ set(concurrency_test_SOURCES
     concurrency/TimerManagerTests.h
 )
 add_executable(concurrency_test ${concurrency_test_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(concurrency_test thrift)
+target_link_libraries(concurrency_test thrift)
 add_test(NAME concurrency_test COMMAND concurrency_test)
 
 set(link_test_SOURCES
@@ -265,7 +265,7 @@ set(link_test_SOURCES
 
 add_executable(link_test ${link_test_SOURCES})
 target_link_libraries(link_test testgencpp_cob)
-LINK_AGAINST_THRIFT_LIBRARY(link_test thrift)
+target_link_libraries(link_test thrift)
 target_link_libraries(link_test testgencpp)
 add_test(NAME link_test COMMAND link_test)
 
@@ -283,7 +283,7 @@ if(WITH_LIBEVENT)
         testgencpp_cob
         ${Boost_LIBRARIES}
     )
-    LINK_AGAINST_THRIFT_LIBRARY(processor_test thriftnb)
+    target_link_libraries(processor_test thriftnb)
     add_test(NAME processor_test COMMAND processor_test)
 
     set(TNonblockingServerTest_SOURCES TNonblockingServerTest.cpp)
@@ -293,7 +293,7 @@ if(WITH_LIBEVENT)
         testgencpp_cob
         ${Boost_LIBRARIES}
     )
-    LINK_AGAINST_THRIFT_LIBRARY(TNonblockingServerTest thriftnb)
+    target_link_libraries(TNonblockingServerTest thriftnb)
     add_test(NAME TNonblockingServerTest COMMAND TNonblockingServerTest)
 
     if(OPENSSL_FOUND AND WITH_OPENSSL)
@@ -304,7 +304,7 @@ if(WITH_LIBEVENT)
         testgencpp_cob
         ${Boost_LIBRARIES}
       )
-      LINK_AGAINST_THRIFT_LIBRARY(TNonblockingSSLServerTest thriftnb)
+      target_link_libraries(TNonblockingSSLServerTest thriftnb)
       add_test(NAME TNonblockingSSLServerTest COMMAND TNonblockingSSLServerTest -- "${CMAKE_CURRENT_SOURCE_DIR}/../../../test/keys")
     endif(OPENSSL_FOUND AND WITH_OPENSSL)
 endif()
@@ -315,7 +315,7 @@ target_link_libraries(OpenSSLManualInitTest
     ${OPENSSL_LIBRARIES}
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(OpenSSLManualInitTest thrift)
+target_link_libraries(OpenSSLManualInitTest thrift)
 add_test(NAME OpenSSLManualInitTest COMMAND OpenSSLManualInitTest)
 
 add_executable(SecurityTest SecurityTest.cpp)
@@ -323,7 +323,7 @@ target_link_libraries(SecurityTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(SecurityTest thrift)
+target_link_libraries(SecurityTest thrift)
 if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT MINGW)
     target_link_libraries(SecurityTest -lrt)
 endif ()
@@ -334,7 +334,7 @@ target_link_libraries(SecurityFromBufferTest
     testgencpp
     ${Boost_LIBRARIES}
 )
-LINK_AGAINST_THRIFT_LIBRARY(SecurityFromBufferTest thrift)
+target_link_libraries(SecurityFromBufferTest thrift)
 if (NOT MSVC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT MINGW)
     target_link_libraries(SecurityFromBufferTest -lrt)
 endif ()

--- a/lib/cpp/test/qt/CMakeLists.txt
+++ b/lib/cpp/test/qt/CMakeLists.txt
@@ -24,9 +24,8 @@ set(TQTcpServerTest_Qt5_SOURCES
 )
 add_executable(TQTcpServerTest_Qt5 ${TQTcpServerTest_Qt5_SOURCES})
 target_link_libraries(TQTcpServerTest_Qt5 testgencpp_cob)
-LINK_AGAINST_THRIFT_LIBRARY(TQTcpServerTest_Qt5 thriftqt5)
-LINK_AGAINST_THRIFT_LIBRARY(TQTcpServerTest_Qt5 thrift)
+target_link_libraries(TQTcpServerTest_Qt5 thriftqt5)
+target_link_libraries(TQTcpServerTest_Qt5 thrift)
 target_link_libraries(TQTcpServerTest_Qt5 Qt5::Test Qt5::Network)
 
 add_test(NAME TQTcpServerTest_Qt5 COMMAND TQTcpServerTest_Qt5)
-

--- a/test/c_glib/CMakeLists.txt
+++ b/test/c_glib/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# Contains the thrift specific LINK_AGAINST_THRIFT_LIBRARY
+# Contains the thrift specific target_link_libraries
 include(ThriftMacros)
 
 find_package(GLIB REQUIRED COMPONENTS gobject)
@@ -39,10 +39,10 @@ set(crosstestgencglib_SOURCES
 	gen-c_glib/t_test_thrift_test_types.h
 )
 add_library(crosstestgencglib STATIC ${crosstestgencglib_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(crosstestgencglib thrift_c_glib)
+target_link_libraries(crosstestgencglib thrift_c_glib)
 
 if (WITH_ZLIB)
-  LINK_AGAINST_THRIFT_LIBRARY(crosstestgencglib thrift_c_glib_zlib) 
+  target_link_libraries(crosstestgencglib thrift_c_glib_zlib)
 endif ()
 
 add_executable(test_server src/test_server.c src/thrift_test_handler.c src/thrift_second_service_handler.c)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ REQUIRE_BOOST_HEADERS()
 set(BOOST_COMPONENTS filesystem program_options random)
 REQUIRE_BOOST_LIBRARIES(BOOST_COMPONENTS)
 
-# Contains the thrift specific LINK_AGAINST_THRIFT_LIBRARY
+# Contains the thrift specific target_link_libraries
 include(ThriftMacros)
 
 find_package(OpenSSL REQUIRED)
@@ -48,34 +48,34 @@ set(crosstestgencpp_SOURCES
     src/ThriftTest_extras.cpp
 )
 add_library(crosstestgencpp STATIC ${crosstestgencpp_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(crosstestgencpp thrift)
+target_link_libraries(crosstestgencpp thrift)
 
 set(crossstressgencpp_SOURCES
     gen-cpp/Service.cpp
 )
 add_library(crossstressgencpp STATIC ${crossstressgencpp_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(crossstressgencpp thrift)
+target_link_libraries(crossstressgencpp thrift)
 
 set(crossspecificnamegencpp_SOURCES
-    gen-cpp/EchoService.cpp 
+    gen-cpp/EchoService.cpp
     gen-cpp/SpecificNameTest_types.cpp
 )
 add_library(crossspecificnamegencpp STATIC ${crossspecificnamegencpp_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(crossspecificnamegencpp thrift)
+target_link_libraries(crossspecificnamegencpp thrift)
 
 add_executable(TestServer src/TestServer.cpp)
 target_link_libraries(TestServer crosstestgencpp ${Boost_LIBRARIES})
-LINK_AGAINST_THRIFT_LIBRARY(TestServer thriftnb)
-LINK_AGAINST_THRIFT_LIBRARY(TestServer thriftz)
+target_link_libraries(TestServer thriftnb)
+target_link_libraries(TestServer thriftz)
 
 add_executable(TestClient src/TestClient.cpp)
 target_link_libraries(TestClient crosstestgencpp ${Boost_LIBRARIES})
-LINK_AGAINST_THRIFT_LIBRARY(TestClient thriftnb)
-LINK_AGAINST_THRIFT_LIBRARY(TestClient thriftz)
+target_link_libraries(TestClient thriftnb)
+target_link_libraries(TestClient thriftz)
 
 add_executable(StressTest src/StressTest.cpp)
 target_link_libraries(StressTest crossstressgencpp ${Boost_LIBRARIES})
-LINK_AGAINST_THRIFT_LIBRARY(StressTest thriftnb)
+target_link_libraries(StressTest thriftnb)
 add_test(NAME StressTest COMMAND StressTest)
 add_test(NAME StressTestConcurrent COMMAND StressTest --client-type=concurrent)
 
@@ -84,15 +84,15 @@ add_test(NAME StressTestConcurrent COMMAND StressTest --client-type=concurrent)
 if (NOT WIN32 AND NOT CYGWIN)
     add_executable(StressTestNonBlocking src/StressTestNonBlocking.cpp)
     target_link_libraries(StressTestNonBlocking crossstressgencpp ${Boost_LIBRARIES})
-    LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftnb)
-    LINK_AGAINST_THRIFT_LIBRARY(StressTestNonBlocking thriftz)
+    target_link_libraries(StressTestNonBlocking thriftnb)
+    target_link_libraries(StressTestNonBlocking thriftz)
     add_test(NAME StressTestNonBlocking COMMAND StressTestNonBlocking)
 endif()
 
 add_executable(SpecificNameTest src/SpecificNameTest.cpp)
 target_link_libraries(SpecificNameTest crossspecificnamegencpp ${Boost_LIBRARIES} ${LIBEVENT_LIB})
-LINK_AGAINST_THRIFT_LIBRARY(SpecificNameTest thrift)
-LINK_AGAINST_THRIFT_LIBRARY(SpecificNameTest thriftnb)
+target_link_libraries(SpecificNameTest thrift)
+target_link_libraries(SpecificNameTest thriftnb)
 add_test(NAME SpecificNameTest COMMAND SpecificNameTest)
 
 #

--- a/tutorial/cpp/CMakeLists.txt
+++ b/tutorial/cpp/CMakeLists.txt
@@ -35,7 +35,7 @@ set(tutorialgencpp_SOURCES
     gen-cpp/tutorial_types.cpp
 )
 add_library(tutorialgencpp STATIC ${tutorialgencpp_SOURCES})
-LINK_AGAINST_THRIFT_LIBRARY(tutorialgencpp thrift)
+target_link_libraries(tutorialgencpp thrift)
 
 add_custom_command(OUTPUT gen-cpp/Calculator.cpp gen-cpp/SharedService.cpp gen-cpp/shared_types.cpp gen-cpp/tutorial_constants.cpp gen-cpp/tutorial_types.cpp
     COMMAND ${THRIFT_COMPILER} --gen cpp -r ${PROJECT_SOURCE_DIR}/tutorial/tutorial.thrift
@@ -43,14 +43,14 @@ add_custom_command(OUTPUT gen-cpp/Calculator.cpp gen-cpp/SharedService.cpp gen-c
 
 add_executable(TutorialServer CppServer.cpp)
 target_link_libraries(TutorialServer tutorialgencpp)
-LINK_AGAINST_THRIFT_LIBRARY(TutorialServer thrift)
+target_link_libraries(TutorialServer thrift)
 if (ZLIB_FOUND)
   target_link_libraries(TutorialServer ${ZLIB_LIBRARIES})
 endif ()
 
 add_executable(TutorialClient CppClient.cpp)
 target_link_libraries(TutorialClient tutorialgencpp)
-LINK_AGAINST_THRIFT_LIBRARY(TutorialClient thrift)
+target_link_libraries(TutorialClient thrift)
 if (ZLIB_FOUND)
   target_link_libraries(TutorialClient ${ZLIB_LIBRARIES})
 endif ()


### PR DESCRIPTION
This PR makes some changes to the cmake C++ build:
 - When available, it will prefer the OpenSSL targets `OpenSSL::OpenSSL` and `OpenSSL::Crypto` over the older libraries variable.
 -  It removes the use of a number of cmake macros that have basically no effect (instead they obscure what will happen), like `TARGET_INCLUDE_DIRECTORIES_THRIFT`, `TARGET_LINK_LIBRARIES_THRIFT`, `LINK_AGAINST_THRIFT_LIBRARY` and `TARGET_LINK_LIBRARIES_THRIFT_AGAINST_THRIFT_LIBRARY`.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
