### PR TITLE
Thrift-5628: Call ResetConsumedMessageSize from ReadMessageEndAsync

### DIFF
--- a/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
@@ -253,6 +253,7 @@ namespace Thrift.Protocol
         public override Task ReadMessageEndAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            Transport.ResetConsumedMessageSize();
             return Task.CompletedTask;
         }
 

--- a/lib/netstd/Thrift/Protocol/TCompactProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TCompactProtocol.cs
@@ -459,6 +459,7 @@ namespace Thrift.Protocol
         public override Task ReadMessageEndAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            Transport.ResetConsumedMessageSize();
             return Task.CompletedTask;
         }
 

--- a/lib/netstd/Thrift/Protocol/TJSONProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TJSONProtocol.cs
@@ -694,7 +694,9 @@ namespace Thrift.Protocol
 
         public override async Task ReadMessageEndAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await ReadJsonArrayEndAsync(cancellationToken);
+            Transport.ResetConsumedMessageSize();
         }
 
         public override async ValueTask<TStruct> ReadStructBeginAsync(CancellationToken cancellationToken)

--- a/lib/netstd/Thrift/Protocol/TProtocolDecorator.cs
+++ b/lib/netstd/Thrift/Protocol/TProtocolDecorator.cs
@@ -156,7 +156,9 @@ namespace Thrift.Protocol
 
         public override async Task ReadMessageEndAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await _wrappedProtocol.ReadMessageEndAsync(cancellationToken);
+            Transport.ResetConsumedMessageSize();
         }
 
         public override async ValueTask<TStruct> ReadStructBeginAsync(CancellationToken cancellationToken)

--- a/lib/netstd/Thrift/Transport/Layered/TBufferedTransport.cs
+++ b/lib/netstd/Thrift/Transport/Layered/TBufferedTransport.cs
@@ -179,6 +179,11 @@ namespace Thrift.Transport
             }
         }
 
+        public override void ResetConsumedMessageSize(long newSize = -1)
+        {
+            base.ResetConsumedMessageSize(newSize);
+            ReadBuffer.ResetConsumedMessageSize(newSize);
+        }
 
         private void CheckNotDisposed()
         {

--- a/lib/netstd/Thrift/Transport/Layered/TFramedTransport.cs
+++ b/lib/netstd/Thrift/Transport/Layered/TFramedTransport.cs
@@ -186,5 +186,11 @@ namespace Thrift.Transport
             }
             IsDisposed = true;
         }
+
+        public override void ResetConsumedMessageSize(long newSize = -1)
+        {
+            base.ResetConsumedMessageSize(newSize);
+            ReadBuffer.ResetConsumedMessageSize(newSize);
+        }
     }
 }

--- a/lib/netstd/Thrift/Transport/Layered/TLayeredTransport.cs
+++ b/lib/netstd/Thrift/Transport/Layered/TLayeredTransport.cs
@@ -1,4 +1,4 @@
-// Licensed to the Apache Software Foundation(ASF) under one
+﻿// Licensed to the Apache Software Foundation(ASF) under one
 // or more contributor license agreements.See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.The ASF licenses this file
@@ -40,6 +40,11 @@ namespace Thrift.Transport
         public override void CheckReadBytesAvailable(long numBytes)
         {
             InnerTransport.CheckReadBytesAvailable(numBytes);
+        }
+
+        public override void ResetConsumedMessageSize(long newSize = -1)
+        {
+            InnerTransport.ResetConsumedMessageSize(newSize);
         }
     }
 }

--- a/lib/netstd/Thrift/Transport/TEndpointTransport.cs
+++ b/lib/netstd/Thrift/Transport/TEndpointTransport.cs
@@ -43,7 +43,7 @@ namespace Thrift.Transport
         /// <summary>
         /// Resets RemainingMessageSize to the configured maximum 
         /// </summary>
-        protected void ResetConsumedMessageSize(long newSize = -1)
+        public override void ResetConsumedMessageSize(long newSize = -1)
         {
             // full reset 
             if (newSize < 0)

--- a/lib/netstd/Thrift/Transport/TTransport.cs
+++ b/lib/netstd/Thrift/Transport/TTransport.cs
@@ -1,4 +1,4 @@
-// Licensed to the Apache Software Foundation(ASF) under one
+﻿// Licensed to the Apache Software Foundation(ASF) under one
 // or more contributor license agreements.See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.The ASF licenses this file
@@ -35,6 +35,7 @@ namespace Thrift.Transport
         public abstract TConfiguration Configuration { get; }
         public abstract void UpdateKnownMessageSize(long size);
         public abstract void CheckReadBytesAvailable(long numBytes);
+        public abstract void ResetConsumedMessageSize(long newSize = -1);
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
Made ResetConsumedMessageSize  a public abstract member of TTransport.
Implemented on all inheritors.
Called ResetConsumedMessageSize from all ReadMessageEndAsync.
