### PR TITLE
THRIFT-5653: UUID should use value 16 in Swift binary protocol

### DIFF
--- a/lib/swift/Sources/TCompactProtocol.swift
+++ b/lib/swift/Sources/TCompactProtocol.swift
@@ -208,8 +208,6 @@ public class TCompactProtocol: TProtocol {
     case .map:    return .map
     case .set:    return .set
     case .list:   return .list
-    case .utf8:   return .binary
-      //case .utf16:  return .binary
     case .uuid:   return .uuid
     }
   }

--- a/lib/swift/Sources/TProtocol.swift
+++ b/lib/swift/Sources/TProtocol.swift
@@ -40,9 +40,7 @@ public enum TType: Int32 {
   case map      = 13
   case set      = 14
   case list     = 15
-  case utf8     = 16
-  //case utf16    = 17
-  case uuid     = 17
+  case uuid     = 16
 }
 
 public protocol TProtocol {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Removes non-standard utf8 type with raw value 16 and replaces uuid raw value with 16. 
Brings Swift in compliance with spec: https://github.com/apache/thrift/blob/0223d6346675c5089c2a2de5fb6f3858e599c9a9/doc/specs/thrift-binary-protocol.md?plain=1#L204

This is technically a breaking change by removing the utf8 type, however this type was non-standard and not documented in the spec.

This causes new failing crosstests with Swift-Java with the binary protocol due to Java not yet being updated to match the spec. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
