### PR TITLE
THRIFT-5565: travis ci to use xenial as base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@
 #
 # Docker Integration
 # see: build/docker/README.md
-# 
+#
 
 sudo: required
-dist: trusty
+# https://docs.travis-ci.com/user/reference/linux
+dist: xenial
 language: cpp
 
 services:


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
travis ci to use xenial as base image  

currently the base image for travis ci is trusty but currently the default is xenial. the ci job itself is done with docker image so upgrading should be easy and low risk.

upgrading to using default distro may improve the wait time for CI given it's the default now and a more recent distro

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
