### PR TITLE
THRIFT-5527: Don't swallow idl exceptions in Process function

### DIFF
--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -52,7 +52,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				EqualsTest.thrift \
 				ConflictArgNamesTest.thrift \
 				ConstOptionalFieldImport.thrift \
-				ConstOptionalField.thrift
+				ConstOptionalField.thrift \
+				ProcessorMiddlewareTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -84,6 +85,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS) EqualsTest.thrift
 	$(THRIFT) $(THRIFTARGS) ConflictArgNamesTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r ConstOptionalField.thrift
+	$(THRIFT) $(THRIFTARGS) ProcessorMiddlewareTest.thrift
 	ln -nfs ../../tests gopath/src/tests
 	cp -r ./dontexportrwtest gopath/src
 	touch gopath
@@ -106,7 +108,8 @@ check: gopath
 				./gopath/src/servicestest/container_test-remote \
 				./gopath/src/duplicateimportstest \
 				./gopath/src/equalstest \
-				./gopath/src/conflictargnamestest
+				./gopath/src/conflictargnamestest \
+				./gopath/src/processormiddlewaretest
 	$(GO) test -mod=mod github.com/apache/thrift/lib/go/thrift
 	$(GO) test -mod=mod ./gopath/src/tests ./gopath/src/dontexportrwtest
 
@@ -145,6 +148,7 @@ EXTRA_DIST = \
 	NamesTest.thrift \
 	OnewayTest.thrift \
 	OptionalFieldsTest.thrift \
+	ProcessorMiddlewareTest.thrift \
 	RefAnnotationFieldsTest.thrift \
 	RequiredFieldTest.thrift \
 	ServicesTest.thrift \

--- a/lib/go/test/ProcessorMiddlewareTest.thrift
+++ b/lib/go/test/ProcessorMiddlewareTest.thrift
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+exception Error {
+  1: optional string foo,
+}
+
+service Service {
+  void ping() throws (
+    1: Error error,
+  );
+}

--- a/lib/go/test/tests/processor_middleware_test.go
+++ b/lib/go/test/tests/processor_middleware_test.go
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/test/gopath/src/processormiddlewaretest"
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+const errorMessage = "foo error"
+
+type serviceImpl struct{}
+
+func (serviceImpl) Ping(_ context.Context) (err error) {
+	return &processormiddlewaretest.Error{
+		Foo: thrift.StringPtr(errorMessage),
+	}
+}
+
+func middleware(t *testing.T) thrift.ProcessorMiddleware {
+	return func(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+		return thrift.WrappedTProcessorFunction{
+			Wrapped: func(ctx context.Context, seqId int32, in, out thrift.TProtocol) (_ bool, err thrift.TException) {
+				defer func() {
+					checkError(t, err)
+				}()
+				return next.Process(ctx, seqId, in, out)
+			},
+		}
+	}
+}
+
+func checkError(tb testing.TB, err error) {
+	tb.Helper()
+
+	var idlErr *processormiddlewaretest.Error
+	if !errors.As(err, &idlErr) {
+		tb.Errorf("expected error to be of type *processormiddlewaretest.Error, actual %T, %#v", err, err)
+		return
+	}
+	if actual := idlErr.GetFoo(); actual != errorMessage {
+		tb.Errorf("expected error message to be %q, actual %q", errorMessage, actual)
+	}
+}
+
+func TestProcessorMiddleware(t *testing.T) {
+	const timeout = time.Second
+
+	processor := processormiddlewaretest.NewServiceProcessor(&serviceImpl{})
+	serverTransport, err := thrift.NewTServerSocket("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Could not find available server port: %v", err)
+	}
+	server := thrift.NewTSimpleServer4(
+		thrift.WrapProcessor(processor, middleware(t)),
+		serverTransport,
+		thrift.NewTHeaderTransportFactoryConf(nil, nil),
+		thrift.NewTHeaderProtocolFactoryConf(nil),
+	)
+	defer server.Stop()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.Serve()
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	cfg := &thrift.TConfiguration{
+		ConnectTimeout: timeout,
+		SocketTimeout:  timeout,
+	}
+	transport := thrift.NewTSocketFromAddrConf(serverTransport.Addr(), cfg)
+	if err := transport.Open(); err != nil {
+		t.Fatalf("Could not open client transport: %v", err)
+	}
+	defer transport.Close()
+	protocol := thrift.NewTHeaderProtocolConf(transport, nil)
+
+	client := processormiddlewaretest.NewServiceClient(thrift.NewTStandardClient(protocol, protocol))
+
+	err = client.Ping(context.Background())
+	checkError(t, err)
+}


### PR DESCRIPTION
Client: go

This allows ProcessorMiddlewares to access such exceptions, unless
there's a network error writing the response (which takes priority).

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
