### PR TITLE
Fix winsock capitalization for case sensitive cross-compilation

### DIFF
--- a/lib/cpp/src/thrift/protocol/TProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TProtocol.h
@@ -22,7 +22,7 @@
 
 #ifdef _WIN32
 // Need to come before any Windows.h includes
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 
 #include <thrift/transport/TTransport.h>

--- a/lib/cpp/src/thrift/windows/GetTimeOfDay.cpp
+++ b/lib/cpp/src/thrift/windows/GetTimeOfDay.cpp
@@ -38,7 +38,7 @@ int thrift_gettimeofday(struct timeval* tv, struct timezone* tz) {
 }
 #else
 #define WIN32_LEAN_AND_MEAN
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <cstdint>
 #include <sstream>
 #include <thrift/transport/TTransportException.h>

--- a/lib/cpp/src/thrift/windows/SocketPair.h
+++ b/lib/cpp/src/thrift/windows/SocketPair.h
@@ -29,7 +29,7 @@
 #endif
 
 // Win32
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <thrift/thrift-config.h>
 
 int thrift_socketpair(int d, int type, int protocol, THRIFT_SOCKET sv[2]);

--- a/lib/cpp/src/thrift/windows/WinFcntl.h
+++ b/lib/cpp/src/thrift/windows/WinFcntl.h
@@ -33,7 +33,7 @@
 #endif
 
 // Win32
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <thrift/transport/PlatformSocket.h>
 
 extern "C" {

--- a/lib/cpp/src/thrift/windows/config.h
+++ b/lib/cpp/src/thrift/windows/config.h
@@ -57,7 +57,7 @@
 #include <thrift/windows/SocketPair.h>
 
 // windows
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #ifndef __MINGW32__

--- a/lib/cpp/test/OpenSSLManualInitTest.cpp
+++ b/lib/cpp/test/OpenSSLManualInitTest.cpp
@@ -21,7 +21,7 @@
 // which will cause the test to fail
 #define MANUAL_OPENSSL_INIT 1
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif
 
 #include <boost/test/unit_test.hpp>

--- a/lib/py/src/ext/endian.h
+++ b/lib/py/src/ext/endian.h
@@ -25,7 +25,7 @@
 #ifndef _WIN32
 #include <netinet/in.h>
 #else
-#include <WinSock2.h>
+#include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")
 #define BIG_ENDIAN (4321)
 #define LITTLE_ENDIAN (1234)


### PR DESCRIPTION
I get the following error when this is not patched while cross-compiling form x86 linux via mingw32:

```bash
[11:36:52] /workspace/srcdir/duckdb/extension/parquet/../../third_party/thrift/thrift/protocol/TProtocol.h:25:22: fatal error: Winsock2.h: No such file or directory
[11:36:52]  #include <Winsock2.h>
[11:36:52]                       ^
[11:36:52] compilation terminated.
```