### PR TITLE
lib: c_glib: fix compile error due to missing unistd.h

### DIFF
--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -19,6 +19,12 @@
 
 /* test a C client with a C++ server  (that makes sense...) */
 
+#include <thrift/config.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Previously, the c_glib library tests failed to compile due to implicit function declarations for `sleep()`, `fork()`, and `alarm()`.

Include `<unistd.h>` to address all of those issues (on platforms that have `<unistd.h>`).

Signed-off-by: Christopher Friedt <cfriedt@meta.com>


```
testthrifttestclient.cpp: In member function 'virtual void TestHandler::testOneway(int)':
testthrifttestclient.cpp:334:5: error: 'sleep' was not declared in this scope
334 |     sleep(sleepFor);
        |     ^~~~~
testthrifttestclient.cpp: In function 'void test_thrift_client()':
testthrifttestclient.cpp:592:3: error: 'sleep' was not declared in this scope; did you mean 'g_usleep'?
    592 |   sleep (5);
            |   ^~~~~
            |   g_usleep
testthrifttestclient.cpp: In function 'int main()':
testthrifttestclient.cpp:616:13: error: 'fork' was not declared in this scope
    616 |   int pid = fork ();
           |             ^~~~
testthrifttestclient.cpp:628:5: error: 'alarm' was not declared in this scope
    628 |     alarm (60);
            |     ^~~~~
testthrifttestclient.cpp:631:5: error: 'sleep' was not declared in this scope; did you mean 'g_usleep'?
    631 |     sleep (1);
           |     ^~~~~
           |     g_usleep
```

cc @Jens-G 