### PR TITLE
Minor tweak to ErrAbandonRequest in go library

### DIFF
--- a/lib/go/thrift/simple_server_test.go
+++ b/lib/go/thrift/simple_server_test.go
@@ -287,3 +287,15 @@ func TestStopTimeoutWithSocketTimeout(t *testing.T) {
 		t.Fatalf("error when stop server:%v", err)
 	}
 }
+
+func TestErrAbandonRequest(t *testing.T) {
+	if !errors.Is(ErrAbandonRequest, ErrAbandonRequest) {
+		t.Error("errors.Is(ErrAbandonRequest, ErrAbandonRequest) returned false")
+	}
+	if !errors.Is(ErrAbandonRequest, context.Canceled) {
+		t.Error("errors.Is(ErrAbandonRequest, context.Canceled) returned false")
+	}
+	if errors.Is(context.Canceled, ErrAbandonRequest) {
+		t.Error("errors.Is(context.Canceled, ErrAbandonRequest) returned true")
+	}
+}


### PR DESCRIPTION
Client: go

Make it unwrap to context.Canceled, since the main use case of it is to
be returned in lieu of context.Canceled to avoid extra writing to the
client, so that if user has any processor middleware that checks for
context.Canceled error those would still work.
