### PR TITLE
THRIFT-5627

### DIFF
--- a/compiler/cpp/src/thrift/generate/go_validator_generator.h
+++ b/compiler/cpp/src/thrift/generate/go_validator_generator.h
@@ -59,7 +59,7 @@ private:
   void indent_down() { go_generator->indent_down(); }
   std::string indent() { return go_generator->indent(); }
 
-  std::string get_field_name(t_field* field);
+  //std::string get_field_name(t_field* field);  -- no impl?
   std::string get_field_reference_name(t_field* field);
 
   std::string GenID(std::string id) { return id + std::to_string(tmp_[id]++); };

--- a/compiler/cpp/src/thrift/generate/validator_parser.h
+++ b/compiler/cpp/src/thrift/generate/validator_parser.h
@@ -110,8 +110,8 @@ private:
   bool bool_val = false;
   t_enum_value* enum_val = nullptr;
   std::string string_val;
-  validation_function* function_val;
-  t_field* field_reference_val;
+  validation_function* function_val = nullptr;
+  t_field* field_reference_val = nullptr;
 
   validation_value_type val_type;
 };
@@ -130,7 +130,7 @@ public:
 private:
   std::string name;
   std::vector<validation_value*> values;
-  validation_rule* inner;
+  validation_rule* inner = nullptr;
 };
 
 class validation_parser {
@@ -202,7 +202,7 @@ private:
                                 std::map<std::string, std::vector<std::string>>& annotations);
   t_field* get_referenced_field(std::string annotation_value);
   validation_value::validation_function* get_validation_function(std::string annotation_value);
-  t_struct* reference;
+  t_struct* reference = nullptr;
 };
 
 #endif

--- a/compiler/cpp/src/thrift/thrifty.yy
+++ b/compiler/cpp/src/thrift/thrifty.yy
@@ -1265,13 +1265,20 @@ SetType:
     }
 
 ListType:
-  tok_list '<' FieldType '>' CppType
+  tok_list CppType '<' FieldType '>' CppType   // the second CppType is for compatibility reasons = deprecated
     {
       pdebug("ListType -> tok_list<FieldType>");
-      check_for_list_of_bytes($3);
-      $$ = new t_list($3);
-      if ($5 != nullptr) {
-        ((t_container*)$$)->set_cpp_name(std::string($5));
+      check_for_list_of_bytes($4);
+      $$ = new t_list($4);
+      if ($2 != nullptr) {
+        ((t_container*)$$)->set_cpp_name(std::string($2));
+      }
+      if ($6 != nullptr) {
+        ((t_container*)$$)->set_cpp_name(std::string($6));
+        pwarning(1, "The syntax 'list<type> cpp_type \"c++ type\"' is deprecated. Use 'list cpp_type \"c++ type\" <type>' instead.\n");
+      }
+      if (($2 != nullptr) && ($6 != nullptr)) {
+        pwarning(1, "Two cpp_types clauses at list<%>\n", $2);
       }
     }
 


### PR DESCRIPTION
THRIFT-5627 More consistent syntax for cpp_type
Patch: Jens Geyer

Second commit fixes a bunch of warnings that showed up in VS2022