### PR TITLE
ruby: fix failing tests with Ruby 3.0

### DIFF
--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -124,7 +124,7 @@ describe 'Thrift::HTTPClientTransport' do
           expect(http).to receive(:use_ssl=).with(true)
           expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
           expect(http).to receive(:post).with(@service_path, "test",
-              "Content-Type" => "application/x-thrift") do
+              {"Content-Type" => "application/x-thrift"}) do
             double("Net::HTTPOK").tap do |response|
               expect(response).to receive(:body).and_return "data"
               expect(response).to receive(:code).and_return "200"
@@ -146,7 +146,7 @@ describe 'Thrift::HTTPClientTransport' do
           expect(http).to receive(:use_ssl=).with(true)
           expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
           expect(http).to receive(:post).with(@service_path, "test",
-              "Content-Type" => "application/x-thrift") do
+              {"Content-Type" => "application/x-thrift"}) do
             double("Net::HTTPOK").tap do |response|
               expect(response).to receive(:body).and_return "data"
               expect(response).to receive(:code).and_return "200"


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The tests were previously failing due to keyword argument changes in Ruby 3.0.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
