### PR TITLE
THRIFT-5599: contrib/fb303 does not compile after C++ library refactorings

### DIFF
--- a/contrib/fb303/cpp/FacebookBase.h
+++ b/contrib/fb303/cpp/FacebookBase.h
@@ -33,11 +33,10 @@
 namespace facebook { namespace fb303 {
 
 using apache::thrift::concurrency::Mutex;
-using apache::thrift::concurrency::ReadWriteMutex;
 using apache::thrift::server::TServer;
 
-struct ReadWriteInt : ReadWriteMutex {int64_t value;};
-struct ReadWriteCounterMap : ReadWriteMutex,
+struct ReadWriteInt : Mutex {int64_t value;};
+struct ReadWriteCounterMap : Mutex,
                              std::map<std::string, ReadWriteInt> {};
 
 /**

--- a/contrib/fb303/cpp/Makefile.am
+++ b/contrib/fb303/cpp/Makefile.am
@@ -47,7 +47,7 @@ AM_CPPFLAGS += $(FB_CPPFLAGS) $(DEBUG_CPPFLAGS)
 # Use <progname|libname>_<FLAG> to set prog / lib specific flag s
 # foo_CXXFLAGS foo_CPPFLAGS foo_LDFLAGS foo_LDADD
 
-fb303_lib = gen-cpp/FacebookService.cpp gen-cpp/fb303_constants.cpp gen-cpp/fb303_types.cpp FacebookBase.cpp ServiceTracker.cpp
+fb303_lib = gen-cpp/FacebookService.cpp gen-cpp/fb303_types.cpp FacebookBase.cpp ServiceTracker.cpp
 
 # Static -- multiple libraries can be defined
 if STATIC
@@ -71,7 +71,7 @@ endif
 $(eval $(call thrift_template,.,../if/fb303.thrift,-I $(thrift_home)/share  --gen cpp:pure_enums ))
 
 include_fb303dir = $(includedir)/thrift/fb303
-include_fb303_HEADERS = FacebookBase.h ServiceTracker.h gen-cpp/FacebookService.h gen-cpp/fb303_constants.h gen-cpp/fb303_types.h
+include_fb303_HEADERS = FacebookBase.h ServiceTracker.h gen-cpp/FacebookService.h gen-cpp/fb303_types.h
 
 include_fb303ifdir = $(prefix)/share/fb303/if
 include_fb303if_HEADERS = ../if/fb303.thrift


### PR DESCRIPTION
contrib/fb303 no longer compiles after [THRIFT-4730](https://issues.apache.org/jira/browse/THRIFT-4730) removed ReadWriteMutex.

The ReadWriteMutex used by fb303 is protecting counter statistics. These are very write-heavy and read-light (these are read only when the Service methods getCounters() or getCounter() are called). Because of this, retaining a read-write mutex to protect these counters is unjustified and we can safely swap this out for a normal Mutex.

Compilation also fails after [THRIFT-5168](https://issues.apache.org/jira/browse/THRIFT-5168) removed generation of *_constants.cpp and *_constants.h generation because the fb303 Makefile explicitly depends on these unnecessary files
