### PR TITLE
fix(sec): upgrade org.codehaus.plexus:plexus-utils to 3.0.24

### DIFF
--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -16,11 +16,7 @@
  KIND, either express or implied. See the License for the
  specific language governing permissions and limitations
  under the License.
- -->
-<project
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+ --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -66,7 +62,7 @@
             <phase>generate-test-resources</phase>
             <configuration>
               <target>
-                <jar destfile="${project.build.directory}/SharedIdl.jar" basedir="${basedir}/src/test/resources" includes="**/*.thrift" />
+                <jar destfile="${project.build.directory}/SharedIdl.jar" basedir="${basedir}/src/test/resources" includes="**/*.thrift"/>
               </target>
             </configuration>
             <goals>
@@ -102,7 +98,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.16</version>
+      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.codehaus.plexus:plexus-utils 3.0.16
- [MPS-2022-11760](https://www.oscs1024.com/hd/MPS-2022-11760)
- [MPS-2022-11786](https://www.oscs1024.com/hd/MPS-2022-11786)


### What did I do？
Upgrade org.codehaus.plexus:plexus-utils from 3.0.16 to 3.0.24 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS