### PR TITLE
THRIFT-5509: Document about IsOpen returns false

### DIFF
--- a/lib/go/thrift/transport.go
+++ b/lib/go/thrift/transport.go
@@ -49,6 +49,10 @@ type TTransport interface {
 	Open() error
 
 	// Returns true if the transport is open
+	//
+	// NOTE: IsOpen returning false does not necessarily mean the connection
+	// is already closed. An explicit Close call should still be done to
+	// avoid connection leaks.
 	IsOpen() bool
 }
 


### PR DESCRIPTION
Client: go

Document that IsOpen returns false does not necessarily mean the
connection is already explicitly closed.

This is Path 1 of THRIFT-5509.

[skip ci]
