### PR TITLE
THRIFT-5488: Define PY_SSIZE_T_CLEAN to fix error with using PyObject_CallFunction in python 3.10

### DIFF
--- a/lib/py/Makefile.am
+++ b/lib/py/Makefile.am
@@ -30,6 +30,7 @@ py3-test: py3-build
 	$(PYTHON3) test/thrift_TZlibTransport.py
 	$(PYTHON3) test/thrift_TCompactProtocol.py
 	$(PYTHON3) test/thrift_TNonblockingServer.py
+	$(PYTHON3) test/thrift_TSerializer.py
 else
 py3-build:
 py3-test:
@@ -55,6 +56,7 @@ check-local: all py3-test
 	$(PYTHON) test/thrift_TZlibTransport.py
 	$(PYTHON) test/thrift_TCompactProtocol.py
 	$(PYTHON) test/thrift_TNonblockingServer.py
+	$(PYTHON) test/thrift_TSerializer.py
 
 
 clean-local:

--- a/lib/py/src/ext/binary.cpp
+++ b/lib/py/src/ext/binary.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "ext/binary.h"
 namespace apache {
 namespace thrift {

--- a/lib/py/src/ext/compact.cpp
+++ b/lib/py/src/ext/compact.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "ext/compact.h"
 
 namespace apache {

--- a/lib/py/test/test_thrift_file/TestServer.thrift
+++ b/lib/py/test/test_thrift_file/TestServer.thrift
@@ -16,7 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
- 
+
+struct Message {
+   1: optional string body,
+   2: optional i64 num,
+}
 
 service TestServer{
 	string add_and_get_msg(1:string msg)

--- a/lib/py/test/thrift_TSerializer.py
+++ b/lib/py/test/thrift_TSerializer.py
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+import os
+import sys
+
+gen_path = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "gen-py"
+)
+sys.path.append(gen_path)
+
+import _import_local_thrift  # noqa
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolFactory
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAcceleratedFactory
+from thrift.protocol.TCompactProtocol import TCompactProtocolFactory
+from thrift.protocol.TCompactProtocol import TCompactProtocolAcceleratedFactory
+from thrift.transport import TTransport
+from thrift.TSerialization import serialize, deserialize
+from TestServer.ttypes import Message
+
+
+class TestSerializer(unittest.TestCase):
+    def setUp(self):
+        self.message = Message("hello thrift", 42)
+        self.binary_serialized = b"\x0b\x00\x01\x00\x00\x00\x0chello thrift\n\x00\x02\x00\x00\x00\x00\x00\x00\x00*\x00"
+        self.compact_serialized = b'\x18\x0chello thrift\x16T\x00'
+
+    def verify(self, serialized, factory):
+        self.assertEqual(serialized, serialize(self.message, factory))
+
+        self.assertEqual(
+            "hello thrift",
+            deserialize(Message(), serialized, factory).body,
+        )
+        self.assertEqual(
+            42, deserialize(Message(), serialized, factory).num
+        )
+
+        self.assertRaises(EOFError, deserialize, Message(), None, factory)
+        self.assertRaises(EOFError, deserialize, Message(), b'', factory)
+        self.assertRaises(TypeError, deserialize, Message(), "test",  factory)
+
+
+    def test_TBinaryProtocol(self):
+        buf = TTransport.TMemoryBuffer()
+        transport = TTransport.TBufferedTransportFactory().getTransport(buf)
+        factory = TBinaryProtocolFactory(transport)
+        self.verify(self.binary_serialized, factory)
+
+
+    def test_TBinaryProtocolAccelerated(self):
+        buf = TTransport.TMemoryBuffer()
+        transport = TTransport.TBufferedTransportFactory().getTransport(buf)
+        factory = TBinaryProtocolAcceleratedFactory(transport)
+        self.verify(self.binary_serialized, factory)
+
+    def test_TCompactProtocol(self):
+        factory = TCompactProtocolFactory()
+        self.verify(self.compact_serialized, factory)
+
+    def test_TCompactProtocolAccelerated(self):
+        factory = TCompactProtocolAcceleratedFactory()
+        self.verify(self.compact_serialized, factory)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[THRIFT-5488](https://issues.apache.org/jira/browse/THRIFT-5488)
## Description
When using the refill  python functions for the fallback scenario in `ProtocolBase<Impl>::readBytes` ([protocol.tcc](../blob/master/lib/py/src/ext/protocol.tcc#L279)), a `SystemError` is raised in python 3.10 (this was only a warning till python 3.9) due to the use of `#yi` for the output buffer argument. The removal of the warning and dropped support is described in [Python issue 40943](https://bugs.python.org/issue40943).

Extra test cases have been added to cover serialization/deserialization both with compact & binary protocol both with and without the c-extension

~~Additionally the environment variable `PYTHONWARNINGS=error` has been added to the configuration of the python cross tests so as to verify this fix, and also catch any deprecations early.~~ (This change was reverted - see #2490 for details)
 
## Testing
- Run the added unit tests and verify they pass for both python 3.9/3.10:
  ```
   cd lib/py
   make && python test/thrift_TSerializer.py
   ```
- Comment out the `PY_SSIZE_T_CLEAN` define in `lib/py/src/ext/binary.cpp` & `lib/py/src/ext/compact.cpp` 
- Re-build and re-run the tests with python 3.9 - verify that the tests pass, but a warning is displayed
- Re-build and re-rerun the tests with python 3.10 - verify that the tests: `test_TBinaryProtocolAccelerated` & `test_TCompactProtocolAccelerated` fail.


Additionally `make cross` can also be used to exercise the failure by settings warnings to errors by setting the environment variable `PYTHONWARNINGS=error`

- [x] Did you create an [Apache Thrift](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
