### PR TITLE
Fix CI build failure due to rust dependency (clap) compilation error

### DIFF
--- a/lib/rs/test/Cargo.toml
+++ b/lib/rs/test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false
 
 [dependencies]
-clap = "2.33"
+clap = "~2.33"
 bitflags = "=1.2"
 
 [dependencies.thrift]

--- a/test/rs/Cargo.toml
+++ b/test/rs/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 publish = false
 
 [dependencies]
-clap = "2.33"
+clap = "~2.33"
 bitflags = "=1.2"
 env_logger = "0.8"
 log = "0.4"

--- a/tutorial/rs/Cargo.toml
+++ b/tutorial/rs/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["Makefile*", "shared.rs", "tutorial.rs"]
 publish = false
 
 [dependencies]
-clap = "2.33"
+clap = "~2.33"
 bitflags = "=1.2"
 
 [dependencies.thrift]


### PR DESCRIPTION
## Description 
CI (cross tests) is currently failing due to the `clap` dependency being pinned as `2.33` instead of `~2.33`. In practice  `2.33` is interpreted as a caret requirement which translates to `>=2.33, < 3.0.0` and thus 2.34 is attempted which results in the following error:

```
error[E0658]: use of unstable library feature 'matches_macro'
   --> /home/aliakber.saifee/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.34.0/src/errors.rs:392:10
    |
392 |         !matches!(
    |          ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/65721
```

An example build failure can be seen in [travis](https://app.travis-ci.com/github/apache/thrift/jobs/551099274#L5789)
<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
