### PR TITLE
Add Package.swift to root of repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.1
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import PackageDescription
+
+let package = Package(
+  name: "Thrift",
+  products: [
+    .library(name: "Thrift", targets: ["Thrift"])
+  ],
+  targets: [
+    .target(name: "Thrift", path: "lib/swift/Sources"),
+    .testTarget(name: "ThriftTests", dependencies: ["Thrift"], path: "lib/swift/Tests/ThriftTests")
+  ]
+)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This will allow the Swift client library to be used with Swift Package Manager, as SPM requires a Package.swift to be at the root of the repository (much like we already have `Thrift.podspec`, `package.json`, `composer.json`, etc).

I did not see the need to create a Jira ticket given how trivial this change is, but I can create one if preferred.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
