### PR TITLE
THRIFT-5480

### DIFF
--- a/lib/netstd/Thrift/Transport/Layered/TFramedTransport.cs
+++ b/lib/netstd/Thrift/Transport/Layered/TFramedTransport.cs
@@ -99,6 +99,7 @@ namespace Thrift.Transport
             ArraySegment<byte> bufSegment;
             ReadBuffer.TryGetBuffer(out bufSegment);
             await InnerTransport.ReadAllAsync(bufSegment.Array, 0, size, cancellationToken);
+            UpdateKnownMessageSize(-1);
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)


### PR DESCRIPTION
THRIFT-5480
netstd
TFramedTransport throws a transport exception when a message is bigger than the previous one, because the knownMessageSize is not reset after a read.
Added a call to update (reset) message size after a frame is read. 