### PR TITLE
Remove excess assertions in python unit tests for serialization/deserialization

### DIFF
--- a/lib/py/test/thrift_TSerializer.py
+++ b/lib/py/test/thrift_TSerializer.py
@@ -53,17 +53,13 @@ class TestSerializer(unittest.TestCase):
             42, deserialize(Message(), serialized, factory).num
         )
 
-        self.assertRaises(EOFError, deserialize, Message(), None, factory)
         self.assertRaises(EOFError, deserialize, Message(), b'', factory)
-        self.assertRaises(TypeError, deserialize, Message(), "test",  factory)
-
 
     def test_TBinaryProtocol(self):
         buf = TTransport.TMemoryBuffer()
         transport = TTransport.TBufferedTransportFactory().getTransport(buf)
         factory = TBinaryProtocolFactory(transport)
         self.verify(self.binary_serialized, factory)
-
 
     def test_TBinaryProtocolAccelerated(self):
         buf = TTransport.TMemoryBuffer()


### PR DESCRIPTION
Asserting on trying to deserialize None, or an invalid serialized buffer result in different exceptions being raised in python2 versus 3.

These errors can be seen for example in [travis ci](https://app.travis-ci.com/github/apache/thrift/jobs/554567087#L5586).

Removing these assertions since the tests were originally added to verify the compatibility issue with python 3.10 in #2487 and that fix can be verified by just asserting on passing an empty buffer. 
  

- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
