### PR TITLE
THRIFT-5524: [java lib] add jdk8-with-postfix for option_type

### DIFF
--- a/lib/java/gradle/generateTestThrift.gradle
+++ b/lib/java/gradle/generateTestThrift.gradle
@@ -24,11 +24,12 @@ ext.genSrc = file("$buildDir/gen-java")
 ext.genBeanSrc = file("$buildDir/gen-javabean")
 ext.genReuseSrc = file("$buildDir/gen-javareuse")
 ext.genFullCamelSrc = file("$buildDir/gen-fullcamel")
+ext.genOptionTypeSrc = file("$buildDir/gen-option-type")
 ext.genUnsafeSrc = file("$buildDir/gen-unsafe")
 
 // Add the generated code directories to the test source set
 sourceSets {
-    test.java.srcDirs genSrc, genBeanSrc, genReuseSrc, genFullCamelSrc, genUnsafeSrc
+    test.java.srcDirs genSrc, genBeanSrc, genReuseSrc, genFullCamelSrc, genUnsafeSrc, genOptionTypeSrc
 }
 
 // ----------------------------------------------------------------------------
@@ -83,6 +84,24 @@ task generateJava(group: 'Build') {
     thriftCompile(it, 'JavaBinaryDefault.thrift')
     thriftCompile(it, 'VoidMethExceptionsTest.thrift')
     thriftCompile(it, 'partial/thrift_test_schema.thrift')
+}
+
+task generateOptionalTypeJdk8Java(group: 'Build') {
+    description = 'Generate the thrift gen-option-type-jdk8 source'
+    generate.dependsOn it
+
+    ext.outputBuffer = new ByteArrayOutputStream()
+
+    thriftCompile(it, 'JavaOptionTypeJdk8Test.thrift', 'java:option_type=jdk8', genOptionTypeSrc)
+}
+
+task generateOptionalTypeJdk8WithPostfixJava(group: 'Build') {
+    description = 'Generate the thrift gen-option-type-jdk8-with-postfix source'
+    generate.dependsOn it
+
+    ext.outputBuffer = new ByteArrayOutputStream()
+
+    thriftCompile(it, 'JavaOptionTypeJdk8WithPostfixTest.thrift', 'java:option_type=jdk8withpostfix', genOptionTypeSrc)
 }
 
 task generateBeanJava(group: 'Build') {

--- a/lib/java/test/org/apache/thrift/TestOptionType.java
+++ b/lib/java/test/org/apache/thrift/TestOptionType.java
@@ -20,11 +20,10 @@
 package org.apache.thrift;
 
 import junit.framework.TestCase;
-import org.apache.thrift.Option;
 
 // Tests and documents behavior for the "Option<T>" type
 public class TestOptionType extends TestCase {
-    public void testSome() throws Exception {
+    public void testSome() {
         String name = "Chuck Norris";
         Option<String> option = Option.fromNullable(name);
 

--- a/lib/java/test/org/apache/thrift/TestOptionals.java
+++ b/lib/java/test/org/apache/thrift/TestOptionals.java
@@ -26,7 +26,7 @@ import thrift.test.Opt30;
 import thrift.test.Opt64;
 import thrift.test.Opt80;
 
-// Exercises the isSet methods using structs from from ManyOptionals.thrift
+// Exercises the isSet methods using structs from ManyOptionals.thrift
 public class TestOptionals extends TestCase {
   public void testEncodingUtils() throws Exception {
     assertEquals((short)0x8, EncodingUtils.setBit((short)0, 3, true));

--- a/lib/java/test/org/apache/thrift/TestOptionalsWithJdk8.java
+++ b/lib/java/test/org/apache/thrift/TestOptionalsWithJdk8.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift;
+
+import junit.framework.TestCase;
+import thrift.test.optiontype.jdk8.Person;
+
+// Tests and documents behavior for the JDK8 "Option<T>" type
+public class TestOptionalsWithJdk8 extends TestCase {
+
+    public void testConstruction() {
+        Person person = new Person(1L, "name");
+        assertFalse(person.getAge().isPresent());
+        assertFalse(person.isSetAge());
+        assertFalse(person.getPhone().isPresent());
+        assertFalse(person.isSetPhone());
+        assertEquals(1L, person.getId());
+        assertTrue(person.isSetId());
+        assertEquals("name", person.getName());
+        assertTrue(person.isSetName());
+
+        assertFalse(person.getAddresses().isPresent());
+        assertEquals(Integer.valueOf(0), person.getAddressesSize().orElse(0));
+        assertFalse(person.getPets().isPresent());
+        assertEquals(Integer.valueOf(0), person.getPetsSize().orElse(0));
+    }
+
+    public void testEmpty() {
+        Person person = new Person();
+        person.setPhone("phone");
+        assertFalse(person.getAge().isPresent());
+        assertFalse(person.isSetAge());
+        assertTrue(person.getPhone().isPresent());
+        assertEquals("phone", person.getPhone().get());
+        assertTrue(person.isSetPhone());
+        assertEquals(0L, person.getId());
+        assertFalse(person.isSetId());
+        assertNull(person.getName());
+        assertFalse(person.isSetName());
+
+        assertFalse(person.getAddresses().isPresent());
+        assertEquals(Integer.valueOf(0), person.getAddressesSize().orElse(0));
+        assertFalse(person.getPets().isPresent());
+        assertEquals(Integer.valueOf(0), person.getPetsSize().orElse(0));
+    }
+}

--- a/lib/java/test/org/apache/thrift/TestOptionalsWithJdk8Postfix.java
+++ b/lib/java/test/org/apache/thrift/TestOptionalsWithJdk8Postfix.java
@@ -1,0 +1,44 @@
+package org.apache.thrift;
+
+import junit.framework.TestCase;
+import thrift.test.optiontype.jdk8withpostfix.Person;
+
+public class TestOptionalsWithJdk8Postfix extends TestCase {
+
+  public void testConstruction() {
+    Person person = new Person(1L, "name");
+    assertFalse(person.getAgeOptional().isPresent());
+    assertEquals(0L, person.getAge());
+    assertFalse(person.isSetAge());
+    assertFalse(person.getPhoneOptional().isPresent());
+    assertFalse(person.isSetPhone());
+    assertEquals(1L, person.getId());
+    assertTrue(person.isSetId());
+    assertEquals("name", person.getName());
+    assertTrue(person.isSetName());
+
+    assertFalse(person.getAddressesOptional().isPresent());
+    assertEquals(Integer.valueOf(0), person.getAddressesSizeOptional().orElse(0));
+    assertFalse(person.getPetsOptional().isPresent());
+    assertEquals(Integer.valueOf(0), person.getPetsSizeOptional().orElse(0));
+  }
+
+  public void testEmpty() {
+    Person person = new Person();
+    person.setPhone("phone");
+    assertFalse(person.getAgeOptional().isPresent());
+    assertFalse(person.isSetAge());
+    assertTrue(person.getPhoneOptional().isPresent());
+    assertEquals("phone", person.getPhoneOptional().get());
+    assertTrue(person.isSetPhone());
+    assertEquals(0L, person.getId());
+    assertFalse(person.isSetId());
+    assertNull(person.getName());
+    assertFalse(person.isSetName());
+
+    assertFalse(person.getAddressesOptional().isPresent());
+    assertEquals(Integer.valueOf(0), person.getAddressesSizeOptional().orElse(0));
+    assertFalse(person.getPetsOptional().isPresent());
+    assertEquals(Integer.valueOf(0), person.getPetsSizeOptional().orElse(0));
+  }
+}

--- a/test/JavaOptionTypeJdk8Test.thrift
+++ b/test/JavaOptionTypeJdk8Test.thrift
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace java thrift.test.optiontype.jdk8
+
+struct Person {
+  1: required i64 id;
+  2: required string name;
+  3: optional i64 age;
+  4: optional string phone;
+  5: optional list<string> addresses;
+  6: optional map<string, Pet> pets;
+}
+
+enum PetType {
+  Cat = 1
+  Dog = 2
+  Bunny = 3
+}
+
+struct Pet {
+  1: required string name;
+  2: optional PetType type;
+}

--- a/test/JavaOptionTypeJdk8WithPostfixTest.thrift
+++ b/test/JavaOptionTypeJdk8WithPostfixTest.thrift
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace java thrift.test.optiontype.jdk8withpostfix
+
+struct Person {
+  1: required i64 id;
+  2: required string name;
+  3: optional i64 age;
+  4: optional string phone;
+  5: optional list<string> addresses;
+  6: optional map<string, Pet> pets;
+}
+
+enum PetType {
+  Cat = 1
+  Dog = 2
+  Bunny = 3
+}
+
+struct Pet {
+  1: required string name;
+  2: optional PetType type;
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -145,6 +145,8 @@ EXTRA_DIST = \
 	JavaBeansTest.thrift \
 	JavaBinaryDefault.thrift \
 	JavaDeepCopyTest.thrift \
+	JavaOptionTypeJdk8Test.thrift \
+	JavaOptionTypeJdk8WithPostfixTest.thrift \
 	JavaTypes.thrift \
 	JsDeepConstructorTest.thrift \
 	ManyOptionals.thrift \


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

java lib: add jdk8-with-postfix for option_type so that instead of just using jdk8 `Optional<T>` type, it'll generate methods with `Optional()` postfix, in parallel with the original getter methods.

this pull request is based on:
- #2525 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
