### PR TITLE
THRIFT-5525: java gen to use reuse_objects instead of reuse-objects as a consistent param casing

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -90,7 +90,8 @@ public:
         sorted_containers_ = true;
       } else if( iter->first.compare("java5") == 0) {
         java5_ = true;
-      } else if( iter->first.compare("reuse-objects") == 0) {
+      } else if( iter->first.compare("reuse_objects") == 0 || iter->first.compare("reuse-objects") == 0) {
+        // keep both reuse_objects and reuse-objects (legacy) for backwards compatibility
         reuse_objects_ = true;
       } else if( iter->first.compare("option_type") == 0) {
         use_option_type_ = true;
@@ -5447,8 +5448,9 @@ THRIFT_REGISTER_GENERATOR(
     "                     Enable rethrow of unhandled exceptions and let them propagate further."
     " (Default behavior is to catch and log it.)\n"
     "    java5:           Generate Java 1.5 compliant code (includes android_legacy flag).\n"
-    "    reuse-objects:   Data objects will not be allocated, but existing instances will be used "
+    "    reuse_objects:   Data objects will not be allocated, but existing instances will be used "
     "(read and write).\n"
+    "    reuse-objects:   Same as 'reuse_objects'.\n"
     "    sorted_containers:\n"
     "                     Use TreeSet/TreeMap instead of HashSet/HashMap as a implementation of "
     "set/map.\n"

--- a/lib/java/gradle/generateTestThrift.gradle
+++ b/lib/java/gradle/generateTestThrift.gradle
@@ -108,7 +108,7 @@ task generateFullCamelJava(group: 'Build') {
 
     ext.outputBuffer = new ByteArrayOutputStream()
 
-    thriftCompile(it, 'ReuseObjects.thrift', 'java:reuse-objects', genReuseSrc)
+    thriftCompile(it, 'ReuseObjects.thrift', 'java:reuse_objects', genReuseSrc)
 }
 
 task generateUnsafeBinariesJava(group: 'Build') {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
java gen to use reuse_objects instead of reuse-objects as a consistent param casing, but keep supporting original naming; motiviation is that almost all current params are using `_` not `-`

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
