### PR TITLE
go: Make socketConn.Close thread-safe

### DIFF
--- a/lib/go/thrift/socket.go
+++ b/lib/go/thrift/socket.go
@@ -194,15 +194,7 @@ func (p *TSocket) IsOpen() bool {
 
 // Closes the socket.
 func (p *TSocket) Close() error {
-	// Close the socket
-	if p.conn != nil {
-		err := p.conn.Close()
-		if err != nil {
-			return err
-		}
-		p.conn = nil
-	}
-	return nil
+	return p.conn.Close()
 }
 
 //Returns the remote address of the socket.

--- a/lib/go/thrift/ssl_socket.go
+++ b/lib/go/thrift/ssl_socket.go
@@ -220,15 +220,7 @@ func (p *TSSLSocket) IsOpen() bool {
 
 // Closes the socket.
 func (p *TSSLSocket) Close() error {
-	// Close the socket
-	if p.conn != nil {
-		err := p.conn.Close()
-		if err != nil {
-			return err
-		}
-		p.conn = nil
-	}
-	return nil
+	return p.conn.Close()
 }
 
 func (p *TSSLSocket) Read(buf []byte) (int, error) {


### PR DESCRIPTION
Client: go

We used to rely on setting the connection inside TSocket/TSSLSocket as
nil after Close is called to mark the connection as closed, but that is
not thread safe and causing TSocket.Close/TSSLSocket.Close cannot be
called concurrently. Use an atomic int to mark closure instead.
