### PR TITLE
fix staleness check in cmake/ctest

### DIFF
--- a/compiler/cpp/test/compiler/Included.thrift
+++ b/compiler/cpp/test/compiler/Included.thrift
@@ -19,6 +19,8 @@
  * under the License.
  */
 
+const string foo = "bar"
+
 struct a_struct {
   1: bool im_true,
   2: bool im_false,


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

fix staleness check in cmake/ctest, the line was mistakenly removed in https://github.com/apache/thrift//commit/944b8e68a099392d80153ebcf26f32ff7f1d893a#diff-f5cd0615ff0ea8e5fb4cc8aae1b13f897a6386fe99238b93e1ea09a71d8c44c3L1

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
