### PR TITLE
THRIFT-5559: Make handler public in Rust codegen

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -2570,7 +2570,7 @@ void t_rs_generator::render_sync_processor_definition_and_impl(t_service *tservi
     << "> {"
     << endl;
   indent_up();
-  f_gen_ << indent() << "handler: H," << endl;
+  f_gen_ << indent() << "pub handler: H," << endl;
   indent_down();
   f_gen_ << indent() << "}" << endl;
   f_gen_ << endl;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Previously it was not possible to access the handler object after it was passed to the service processor. This practically prevents the use of any state which is not wrapped by a reference counted pointer. Especially in single-threaded scenarios, this may be undesirable.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ x ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ x ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ x ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ x ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
