### PR TITLE
THRIFT-5646 Check for the presence of Gradle to build the Kotlin library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,9 +211,10 @@ AM_CONDITIONAL([WITH_JAVA], [test "$have_java" = "yes"])
 AX_THRIFT_LIB(kotlin, [Kotlin], yes)
 if test "$with_kotlin" = "yes";  then
   AX_JAVAC_AND_JAVA
+  AC_PATH_PROG([GRADLE], [gradle])
   AC_SUBST(CLASSPATH)
   AC_SUBST(GRADLE_OPTS)
-  if test "x$JAVA" != "x" && test "x$JAVAC" != "x" ; then
+  if test "x$JAVA" != "x" && test "x$JAVAC" != "x" && "x$GRADLE" != "x" ; then
     have_kotlin="yes"
   fi
 fi


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Gradle is required to build the Kotlin library so we should check for its presence during the configure process. Currently, it only checks for the presence of Java so if Java is installed but Gradle is not, the build will fail. This PR adds the Gradle check for Kotlin.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
