### PR TITLE
Minor fixes to satisfy MSVC 2022 in c++20 mode

### DIFF
--- a/compiler/cpp/src/thrift/thriftl.ll
+++ b/compiler/cpp/src/thrift/thriftl.ll
@@ -76,17 +76,17 @@
 #include "thrift/thrifty.hh"
 #endif
 
-void integer_overflow(char* text) {
+void integer_overflow(const char* text) {
   yyerror("This integer is too big: \"%s\"\n", text);
   exit(1);
 }
 
-void unexpected_token(char* text) {
+void unexpected_token(const char* text) {
   yyerror("Unexpected token in input: \"%s\"\n", text);
   exit(1);
 }
 
-void error_no_longer_supported(char* text, char* replace_with) {
+void error_no_longer_supported(const char* text, const char* replace_with) {
   yyerror("\"%s\" is no longer supported, use \"%s\" instead. Line %d\n", text, replace_with, yylineno);
   exit(1);
 }


### PR DESCRIPTION
This PR contains mostly pedantic whitespace changes. Three arguments of type `char*` can be more pedantically set to `const char*` because they do not modify the values. This resolves a build error with Visual Studio 2022 (current latest).

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.