### PR TITLE
Fix invalid optional members and argument generation for typescript

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -910,7 +910,14 @@ void t_js_generator::generate_js_struct_definition(ostream& out,
     }
     if (gen_ts_) {
       string ts_access = gen_node_ ? "public " : "";
-      f_types_ts_ << ts_indent() << ts_access << (*m_iter)->get_name() << ts_get_req(*m_iter) << ": "
+      string member_name = (*m_iter)->get_name();
+
+      // Special case. Exceptions derive from Error, and error has a non optional message field.
+      // Ignore the optional flag in this case, otherwise we will generate a incompatible field
+      // in the eyes of typescript. 
+      string optional_flag = is_exception && member_name == "message" ? "" : ts_get_req(*m_iter);
+ 
+      f_types_ts_ << ts_indent() << ts_access << member_name << optional_flag << ": "
                   << ts_get_type((*m_iter)->get_type()) << ";" << endl;
     }
   }
@@ -2802,8 +2809,16 @@ std::string t_js_generator::ts_function_signature(t_function* tfunction, bool in
 
   str = tfunction->get_name() + "(";
 
+  bool has_written_optional = false;
+
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    str += (*f_iter)->get_name() + ts_get_req(*f_iter) + ": " + ts_get_type((*f_iter)->get_type());
+    // Ensure that non optional parameters do not follow optional parameters
+    // E.g. public foo(a: string, b?: string; c: string) is invalid, c must be optional, or b non-optional
+    string original_optional = ts_get_req(*f_iter);
+    string optional = has_written_optional ? "?" : original_optional;
+    has_written_optional = has_written_optional || optional.size() > 0;
+
+    str += (*f_iter)->get_name() + optional + ": " + ts_get_type((*f_iter)->get_type());
 
     if (f_iter + 1 != fields.end() || (include_callback && fields.size() > 0)) {
       str += ", ";


### PR DESCRIPTION
Fixes two cases where the optional flag `?` is generated incorrectly for typescript, leading to invalid typescript generation that cannot pass `tsc` builds. 

### 1. Exception types with optional message

It is possible to set an optional message parameter on thrift exception types. 

```thrift
exception Bad { 
    1: string message = "";
}
```

However, for the javascript runtime, thrift exception types ultimately derive from `Error` which has a *required* message field. 

**Before**
```ts
export declare class Bad extends Thrift.TException {
    message?: string;
}

/*
Error: TS2416
Property 'message' in type 'T' is not assignable to the same property in base type 'Error'.
  Type 'string | undefined' is not assignable to type 'string'.
    Type 'undefined' is not assignable to type 'string'.(2416)
*/
```

**After**
Special case `message` fields for exception types.
```ts
export declare class Bad extends Thrift.TException {
    message: string;
}
```

### Non-optional function arguments after optional arguments
For service methods it is possible to have non-optional arguments after optional arguments, however this is *not* valid in typescript. 

```thrift
service Blah { 
    double getBlah(1: string arg1, 2: string arg2 = "foo", 3: string arg3);
    //                                ~~~~~~~~~~~~~~~~
}
```

**Before**
```ts
export declare class BlahClient {
    getBlah(arg1: string, arg2?: string, arg3: string): Promise<number>;
    //                                   ~~~~~~~~~~~~~~~~
}

/*
Error: TS1016
A required parameter cannot follow an optional parameter.
*/
```

**After**
Do not write non-optional parameters after optional parameters. One could argue the correct fix for this is to re-order the parameters from non-optional to optional, but this will lead to the parameter order drifting from how it is defined within the service. 
```ts
export declare class BlahClient {
    getBlah(arg1: string, arg2?: string, arg3?: string): Promise<number>;
    //                                   ~~~~~~~~~~~~~~
}
```
 