### PR TITLE
lib: cpp: transport: file descriptor leak in TServerSocket::close()

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -745,6 +745,9 @@ void TServerSocket::close() {
   if (childInterruptSockWriter_ != THRIFT_INVALID_SOCKET) {
     ::THRIFT_CLOSESOCKET(childInterruptSockWriter_);
   }
+  if (pChildInterruptSockReader_ != nullptr) {
+    ::THRIFT_CLOSESOCKET(*pChildInterruptSockReader_);
+  }
   serverSocket_ = THRIFT_INVALID_SOCKET;
   interruptSockWriter_ = THRIFT_INVALID_SOCKET;
   interruptSockReader_ = THRIFT_INVALID_SOCKET;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Close a file descriptor leak in TServerSocket::close(). This was discovered in the final stages of porting Thrift to the Zephyr RTOS, which has a finite-sized file descriptor table.

Details at the URL below.
https://issues.apache.org/jira/browse/THRIFT-5677

cc: @Jens-G 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
