### PR TITLE
THRIFT-5659: lib: cpp: protocol: declare  when methods override

### DIFF
--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
@@ -166,19 +166,19 @@ public:
 
   inline uint32_t readBinary(std::string& str);
 
-  int getMinSerializedSize(TType type);
+  int getMinSerializedSize(TType type) override;
 
-  void checkReadBytesAvailable(TSet& set)
+  void checkReadBytesAvailable(TSet& set) override
   {
       trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
   }
 
-  void checkReadBytesAvailable(TList& list)
+  void checkReadBytesAvailable(TList& list) override
   {
       trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
   }
 
-  void checkReadBytesAvailable(TMap& map)
+  void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
       trans_->checkReadBytesAvailable(map.size_ * elmSize);

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -140,19 +140,19 @@ public:
 
   uint32_t writeBinary(const std::string& str);
 
-  int getMinSerializedSize(TType type);
+  int getMinSerializedSize(TType type) override;
 
-  void checkReadBytesAvailable(TSet& set)
+  void checkReadBytesAvailable(TSet& set) override
   {
       trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
   }
 
-  void checkReadBytesAvailable(TList& list)
+  void checkReadBytesAvailable(TList& list) override
   {
       trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
   }
 
-  void checkReadBytesAvailable(TMap& map)
+  void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
       trans_->checkReadBytesAvailable(map.size_ * elmSize);

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.h
@@ -245,19 +245,19 @@ public:
 
   uint32_t readBinary(std::string& str);
 
-  int getMinSerializedSize(TType type);
+  int getMinSerializedSize(TType type) override;
 
-  void checkReadBytesAvailable(TSet& set)
+  void checkReadBytesAvailable(TSet& set) override
   {
       trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
   }
 
-  void checkReadBytesAvailable(TList& list)
+  void checkReadBytesAvailable(TList& list) override
   {
       trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
   }
 
-  void checkReadBytesAvailable(TMap& map)
+  void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
       trans_->checkReadBytesAvailable(map.size_ * elmSize);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This avoids compiler warnings about inconsistent use of `override` like the one below.
```
In file included from /Users/cfriedt/workspace/thrift/test/cpp/src/TestServer.cpp:29:
/Users/cfriedt/workspace/thrift/lib/cpp/src/thrift/protocol/TJSONProtocol.h:255:8: warning: 'checkReadBytesAvailable' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void checkReadBytesAvailable(TList& list)
       ^
/Users/cfriedt/workspace/thrift/lib/cpp/src/thrift/protocol/TProtocol.h:563:16: note: overridden virtual function is here
  virtual void checkReadBytesAvailable(TList& list)
```

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
