### PR TITLE
THRIFT-5526: java gen to use private_members instead of private-members as a consistent param casing

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -78,7 +78,8 @@ public:
         bean_style_ = true;
       } else if( iter->first.compare("android") == 0) {
         android_style_ = true;
-      } else if( iter->first.compare("private-members") == 0) {
+      } else if( iter->first.compare("private_members") == 0 || iter->first.compare("private-members") == 0) {
+        // keep both private_members and private-members (legacy) for backwards compatibility
         private_members_ = true;
       } else if( iter->first.compare("nocamel") == 0) {
         nocamel_style_ = true;
@@ -5435,8 +5436,9 @@ THRIFT_REGISTER_GENERATOR(
     java,
     "Java",
     "    beans:           Members will be private, and setter methods will return void.\n"
-    "    private-members: Members will be private, but setter methods will return 'this' like "
+    "    private_members: Members will be private, but setter methods will return 'this' like "
     "usual.\n"
+    "    private-members: Same as 'private_members'.\n"
     "    nocamel:         Do not use CamelCase field accessors with beans.\n"
     "    fullcamel:       Convert underscored_accessor_or_service_names to camelCase.\n"
     "    android:         Generated structures are Parcelable.\n"

--- a/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestThrift.java
+++ b/contrib/thrift-maven-plugin/src/test/java/org/apache/thrift/maven/TestThrift.java
@@ -73,7 +73,7 @@ public class TestThrift {
 
     @Test
     public void testThriftCompileWithGeneratorOption() throws Exception {
-        builder.setGenerator("java:private-members");
+        builder.setGenerator("java:private_members");
         executeThriftCompile();
     }
 


### PR DESCRIPTION


<!-- Explain the changes in the pull request below: -->

java gen to use private_members instead of private-members as a consistent param casing  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
