### PR TITLE
THRIFT-4100: Extract Rust read/write struct methods into a trait

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -571,7 +571,7 @@ void t_rs_generator::render_attributes_and_includes() {
   f_gen_ << endl;
   f_gen_ << "use thrift::OrderedFloat;" << endl;
   f_gen_ << "use thrift::{ApplicationError, ApplicationErrorKind, ProtocolError, ProtocolErrorKind, TThriftClient};" << endl;
-  f_gen_ << "use thrift::protocol::{TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TInputProtocol, TOutputProtocol, TSetIdentifier, TStructIdentifier, TType};" << endl;
+  f_gen_ << "use thrift::protocol::{TFieldIdentifier, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TInputProtocol, TOutputProtocol, TSerializable, TSetIdentifier, TStructIdentifier, TType};" << endl;
   f_gen_ << "use thrift::protocol::field_id;" << endl;
   f_gen_ << "use thrift::protocol::verify_expected_message_type;" << endl;
   f_gen_ << "use thrift::protocol::verify_expected_sequence_number;" << endl;
@@ -933,10 +933,17 @@ void t_rs_generator::render_enum_impl(t_enum* tenum, const string& enum_name) {
     f_gen_ << indent() << "];" << endl;
   }
 
+  indent_down();
+  f_gen_ << "}" << endl;
+  f_gen_ << endl;
+
+  f_gen_ << "impl TSerializable for " << enum_name << " {" << endl;
+  indent_up();
+
   f_gen_ << indent() << "#[allow(clippy::trivially_copy_pass_by_ref)]" << endl;
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
+    << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
   f_gen_ << indent() << "o_prot.write_i32(self.0)" << endl;
@@ -945,7 +952,7 @@ void t_rs_generator::render_enum_impl(t_enum* tenum, const string& enum_name) {
 
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << enum_name << "> {"
+    << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << enum_name << "> {"
     << endl;
   indent_up();
   f_gen_ << indent() << "let enum_value = i_prot.read_i32()?;" << endl;
@@ -1185,12 +1192,21 @@ void t_rs_generator::render_struct_impl(
     render_struct_constructor(struct_name, tstruct, struct_type);
   }
 
-  render_struct_sync_read(struct_name, tstruct, struct_type);
-  render_struct_sync_write(tstruct, struct_type);
-
   if (struct_type == t_rs_generator::T_RESULT) {
     render_result_struct_to_result_method(tstruct);
   }
+
+  if (struct_type == t_rs_generator::T_REGULAR || struct_type == t_rs_generator::T_EXCEPTION) {
+    indent_down();
+    f_gen_ << "}" << endl;
+    f_gen_ << endl;
+
+    f_gen_ << "impl TSerializable for " << struct_name << " {" << endl;
+    indent_up();
+  }
+
+  render_struct_sync_read(struct_name, tstruct, struct_type);
+  render_struct_sync_write(tstruct, struct_type);
 
   indent_down();
   f_gen_ << "}" << endl;
@@ -1427,7 +1443,7 @@ void t_rs_generator::render_union_definition(const string& union_name, t_struct*
 }
 
 void t_rs_generator::render_union_impl(const string& union_name, t_struct* tstruct) {
-  f_gen_ << "impl " << union_name << " {" << endl;
+  f_gen_ << "impl TSerializable for " << union_name << " {" << endl;
   indent_up();
 
   render_union_sync_read(union_name, tstruct);
@@ -1450,7 +1466,6 @@ void t_rs_generator::render_struct_sync_write(
 ) {
   f_gen_
     << indent()
-    << visibility_qualifier(struct_type)
     << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
@@ -1483,7 +1498,7 @@ void t_rs_generator::render_struct_sync_write(
 void t_rs_generator::render_union_sync_write(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
+    << "fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {"
     << endl;
   indent_up();
 
@@ -1723,7 +1738,6 @@ void t_rs_generator::render_struct_sync_read(
 ) {
   f_gen_
     << indent()
-    << visibility_qualifier(struct_type)
     << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << struct_name << "> {"
     << endl;
 
@@ -1846,7 +1860,7 @@ void t_rs_generator::render_struct_sync_read(
 void t_rs_generator::render_union_sync_read(const string &union_name, t_struct *tstruct) {
   f_gen_
     << indent()
-    << "pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << union_name << "> {"
+    << "fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<" << union_name << "> {"
     << endl;
   indent_up();
 

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -102,6 +102,14 @@ pub use self::compact::{
 pub use self::multiplexed::TMultiplexedOutputProtocol;
 pub use self::stored::TStoredInputProtocol;
 
+/// Reads and writes the struct to Thrift protocols.
+///
+/// It is implemented in generated code for Thrift `struct`, `union`, and `enum` types.
+pub trait TSerializable: Sized {
+    fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> crate::Result<Self>;
+    fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> crate::Result<()>;
+}
+
 // Default maximum depth to which `TInputProtocol::skip` will skip a Thrift
 // field. A default is necessary because Thrift structs or collections may
 // contain nested structs and collections, which could result in indefinite


### PR DESCRIPTION
Client: rs

In order for code to be generic over any generated Thrift object, extract the read and write methods into a `trait`.

[THRIFT-4100](https://issues.apache.org/jira/browse/THRIFT-4100)