### PR TITLE
Include readme in python packaged sources

### DIFF
--- a/lib/py/MANIFEST.in
+++ b/lib/py/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include src/ext/*


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Since the README.md file is now being used for `long_description` (as per #2458) it needs to be included in package files.
  

