### PR TITLE
THRIFT-5504 CA2254 Message template should be compile time constant

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -2428,7 +2428,7 @@ void t_netstd_generator::generate_process_function_async(ostream& out, t_service
     out << indent() << "var " << tmpvar << " = $\"Error occurred in {GetType().FullName}: {" << tmpex << ".Message}\";" << endl;
     out << indent() << "if(_logger != null)" << endl;
     indent_up();
-    out << indent() << "_logger.LogError(" << tmpex << ", " << tmpvar << ");" << endl;
+    out << indent() << "_logger.LogError(\"{Exception}, {Message}\", " << tmpex << ", " << tmpvar << ");" << endl;
     indent_down();
     out << indent() << "else" << endl;
     indent_up();


### PR DESCRIPTION
Client netstd
Patch: Jens Geyer

There's another location with the same issue.