### PR TITLE
THRIFT-5486 : fix issues found by spotbugs

### DIFF
--- a/lib/java/src/org/apache/thrift/TDeserializer.java
+++ b/lib/java/src/org/apache/thrift/TDeserializer.java
@@ -680,20 +680,6 @@ public class TDeserializer {
     return this.processor_.prepareEnum(enumClass, ordinal);
   }
 
-  private <T extends TBase> T createNewStruct(ThriftMetadata.ThriftStruct data) {
-    T instance = null;
-
-    try {
-      instance = (T) this.getStructClass(data).newInstance();
-    } catch (InstantiationException e) {
-      throw new RuntimeException(e);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-
-    return instance;
-  }
-
   private <T extends TBase> Class<T> getStructClass(ThriftMetadata.ThriftStruct data) {
     return (Class<T>) ((StructMetaData) data.data.valueMetaData).structClass;
   }

--- a/lib/java/src/org/apache/thrift/partial/PartialThriftComparer.java
+++ b/lib/java/src/org/apache/thrift/partial/PartialThriftComparer.java
@@ -267,13 +267,15 @@ public class PartialThriftComparer<T extends TBase> {
       return false;
     }
 
-    for (Object k1 : m1.keySet()) {
+    for (Map.Entry e1 : m1.entrySet()) {
+      Object k1 = e1.getKey();
+
       if (!m2.containsKey(k1)) {
         appendResult(data, sb, "Key %s in m1 not found in m2", k1);
         return false;
       }
 
-      Object v1 = m1.get(k1);
+      Object v1 = e1.getValue();
       Object v2 = m2.get(k1);
       if (!this.areEqual(data.valueData, v1, v2, sb)) {
         return false;

--- a/lib/java/src/org/apache/thrift/partial/ThriftMetadata.java
+++ b/lib/java/src/org/apache/thrift/partial/ThriftMetadata.java
@@ -236,17 +236,6 @@ public class ThriftMetadata {
           throw unsupportedFieldTypeException(fieldType);
       }
     }
-
-    private ThriftStruct getParentStruct() {
-      ThriftObject tparent = parent;
-      while (tparent != null) {
-        if (tparent instanceof ThriftStruct) {
-          return (ThriftStruct) tparent;
-        }
-        tparent = tparent.parent;
-      }
-      return null;
-    }
   }
 
   public static class ThriftEnum extends ThriftObject {


### PR DESCRIPTION
Fixes the following issues found by spotbugs:

1. Private method org.apache.thrift.partial.ThriftMetadata$ThriftPrimitive.getParentStruct() is never called
2. Private method org.apache.thrift.TDeserializer.createNewStruct(ThriftMetadata$ThriftStruct) is never called
3. org.apache.thrift.partial.PartialThriftComparer.areEqual(ThriftMetadata$ThriftMap, Object, Object, StringBuilder) makes inefficient use of keySet iterator instead of entrySet iterator