### PR TITLE
THRIFT-5603: add operator == for TEnumIterator

### DIFF
--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -62,10 +62,8 @@ public:
     return ii_ == rhs.ii_ && n_ == rhs.n_;
   }
 
-  bool operator!=(const TEnumIterator& end) const {
-    THRIFT_UNUSED_VARIABLE(end);
-    assert(end.n_ == -1);
-    return (ii_ != n_);
+  bool operator!=(const TEnumIterator& rhs) const {
+    return ii_ != rhs.ii_ || n_ != rhs.n_;
   }
 
   std::pair<int, const char*> operator*() const { return std::make_pair(enums_[ii_], names_[ii_]); }

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -59,11 +59,15 @@ public:
   int operator++() { return ++ii_; }
 
   bool operator==(const TEnumIterator& rhs) const {
-    return ii_ == rhs.ii_ && n_ == rhs.n_;
+    bool is_end = ii_ == n_ || n_ == -1;
+    bool is_rhs_end = rhs.ii_ == rhs.n_ || rhs.n_ == -1;
+    return (ii_ == rhs.ii_ && n_ == rhs.n_) || (is_end && is_rhs_end);
   }
 
   bool operator!=(const TEnumIterator& rhs) const {
-    return ii_ != rhs.ii_ || n_ != rhs.n_;
+    bool is_end = ii_ == n_ || n_ == -1;
+    bool is_rhs_end = rhs.ii_ == rhs.n_ || rhs.n_ == -1;
+    return (ii_ != rhs.ii_ || n_ != rhs.n_) && (!is_end || !is_rhs_end);
   }
 
   std::pair<int, const char*> operator*() const { return std::make_pair(enums_[ii_], names_[ii_]); }

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -64,11 +64,7 @@ public:
     return (ii_ == rhs.ii_ && n_ == rhs.n_) || (is_end && is_rhs_end);
   }
 
-  bool operator!=(const TEnumIterator& rhs) const {
-    bool is_end = ii_ == n_ || n_ == -1;
-    bool is_rhs_end = rhs.ii_ == rhs.n_ || rhs.n_ == -1;
-    return (ii_ != rhs.ii_ || n_ != rhs.n_) && (!is_end || !is_rhs_end);
-  }
+  bool operator!=(const TEnumIterator& rhs) const { return !(*this == rhs); }
 
   std::pair<int, const char*> operator*() const { return std::make_pair(enums_[ii_], names_[ii_]); }
 

--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -58,7 +58,11 @@ public:
 
   int operator++() { return ++ii_; }
 
-  bool operator!=(const TEnumIterator& end) {
+  bool operator==(const TEnumIterator& rhs) const {
+    return ii_ == rhs.ii_ && n_ == rhs.n_;
+  }
+
+  bool operator!=(const TEnumIterator& end) const {
     THRIFT_UNUSED_VARIABLE(end);
     assert(end.n_ == -1);
     return (ii_ != n_);

--- a/lib/cpp/src/thrift/windows/Operators.h
+++ b/lib/cpp/src/thrift/windows/Operators.h
@@ -29,11 +29,6 @@ namespace thrift {
 
 class TEnumIterator;
 
-inline bool operator==(const TEnumIterator&, const TEnumIterator&) {
-  // Not entirely sure what the test should be here. It is only to enable
-  // iterator debugging and is not used in release mode.
-  return true;
-}
 }
 } // apache::thrift
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
We want to enable the compile option `-D_GLIBCXX_DEBUG` to find potential bugs, but we meet compile errors: [error_log.txt](https://issues.apache.org/jira/secure/attachment/13046360/13046360_error_log.txt)

Let's see the code in apache arrow project: https://github.com/apache/arrow/blob/984b59a2b4edb03479947c46007fc6142447f759/cpp/src/generated/parquet_types.cpp#L36

It constructs a std::map from a pair of iterators. However, in the debug mode of std::map (say, std::__debug::map), it will add additional check (such as boundary check) and need an operator == for these iterators.

So, I want to add an operator ==.

Apache Jira ticket: https://issues.apache.org/jira/browse/THRIFT-5603

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
