### PR TITLE
Fix bug in THttpClient proxy handling

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -100,7 +100,7 @@ class THttpClient(TTransportBase):
         ap = "%s:%s" % (urllib.parse.unquote(proxy.username),
                         urllib.parse.unquote(proxy.password))
         cr = base64.b64encode(ap.encode()).strip()
-        return "Basic " + cr
+        return "Basic " + cr.decode()
 
     def using_proxy(self):
         return self.realhost is not None


### PR DESCRIPTION
Previously, creating an instance of this class would throw whenever the http(s)_proxy environment variables were set, since it tried concatenating a string with a bytes array.