### PR TITLE
netstd Server: Add IPv6

### DIFF
--- a/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
@@ -44,7 +44,8 @@ namespace Thrift.Transport.Server
             try
             {
                 // Make server socket
-                _server = new TcpListener(IPAddress.Any, port);
+		_server = new TcpListener(IPAddress.IPv6Any, port);
+                _server.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
                 _server.Server.NoDelay = true;
             }
             catch (Exception)

--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -229,6 +229,7 @@ class TServerSocket(TSocketBase, TServerTransportBase):
                     os.unlink(res[4])
 
         self.handle = socket.socket(res[0], res[1])
+        self.handle.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
         self.handle.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if hasattr(self.handle, 'settimeout'):
             self.handle.settimeout(None)


### PR DESCRIPTION
Unlike servers in other languages (tested: cpp & python), netstd (Csharp) listens only on IPv4. This can cause errors and delays on clients if they use "localhost" for hostname.

<!-- Explain the changes in the pull request below: -->


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

  PS: Could you update PyPI when this gets released (I guess with version 0.18.0)?
