### PR TITLE
[ruby] Fix shorten-64-to-32 errors on macOS

### DIFF
--- a/lib/rb/ext/binary_protocol_accelerated.c
+++ b/lib/rb/ext/binary_protocol_accelerated.c
@@ -82,7 +82,7 @@ static void write_string_direct(VALUE trans, VALUE str) {
     rb_raise(rb_eStandardError, "Value should be a string");
   }
   str = convert_to_utf8_byte_buffer(str);
-  write_i32_direct(trans, RSTRING_LEN(str));
+  write_i32_direct(trans, (int32_t)RSTRING_LEN(str));
   rb_funcall(trans, write_method_id, 1, str);
 }
 
@@ -223,7 +223,7 @@ VALUE rb_thrift_binary_proto_write_binary(VALUE self, VALUE buf) {
   CHECK_NIL(buf);
   VALUE trans = GET_TRANSPORT(self);
   buf = force_binary_encoding(buf);
-  write_i32_direct(trans, RSTRING_LEN(buf));
+  write_i32_direct(trans, (int32_t)RSTRING_LEN(buf));
   rb_funcall(trans, write_method_id, 1, buf);
   return Qnil;
 }
@@ -403,9 +403,9 @@ VALUE rb_thrift_binary_proto_read_binary(VALUE self) {
 void Init_binary_protocol_accelerated() {
   VALUE thrift_binary_protocol_class = rb_const_get(thrift_module, rb_intern("BinaryProtocol"));
 
-  VERSION_1 = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_1")));
-  VERSION_MASK = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_MASK")));
-  TYPE_MASK = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("TYPE_MASK")));
+  VERSION_1 = (int)rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_1")));
+  VERSION_MASK = (int)rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_MASK")));
+  TYPE_MASK = (int)rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("TYPE_MASK")));
 
   VALUE bpa_class = rb_define_class_under(thrift_module, "BinaryProtocolAccelerated", thrift_binary_protocol_class);
 

--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -315,7 +315,7 @@ VALUE rb_thrift_compact_proto_write_string(VALUE self, VALUE str) {
 VALUE rb_thrift_compact_proto_write_binary(VALUE self, VALUE buf) {
   buf = force_binary_encoding(buf);
   VALUE transport = GET_TRANSPORT(self);
-  write_varint32(transport, RSTRING_LEN(buf));
+  write_varint32(transport, (uint32_t)RSTRING_LEN(buf));
   WRITE(transport, StringValuePtr(buf), RSTRING_LEN(buf));
   return Qnil;
 }
@@ -452,7 +452,7 @@ VALUE rb_thrift_compact_proto_read_message_begin(VALUE self) {
   }
   
   int8_t type = (version_and_type >> TYPE_SHIFT_AMOUNT) & TYPE_BITS;
-  int32_t seqid = read_varint64(self);
+  int32_t seqid = (int32_t)read_varint64(self);
   VALUE messageName = rb_thrift_compact_proto_read_string(self);
   return rb_ary_new3(3, messageName, INT2FIX(type), INT2NUM(seqid));
 }
@@ -490,7 +490,7 @@ VALUE rb_thrift_compact_proto_read_field_begin(VALUE self) {
 }
 
 VALUE rb_thrift_compact_proto_read_map_begin(VALUE self) {
-  int32_t size = read_varint64(self);
+  int32_t size = (int32_t)read_varint64(self);
   uint8_t key_and_value_type = size == 0 ? 0 : read_byte_direct(self);
   return rb_ary_new3(3, INT2FIX(get_ttype(key_and_value_type >> 4)), INT2FIX(get_ttype(key_and_value_type & 0xf)), INT2FIX(size));
 }
@@ -499,7 +499,7 @@ VALUE rb_thrift_compact_proto_read_list_begin(VALUE self) {
   uint8_t size_and_type = read_byte_direct(self);
   int32_t size = (size_and_type >> 4) & 0x0f;
   if (size == 15) {
-    size = read_varint64(self);
+    size = (int32_t)read_varint64(self);
   }
   uint8_t type = get_ttype(size_and_type & 0x0f);
   return rb_ary_new3(2, INT2FIX(type), INT2FIX(size));
@@ -528,7 +528,7 @@ VALUE rb_thrift_compact_proto_read_i16(VALUE self) {
 }
 
 VALUE rb_thrift_compact_proto_read_i32(VALUE self) {
-  return INT2NUM(zig_zag_to_int(read_varint64(self)));
+  return INT2NUM(zig_zag_to_int((int32_t)read_varint64(self)));
 }
 
 VALUE rb_thrift_compact_proto_read_i64(VALUE self) {
@@ -569,10 +569,10 @@ static void Init_constants() {
   thrift_compact_protocol_class = rb_const_get(thrift_module, rb_intern("CompactProtocol"));
   rb_global_variable(&thrift_compact_protocol_class);
 
-  VERSION = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION")));
-  VERSION_MASK = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION_MASK")));
-  TYPE_MASK = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("TYPE_MASK")));
-  TYPE_BITS = rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("TYPE_BITS")));
+  VERSION = (int32_t)rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION")));
+  VERSION_MASK = (int32_t)rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("VERSION_MASK")));
+  TYPE_MASK = (int32_t)rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("TYPE_MASK")));
+  TYPE_BITS = (int32_t)rb_num2ll(rb_const_get(thrift_compact_protocol_class, rb_intern("TYPE_BITS")));
   TYPE_SHIFT_AMOUNT = FIX2INT(rb_const_get(thrift_compact_protocol_class, rb_intern("TYPE_SHIFT_AMOUNT")));
   PROTOCOL_ID = FIX2INT(rb_const_get(thrift_compact_protocol_class, rb_intern("PROTOCOL_ID")));
 

