### PR TITLE
Use openssl and zlib targets

### DIFF
--- a/lib/c_glib/CMakeLists.txt
+++ b/lib/c_glib/CMakeLists.txt
@@ -97,10 +97,16 @@ target_link_libraries(thrift_c_glib PUBLIC ${SYSLIBS})
 
 # If Zlib is not found just ignore the Zlib stuff
 if(WITH_ZLIB)
-    include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
     ADD_LIBRARY_THRIFT(thrift_c_glib_zlib ${thrift_c_glib_zlib_SOURCES})
-    target_link_libraries(thrift_c_glib_zlib ${SYSLIBS} ${ZLIB_LIBRARIES})
-    target_link_libraries(thrift_c_glib_zlib thrift_c_glib)
+    target_link_libraries(thrift_c_glib_zlib PUBLIC ${SYSLIBS})
+    target_link_libraries(thrift_c_glib_zlib PUBLIC thrift_c_glib)
+
+    if(TARGET ZLIB::ZLIB)
+        target_link_libraries(thrift_c_glib_zlib PUBLIC ZLIB::ZLIB)
+    else()
+        include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+        target_link_libraries(thrift_c_glib_zlib PUBLIC ${ZLIB_LIBRARIES})
+    endif()
 endif()
 
 # Install the headers

--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -182,11 +182,17 @@ endif()
 
 if(WITH_ZLIB)
     find_package(ZLIB REQUIRED)
-    include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
     ADD_LIBRARY_THRIFT(thriftz ${thriftcppz_SOURCES})
     target_link_libraries(thriftz PUBLIC thrift)
-    target_link_libraries(thriftz PUBLIC ${ZLIB_LIBRARIES})
+
+    if(TARGET ZLIB::ZLIB)
+        target_link_libraries(thriftz PUBLIC ZLIB::ZLIB)
+    else()
+        include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+        target_link_libraries(thriftz PUBLIC ${ZLIB_LIBRARIES})
+    endif()
+
     ADD_PKGCONFIG_THRIFT(thrift-z)
 endif()
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  If available the targets of OpenSSL and ZLIB should be used instead of library paths