### PR TITLE
Update Go versions used in travis and LANGUAGES.md

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -151,7 +151,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.16.13</td><td>1.17.6</td>
+<!-- Language Levels -------><td>1.17.9</td><td>1.18.1</td>
 <!-- Low-Level Transports --><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cred.png" alt=""/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Protocols -------------><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td><td><img src="doc/images/cgrn.png" alt="Yes"/></td>

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -132,9 +132,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18.1
 ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
             tar -C /usr/local -xzf golang.tar.gz && \

--- a/build/docker/ubuntu-disco/Dockerfile
+++ b/build/docker/ubuntu-disco/Dockerfile
@@ -131,9 +131,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.17.6
+ENV GOLANG_VERSION 1.18.1
 ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+ENV GOLANG_DOWNLOAD_SHA256 b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
             tar -C /usr/local -xzf golang.tar.gz && \

--- a/build/docker/ubuntu-xenial/Dockerfile
+++ b/build/docker/ubuntu-xenial/Dockerfile
@@ -136,9 +136,9 @@ RUN apt-get install -y --no-install-recommends \
       libglib2.0-dev
 
 # golang
-ENV GOLANG_VERSION 1.16.13
+ENV GOLANG_VERSION 1.17.9
 ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 275fc03c90c13b0bbff13125a43f1f7a9f9c00a0d5a9f2d5b16dbc2fa2c6e12a
+ENV GOLANG_DOWNLOAD_SHA256 9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz && \
       echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - && \
       tar -C /usr/local -xzf golang.tar.gz && \

--- a/configure.ac
+++ b/configure.ac
@@ -360,6 +360,7 @@ if test "$with_go" = "yes";  then
     AS_IF([test -n "$GO"],[
       ax_go_version="1.4"
       ax_go17_version="1.7"
+      ax_go118_version="1.18"
 
       AC_MSG_CHECKING([for Go version])
       golang_version=`$GO version 2>&1 | $SED -e 's/\(go \)\(version \)\(go\)\(@<:@0-9@:>@.@<:@0-9@:>@.@<:@0-9@:>@\)\(@<:@\*@:>@*\).*/\4/'`
@@ -379,6 +380,13 @@ if test "$with_go" = "yes";  then
       :
         go_version_lt_17="no"
       ])
+      AX_COMPARE_VERSION([$golang_version],[ge],[$ax_go118_version],[
+      :
+        go_version_ge_118="yes"
+      ],[
+      :
+        go_version_ge_118="no"
+      ])
     ],[
       AC_MSG_WARN([could not find Go ])
       have_go="no"
@@ -387,6 +395,7 @@ if test "$with_go" = "yes";  then
 fi
 AM_CONDITIONAL(WITH_GO, [test "$have_go" = "yes"])
 AM_CONDITIONAL([GOVERSION_LT_17], [test "$go_version_lt_17" = "yes"])
+AM_CONDITIONAL([GOVERSION_GE_118], [test "$go_version_ge_118" = "yes"])
 
 AX_THRIFT_LIB(swift, [Swift], yes)
 have_swift="no"

--- a/lib/go/Makefile.am
+++ b/lib/go/Makefile.am
@@ -23,6 +23,12 @@ if WITH_TESTS
 SUBDIRS += test test/fuzz
 endif
 
+if GOVERSION_GE_118
+GOBUILDEXTRA = -buildvcs=false
+else
+GOBUILDEXTRA =
+endif
+
 install:
 	@echo '##############################################################'
 	@echo '##############################################################'
@@ -30,14 +36,17 @@ install:
 	@echo '##############################################################'
 	@echo '##############################################################'
 
+# NOTE: We have to disable stdmethods in go vet until
+# https://github.com/golang/go/issues/52445 is fixed.
 check-local:
+	$(GO) vet -mod=mod -stdmethods=false github.com/apache/thrift/lib/go/thrift
 	$(GO) test -mod=mod -race ./thrift
 
 clean-local:
 	$(RM) -rf pkg
 
 all-local:
-	$(GO) build -mod=mod ./thrift
+	$(GO) build $(GOBUILDEXTRA) -mod=mod ./thrift
 
 EXTRA_DIST = \
 	thrift \

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -17,6 +17,12 @@
 # under the License.
 #
 
+if GOVERSION_GE_118
+GOBUILDEXTRA = -buildvcs=false
+else
+GOBUILDEXTRA =
+endif
+
 THRIFTARGS = -out gopath/src/ --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift,package_prefix=github.com/apache/thrift/lib/go/test/gopath/src/$(COMPILER_EXTRAFLAG)
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 
@@ -91,7 +97,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	touch gopath
 
 check: gopath
-	$(GO) build -mod=mod \
+	$(GO) build $(GOBUILDEXTRA) -mod=mod \
 				./gopath/src/includestest \
 				./gopath/src/binarykeytest \
 				./gopath/src/servicestest \

--- a/lib/go/test/fuzz/Makefile.am
+++ b/lib/go/test/fuzz/Makefile.am
@@ -33,4 +33,4 @@ EXTRA_DIST = \
 	fuzz.go \
 	fuzz_test.go \
 	go.mod \
-	go.sum 
+	go.sum

--- a/lib/go/thrift/binary_protocol.go
+++ b/lib/go/thrift/binary_protocol.go
@@ -130,7 +130,6 @@ func (p *TBinaryProtocol) WriteMessageBegin(ctx context.Context, name string, ty
 		e = p.WriteI32(ctx, seqId)
 		return e
 	}
-	return nil
 }
 
 func (p *TBinaryProtocol) WriteMessageEnd(ctx context.Context) error {

--- a/lib/go/thrift/protocol.go
+++ b/lib/go/thrift/protocol.go
@@ -180,5 +180,4 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 	default:
 		return NewTProtocolExceptionWithType(INVALID_DATA, fmt.Errorf("Unknown data type %d", fieldType))
 	}
