### PR TITLE
THRIFT-5617: T(SSL)Socket TCP keep-alive incorrectly applies SO_KEEPA…

### DIFF
--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -131,9 +131,9 @@ class TSocket(TSocketBase):
         for family, socktype, _, _, sockaddr in addrs:
             handle = self._do_open(family, socktype)
 
-            # TCP_KEEPALIVE
+            # TCP keep-alive
             if self._socket_keepalive:
-                handle.setsockopt(socket.IPPROTO_TCP, socket.SO_KEEPALIVE, 1)
+                handle.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
             handle.settimeout(self._timeout)
             try:


### PR DESCRIPTION
…LIVE to IPPROTO_TCP

Affected languages: Python

<!-- Explain the changes in the pull request below: -->
Apply socket.SO_KEEPALIVE at the socket.SOL_SOCKET, not socket.IPPROTO_TCP, level

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [✓] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [✓] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [✓] Did you squash your changes to a single commit?  (not required, but preferred)
- [✓] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [N/A] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
