### PR TITLE
Fix <Shlwapi.h>, <Windows.h> capitalization for case sensitive cross compile.

### DIFF
--- a/compiler/cpp/tests/catch/catch.hpp
+++ b/compiler/cpp/tests/catch/catch.hpp
@@ -6338,7 +6338,7 @@ namespace Catch {
 #endif
 
 #ifdef __AFXDLL
-#include <AfxWin.h>
+#include <afxwin.h>
 #else
 #include <windows.h>
 #endif

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -25,7 +25,7 @@
 #include <thrift/transport/THttpServer.h>
 #include <thrift/transport/TSocket.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
-  #include <Shlwapi.h>
+  #include <shlwapi.h>
 #endif
 
 using std::string;

--- a/lib/cpp/src/thrift/transport/TPipeServer.cpp
+++ b/lib/cpp/src/thrift/transport/TPipeServer.cpp
@@ -27,8 +27,8 @@
 #ifdef _WIN32
 #include <thrift/windows/OverlappedSubmissionThread.h>
 #include <thrift/windows/Sync.h>
-#include <AccCtrl.h>
-#include <Aclapi.h>
+#include <accctrl.h>
+#include <aclapi.h>
 #include <sddl.h>
 #endif //_WIN32
 

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -70,7 +70,7 @@
 // adds problematic macros like min() and max(). Try to work around:
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #undef NOMINMAX
 #undef WIN32_LEAN_AND_MEAN
 #endif

--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -31,7 +31,7 @@
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/THttpServer.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #define THRIFT_strncasecmp(str1, str2, len) _strnicmp(str1, str2, len)
 #define THRIFT_strcasestr(haystack, needle) StrStrIA(haystack, needle)
 #else

--- a/lib/cpp/src/thrift/windows/SocketPair.cpp
+++ b/lib/cpp/src/thrift/windows/SocketPair.cpp
@@ -34,7 +34,7 @@
 #include <string.h>
 
 // Win32
-#include <WS2tcpip.h>
+#include <ws2tcpip.h>
 
 int thrift_socketpair(int d, int type, int protocol, THRIFT_SOCKET sv[2]) {
   THRIFT_UNUSED_VARIABLE(protocol);

--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -37,7 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define _THRIFT_UNDEF_WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 #ifdef _THRIFT_UNDEF_NOMINMAX
 #undef NOMINMAX
 #undef _THRIFT_UNDEF_NOMINMAX


### PR DESCRIPTION
Like #2518, in cross compiling thrift in https://github.com/JuliaPackaging/Yggdrasil/pull/5427, I encountered:

```
[12:29:29] /workspace/srcdir/thrift/lib/cpp/src/thrift/transport/THttpServer.cpp:28:23: fatal error: Shlwapi.h: No such file or directory
```

There might be more cases of these includes, so Work in Progress for now.