### PR TITLE
THRIFT-5494: fix cpu full caused by infinite select() when frameSize < maxReadBufferBytes but readBufferBytesAllocated.get() + frameSize always greater than MAX_READ_BUFFER_BYTES

### DIFF
--- a/lib/java/src/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -352,9 +352,10 @@ public abstract class AbstractNonblockingServer extends TServer {
 
           // if this frame will always be too large for this server, log the
           // error and close the connection.
-          if (frameSize > MAX_READ_BUFFER_BYTES) {
+          if (frameSize > trans_.getMaxFrameSize()) {
             LOGGER.error("Read a frame size of " + frameSize
-                + ", which is bigger than the maximum allowable buffer size for ALL connections.");
+                + ", which is bigger than the maximum allowable frame size "
+                + trans_.getMaxFrameSize() + " for ALL connections.");
             return false;
           }
 

--- a/lib/java/src/org/apache/thrift/transport/TEndpointTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TEndpointTransport.java
@@ -26,15 +26,20 @@ public abstract class TEndpointTransport extends TTransport{
 
     protected long getMaxMessageSize() { return getConfiguration().getMaxMessageSize(); }
 
+    public int getMaxFrameSize() { return getConfiguration().getMaxFrameSize(); }
+
+    public void setMaxFrameSize(int maxFrameSize) { getConfiguration().setMaxFrameSize(maxFrameSize); }
+
     protected long knownMessageSize;
     protected long remainingMessageSize;
 
     private TConfiguration _configuration;
+
     public TConfiguration getConfiguration() {
         return _configuration;
     }
 
-    public TEndpointTransport( TConfiguration config) throws TTransportException {
+    public TEndpointTransport(TConfiguration config) throws TTransportException {
         _configuration = Objects.isNull(config) ? new TConfiguration() : config;
 
         resetConsumedMessageSize(-1);

--- a/lib/java/src/org/apache/thrift/transport/TServerTransport.java
+++ b/lib/java/src/org/apache/thrift/transport/TServerTransport.java
@@ -22,6 +22,8 @@ package org.apache.thrift.transport;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 
+import org.apache.thrift.TConfiguration;
+
 /**
  * Server transport. Object which provides client transports.
  *
@@ -32,6 +34,7 @@ public abstract class TServerTransport implements Closeable {
     int backlog = 0; // A value of 0 means the default value will be used (currently set at 50)
     int clientTimeout = 0;
     InetSocketAddress bindAddr;
+    int maxFrameSize = TConfiguration.DEFAULT_MAX_FRAME_SIZE;
 
     public T backlog(int backlog) {
       this.backlog = backlog;
@@ -50,6 +53,11 @@ public abstract class TServerTransport implements Closeable {
 
     public T bindAddr(InetSocketAddress bindAddr) {
       this.bindAddr = bindAddr;
+      return (T) this;
+    }
+
+    public T maxFrameSize(int maxFrameSize) {
+      this.maxFrameSize = maxFrameSize;
       return (T) this;
     }
   }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

We encountered a problem that caused the CPU to fill up (24 thread, 40 core), it seems to be due to the readBufferBytesAllocated not being properly calculated and the frameSize is large.

So i think that even if the variable is correctly evaluated, it is necessary to add a separate parameter limit to the frameSize, rather than reusing the maxReadBufferBytes.

ps. this large frame should be come from security check detection, also it could be attack

24 core is full
![image](https://user-images.githubusercontent.com/42178996/155457887-406ddbef-0beb-47a4-bf67-ee069033efb1.png)

big request caused inifinite loop
![image](https://user-images.githubusercontent.com/42178996/155457553-06e399ab-f651-48fe-96e3-f48d4231809b.png)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
