### PR TITLE
Add a generic sync.Pool wrapper to go library

### DIFF
--- a/lib/go/thrift/deserializer.go
+++ b/lib/go/thrift/deserializer.go
@@ -21,7 +21,6 @@ package thrift
 
 import (
 	"context"
-	"sync"
 )
 
 type TDeserializer struct {
@@ -81,7 +80,7 @@ func (t *TDeserializer) Read(ctx context.Context, msg TStruct, b []byte) (err er
 // It must be initialized with either NewTDeserializerPool or
 // NewTDeserializerPoolSizeFactory.
 type TDeserializerPool struct {
-	pool sync.Pool
+	pool *pool[TDeserializer]
 }
 
 // NewTDeserializerPool creates a new TDeserializerPool.
@@ -89,11 +88,7 @@ type TDeserializerPool struct {
 // NewTDeserializer can be used as the arg here.
 func NewTDeserializerPool(f func() *TDeserializer) *TDeserializerPool {
 	return &TDeserializerPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				return f()
-			},
-		},
+		pool: newPool(f, nil),
 	}
 }
 
@@ -104,28 +99,26 @@ func NewTDeserializerPool(f func() *TDeserializer) *TDeserializerPool {
 // larger than that. It just dictates the initial size.
 func NewTDeserializerPoolSizeFactory(size int, factory TProtocolFactory) *TDeserializerPool {
 	return &TDeserializerPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				transport := NewTMemoryBufferLen(size)
-				protocol := factory.GetProtocol(transport)
+		pool: newPool(func() *TDeserializer {
+			transport := NewTMemoryBufferLen(size)
+			protocol := factory.GetProtocol(transport)
 
-				return &TDeserializer{
-					Transport: transport,
-					Protocol:  protocol,
-				}
-			},
-		},
+			return &TDeserializer{
+				Transport: transport,
+				Protocol:  protocol,
+			}
+		}, nil),
 	}
 }
 
 func (t *TDeserializerPool) ReadString(ctx context.Context, msg TStruct, s string) error {
-	d := t.pool.Get().(*TDeserializer)
-	defer t.pool.Put(d)
+	d := t.pool.get()
+	defer t.pool.put(&d)
 	return d.ReadString(ctx, msg, s)
 }
 
 func (t *TDeserializerPool) Read(ctx context.Context, msg TStruct, b []byte) error {
-	d := t.pool.Get().(*TDeserializer)
-	defer t.pool.Put(d)
+	d := t.pool.get()
+	defer t.pool.put(&d)
 	return d.Read(ctx, msg, b)
 }

--- a/lib/go/thrift/http_client.go
+++ b/lib/go/thrift/http_client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -136,7 +135,7 @@ func (p *THttpClient) closeResponse() error {
 		// reused. Errors are being ignored here because if the connection is invalid
 		// and this fails for some reason, the Close() method will do any remaining
 		// cleanup.
-		io.Copy(ioutil.Discard, p.response.Body)
+		io.Copy(io.Discard, p.response.Body)
 
 		err = p.response.Body.Close()
 	}

--- a/lib/go/thrift/pool_test.go
+++ b/lib/go/thrift/pool_test.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+type poolTest int
+
+func TestPoolReset(t *testing.T) {
+	p := newPool(nil, func(elem *poolTest) {
+		*elem = 0
+	})
+	f := func(i int) (passed bool) {
+		pt := p.get()
+		defer func() {
+			p.put(&pt)
+			if pt != nil {
+				t.Errorf("Expected pt to be nil after put, got %#v", pt)
+				passed = false
+			}
+		}()
+		if *pt != 0 {
+			t.Errorf("Expected *pt to be reset to 0 after get, got %d", *pt)
+		}
+		*pt = poolTest(i)
+		return !t.Failed()
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/lib/go/thrift/protocol_test.go
+++ b/lib/go/thrift/protocol_test.go
@@ -22,7 +22,7 @@ package thrift
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -60,7 +60,7 @@ type HTTPEchoServer struct{}
 type HTTPHeaderEchoServer struct{}
 
 func (p *HTTPEchoServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	buf, err := ioutil.ReadAll(req.Body)
+	buf, err := io.ReadAll(req.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write(buf)
@@ -71,7 +71,7 @@ func (p *HTTPEchoServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (p *HTTPHeaderEchoServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	buf, err := ioutil.ReadAll(req.Body)
+	buf, err := io.ReadAll(req.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write(buf)

--- a/lib/go/thrift/simple_server_test.go
+++ b/lib/go/thrift/simple_server_test.go
@@ -201,11 +201,11 @@ func TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop(t *testing.T) {
 
 	netConn, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil || netConn == nil {
-		t.Fatal("error when dial server")
+		t.Fatalf("error when dial server: %v", err)
 	}
 	time.Sleep(networkWaitDuration)
 
-	serverStopTimeout := 50 * time.Millisecond
+	const serverStopTimeout = 50 * time.Millisecond
 	backupServerStopTimeout := ServerStopTimeout
 	t.Cleanup(func() {
 		ServerStopTimeout = backupServerStopTimeout
@@ -213,13 +213,12 @@ func TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop(t *testing.T) {
 	ServerStopTimeout = serverStopTimeout
 
 	st := time.Now()
-	err = serv.Stop()
-	if err != nil {
+	if err := serv.Stop(); err != nil {
 		t.Errorf("error when stop server:%v", err)
 	}
 
 	if elapsed := time.Since(st); elapsed < serverStopTimeout {
-		t.Errorf("stop cost less time than server stop timeout, server stop timeout:%v,cost time:%v", ServerStopTimeout, elapsed)
+		t.Errorf("stop cost less time than server stop timeout, server stop timeout:%v,cost time:%v", serverStopTimeout, elapsed)
 	}
 }
 


### PR DESCRIPTION
Since we dropped support of Go 1.18-, use generic to avoid dealing with
type assertions with interface{}/any.

While I'm here, also remove the usages of ioutil, as that's officially
marked as deprecated in Go 1.19.

Client: go
