### PR TITLE
THRIFT-5656 Escape Delphi keywords with '&' prefix instead of '_' suffix

### DIFF
--- a/lib/delphi/test/TestClient.pas
+++ b/lib/delphi/test/TestClient.pas
@@ -956,7 +956,7 @@ begin
   except
     on x:TXception do begin
       Expect( x.__isset_ErrorCode, 'x.__isset_ErrorCode = '+BoolToString(x.__isset_ErrorCode));
-      Expect( x.__isset_Message_,  'x.__isset_Message_ = '+BoolToString(x.__isset_Message_));
+      Expect( x.__isset_Message,  'x.__isset_Message = '+BoolToString(x.__isset_Message));
       Expect( x.ErrorCode = 1001, 'x.ErrorCode = '+IntToStr(x.ErrorCode));
       Expect( x.Message_ = 'This is an Xception', 'x.Message = "'+x.Message_+'"');
     end;

--- a/lib/delphi/test/codegen/run-Pascal-Codegen-Tests.bat.tmpl
+++ b/lib/delphi/test/codegen/run-Pascal-Codegen-Tests.bat.tmpl
@@ -67,6 +67,10 @@ if exist "%TARGET%\*.thrift"      del "%TARGET%\*.thrift"       /Q
 if exist "%TARGET%\%SUBDIR%\*.*"  del "%TARGET%\%SUBDIR%\*.*"   /Q
 if exist "%OUTDCU%\*.*"           del "%OUTDCU%\*.*"            /Q
 
+rem init logfile
+echo Errors > "%LOGFILE%"
+echo ---------------- >> "%LOGFILE%"
+
 rem * recurse through thrift WC and "my thrift files" folder
 rem * copies all .thrift files into thrift-testing
 call %0 %SOURCE%

--- a/lib/delphi/test/serializer/TestSerializer.Data.pas
+++ b/lib/delphi/test/serializer/TestSerializer.Data.pas
@@ -213,7 +213,7 @@ class function Fixtures.CreateNesting : INesting;
 var bonk : IBonk;
 begin
   bonk := TBonkImpl.Create;
-  bonk.Type_   := 31337;
+  bonk.&Type   := 31337;
   bonk.Message := 'I am a bonk... xor!';
 
   result := TNestingImpl.Create;
@@ -262,11 +262,11 @@ begin
   // one with two
   stage2 := TThriftListImpl<IBonk>.Create;
   b := TBonkImpl.Create;
-  b.type_ := 1;
+  b.&type := 1;
   b.message := 'Wait.';
   stage2.Add( b);
   b := TBonkImpl.Create;
-  b.type_ := 2;
+  b.&type := 2;
   b.message := 'What?';
   stage2.Add( b);
   result.Bonks.Add( 'two', stage2);
@@ -274,15 +274,15 @@ begin
   // one with three
   stage2 := TThriftListImpl<IBonk>.Create;
   b := TBonkImpl.Create;
-  b.type_ := 3;
+  b.&type := 3;
   b.message := 'quoth';
   stage2.Add( b);
   b := TBonkImpl.Create;
-  b.type_ := 4;
+  b.&type := 4;
   b.message := 'the raven';
   stage2.Add( b);
   b := TBonkImpl.Create;
-  b.type_ := 5;
+  b.&type := 5;
   b.message := 'nevermore';
   stage2.Add( b);
   result.bonks.Add( 'three', stage2);


### PR DESCRIPTION
Client: Delphi
Patch: Jens Geyer
