### PR TITLE
THRIFT-5492: Add readEnd to TBufferedTransport

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -270,6 +270,11 @@ public:
    */
   uint32_t readAll(uint8_t* buf, uint32_t len) { return TBufferBase::readAll(buf, len); }
 
+  uint32_t readEnd() override {
+    resetConsumedMessageSize();
+    return 0;
+  }
+
 protected:
   void initPointers() {
     setReadBuffer(rBuf_.get(), 0);

--- a/test/StressTest.thrift
+++ b/test/StressTest.thrift
@@ -31,5 +31,6 @@ service Service {
   list<i8>  echoList(1: list<i8> arg),
   set<i8>  echoSet(1: set<i8> arg),
   map<i8, i8>  echoMap(1: map<i8, i8> arg),
+  binary echoBinary(1: binary arg),
 }
 

--- a/test/cpp/src/StressTestNonBlocking.cpp
+++ b/test/cpp/src/StressTestNonBlocking.cpp
@@ -99,6 +99,9 @@ public:
   void echoList(vector<int8_t>& out, const vector<int8_t>& arg) override { out = arg; }
   void echoSet(set<int8_t>& out, const set<int8_t>& arg) override { out = arg; }
   void echoMap(map<int8_t, int8_t>& out, const map<int8_t, int8_t>& arg) override { out = arg; }
+  void echoBinary(string& out, const string& arg) override {
+    out = arg;
+  }
 
 private:
   count_map counts_;


### PR DESCRIPTION
client: cpp

Add a readEnd implementation to TBufferedTransport which resets the consumed
message size.  Without this it was noticed that calls to the transport's
consume method would slowly decrement the remainingMessageSize_ and the
remainingMessageSize_ was never reset.  A client could send many messages to
the server, eventually bringing remainingMessageSize_ below zero causing an
EOD_OF_FILE exception.
