### PR TITLE
lib: cpp: add missing functional and cmath includes

### DIFF
--- a/lib/cpp/src/thrift/async/TAsyncBufferProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncBufferProcessor.h
@@ -20,6 +20,7 @@
 #ifndef _THRIFT_TASYNC_BUFFER_PROCESSOR_H_
 #define _THRIFT_TASYNC_BUFFER_PROCESSOR_H_ 1
 
+#include <functional>
 #include <memory>
 #include <thrift/transport/TBufferTransports.h>
 

--- a/lib/cpp/src/thrift/async/TAsyncProcessor.h
+++ b/lib/cpp/src/thrift/async/TAsyncProcessor.h
@@ -20,9 +20,11 @@
 #ifndef _THRIFT_TASYNCPROCESSOR_H_
 #define _THRIFT_TASYNCPROCESSOR_H_ 1
 
-#include <thrift/protocol/TProtocol.h>
+#include <functional>
 #include <memory>
+
 #include <thrift/TProcessor.h>
+#include <thrift/protocol/TProtocol.h>
 
 namespace apache {
 namespace thrift {

--- a/lib/cpp/src/thrift/concurrency/FunctionRunner.h
+++ b/lib/cpp/src/thrift/concurrency/FunctionRunner.h
@@ -20,8 +20,10 @@
 #ifndef _THRIFT_CONCURRENCY_FUNCTION_RUNNER_H
 #define _THRIFT_CONCURRENCY_FUNCTION_RUNNER_H 1
 
-#include <thrift/concurrency/Thread.h>
+#include <functional>
 #include <memory>
+
+#include <thrift/concurrency/Thread.h>
 
 namespace apache {
 namespace thrift {

--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <cmath>
 
 #include <thrift/transport/TBufferTransports.h>
 

--- a/lib/cpp/src/thrift/transport/TServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TServerSocket.h
@@ -20,6 +20,8 @@
 #ifndef _THRIFT_TRANSPORT_TSERVERSOCKET_H_
 #define _THRIFT_TRANSPORT_TSERVERSOCKET_H_ 1
 
+#include <functional>
+
 #include <thrift/concurrency/Mutex.h>
 #include <thrift/transport/PlatformSocket.h>
 #include <thrift/transport/TServerTransport.h>


### PR DESCRIPTION
Manual runs of the autotools docker script were failing due to `std::functional` not being a member of `std`. Similar error messages for `std::ceil` and `std::log`.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
No
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
No
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
Yes
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
Yes
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
