### PR TITLE
THRIFT-5657: Use Swift 5.7 in all CI (github actions + travis)

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -343,7 +343,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/swift/README.md">Swift</a></td>
 <!-- Since -----------------><td>0.12.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td colspan=2>4.2.1</td>
+<!-- Language Levels -------><td colspan=2>5.7</td>
 <!-- Field types -----------><td><img src="/doc/images/cred.png" alt=""/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -264,10 +264,13 @@ RUN apt-get install -yq \
       libpython-dev \
       libxml2-dev && \
       cd / && \
-      wget --quiet https://swift.org/builds/swift-5.1.4-release/ubuntu1804/swift-5.1.4-RELEASE/swift-5.1.4-RELEASE-ubuntu18.04.tar.gz && \
-      tar xf swift-5.1.4-RELEASE-ubuntu18.04.tar.gz --strip-components=1 && \
-      rm swift-5.1.4-RELEASE-ubuntu18.04.tar.gz && \
-      swift --version
+      wget --quiet https://download.swift.org/swift-5.7-release/ubuntu1804/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu18.04.tar.gz && \
+      tar xf swift-5.7-RELEASE-ubuntu18.04.tar.gz && \
+      mv swift-5.7-RELEASE-ubuntu18.04 /usr/share/swift && \
+      rm swift-5.7-RELEASE-ubuntu18.04.tar.gz
+
+ENV PATH /usr/share/swift/usr/bin:$PATH
+RUN swift --version
 
 # Locale(s) for cpp unit tests
 RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -251,10 +251,13 @@ RUN apt-get install -yq \
       libpython2-dev \
       libxml2-dev && \
       cd / && \
-      wget --quiet https://swift.org/builds/swift-5.3.3-release/ubuntu2004/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu20.04.tar.gz && \
-      tar xf swift-5.3.3-RELEASE-ubuntu20.04.tar.gz --strip-components=1 && \
-      rm swift-5.3.3-RELEASE-ubuntu20.04.tar.gz && \
-      swift --version
+      wget --quiet https://download.swift.org/swift-5.7-release/ubuntu2004/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu20.04.tar.gz && \
+      tar xf swift-5.7-RELEASE-ubuntu20.04.tar.gz && \
+      mv swift-5.7-RELEASE-ubuntu20.04 /usr/share/swift && \
+      rm swift-5.7-RELEASE-ubuntu20.04.tar.gz
+
+ENV PATH /usr/share/swift/usr/bin:$PATH
+RUN swift --version
 
 # Locale(s) for cpp unit tests
 RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -252,9 +252,12 @@ RUN apt-get install -yq \
   libxml2-dev && \
   cd / && \
   wget --quiet https://download.swift.org/swift-5.7-release/ubuntu2204/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu22.04.tar.gz && \
-  tar xf swift-5.7-RELEASE-ubuntu22.04.tar.gz --strip-components=1 && \
-  rm swift-5.7-RELEASE-ubuntu22.04.tar.gz && \
-  swift --version
+  tar xf swift-5.7-RELEASE-ubuntu22.04.tar.gz && \
+  mv swift-5.7-RELEASE-ubuntu22.04 /usr/share/swift && \
+  rm swift-5.7-RELEASE-ubuntu22.04.tar.gz
+
+ENV PATH /usr/share/swift/usr/bin:$PATH
+RUN swift --version
 
 # Locale(s) for cpp unit tests
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Standardizes the version of Swift used across all CI (actions + travis) to Swift 5.7 (the latest version)

This should fix the current Travis Swift build failure on Linux due to an older version being used:
```
/thrift/src/lib/swift/Sources/TSocketServer.swift:83:60: error: type 'CFSocketError' (aka 'Int') has no member 'success'
      if CFSocketSetAddress(sock, cfaddr) != CFSocketError.success { //kCFSocketSuccess {
                                             ~~~~~~~~~~~~~ ^~~~~~~
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
