### PR TITLE
THRIFT-5470 Error: Constraint check failure for haxe.ds.ObjectMap.K

### DIFF
--- a/lib/haxe/src/org/apache/thrift/helper/ObjectSet.hx
+++ b/lib/haxe/src/org/apache/thrift/helper/ObjectSet.hx
@@ -22,7 +22,7 @@ package org.apache.thrift.helper;
 import Map;
 
 
-class ObjectSet<K> {
+class ObjectSet<K:{}> {
 
     private var _elements = new haxe.ds.ObjectMap<K,Int>();
     private var _size : Int = 0;


### PR DESCRIPTION
Client: hx
Patch: Jens Geyer
