### PR TITLE
Enhance TFramedTransport performance for nodejs

### DIFF
--- a/lib/nodejs/lib/thrift/framed_transport.js
+++ b/lib/nodejs/lib/thrift/framed_transport.js
@@ -34,36 +34,31 @@ function TFramedTransport(buffer, callback) {
 TFramedTransport.prototype = new THeaderTransport();
 
 TFramedTransport.receiver = function(callback, seqid) {
-  var residual = null;
-
+  var residual = [];
+  
   return function(data) {
-    // Prepend any residual data from our previous read
-    if (residual) {
-      data = Buffer.concat([residual, data]);
-      residual = null;
+    // push received data to residual
+    for(var i = 0; i < data.length; ++i) {
+      residual.push(data[i])
     }
 
-    // framed transport
-    while (data.length) {
-      if (data.length < 4) {
-        // Not enough bytes to continue, save and resume on next packet
-        residual = data;
+    while (residual.length > 0) {      
+      if (residual.length < 4) {
+		// Not enough bytes to continue, save and resume on next packet
         return;
       }
-      var frameSize = binary.readI32(data, 0);
-      if (data.length < 4 + frameSize) {
-        // Not enough bytes to continue, save and resume on next packet
-        residual = data;
+      // get single package sieze
+      var frameSize = binary.readI32(Buffer.from(residual.slice(0, 4)), 0);
+      // Not enough bytes to continue, save and resume on next packet
+      if (residual.length < 4 + frameSize) {
         return;
       }
 
-      var frame = data.slice(4, 4 + frameSize);
-      residual = data.slice(4 + frameSize);
-
+      // splice first 4 bytes
+      residual.splice(0, 4)
+      // get package data
+      var frame = Buffer.from(residual.splice(0, frameSize));      
       callback(new TFramedTransport(frame), seqid);
-
-      data = residual;
-      residual = null;
     }
   };
 };


### PR DESCRIPTION
# Enhance TFramedTransport performance for nodejs 
1.  use `array.push` instread of `Array.concat`, `array.push` is more effective than `Array.concat`, see benchmark results
2.  reduce data copy action for improving performance.

```javascript
const Benchmark = require('benchmark');

const buffer = Buffer.alloc(1024)
buffer.fill('A')
const loop = 1024;

const suite = new Benchmark.Suite()

suite
  .add('Buffer.concat', function () {
    let target = Buffer.alloc(0)
    for(let i = 0; i < loop; ++i){
      target = Buffer.concat([target, buffer], target.length + buffer.length)
    }
  })
  .add('Array.push', function () {
    const target = []
    for(let i = 0; i < loop; ++i){
      for(let j = 0; j < buffer.length; ++j){
        target.push(buffer[i])
      }
    }
  })
  .on('cycle', function(event) {
    console.log(String(event.target));
  })
  .on('complete', function() {
    console.log('Fastest is ' + this.filter('fastest').map('name'));
    // console.log(this)
  })
  .run({ async: true })
```

```shell
results:
Buffer.concat x 6.72 ops/sec ±21.71% (24 runs sampled)
Array.push x 47.35 ops/sec ±1.56% (61 runs sampled)
Fastest is Array.push
```