### PR TITLE
THRIFT-5499: Use blocking Read/Write calls to make sure the Receive/S…

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/TStreamTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TStreamTransport.cs
@@ -80,11 +80,8 @@ namespace Thrift.Transport.Client
                     "Cannot read from null inputstream");
             }
 
-#if NETSTANDARD2_0
-            return await InputStream.ReadAsync(buffer, offset, length, cancellationToken);
-#else
-            return await InputStream.ReadAsync(new Memory<byte>(buffer, offset, length), cancellationToken);
-#endif
+            // The ReadAsync method should not be used since it does not check the ReceiveTimeout property.
+            return await Task.Run( () => InputStream.Read( buffer, offset, length ), cancellationToken );
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)
@@ -95,11 +92,8 @@ namespace Thrift.Transport.Client
                     "Cannot write to null outputstream");
             }
 
-#if NETSTANDARD2_0
-            await OutputStream.WriteAsync(buffer, offset, length, cancellationToken);
-#else
-            await OutputStream.WriteAsync(buffer.AsMemory(offset, length), cancellationToken);
-#endif
+            // The WriteAsync method should not be used since it does not check the SendTimeout property.
+            await Task.Run( () => OutputStream.Write( buffer, offset, length ), cancellationToken );
         }
 
         public override async Task FlushAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
…endTimeout is checked.

Client: netstd

<!-- Explain the changes in the pull request below: -->
The Read/Write operations on the TCP-stream are now blocking calls wrapped in a Task.
This ensures the Send/ReceiveTimeout properties of the TcpClient are used.

It is important that the (TSocket)Transport is closed/disposed when this exception is thrown.
Otherwise the next Read operation will read the message that is sent after the timeout in the stream.

Imo this is not a breaking change because this is the desired behavior.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
