### PR TITLE
THRIFT-5601: Fix forward typedef in go compiler

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.h
@@ -264,8 +264,9 @@ public:
   std::string argument_list(t_struct* tstruct);
   std::string type_to_enum(t_type* ttype);
   std::string type_to_go_type(t_type* ttype);
-  std::string type_to_go_type_with_opt(t_type* ttype, bool optional_field);
+  std::string type_to_go_type_with_opt(t_type* ttype, bool optional_field, bool is_container_value);
   std::string type_to_go_key_type(t_type* ttype);
+  std::string type_to_go_container_value_type(t_type* ttype);
   std::string type_to_spec_args(t_type* ttype);
 
   void indent_up() { t_generator::indent_up(); }

--- a/lib/go/test/ForwardTypedef.thrift
+++ b/lib/go/test/ForwardTypedef.thrift
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// https://issues.apache.org/jira/browse/THRIFT-5601
+
+namespace go forwardtypedef
+
+struct Struct {
+  1: optional Def foo
+  2: optional Exc bar
+}
+
+typedef i32 Def
+
+exception Exc {
+  1: optional i32 code
+}

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -61,7 +61,8 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				ConstOptionalField.thrift \
 				ProcessorMiddlewareTest.thrift \
 				ClientMiddlewareExceptionTest.thrift \
-				ValidateTest.thrift
+				ValidateTest.thrift \
+				ForwardTypedef.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
@@ -96,6 +97,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 	$(THRIFT) $(THRIFTARGS_SKIP_REMOTE) ProcessorMiddlewareTest.thrift
 	$(THRIFT) $(THRIFTARGS) ClientMiddlewareExceptionTest.thrift
 	$(THRIFT) $(THRIFTARGS) ValidateTest.thrift
+	$(THRIFT) $(THRIFTARGS) ForwardTypedef.thrift
 	ln -nfs ../../tests gopath/src/tests
 	cp -r ./dontexportrwtest gopath/src
 	touch gopath
@@ -121,7 +123,8 @@ check: gopath
 				./gopath/src/conflictargnamestest \
 				./gopath/src/processormiddlewaretest \
 				./gopath/src/clientmiddlewareexceptiontest \
-				./gopath/src/validatetest
+				./gopath/src/validatetest \
+				./gopath/src/forwardtypedef
 	$(GO) test github.com/apache/thrift/lib/go/thrift
 	$(GO) test ./gopath/src/tests ./gopath/src/dontexportrwtest
 


### PR DESCRIPTION
Client: go

While https://github.com/apache/thrift/pull/951 fixed the bug with forward typedef used in container values, it also introduced a bug that broke forward typedef used in other cases in go code. Limit the fix of it to only the container key and value types to fix other cases.
