### PR TITLE
THRIFT-5544: add java code gen param to support including field annotation as metadata

### DIFF
--- a/lib/java/gradle/generateTestThrift.gradle
+++ b/lib/java/gradle/generateTestThrift.gradle
@@ -86,6 +86,7 @@ task generateJava(group: 'Build') {
     thriftCompile(it, 'EnumContainersTest.thrift')
     thriftCompile(it, 'JavaBinaryDefault.thrift')
     thriftCompile(it, 'VoidMethExceptionsTest.thrift')
+    thriftCompile(it, 'AnnotationTest.thrift')
     thriftCompile(it, 'partial/thrift_test_schema.thrift')
 }
 
@@ -132,4 +133,13 @@ task generateUnsafeBinariesJava(group: 'Build') {
     ext.outputBuffer = new ByteArrayOutputStream()
 
     thriftCompile(it, 'UnsafeTypes.thrift', 'java:unsafe_binaries', genUnsafeSrc)
+}
+
+task generateWithAnnotationMetadata(group: 'Build') {
+    description = 'Generate with annotation enabled and add to the default source'
+    generate.dependsOn it
+
+    ext.outputBuffer = new ByteArrayOutputStream()
+
+    thriftCompile(it, 'JavaAnnotationTest.thrift', 'java:annotations_as_metadata', genSrc)
 }

