### PR TITLE
THRIFT-5529 missing space in between "<" and "::" in c++ generator

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -2476,7 +2476,7 @@ void t_cpp_generator::generate_service_client(t_service* tservice, string style)
     f_header_ << indent() << service_name_ << style << "Client" << short_suffix << "(" << prot_ptr
 		<< " prot";
 	if (style == "Concurrent") {
-		f_header_ << ", std::shared_ptr<::apache::thrift::async::TConcurrentClientSyncInfo> sync";
+		f_header_ << ", std::shared_ptr< ::apache::thrift::async::TConcurrentClientSyncInfo> sync";
 	}
 	f_header_ << ") ";
 
@@ -2499,7 +2499,7 @@ void t_cpp_generator::generate_service_client(t_service* tservice, string style)
     f_header_ << indent() << service_name_ << style << "Client" << short_suffix << "(" << prot_ptr
 		<< " iprot, " << prot_ptr << " oprot";
 	if (style == "Concurrent") {
-		f_header_ << ", std::shared_ptr<::apache::thrift::async::TConcurrentClientSyncInfo> sync";
+		f_header_ << ", std::shared_ptr< ::apache::thrift::async::TConcurrentClientSyncInfo> sync";
 	}
 	f_header_ << ") ";
 	
@@ -2659,7 +2659,7 @@ void t_cpp_generator::generate_service_client(t_service* tservice, string style)
 
     if (style == "Concurrent") {
       f_header_ <<
-        indent() << "std::shared_ptr<::apache::thrift::async::TConcurrentClientSyncInfo> sync_;"<<endl;
+        indent() << "std::shared_ptr< ::apache::thrift::async::TConcurrentClientSyncInfo> sync_;"<<endl;
     }
     indent_down();
   }


### PR DESCRIPTION
Added missing space in lines containing:  `std::shared_ptr<::apache::thrift::async::TConcurrentClientSyncInfo> sync`
There is a comment related to the issue in [t_cpp_generator.cc](https://github.com/apache/thrift/blob/8fea4ea0c1469bef5c06efd9a125b94f3bf66922/compiler/cpp/src/thrift/generate/t_cpp_generator.cc#L4324)