### PR TITLE
THRIFT-5647: Add ECONNRESET definition for macOS.

### DIFF
--- a/lib/d/src/thrift/async/socket.d
+++ b/lib/d/src/thrift/async/socket.d
@@ -37,6 +37,10 @@ version (Windows) {
   import core.sys.posix.sys.socket : connect;
 } else static assert(0, "Don't know connect on this platform.");
 
+version (OSX) {
+  import core.stdc.errno : ECONNRESET;
+}
+
 version (Win32) {
   import core.stdc.config : __c_long;
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Other platforms seem to compile fine, ECONNRESET is undeclared on macOS. Add the appropriate definition so the library builds on macOS.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
