### PR TITLE
fix binary protocol's first byte value description in thrift-rpc.md

### DIFF
--- a/doc/specs/thrift-rpc.md
+++ b/doc/specs/thrift-rpc.md
@@ -151,7 +151,7 @@ always slightly faster.
 ## Compatibility
 
 A server could automatically determine whether a client talks the binary protocol or the compact protocol by
-investigating the first byte. If the value is `1000 0001` or `0000 0000` (assuming a name shorter than ±16 MB) it is the
+investigating the first byte. If the value is `1000 0000` or `0000 0000` (assuming a name shorter than ±16 MB) it is the
 binary protocol. When the value is `1000 0010` it is talking the compact protocol.
 
 ## Framed vs. unframed transport


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

based on TBinaryProtocol.java, the strictWrite would write VERSION_1 | message.type  first. and the first byte would be 0x80. but in thrift-rpc.md, it's described as 0x81.