### PR TITLE
THRIFT-5663: lib: cpp: usleep was not declared in this scope

### DIFF
--- a/lib/cpp/src/thrift/transport/TFDTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TFDTransport.cpp
@@ -20,9 +20,6 @@
 #include <cerrno>
 #include <exception>
 
-#include <thrift/transport/TFDTransport.h>
-#include <thrift/transport/PlatformSocket.h>
-
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -30,6 +27,9 @@
 #ifdef _WIN32
 #include <io.h>
 #endif
+
+#include <thrift/transport/TFDTransport.h>
+#include <thrift/transport/PlatformSocket.h>
 
 using std::string;
 

--- a/lib/cpp/src/thrift/transport/TFileTransport.cpp
+++ b/lib/cpp/src/thrift/transport/TFileTransport.cpp
@@ -19,11 +19,6 @@
 
 #include <thrift/thrift-config.h>
 
-#include <thrift/transport/TFileTransport.h>
-#include <thrift/transport/TTransportUtils.h>
-#include <thrift/transport/PlatformSocket.h>
-#include <thrift/concurrency/FunctionRunner.h>
-
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #else
@@ -48,6 +43,11 @@
 #ifdef _WIN32
 #include <io.h>
 #endif
+
+#include <thrift/transport/TFileTransport.h>
+#include <thrift/transport/TTransportUtils.h>
+#include <thrift/transport/PlatformSocket.h>
+#include <thrift/concurrency/FunctionRunner.h>
 
 namespace apache {
 namespace thrift {


### PR DESCRIPTION
Several build failures in Travis resulted from an include-order problem in `TFileTransport.cpp`.

```
libtool: compile:  g++ -std=c++11 -DHAVE_CONFIG_H -I/usr/include -I./src -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Wall -Wextra -pedantic -g -O2 -MT src/thrift/transport/TFDTransport.lo -MD -MP -MF src/thrift/transport/.deps/TFDTransport.Tpo -c src/thrift/transport/TFDTransport.cpp -o src/thrift/transport/TFDTransport.o >/dev/null 2>&1
libtool: compile:  g++ -std=c++11 -DHAVE_CONFIG_H -I/usr/include -I./src -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Wall -Wextra -pedantic -g -O2 -MT src/thrift/transport/TFileTransport.lo -MD -MP -MF src/thrift/transport/.deps/TFileTransport.Tpo -c src/thrift/transport/TFileTransport.cpp  -fPIC -DPIC -o src/thrift/transport/.libs/TFileTransport.o
In file included from ./src/thrift/Thrift.h:23:0,
                 from ./src/thrift/transport/TTransport.h:23,
                 from ./src/thrift/transport/TFileTransport.h:23,
                 from src/thrift/transport/TFileTransport.cpp:22:
./src/thrift/concurrency/FunctionRunner.h: In member function 'virtual void apache::thrift::concurrency::FunctionRunner::run()':
./src/thrift/transport/PlatformSocket.h:118:29: error: 'usleep' was not declared in this scope
 #  define THRIFT_SLEEP_USEC usleep
                             ^
./src/thrift/concurrency/FunctionRunner.h:104:9: note: in expansion of macro 'THRIFT_SLEEP_USEC'
         THRIFT_SLEEP_USEC(intervalMs_ * 1000);
         ^~~~~~~~~~~~~~~~~
./src/thrift/transport/PlatformSocket.h:118:29: note: suggested alternative: 'fseek'
 #  define THRIFT_SLEEP_USEC usleep
                             ^
./src/thrift/concurrency/FunctionRunner.h:104:9: note: in expansion of macro 'THRIFT_SLEEP_USEC'
         THRIFT_SLEEP_USEC(intervalMs_ * 1000);
         ^~~~~~~~~~~~~~~~~
```

A cleaner solution would be better to simply include `<unistd.h>` in `PlatformSocket.h` but it's possible that might slow down compilation.

The solution is just to include `<unistd.h>` before evaluating `THRIFT_SLEEP_USEC(intervalMs_ * 1000);`

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
