### PR TITLE
THRIFT-5472: Retract bad go module version under lib/go/thrift

### DIFF
--- a/lib/go/thrift/go.mod
+++ b/lib/go/thrift/go.mod
@@ -1,0 +1,6 @@
+module github.com/apache/thrift/lib/go/thrift
+
+go 1.17
+
+// See https://github.com/apache/thrift/releases/tag/lib%2Fgo%2Fthrift%2Fv0.0.1-do-not-use
+retract [v0.0.0-00000000000000-000000000000, v0.0.1-do-not-use]


### PR DESCRIPTION
Currently when people going to
https://pkg.go.dev/github.com/apache/thrift@v0.15.0/lib/go/thrift it
shows that a previous version with lib/go/thrift/go.mod file is the
latest version.

With solution provided in
https://github.com/golang/go/issues/49015#issuecomment-944993211, this
commit will NOT be merged, but tagged as
`lib/go/thrift/v0.0.1-do-not-use`, in order to retract the bad version
and make `v0.15.0` and the future versions as the correct latest version
recognized by go toolchain.

[skip ci]
