### PR TITLE
THRIFT-5567: remove cl namespace references

### DIFF
--- a/tutorial/shared.thrift
+++ b/tutorial/shared.thrift
@@ -22,7 +22,6 @@
  * these definitions.
  */
 
-namespace cl shared
 namespace cpp shared
 namespace d share // "shared" would collide with the eponymous D keyword.
 namespace dart shared

--- a/tutorial/tutorial.thrift
+++ b/tutorial/tutorial.thrift
@@ -63,7 +63,6 @@ include "shared.thrift"
  * target languages.
  */
 
-namespace cl tutorial
 namespace cpp tutorial
 namespace d tutorial
 namespace dart tutorial


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
warnings in build:

```
generate:
     [exec] [WARNING:/opt/thrift/src/tutorial/shared.thrift:26] No generator named 'cl' could be found!
     [exec] [WARNING:/opt/thrift/src/tutorial/tutorial.thrift:67] No generator named 'cl' could be found!
```  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
