### PR TITLE
THRIFT-5661: lib: cpp: TOutput: add zephyr-specific strerror_s implementation

### DIFF
--- a/lib/cpp/src/thrift/TOutput.cpp
+++ b/lib/cpp/src/thrift/TOutput.cpp
@@ -105,6 +105,9 @@ void TOutput::perror(const char* message, int errno_copy) {
 }
 
 std::string TOutput::strerror_s(int errno_copy) {
+#ifdef __ZEPHYR__
+  return std::string(strerror(errno_copy));
+#else
   char b_errbuf[1024] = {'\0'};
 
 #ifdef HAVE_STRERROR_R
@@ -139,6 +142,7 @@ std::string TOutput::strerror_s(int errno_copy) {
   // to ensure that the string object is constructed before
   // b_error becomes invalid?
   return std::string(b_error);
+#endif // __ZEPHYR__
 }
 }
 } // apache::thrift


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
In Zephyr, optimize `TOutput::strerror_s` to minimize (stack) space. The Zephyr string error table is in ROM in any case, so string values will not be overwritten (if they happen to be compiled-in).
 
- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
