### PR TITLE
workaround MSVC compiler bug

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_generator.h
@@ -419,7 +419,9 @@ public:
     old_file.open(output_file_path.c_str(), std::ios::in);
 
     if (old_file) {
-      std::string const old_file_contents(static_cast<std::ostringstream const&>(std::ostringstream() << old_file.rdbuf()).str());
+      std::ostringstream oss;
+      oss << old_file.rdbuf();
+      std::string const old_file_contents(oss.str());
       old_file.close();
 
       if (old_file_contents != str()) {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
On recent MSVC versions, the thrift compiler fails to build under C++17 or C++20 -- as far as I can tell this is a bug in MSVC.
Splitting that clever "read the whole file into a string"-line into several seems to avoid it, with no functional change.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->