### PR TITLE
THRIFT-5532: Fix headers bug in Thrift/HttpClient.pm

### DIFF
--- a/lib/perl/lib/Thrift/HttpClient.pm
+++ b/lib/perl/lib/Thrift/HttpClient.pm
@@ -186,7 +186,8 @@ sub flush
     $out->setpos(0); # rewind
     my $buf = join('', <$out>);
 
-    my $request = HTTP::Request->new(POST => $self->{url}, ($self->{headers} || undef), $buf);
+    my $request = HTTP::Request->new(POST => $self->{url}, undef, $buf);
+    map { $request->header($_ => $self->{headers}->{$_}) } keys %{$self->{headers}};
     my $response = $ua->request($request);
     my $content_ref = $response->content_ref;
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This fixes a bug in the headers being passed into HTTP::Request. Previously these were being set as a hash reference which is incorrect as it should be either an HTTP::Headers object or an array reference. The details are in the Jira issue.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
