### PR TITLE
THRIFT-5576: fix old-style cast and redundant copy

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -781,8 +781,9 @@ void t_cpp_generator::print_const_value(ostream& out,
     string v2 = render_const_value(out, name, type, value);
     indent(out) << name << " = " << v2 << ";" << endl << endl;
   } else if (type->is_enum()) {
-    indent(out) << name << " = (" << type_name(type) << ")" << value->get_integer() << ";" << endl
-                << endl;
+    indent(out) << name
+                << " = static_cast<" << type_name(type) << '>'
+                << '(' << value->get_integer() << ");" << endl << endl;
   } else if (type->is_struct() || type->is_xception()) {
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();
     vector<t_field*>::const_iterator f_iter;
@@ -801,8 +802,8 @@ void t_cpp_generator::print_const_value(ostream& out,
       if (field_type == nullptr) {
         throw "type error: " + type->get_name() + " has no field " + v_iter->first->get_string();
       }
-      string val = render_const_value(out, name, field_type, v_iter->second);
-      indent(out) << name << "." << v_iter->first->get_string() << " = " << val << ";" << endl;
+      string item_val = render_const_value(out, name, field_type, v_iter->second);
+      indent(out) << name << "." << v_iter->first->get_string() << " = " << item_val << ";" << endl;
       if (is_nonrequired_field) {
         indent(out) << name << ".__isset." << v_iter->first->get_string() << " = true;" << endl;
       }
@@ -815,8 +816,8 @@ void t_cpp_generator::print_const_value(ostream& out,
     map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       string key = render_const_value(out, name, ktype, v_iter->first);
-      string val = render_const_value(out, name, vtype, v_iter->second);
-      indent(out) << name << ".insert(std::make_pair(" << key << ", " << val << "));" << endl;
+      string item_val = render_const_value(out, name, vtype, v_iter->second);
+      indent(out) << name << ".insert(std::make_pair(" << key << ", " << item_val << "));" << endl;
     }
     out << endl;
   } else if (type->is_list()) {
@@ -824,8 +825,8 @@ void t_cpp_generator::print_const_value(ostream& out,
     const vector<t_const_value*>& val = value->get_list();
     vector<t_const_value*>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
-      string val = render_const_value(out, name, etype, *v_iter);
-      indent(out) << name << ".push_back(" << val << ");" << endl;
+      string item_val = render_const_value(out, name, etype, *v_iter);
+      indent(out) << name << ".push_back(" << item_val << ");" << endl;
     }
     out << endl;
   } else if (type->is_set()) {
@@ -833,8 +834,8 @@ void t_cpp_generator::print_const_value(ostream& out,
     const vector<t_const_value*>& val = value->get_list();
     vector<t_const_value*>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
-      string val = render_const_value(out, name, etype, *v_iter);
-      indent(out) << name << ".insert(" << val << ");" << endl;
+      string item_val = render_const_value(out, name, etype, *v_iter);
+      indent(out) << name << ".insert(" << item_val << ");" << endl;
     }
     out << endl;
   } else {
@@ -880,7 +881,8 @@ string t_cpp_generator::render_const_value(ostream& out,
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
   } else if (type->is_enum()) {
-    render << "(" << type_name(type) << ")" << value->get_integer();
+    render << "static_cast<" << type_name(type) << '>'
+           << '(' << value->get_integer() << ')';
   } else {
     string t = tmp("tmp");
     indent(out) << type_name(type) << " " << t << ";" << endl;
@@ -1203,8 +1205,7 @@ void t_cpp_generator::generate_struct_declaration(ostream& out,
     // do more of these in the initializer list.
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
       t_type* t = get_true_type((*m_iter)->get_type());
-
-      if (!t->is_base_type()) {
+      if (!t->is_base_type() && !t->is_enum() && !is_reference(*m_iter)) {
         t_const_value* cv = (*m_iter)->get_value();
         if (cv != nullptr) {
           print_const_value(out, (*m_iter)->get_name(), t, cv);


### PR DESCRIPTION

**_Generated was:_**
```CPP
class FU_LB : public virtual ::apache::thrift::TBase {
 public:

  FU_LB(const FU_LB&);
  FU_LB(FU_LB&&) noexcept;
  FU_LB& operator=(const FU_LB&);
  FU_LB& operator=(FU_LB&&) noexcept;
  FU_LB() noexcept
        : ctrl(0),
          op((FU_LIST_OP::type)0),
          pos(0) {
    op = (FU_LIST_OP::type)0;

  }

  virtual ~FU_LB() noexcept;
 ```
 
**_Generated became:_**
 ```CPP
class FU_LB : public virtual ::apache::thrift::TBase {
 public:

  FU_LB(const FU_LB&);
  FU_LB(FU_LB&&) noexcept;
  FU_LB& operator=(const FU_LB&);
  FU_LB& operator=(FU_LB&&) noexcept;
  FU_LB() noexcept
        : ctrl(0),
          op(static_cast<FU_LIST_OP::type>(0)),
          pos(0) {
  }

  virtual ~FU_LB() noexcept;
 ```
 
