### PR TITLE
THRIFT-5510: On Windows NOMINMAX and WIN32_LEAN_AND_MEAN are unset e…

### DIFF
--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -29,11 +29,23 @@
 
 // Including Windows.h can conflict with Winsock2 usage, and also
 // adds problematic macros like min() and max(). Try to work around:
+#ifndef NOMINMAX
 #define NOMINMAX
+#define _THRIFT_UNDEF_NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#define _THRIFT_UNDEF_WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
+#ifdef _THRIFT_UNDEF_NOMINMAX
 #undef NOMINMAX
+#undef _THRIFT_UNDEF_NOMINMAX
+#endif
+#ifdef _THRIFT_UNDEF_WIN32_LEAN_AND_MEAN
 #undef WIN32_LEAN_AND_MEAN
+#undef _THRIFT_UNDEF_WIN32_LEAN_AND_MEAN
+#endif
 
 /*
   Lightweight synchronization objects that only make sense on Windows.  For cross-platform


### PR DESCRIPTION
…ven if set before

Only define and undefine NOMINMAX and WIN32_LEAN_AND_MEAN if they have not been set before.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
