### PR TITLE
THRIFT-5602: Use std::unique_ptr instead of boost::scoped_array

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -23,7 +23,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-#include <boost/scoped_array.hpp>
 
 #include <thrift/transport/TTransport.h>
 #include <thrift/transport/TVirtualTransport.h>
@@ -281,8 +280,8 @@ protected:
 
   uint32_t rBufSize_;
   uint32_t wBufSize_;
-  boost::scoped_array<uint8_t> rBuf_;
-  boost::scoped_array<uint8_t> wBuf_;
+  std::unique_ptr<uint8_t[]> rBuf_;
+  std::unique_ptr<uint8_t[]> wBuf_;
 };
 
 /**
@@ -422,8 +421,8 @@ protected:
 
   uint32_t rBufSize_;
   uint32_t wBufSize_;
-  boost::scoped_array<uint8_t> rBuf_;
-  boost::scoped_array<uint8_t> wBuf_;
+  std::unique_ptr<uint8_t[]> rBuf_;
+  std::unique_ptr<uint8_t[]> wBuf_;
   uint32_t bufReclaimThresh_;
   uint32_t maxFrameSize_;
 };

--- a/lib/cpp/src/thrift/transport/TFileTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TFileTransport.cpp
@@ -427,7 +427,7 @@ void TFileTransport::writerThread() {
 
             auto* zeros = new uint8_t[padding];
             memset(zeros, '\0', padding);
-            boost::scoped_array<uint8_t> array(zeros);
+            std::unique_ptr<uint8_t[]> array(zeros);
             if (-1 == ::THRIFT_WRITE(fd_, zeros, padding)) {
               int errno_copy = THRIFT_ERRNO;
               GlobalOutput.perror("TFileTransport: writerThread() error while padding zeros ",

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -33,8 +33,6 @@
 #include <inttypes.h>
 #endif
 
-#include <boost/scoped_array.hpp>
-
 #include <thrift/protocol/TProtocolTypes.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TTransport.h>
@@ -223,7 +221,7 @@ protected:
 
   // Buffers to use for transform processing
   uint32_t tBufSize_;
-  boost::scoped_array<uint8_t> tBuf_;
+  std::unique_ptr<uint8_t[]> tBuf_;
 
   void readString(uint8_t*& ptr, /* out */ std::string& str, uint8_t const* headerBoundary);
 

--- a/lib/cpp/test/TransportTest.cpp
+++ b/lib/cpp/test/TransportTest.cpp
@@ -379,7 +379,7 @@ void alarm_handler() {
   // Write some data to the transport to hopefully unblock it.
   auto* buf = new uint8_t[info->writeLength];
   memset(buf, 'b', info->writeLength);
-  boost::scoped_array<uint8_t> array(buf);
+  std::unique_ptr<uint8_t[]> array(buf);
   info->transport->write(buf, info->writeLength);
   info->transport->flush();
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

It seems that Apache Thrift wants to drop Boost dependency eventually.
See also: https://github.com/apache/thrift/blob/4646a3557b822c3893dc6773882a689118b77611/lib/cpp/CMakeLists.txt#L20-L21

    # Remove the following once lib/cpp no longer depends on boost headers:
    include(BoostMacros)

This is a step for it. We don't need to use boost::scoped_array because
we can use std::unique_ptr. We require C++11 or later and std::unique_ptr
can be used with C++11 or later.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
