### PR TITLE
Ensure python warnings are treated as errors

### DIFF
--- a/test/tests.json
+++ b/test/tests.json
@@ -248,7 +248,10 @@
         "TestServer.py",
         "--verbose",
         "--genpydir=gen-py"
-      ]
+      ],
+      "env": {
+        "PYTHONWARNINGS": "error"
+      }
     },
     "client": {
       "timeout": 10,
@@ -257,7 +260,10 @@
         "--verbose",
         "--host=localhost",
         "--genpydir=gen-py"
-      ]
+      ],
+      "env": {
+        "PYTHONWARNINGS": "error"
+      }
     },
     "transports": [
       "buffered",
@@ -298,7 +304,10 @@
         "TestServer.py",
         "--verbose",
         "--genpydir=gen-py"
-      ]
+      ],
+      "env": {
+        "PYTHONWARNINGS": "error"
+      }
     },
     "client": {
       "timeout": 10,
@@ -307,7 +316,10 @@
         "TestClient.py",
         "--host=localhost",
         "--genpydir=gen-py"
-      ]
+      ],
+      "env": {
+        "PYTHONWARNINGS": "error"
+      }
     },
     "transports": [
       "buffered",


### PR DESCRIPTION
## Description

Adds environment variable `PYTHONWARNINGS=error` for python cross tests to catch deprecation warnings that could lead to incompatibility in future versions.
  
:warning: This PR is created only to demonstrate the failure on master - but can be closed once #2487 is merged (which contains the change in the cross test config)

