### PR TITLE
Update ordered-float dependency to latest version

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["thrift"]
 byteorder = "1.3"
 integer-encoding = "3.0"
 log = {version = "0.4", optional = true}
-ordered-float = "2.0"
+ordered-float = "3.0"
 threadpool = {version = "1.7", optional = true}
 
 [features]


### PR DESCRIPTION
Version 2.0.0 had RUSTSEC advisory, see https://github.com/rustsec/advisory-db/blob/main/crates/ordered-float/RUSTSEC-2020-0082.md

2.0.1 resolved the issue but I figured this is a good opportunity to move to the latest version.

I did not create a JIRA issue since this is a trivial change, but I am happy to do that if needed.