### PR TITLE
THRIFT-5658: lib: cpp: TProtocol: support zephyr byteorder

### DIFF
--- a/lib/cpp/src/thrift/protocol/TProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TProtocol.h
@@ -86,6 +86,20 @@ static inline To bitwise_cast(From from) {
 #include <sys/param.h>
 #endif
 
+#ifdef __ZEPHYR__
+#  include <zephyr/sys/byteorder.h>
+
+#  define __THRIFT_BYTE_ORDER __BYTE_ORDER__
+#  define __THRIFT_LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#  define __THRIFT_BIG_ENDIAN __ORDER_BIG_ENDIAN__
+
+#  if __THRIFT_BYTE_ORDER == __THRIFT_BIG_ENDIAN
+#    undef bswap_64
+#    undef bswap_32
+#    undef bswap_16
+#  endif
+#endif
+
 #ifndef __THRIFT_BYTE_ORDER
 # if defined(BYTE_ORDER) && defined(LITTLE_ENDIAN) && defined(BIG_ENDIAN)
 #  define __THRIFT_BYTE_ORDER BYTE_ORDER


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Zephyr's byteorder is defined in `<zephyr/sys/byteorder.h>`. However, the `bswap_xx` macros are also defined there. They need to be `#undef`d first when building for big-endian architectures, since the Thrift byteorder macros are no-ops for little-endian architectures.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
