### PR TITLE
THRIFT-5418: C++ to_string and ostream operator not always generated

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -620,6 +620,8 @@ void t_cpp_generator::generate_enum(t_enum* tenum) {
 
   generate_enum_to_string_helper_function_decl(f_types_, tenum);
   generate_enum_to_string_helper_function(f_types_impl_, tenum);
+
+  has_members_ = true;
 }
 
 void t_cpp_generator::generate_enum_ostream_operator_decl(std::ostream& out, t_enum* tenum) {


### PR DESCRIPTION
If a thrift file only contains an enum, then the c++ source file with
the implementation for to_string and ostream operator<< is not
generated.
This bug was introduced in PR #2095 / THRIFT-5168.

<!-- Explain the changes in the pull request below: -->
  
To fix this issue also set `has_members_` to true in `t_cpp_generator::generate_enum`, not only in `t_cpp_generator::generate_cpp_struct`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
