### PR TITLE
THRIFT-3956 Java keywords that are legal in IDL can lead to generated code that will not compile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,7 +157,6 @@ EXTRA_DIST = \
 	doc \
 	dub.json \
 	go.mod \
-	go.sum \
 	jitpack.yml \
 	LANGUAGES.md \
 	LICENSE \


### PR DESCRIPTION
I might have overlooked a few cases. I used the test case from that ticket.