### PR TITLE
THRIFT-5495: close client when shutdown server in go lib

### DIFF
--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -20,6 +20,7 @@
 package thrift
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -48,15 +49,26 @@ var ErrAbandonRequest = errors.New("request abandoned")
 // If it's changed to <=0, the feature will be disabled.
 var ServerConnectivityCheckInterval = time.Millisecond * 5
 
+// ServerStopTimeout defines max stop wait duration used by
+// server stop to avoid hanging too long to wait for all client connections to be closed gracefully.
+//
+// It's defined as a variable instead of constant, so that thrift server
+// implementations can change its value to control the behavior.
+//
+// If it's set to <=0, the feature will be disabled(by default), and the server will wait for
+// for all the client connections to be closed gracefully.
+var ServerStopTimeout = time.Duration(0)
+
 /*
  * This is not a typical TSimpleServer as it is not blocked after accept a socket.
  * It is more like a TThreadedServer that can handle different connections in different goroutines.
  * This will work if golang user implements a conn-pool like thing in client side.
  */
 type TSimpleServer struct {
-	closed int32
-	wg     sync.WaitGroup
-	mu     sync.Mutex
+	closed   int32
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+	stopChan chan struct{}
 
 	processorFactory       TProcessorFactory
 	serverTransport        TServerTransport
@@ -121,6 +133,7 @@ func NewTSimpleServerFactory6(processorFactory TProcessorFactory, serverTranspor
 		outputTransportFactory: outputTransportFactory,
 		inputProtocolFactory:   inputProtocolFactory,
 		outputProtocolFactory:  outputProtocolFactory,
+		stopChan:               make(chan struct{}),
 	}
 }
 
@@ -192,11 +205,25 @@ func (p *TSimpleServer) innerAccept() (int32, error) {
 		return 0, err
 	}
 	if client != nil {
-		p.wg.Add(1)
+		ctx, cancel := context.WithCancel(context.Background())
+		p.wg.Add(2)
+
 		go func() {
 			defer p.wg.Done()
+			defer cancel()
 			if err := p.processRequests(client); err != nil {
 				p.logger(fmt.Sprintf("error processing request: %v", err))
+			}
+		}()
+
+		go func() {
+			defer p.wg.Done()
+			select {
+			case <-ctx.Done():
+				// client exited, do nothing
+			case <-p.stopChan:
+				// TSimpleServer.Close called, close the client connection
+				client.Close()
 			}
 		}()
 	}
@@ -229,12 +256,31 @@ func (p *TSimpleServer) Serve() error {
 func (p *TSimpleServer) Stop() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
 	if atomic.LoadInt32(&p.closed) != 0 {
 		return nil
 	}
 	atomic.StoreInt32(&p.closed, 1)
 	p.serverTransport.Interrupt()
-	p.wg.Wait()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		p.wg.Wait()
+	}()
+
+	if ServerStopTimeout > 0 {
+		timer := time.NewTimer(ServerStopTimeout)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+		}
+		close(p.stopChan)
+		timer.Stop()
+	}
+
+	<-ctx.Done()
+	p.stopChan = make(chan struct{})
 	return nil
 }
 

--- a/test/go/src/common/clientserver_test.go
+++ b/test/go/src/common/clientserver_test.go
@@ -75,7 +75,7 @@ func doUnit(t *testing.T, unit *test_unit) {
 		t.Errorf("Unable to start server: %v", err)
 		return
 	}
-	go server.AcceptLoop()
+	go server.Serve()
 	defer server.Stop()
 	client, trans, err := StartClient(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl)
 	if err != nil {


### PR DESCRIPTION
Client: [go]

If there is client connection and no data is send，we will encounter hang druing server stop:
1>If transport factory conf with socket timeout,we will hang until the deadline of the socket

2>If transport factory conf without socket timeout,we will hang forever

Stack As below:
goroutine 140800 [IO wait, 2706 minutes]:
internal/poll.runtime_pollWait(0x7fbf804fb100, 0x72)
  runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc009087700, 0xc008196000, 0x0)
  internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
  internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc009087700, {0xc008196000, 0x10000, 0x10000})
  internal/poll/fd_unix.go:167 +0x25a
net.(*netFD).Read(0xc009087700, {0xc008196000, 0x0, 0xc0061089b8})
  net/fd_posix.go:56 +0x29
net.(*conn).Read(0xc007c98038, {0xc008196000, 0x0, 0xc006108978})
  net/net.go:183 +0x45
github.com/apache/thrift/lib/go/thrift.(*socketConn).Read(0x246aae0, {0xc008196000, 0xc0058b4ed0, 0x246aae0})
  github.com/apache/thrift@v0.15.0/lib/go/thrift/socket_conn.go:101 +0x44
github.com/apache/thrift/lib/go/thrift.(*TSocket).Read(0xc003555460, {0xc008196000, 0x10000, 0x10000})
  github.com/apache/thrift@v0.15.0/lib/go/thrift/socket.go:221 +0x67
bufio.(*Reader).Read(0xc005657320, {0xc001da1000, 0x1000, 0x203000})
  bufio/bufio.go:227 +0x1b4
github.com/apache/thrift/lib/go/thrift.(*TBufferedTransport).Read(0xc0035554a0, {0xc001da1000, 0x431e10, 0x64})
  github.com/apache/thrift@v0.15.0/lib/go/thrift/buffered_transport.go:67 +0x45
bufio.(*Reader).Read(0xc005657380, {0xc0090877f0, 0x4, 0x4b5bac0})
  bufio/bufio.go:227 +0x1b4
io.ReadAtLeast({0x30c0520, 0xc005657380}, {0xc0090877f0, 0x4, 0x4}, 0x4)
  io/io.go:328 +0x9a
io.ReadFull(...)
  io/io.go:347
github.com/apache/thrift/lib/go/thrift.(*TFramedTransport).readFrame(0xc009087780)
  github.com/apache/thrift@v0.15.0/lib/go/thrift/framed_transport.go:199 +0x3c
github.com/apache/thrift/lib/go/thrift.(*TFramedTransport).Read(0xc009087780, {0xc0090877f0, 0x1, 0x4})
  github.com/apache/thrift@v0.15.0/lib/go/thrift/framed_transport.go:148 +0x130
github.com/apache/thrift/lib/go/thrift.(*TFramedTransport).ReadByte(0xc009087780)
  github.com/apache/thrift@v0.15.0/lib/go/thrift/framed_transport.go:157 +0x2e
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).readByteDirect(...)
  github.com/apache/thrift@v0.15.0/lib/go/thrift/compact_protocol.go:766
github.com/apache/thrift/lib/go/thrift.(*TCompactProtocol).ReadMessageBegin(0xc008765040, {0x311a118, 0xc00319ede0})
  github.com/apache/thrift@v0.15.0/lib/go/thrift/compact_protocol.go:367 +0x62
