### PR TITLE
THRIFT-5569: add negative size checks in Go generator when reading maps, sets and lists

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -3369,6 +3369,9 @@ void t_go_generator::generate_deserialize_container(ostream& out,
   // Declare variables, read header
   if (ttype->is_map()) {
     out << indent() << "_, _, size, err := iprot.ReadMapBegin(ctx)" << endl;
+    out << indent() << "if size < 0 {" << endl;
+    out << indent() << "  return errors.New(\"map size is negative\")" << endl;
+    out << indent() << "}" << endl;
     out << indent() << "if err != nil {" << endl;
     out << indent() << "  return thrift.PrependError(\"error reading map begin: \", err)" << endl;
     out << indent() << "}" << endl;
@@ -3376,6 +3379,9 @@ void t_go_generator::generate_deserialize_container(ostream& out,
     out << indent() << prefix << eq << " " << (pointer_field ? "&" : "") << "tMap" << endl;
   } else if (ttype->is_set()) {
     out << indent() << "_, size, err := iprot.ReadSetBegin(ctx)" << endl;
+    out << indent() << "if size < 0 {" << endl;
+    out << indent() << "  return errors.New(\"set size is negative\")" << endl;
+    out << indent() << "}" << endl;
     out << indent() << "if err != nil {" << endl;
     out << indent() << "  return thrift.PrependError(\"error reading set begin: \", err)" << endl;
     out << indent() << "}" << endl;
@@ -3383,6 +3389,9 @@ void t_go_generator::generate_deserialize_container(ostream& out,
     out << indent() << prefix << eq << " " << (pointer_field ? "&" : "") << "tSet" << endl;
   } else if (ttype->is_list()) {
     out << indent() << "_, size, err := iprot.ReadListBegin(ctx)" << endl;
+    out << indent() << "if size < 0 {" << endl;
+    out << indent() << "  return errors.New(\"list size is negative\")" << endl;
+    out << indent() << "}" << endl;
     out << indent() << "if err != nil {" << endl;
     out << indent() << "  return thrift.PrependError(\"error reading list begin: \", err)" << endl;
     out << indent() << "}" << endl;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This adds a negative size checks in the Go generator for code generated when reading maps, sets and lists.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
