### PR TITLE
THRIFT-5469: fix skip map value without depth limit

### DIFF
--- a/lib/go/thrift/protocol.go
+++ b/lib/go/thrift/protocol.go
@@ -146,7 +146,11 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 			if err != nil {
 				return err
 			}
-			self.Skip(ctx, valueType)
+
+			err = Skip(ctx, self, valueType, maxDepth-1)
+			if err != nil {
+				return err
+			}
 		}
 		return self.ReadMapEnd(ctx)
 	case SET:


### PR DESCRIPTION
Fix skip map value without depth limit

we use the go lib to create flume server in golang，and the client hacked to use the socket to send urgent data to keep the connection alive, thus the data is dirty, and the server seems to skip between struct and map over and over again, and finally ends in stack overflow:

runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc06a178370 stack=[0xc06a178000, 0xc08a178000]
fatal error: stack overflow

runtime stack:
runtime.throw(0x35cae7c, 0xe)
runtime/panic.go:1116 +0x72
runtime.newstack()
runtime/stack.go:1060 +0x78d
runtime.morestack()
runtime/asm_amd64.s:449 +0x8f

goroutine 3910 [running]:
runtime.getitab(0x302d060, 0x2d88760, 0x40008000c001001, 0xc0000000a00)
runtime/iface.go:33 +0x385 fp=0xc06a178380 sp=0xc06a178378 pc=0x40d085
runtime.assertE2I2(0x302d060, 0x2d88760, 0x53aa330, 0x50000000000, 0x0, 0x0)
runtime/iface.go:499 +0x45 fp=0xc06a1783b0 sp=0xc06a178380 pc=0x40e305
fmt.(*pp).handleMethods(0xc03dbda000, 0x76, 0x27ee00)
fmt/print.go:594 +0x88 fp=0xc06a178620 sp=0xc06a1783b0 pc=0x501428
fmt.(*pp).printArg(0xc03dbda000, 0x2d88760, 0x53aa330, 0x76)
fmt/print.go:713 +0x216 fp=0xc06a1786b8 sp=0xc06a178620 pc=0x501c96
fmt.(*pp).doPrintf(0xc03dbda000, 0x35e4ce9, 0x18, 0xc06a178840, 0x1, 0x1)
fmt/print.go:1030 +0x168 fp=0xc06a1787a0 sp=0xc06a1786b8 pc=0x505328
fmt.Errorf(0x35e4ce9, 0x18, 0xc06a178840, 0x1, 0x1, 0x4, 0x1)
fmt/errors.go:20 +0x77 fp=0xc06a178808 sp=0xc06a1787a0 pc=0x4fb277
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).getTType(0xc00843bf40, 0xe, 0x0, 0x0, 0xc06a1788c0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:848 +0xb5 fp=0xc06a178860 sp=0xc06a178808 pc=0xd22f35
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).ReadFieldBegin(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0x0, 0x0, 0x0, 0x0, 0x1)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:451 +0x9b fp=0xc06a1788b8 sp=0xc06a178860 pc=0xd2157b
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x62, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:125 +0x51e fp=0xc06a178978 sp=0xc06a1788b8 pc=0xd301be
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a1789c8 sp=0xc06a178978 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a178a88 sp=0xc06a1789c8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a178b48 sp=0xc06a178a88 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a178b98 sp=0xc06a178b48 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a178c58 sp=0xc06a178b98 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a178d18 sp=0xc06a178c58 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a178d68 sp=0xc06a178d18 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a178e28 sp=0xc06a178d68 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a178ee8 sp=0xc06a178e28 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a178f38 sp=0xc06a178ee8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a178ff8 sp=0xc06a178f38 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a1790b8 sp=0xc06a178ff8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179108 sp=0xc06a1790b8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a1791c8 sp=0xc06a179108 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179288 sp=0xc06a1791c8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a1792d8 sp=0xc06a179288 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179398 sp=0xc06a1792d8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179458 sp=0xc06a179398 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a1794a8 sp=0xc06a179458 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179568 sp=0xc06a1794a8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179628 sp=0xc06a179568 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179678 sp=0xc06a179628 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179738 sp=0xc06a179678 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a1797f8 sp=0xc06a179738 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179848 sp=0xc06a1797f8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179908 sp=0xc06a179848 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a1799c8 sp=0xc06a179908 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179a18 sp=0xc06a1799c8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179ad8 sp=0xc06a179a18 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179b98 sp=0xc06a179ad8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179be8 sp=0xc06a179b98 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179ca8 sp=0xc06a179be8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179d68 sp=0xc06a179ca8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179db8 sp=0xc06a179d68 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a179e78 sp=0xc06a179db8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a179f38 sp=0xc06a179e78 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a179f88 sp=0xc06a179f38 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a048 sp=0xc06a179f88 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17a108 sp=0xc06a17a048 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17a158 sp=0xc06a17a108 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a218 sp=0xc06a17a158 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17a2d8 sp=0xc06a17a218 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17a328 sp=0xc06a17a2d8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a3e8 sp=0xc06a17a328 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17a4a8 sp=0xc06a17a3e8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17a4f8 sp=0xc06a17a4a8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a5b8 sp=0xc06a17a4f8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17a678 sp=0xc06a17a5b8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17a6c8 sp=0xc06a17a678 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a788 sp=0xc06a17a6c8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17a848 sp=0xc06a17a788 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17a898 sp=0xc06a17a848 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17a958 sp=0xc06a17a898 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17aa18 sp=0xc06a17a958 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17aa68 sp=0xc06a17aa18 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17ab28 sp=0xc06a17aa68 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17abe8 sp=0xc06a17ab28 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17ac38 sp=0xc06a17abe8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17acf8 sp=0xc06a17ac38 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17adb8 sp=0xc06a17acf8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17ae08 sp=0xc06a17adb8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17aec8 sp=0xc06a17ae08 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17af88 sp=0xc06a17aec8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17afd8 sp=0xc06a17af88 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b098 sp=0xc06a17afd8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17b158 sp=0xc06a17b098 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17b1a8 sp=0xc06a17b158 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b268 sp=0xc06a17b1a8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17b328 sp=0xc06a17b268 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17b378 sp=0xc06a17b328 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b438 sp=0xc06a17b378 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17b4f8 sp=0xc06a17b438 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17b548 sp=0xc06a17b4f8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b608 sp=0xc06a17b548 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17b6c8 sp=0xc06a17b608 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17b718 sp=0xc06a17b6c8 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b7d8 sp=0xc06a17b718 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17b898 sp=0xc06a17b7d8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17b8e8 sp=0xc06a17b898 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17b9a8 sp=0xc06a17b8e8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17ba68 sp=0xc06a17b9a8 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17bab8 sp=0xc06a17ba68 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17bb78 sp=0xc06a17bab8 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17bc38 sp=0xc06a17bb78 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17bc88 sp=0xc06a17bc38 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17bd48 sp=0xc06a17bc88 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17be08 sp=0xc06a17bd48 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17be58 sp=0xc06a17be08 pc=0xd229dd
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xd, 0x3f, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:146 +0xabd fp=0xc06a17bf18 sp=0xc06a17be58 pc=0xd3075d
github.com/apache/thrift/lib/go/thrift.Skip(0x3b29e40, 0xc033d1a540, 0x3b72cc0, 0xc00843bf40, 0xc, 0x40, 0x0, 0x0)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:129 +0x578 fp=0xc06a17bfd8 sp=0xc06a17bf18 pc=0xd30218
github.com/apache/thrift/lib/go/thrift.SkipDefaultDepth(...)
github.com/apache/thrift@v0.14.2/lib/go/thrift/protocol.go:88
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).Skip(0xc00843bf40, 0x3b29e40, 0xc033d1a540, 0xc00843bf0c, 0xa, 0x3e)
github.com/apache/thrift@v0.14.2/lib/go/thrift/compact_protocol.go:646 +0x5d fp=0xc06a17c028 sp=0xc06a17bfd8 pc=0xd229dd
created by github.com/apache/thrift/lib/go/thrift.(*TSimpleServer).innerAccept
github.com/apache/thrift@v0.14.2/lib/go/thrift/simple_server.go:196 +0x14d
