### PR TITLE
Fix warning C4515: 'protocol': namespace uses itself

### DIFF
--- a/lib/cpp/src/thrift/protocol/TList.h
+++ b/lib/cpp/src/thrift/protocol/TList.h
@@ -26,8 +26,6 @@ namespace apache {
 namespace thrift {
 namespace protocol {
 
-// using namespace apache::thrift::protocol;
-
 /**
  * Helper class that encapsulates list metadata.
  *

--- a/lib/cpp/src/thrift/protocol/TMap.h
+++ b/lib/cpp/src/thrift/protocol/TMap.h
@@ -26,8 +26,6 @@ namespace apache {
 namespace thrift {
 namespace protocol {
 
-using namespace apache::thrift::protocol;
-
 /**
  * Helper class that encapsulates map metadata.
  *

--- a/lib/cpp/src/thrift/protocol/TSet.h
+++ b/lib/cpp/src/thrift/protocol/TSet.h
@@ -27,8 +27,6 @@ namespace apache {
 namespace thrift {
 namespace protocol {
 
-using namespace apache::thrift::protocol;
-
 /**
  * Helper class that encapsulates set metadata.
  *


### PR DESCRIPTION
This warning can been seen when compiling generated code using Visual Studio 16.11.