### PR TITLE
THRIFT-5506 + THRIFT-5505

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.h
@@ -69,16 +69,16 @@ public:
   map<string, int> get_keywords_list() const;
 
   // overrides
-  void init_generator();
-  void close_generator();
-  void generate_consts(vector<t_const*> consts);
+  void init_generator() override;
+  void close_generator() override;
+  void generate_consts(vector<t_const*> consts) override;
   void generate_consts(ostream& out, vector<t_const*> consts);
-  void generate_typedef(t_typedef* ttypedef);
-  void generate_enum(t_enum* tenum);
+  void generate_typedef(t_typedef* ttypedef) override;
+  void generate_enum(t_enum* tenum) override;
   void generate_enum(ostream& out, t_enum* tenum);
-  void generate_struct(t_struct* tstruct);
-  void generate_xception(t_struct* txception);
-  void generate_service(t_service* tservice);
+  void generate_struct(t_struct* tstruct) override;
+  void generate_xception(t_struct* txception) override;
+  void generate_service(t_service* tservice) override;
 
   // additional files
   void generate_extensions_file();
@@ -148,7 +148,7 @@ public:
   string func_name(t_function* tfunc, bool suppress_mapping = false);
   string func_name(std::string fname, bool suppress_mapping = false);
   string convert_to_pascal_case(const string& str);
-  string get_enum_class_name(t_type* type);
+  string get_enum_class_name(t_type* type) override;
 
 protected:
   std::string autogen_comment() override {

--- a/compiler/cpp/src/thrift/parse/t_field.h
+++ b/compiler/cpp/src/thrift/parse/t_field.h
@@ -41,6 +41,7 @@ public:
     : type_(type),
       name_(name),
       key_(0),
+	  req_(T_OPT_IN_REQ_OUT),
       value_(nullptr),
       xsd_optional_(false),
       xsd_nillable_(false),


### PR DESCRIPTION
* THRIFT-5506 C26495 variable "t_field::req_" not initialized, t_field.h:40
Compiler General
Patch: Jens Geyer

* THRIFT-5505 error: 'close_generator' overrides a member function but is not marked 'override'
Client: netstd
Patch: Jens Geyer

