### PR TITLE
THRIFT-5467 Python: fix CannotSendHeader exception

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -91,6 +91,7 @@ class THttpClient(TTransportBase):
         self.__http_response = None
         self.__timeout = None
         self.__custom_headers = None
+        self.headers = None
 
     @staticmethod
     def basic_proxy_auth_header(proxy):
@@ -175,6 +176,12 @@ class THttpClient(TTransportBase):
             for key, val in six.iteritems(self.__custom_headers):
                 self.__http.putheader(key, val)
 
+        # Saves the cookie sent by the server in the previous response.
+        # HTTPConnection.putheader can only be called after a request has been
+        # started, and before it's been sent.
+        if self.headers and 'Set-Cookie' in self.headers:
+            self.__http.putheader('Cookie', self.headers['Set-Cookie'])
+
         self.__http.endheaders()
 
         # Write payload
@@ -185,7 +192,3 @@ class THttpClient(TTransportBase):
         self.code = self.__http_response.status
         self.message = self.__http_response.reason
         self.headers = self.__http_response.msg
-
-        # Saves the cookie sent by the server response
-        if 'Set-Cookie' in self.headers:
-            self.__http.putheader('Cookie', self.headers['Set-Cookie'])


### PR DESCRIPTION
Based on the python source for `http.client`, `HTTPConnection.putheader`
can only be called after a request has been started, and before it's
been sent. Otherwise it will throw a `http.client.CannotSendHeader`
exception.

If the server returns a `Set-Cookie` header, the client will always
fail with the `CannotSendHeader` exception because `HTTPConnection.putheader`
is called after reading the response.

With this patch we will call this method before the request has been sent.