### PR TITLE
THRIFT-5595: Avoid peek request with SSLSocket

### DIFF
--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -94,6 +94,9 @@ class TSocket(TSocketBase):
                 if exc.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
                     return True
                 return False
+            except ValueError:
+                # SSLSocket fails on recv with non-zero flags; fallback to the old behavior
+                return True
         finally:
             self.handle.settimeout(original_timeout)
 

--- a/lib/py/test/test_socket.py
+++ b/lib/py/test/test_socket.py
@@ -25,6 +25,7 @@ class TSocketTest(unittest.TestCase):
             acc.start()
 
             sock = TSocket(host="localhost", port=acc.port)
+            self.assertFalse(sock.isOpen())
             sock.open()
             sock.setTimeout(timeout)
 

--- a/lib/py/test/test_sslsocket.py
+++ b/lib/py/test/test_sslsocket.py
@@ -158,7 +158,9 @@ class TSSLSocketTest(unittest.TestCase):
     def _assert_connection_success(self, server, path=None, **client_args):
         with self._connectable_client(server, path=path, **client_args) as (acc, client):
             try:
+                self.assertFalse(client.isOpen())
                 client.open()
+                self.assertTrue(client.isOpen())
                 client.write(b"hello")
                 self.assertEqual(client.read(5), b"there")
                 self.assertTrue(acc.client is not None)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
The update to TSocket in https://github.com/MikaelSmith/thrift/commit/01d53f483a7531ad4899b522060e8913dca309fb errors for TSSLSocket with
```
ValueError: non-zero flags not allowed in calls to recv() on <class 'ssl.SSLSocket'>
```
Handles ValueError from ssl.SSLSocket to fix isOpen when using TSSLSocket.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