--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -54,7 +54,7 @@ VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value) {
   
   index += length;
   if (index > RSTRING_LEN(buf)) {
-    index = RSTRING_LEN(buf);
+    index = (int)RSTRING_LEN(buf);
   }
   if (index >= GARBAGE_BUFFER_SIZE) {
     rb_ivar_set(self, buf_ivar_id, rb_funcall(buf, slice_method_id, 2, INT2FIX(index), INT2FIX(RSTRING_LEN(buf) - 1)));

--- a/lib/rb/ext/struct.c
+++ b/lib/rb/ext/struct.c
@@ -225,7 +225,7 @@ VALUE get_field_value(VALUE obj, VALUE field_name) {
 }
 
 static void write_container(int ttype, VALUE field_info, VALUE value, VALUE protocol) {
-  int sz, i;
+  long sz, i;
 
   if (ttype == TTYPE_MAP) {
     VALUE keys;


### PR DESCRIPTION
Since the extconf.rb pass `-Werror`, the gem won't compile.

```
$ ruby --version
ruby 3.1.0dev (2021-10-06T06:42:37Z master d53493715c) [x86_64-darwin20]
$ gem install thrift
Building native extensions. This could take a while...
ERROR:  Error installing thrift:
	ERROR: Failed to build gem native extension.

    current directory: /Users/byroot/.gem/ruby/3.1.0/gems/thrift-0.15.0/ext
/opt/rubies/3.1.0-dev/bin/ruby -I /opt/rubies/3.1.0-dev/lib/ruby/3.1.0 -r ./siteconf20211013-11520-x7l42b.rb extconf.rb
checking for strlcpy() in string.h... yes
creating Makefile

current directory: /Users/byroot/.gem/ruby/3.1.0/gems/thrift-0.15.0/ext
make DESTDIR\= clean

current directory: /Users/byroot/.gem/ruby/3.1.0/gems/thrift-0.15.0/ext
make DESTDIR\=
compiling binary_protocol_accelerated.c
binary_protocol_accelerated.c:85:27: error: implicit conversion loses integer precision: 'long' to 'int32_t' (aka 'int') [-Werror,-Wshorten-64-to-32]
  write_i32_direct(trans, RSTRING_LEN(str));
  ~~~~~~~~~~~~~~~~        ^~~~~~~~~~~~~~~~
/opt/rubies/3.1.0-dev/include/ruby-3.1.0/ruby/internal/core/rstring.h:50:27: note: expanded from macro 'RSTRING_LEN'
#define RSTRING_LEN       RSTRING_LEN
                          ^
binary_protocol_accelerated.c:226:27: error: implicit conversion loses integer precision: 'long' to 'int32_t' (aka 'int') [-Werror,-Wshorten-64-to-32]
  write_i32_direct(trans, RSTRING_LEN(buf));
  ~~~~~~~~~~~~~~~~        ^~~~~~~~~~~~~~~~
/opt/rubies/3.1.0-dev/include/ruby-3.1.0/ruby/internal/core/rstring.h:50:27: note: expanded from macro 'RSTRING_LEN'
#define RSTRING_LEN       RSTRING_LEN
                          ^
binary_protocol_accelerated.c:406:15: error: implicit conversion loses integer precision: 'long long' to 'int' [-Werror,-Wshorten-64-to-32]
  VERSION_1 = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_1")));
            ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
binary_protocol_accelerated.c:407:18: error: implicit conversion loses integer precision: 'long long' to 'int' [-Werror,-Wshorten-64-to-32]
  VERSION_MASK = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("VERSION_MASK")));
               ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
binary_protocol_accelerated.c:408:15: error: implicit conversion loses integer precision: 'long long' to 'int' [-Werror,-Wshorten-64-to-32]
  TYPE_MASK = rb_num2ll(rb_const_get(thrift_binary_protocol_class, rb_intern("TYPE_MASK")));
            ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
5 errors generated.
make: *** [binary_protocol_accelerated.o] Error 1
```

cc @Jens-G 