### PR TITLE
THRIFT-5572: add travis_wait for rebuilding docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ services:
   - docker
 
 install:
-  - if [[ `uname` == "Linux" ]]; then build/docker/refresh.sh; fi
+  # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+  # adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
+  # without printing to stdout, resulting in build failures
+  - if [[ `uname` == "Linux" ]]; then travis_wait build/docker/refresh.sh; fi
 
 stages:
   - docker    # docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,7 @@ services:
   - docker
 
 install:
-  # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-  # adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
-  # without printing to stdout, resulting in build failures
-  - if [[ `uname` == "Linux" ]]; then travis_wait build/docker/refresh.sh; fi
+  - if [[ `uname` == "Linux" ]]; then build/docker/refresh.sh; fi
 
 stages:
   - docker    # docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ services:
   - docker
 
 install:
-  - if [[ `uname` == "Linux" ]]; then build/docker/refresh.sh; fi
+  # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+  # adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
+  # without printing to stdout, resulting in build failures
+  - if [[ `uname` == "Linux" ]]; then travis_wait 45 build/docker/refresh.sh; fi
 
 stages:
   - docker    # docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
   # adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
   # without printing to stdout, resulting in build failures
-  - if [[ `uname` == "Linux" ]]; then travis_wait 45 build/docker/refresh.sh; fi
+  - if [[ `uname` == "Linux" ]]; then travis_wait 40 build/docker/refresh.sh; fi
 
 stages:
   - docker    # docker images

--- a/build/docker/refresh.sh
+++ b/build/docker/refresh.sh
@@ -43,7 +43,7 @@ function dockerfile_changed {
 #
 # If this build has no DOCKER_PASS and it is in the docker stage
 # then there's no reason to do any processing because we cannot
-# push the result if the Dockerfile changed.
+# push the result if the Dockerfile changed.  
 #
 
 if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ -z "$DOCKER_PASS" ]]; then
@@ -70,13 +70,9 @@ popd
 #
 
 echo Rebuilding docker image $DISTRO
+docker build --tag $DOCKER_TAG build/docker/$DISTRO
 
-# https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-# adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
-# without printing to stdout, resulting in build failures
-travis_wait 45 docker build --tag $DOCKER_TAG build/docker/$DISTRO
-
-if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ ! -z "$DOCKER_USER" ]] && [[ ! -z "$DOCKER_PASS" ]]; then
+if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ ! -z "$DOCKER_USER" ]] && [[ ! -z "$DOCKER_PASS" ]]; then 
   echo Pushing docker image $DOCKER_TAG
   docker login -u $DOCKER_USER -p $DOCKER_PASS
   docker push $DOCKER_TAG

--- a/build/docker/refresh.sh
+++ b/build/docker/refresh.sh
@@ -43,7 +43,7 @@ function dockerfile_changed {
 #
 # If this build has no DOCKER_PASS and it is in the docker stage
 # then there's no reason to do any processing because we cannot
-# push the result if the Dockerfile changed.  
+# push the result if the Dockerfile changed.
 #
 
 if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ -z "$DOCKER_PASS" ]]; then
@@ -70,9 +70,13 @@ popd
 #
 
 echo Rebuilding docker image $DISTRO
-docker build --tag $DOCKER_TAG build/docker/$DISTRO
 
-if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ ! -z "$DOCKER_USER" ]] && [[ ! -z "$DOCKER_PASS" ]]; then 
+# https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+# adding `travis_wait` because kerl building in the docker file takes >10 min for building erlang
+# without printing to stdout, resulting in build failures
+travis_wait 45 docker build --tag $DOCKER_TAG build/docker/$DISTRO
+
+if [[ "$TRAVIS_BUILD_STAGE" == "docker" ]] && [[ ! -z "$DOCKER_USER" ]] && [[ ! -z "$DOCKER_PASS" ]]; then
   echo Pushing docker image $DOCKER_TAG
   docker login -u $DOCKER_USER -p $DOCKER_PASS
   docker push $DOCKER_TAG


### PR DESCRIPTION
because building image requires kerl to build erlang, which requires >10
min to build and meanwhile not printing to stdout, failing the travis
build

Currently the travis CI is broken because the step when kerl is building erlang OTP from source but the build process produces no output for >10 mins and travis will then fail the build if no output is detected.

The max number of build errors has been reached so now the travis CI build is suspended.

The easy fix is to allow travis to wait a bit longer (the erlang build itself takes around 1100 seconds).

<!-- Explain the changes in the pull request below: -->

this is a follow up on:
- https://github.com/apache/thrift/pull/2541

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
