### PR TITLE
Improve enum support for json generator

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_json_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_json_generator.cc
@@ -245,7 +245,7 @@ void t_json_generator::end_array() {
 
 void t_json_generator::write_type_spec_object(const char* name, t_type* ttype) {
   ttype = ttype->get_true_type();
-  if (ttype->is_struct() || ttype->is_xception() || ttype->is_container()) {
+  if (ttype->is_struct() || ttype->is_xception() || ttype->is_container() || ttype->is_enum()) {
     write_key_and(name);
     start_object(NO_INDENT);
     write_key_and("typeId");
@@ -275,7 +275,7 @@ void t_json_generator::write_type_spec(t_type* ttype) {
     end_object();
   }
 
-  if (ttype->is_struct() || ttype->is_xception()) {
+  if (ttype->is_struct() || ttype->is_xception() || ttype->is_enum()) {
     write_key_and_string("class", get_qualified_name(ttype));
   } else if (ttype->is_map()) {
     t_type* ktype = ((t_map*)ttype)->get_key_type();
@@ -780,7 +780,7 @@ string t_json_generator::get_type_name(t_type* ttype) {
     return "map";
   }
   if (ttype->is_enum()) {
-    return "i32";
+    return "enum";
   }
   if (ttype->is_struct()) {
     return ((t_struct*)ttype)->is_union() ? "union" : "struct";

--- a/lib/json/schema.json
+++ b/lib/json/schema.json
@@ -23,7 +23,8 @@
         "union",
         "struct",
         "binary",
-        "uuid"
+        "uuid",
+        "enum"
       ]
     },
     "base-type": {
@@ -67,7 +68,7 @@
       "type": "object",
       "properties": {
         "typeId": {
-          "enum": [ "union", "struct", "exception" ]
+          "enum": [ "union", "struct", "exception", "enum" ]
         }
       },
       "required": [ "typeId", "class" ]


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The json generator currently outputs the type `i32` for all enum fields. This commit changes it to output `enum` instead and output a `class` property with a reference to the actual enum type, similar to how it works for structs.

This is a breaking change for the json generator because it introduces a new type id (`enum`) which also includes a `class` reference.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
