### PR TITLE
lib/java/build.gradle: Removed jcenter() after repeated errors

### DIFF
--- a/lib/java/build.gradle
+++ b/lib/java/build.gradle
@@ -27,7 +27,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         gradlePluginPortal()
     }
 


### PR DESCRIPTION
There are repeated gradle errors since the jcenter server is currently not working. The build works for me when removing jcenter from the gradle / maven repositories.

- [x] Did not create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket for trivial change.
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
