### PR TITLE
THRIFT-5500 uncompilable code when a .thrift struct named 'System' is present

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -1794,7 +1794,7 @@ void t_netstd_generator::generate_netstd_struct_equals(ostream& out, t_struct* t
         }
         else
         {
-            out << "System.Object.Equals(";
+            out << "global::System.Object.Equals(";
         }
         out << prop_name((*f_iter)) << ", other." << prop_name((*f_iter)) << ")";
         if (!field_is_required((*f_iter)))


### PR DESCRIPTION
https://issues.apache.org/jira/projects/THRIFT/issues/THRIFT-5500

Fixes by adding `global::` in front of the call to `System.Object.Equals(...)`