### PR TITLE
build: docker: scripts: autotools: do not fail if .m2/ exists

### DIFF
--- a/build/docker/scripts/autotools.sh
+++ b/build/docker/scripts/autotools.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ev
 
-mkdir ~/.m2
+mkdir -p ~/.m2
 tee >~/.m2/settings.xml <<EOF
 <settings xmlns='http://maven.apache.org/SETTINGS/1.0.0'>
   <mirrors>


### PR DESCRIPTION
Previously, when doing manual runs inside of the docker container, the `autotools.sh` script would fail if the `.m2/` directory already existed. This was a minor annoyance.

Simply pass the `-p` flag to `mkdir`.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