--- a/lib/java/src/main/java/org/apache/thrift/meta_data/FieldMetaData.java
+++ b/lib/java/src/main/java/org/apache/thrift/meta_data/FieldMetaData.java
@@ -19,9 +19,14 @@
 
 package org.apache.thrift.meta_data;
 
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
@@ -42,18 +47,28 @@ public class FieldMetaData implements java.io.Serializable {
   public final String fieldName;
   public final byte requirementType;
   public final FieldValueMetaData valueMetaData;
-  private static final Map<Class<? extends TBase>, Map<? extends TFieldIdEnum, FieldMetaData>> structMap;
-  
-  static {
-    structMap = new ConcurrentHashMap<Class<? extends TBase>, Map<? extends TFieldIdEnum, FieldMetaData>>();
-  }
-  
+  private final Map<String, String> fieldAnnotations;
+  private static final Map<Class<? extends TBase>, Map<? extends TFieldIdEnum, FieldMetaData>> structMap = new ConcurrentHashMap<>();
+
   public FieldMetaData(String name, byte req, FieldValueMetaData vMetaData){
-    this.fieldName = name;
-    this.requirementType = req;
-    this.valueMetaData = vMetaData;
+    this(name, req, vMetaData, Collections.emptyMap());
   }
-  
+
+  public FieldMetaData(String fieldName, byte requirementType, FieldValueMetaData valueMetaData, Map<String, String> fieldAnnotations) {
+    this.fieldName = fieldName;
+    this.requirementType = requirementType;
+    this.valueMetaData = valueMetaData;
+    this.fieldAnnotations = fieldAnnotations;
+  }
+
+  /**
+   * @return an unmodifiable view of the annotations for this field, empty if no annotations present or code gen param
+   * is not turned on
+   */
+  public Map<String, String> getFieldAnnotations() {
+    return Collections.unmodifiableMap(fieldAnnotations);
+  }
+
   public static void addStructMetaDataMap(Class<? extends TBase> sClass, Map<? extends TFieldIdEnum, FieldMetaData> map){
     structMap.put(sClass, map);
   }

--- a/lib/java/src/test/java/org/apache/thrift/TestAnnotationMetadata.java
+++ b/lib/java/src/test/java/org/apache/thrift/TestAnnotationMetadata.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.junit.Assert;
+import org.junit.Test;
+import thrift.test.OneOfEachBeans;
+import thrift.test.annotations.OneOfEachBeansWithAnnotations;
+
+public class TestAnnotationMetadata {
+
+    @Test
+    public void testWithoutParamShouldGenerateEmpty() {
+        Map<? extends TFieldIdEnum, FieldMetaData> structMetaDataMap = FieldMetaData.getStructMetaDataMap(OneOfEachBeans.class);
+        {
+            Map<String, String> metadata = structMetaDataMap.get(OneOfEachBeans._Fields.I16_LIST).getFieldAnnotations();
+            Assert.assertEquals(Collections.emptyMap(), metadata);
+        }
+        {
+            Map<String, String> metadata = structMetaDataMap.get(OneOfEachBeans._Fields.A_BITE).getFieldAnnotations();
+            Assert.assertEquals(Collections.emptyMap(), metadata);
+        }
+    }
+
+    @Test
+    public void testGeneratedAnnotations() {
+        Map<? extends TFieldIdEnum, FieldMetaData> structMetaDataMap = FieldMetaData.getStructMetaDataMap(OneOfEachBeansWithAnnotations.class);
+        {
+            Map<String, String> metadata = structMetaDataMap.get(OneOfEachBeansWithAnnotations._Fields.I16_LIST).getFieldAnnotations();
+            Assert.assertEquals(Collections.emptyMap(), metadata);
+        }
+        {
+            Map<String, String> metadata = structMetaDataMap.get(OneOfEachBeansWithAnnotations._Fields.A_BITE).getFieldAnnotations();
+            Map<String, String> expected = new HashMap<>();
+            expected.put("compression", "false");
+            Assert.assertEquals(expected, metadata);
+        }
+    }
+}

--- a/lib/java/src/test/resources/JavaAnnotationTest.thrift
+++ b/lib/java/src/test/resources/JavaAnnotationTest.thrift
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test.annotations
+
+struct OneOfEachBeansWithAnnotations {
+  1: bool boolean_field,
+  2: byte a_bite (compression = "false"),
+  3: i16 integer16 (must_be_postive = "true"),
+  4: i32 integer32,
+  5: i64 integer64,
+  6: double double_precision (nan_inf_allowed = "false"),
+  7: string some_characters,
+  8: binary base64,
+  9: list<byte> byte_list (non_empty = "true"),
+  10: list<i16> i16_list,
+  11: list<i64> i64_list
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
add java code gen param to support including field annotation as metadata

Currently the code generator has a map of string to string field that denotes the "annotations" for a field: https://github.com/apache/thrift/blob/90ea2e8398eda32da8be0b3514516e7ad932a869/compiler/cpp/src/thrift/parse/t_field.h#L109

It is made available to generators such as JSON (in https://github.com/apache/thrift/blob/90ea2e8398eda32da8be0b3514516e7ad932a869/compiler/cpp/src/thrift/generate/t_json_generator.cc#L267-L274) to allow (runtime) interpretation of such metadata.

In Java, similar mechanism exists to register field metadata (via https://github.com/apache/thrift/blob/90ea2e8398eda32da8be0b3514516e7ad932a869/compiler/cpp/src/thrift/generate/t_java_generator.cc#L2862-L2865 which calls `org.apache.thrift.meta_data.FieldMetaData#addStructMetaDataMap` method to register into a centralized places. Such metadata is useful, e.g. the microservice framework Ameria [uses it][1] to dynamically proxy requests.

However the existing field metadata only contain information about field id, type, and name, but it does not contain annotations. Adding annotations will be useful for situations e.g. (these are useful enablement at user side, make possible if annotation is included)

- some static metadata is useful at runtime for dynamic operations, e.g. like what `deprecated` means in the context of a field, adding `obfuscated` allows the user site to decide to obfuscate detailed information
- allows for more richer and more type specific validation and transformation logic, e.g. since we can only have string as field type, adding `date_format="YYYY-MM-DD"` allows the thrift struct to be interpreted as a local date and thus can automatically be converted to java.time.LocalDate

This should be a back-compatible change as the default behavior is not to include the annotation. A second constructor can be added to allow included annotation to exist and register.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

[1]: https://github.com/line/armeria/blob/5c2efebc7ba2350540d0554f530c173a49eb4c19/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java#L553-L554
