### PR TITLE
moved websocket cpp server to openssl sections as it depends on it

### DIFF
--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -54,8 +54,6 @@ set(thriftcpp_SOURCES
    src/thrift/transport/TServerSocket.cpp
    src/thrift/transport/TTransportUtils.cpp
    src/thrift/transport/TBufferTransports.cpp
-   src/thrift/transport/TWebSocketServer.h
-   src/thrift/transport/TWebSocketServer.cpp
    src/thrift/transport/SocketCommon.cpp
    src/thrift/server/TConnectedClient.cpp
    src/thrift/server/TServerFramework.cpp
@@ -102,6 +100,8 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
     list(APPEND thriftcpp_SOURCES
        src/thrift/transport/TSSLSocket.cpp
        src/thrift/transport/TSSLServerSocket.cpp
+       src/thrift/transport/TWebSocketServer.h
+       src/thrift/transport/TWebSocketServer.cpp
     )
     if(TARGET OpenSSL::SSL OR TARGET OpenSSL::Crypto)
         if(TARGET OpenSSL::SSL)


### PR DESCRIPTION
I've moved `TWebSocketServer` into the OpenSSL section of the CMake, as the web socket server depends on OpenSSL. This is currently breaking the optional building with OpenSSL. So right now even tho one has disabled OpenSSL, it still uses  `bio` and `evp` from OpenSSL.