-	return nil
 }

--- a/lib/go/thrift/serializer_test.go
+++ b/lib/go/thrift/serializer_test.go
@@ -258,11 +258,13 @@ func TestSerializerPoolAsync(t *testing.T) {
 					}
 					str, err := s.WriteString(context.Background(), &m)
 					if err != nil {
-						t.Fatal("serialize:", err)
+						t.Error("serialize:", err)
+						return
 					}
 					var m1 MyTestStruct
 					if err = d.ReadString(context.Background(), &m1, str); err != nil {
-						t.Fatal("deserialize:", err)
+						t.Error("deserialize:", err)
+						return
 
 					}
 

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -19,6 +19,12 @@
 
 BUILT_SOURCES = gopath
 
+if GOVERSION_GE_118
+GOINSTALLEXTRA = -buildvcs=false
+else
+GOINSTALLEXTRA =
+endif
+
 THRIFTCMD = $(THRIFT) -out src/gen --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift,package_prefix=github.com/apache/thrift/test/go/src/gen/$(COMPILER_EXTRAFLAG)
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 
@@ -37,13 +43,13 @@ gopath: $(THRIFT) ThriftTest.thrift
 	touch gopath
 
 bin/testclient: gopath
-	GOPATH=`pwd` $(GO) install -mod=mod ./src/bin/testclient
+	GOPATH=`pwd` $(GO) install $(GOINSTALLEXTRA) -mod=mod ./src/bin/testclient
 
 bin/testserver: gopath
-	GOPATH=`pwd` $(GO) install -mod=mod ./src/bin/testserver
+	GOPATH=`pwd` $(GO) install $(GOINSTALLEXTRA) -mod=mod ./src/bin/testserver
 
 bin/stress: gopath
-	GOPATH=`pwd` $(GO) install -mod=mod ./src/bin/stress
+	GOPATH=`pwd` $(GO) install $(GOINSTALLEXTRA) -mod=mod ./src/bin/stress
 
 clean-local:
 	$(RM) -r src/gen src/github.com/golang src/thrift bin pkg gopath ThriftTest.thrift

--- a/test/go/genmock.sh
+++ b/test/go/genmock.sh
@@ -4,7 +4,7 @@ set -e
 
 export GOPATH=$(mktemp -d -t gopath-XXXXXXXXXX)
 
-GO111MODULE=on go install -mod=mod github.com/golang/mock/mockgen
+go install -mod=mod github.com/golang/mock/mockgen
 
 `go env GOPATH`/bin/mockgen -build_flags "-mod=mod" -destination=src/common/mock_handler.go -package=common github.com/apache/thrift/test/go/src/gen/thrifttest ThriftTest
 

--- a/tutorial/go/Makefile.am
+++ b/tutorial/go/Makefile.am
@@ -17,14 +17,20 @@
 # under the License.
 #
 
+if GOVERSION_GE_118
+GOBUILDEXTRA = -buildvcs=false
+else
+GOBUILDEXTRA =
+endif
+
 gen-go/tutorial/calculator.go gen-go/shared/shared_service.go: $(top_srcdir)/tutorial/tutorial.thrift
 	$(THRIFT) --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift,package_prefix=github.com/apache/thrift/tutorial/go/gen-go/$(COMPILER_EXTRAFLAG) -r $<
 
 all-local: gen-go/tutorial/calculator.go
 
 check: thirdparty-dep all
-	$(GO) build -mod=mod -o go-tutorial ./src
-	$(GO) build -mod=mod -o calculator-remote ./gen-go/tutorial/calculator-remote/calculator-remote.go
+	$(GO) build $(GOBUILDEXTRA) -mod=mod -o go-tutorial ./src
+	$(GO) build $(GOBUILDEXTRA) -mod=mod -o calculator-remote ./gen-go/tutorial/calculator-remote/calculator-remote.go
 
 thirdparty-dep:
 


### PR DESCRIPTION
Client: go

Per our support policy, drop support of go 1.16 and add support of go
1.18.

Also enable go vet in make check, and fix issues reported by go vet.
