### PR TITLE
THRIFT-5678: lib: cpp: TConnectedClient: warning due to non-virtual dtor

### DIFF
--- a/lib/cpp/src/thrift/TNonCopyable.h
+++ b/lib/cpp/src/thrift/TNonCopyable.h
@@ -30,7 +30,7 @@ namespace thrift {
 class TNonCopyable {
 protected:
   TNonCopyable() = default;
-  ~TNonCopyable() = default;
+  virtual ~TNonCopyable() = default;
 
   TNonCopyable(const TNonCopyable&) = delete;
   TNonCopyable& operator=(const TNonCopyable&) = delete;

--- a/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.h
+++ b/lib/cpp/src/thrift/async/TConcurrentClientSyncInfo.h
@@ -36,7 +36,7 @@ class TConcurrentClientSyncInfo;
 class TConcurrentSendSentry {
 public:
   explicit TConcurrentSendSentry(TConcurrentClientSyncInfo* sync);
-  ~TConcurrentSendSentry();
+  virtual ~TConcurrentSendSentry();
 
   void commit();
 
@@ -48,7 +48,7 @@ private:
 class TConcurrentRecvSentry {
 public:
   TConcurrentRecvSentry(TConcurrentClientSyncInfo* sync, int32_t seqid);
-  ~TConcurrentRecvSentry();
+  virtual ~TConcurrentRecvSentry();
 
   void commit();
 

--- a/lib/cpp/src/thrift/async/TEvhttpServer.h
+++ b/lib/cpp/src/thrift/async/TEvhttpServer.h
@@ -50,7 +50,7 @@ public:
    */
   TEvhttpServer(std::shared_ptr<TAsyncBufferProcessor> processor, int port);
 
-  ~TEvhttpServer();
+  virtual ~TEvhttpServer();
 
   static void request(struct evhttp_request* req, void* self);
   int serve();

--- a/lib/cpp/src/thrift/transport/TFileTransport.h
+++ b/lib/cpp/src/thrift/transport/TFileTransport.h
@@ -123,7 +123,7 @@ typedef struct readState {
 class TFileTransportBuffer {
 public:
   TFileTransportBuffer(uint32_t size);
-  ~TFileTransportBuffer();
+  virtual ~TFileTransportBuffer();
 
   bool addEvent(eventInfo* event);
   eventInfo* getNext();

--- a/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
+++ b/lib/cpp/src/thrift/windows/OverlappedSubmissionThread.h
@@ -105,7 +105,7 @@ private:
   // thread details
 private:
   TOverlappedSubmissionThread();
-  ~TOverlappedSubmissionThread();
+  virtual ~TOverlappedSubmissionThread();
   void run();
   static unsigned __stdcall thread_proc(void* addr);
 
@@ -122,7 +122,7 @@ private:
 
 public:
   TAutoOverlapThread() : p(TOverlappedSubmissionThread::acquire_instance()) {}
-  ~TAutoOverlapThread() { TOverlappedSubmissionThread::release_instance(); }
+  virtual ~TAutoOverlapThread() { TOverlappedSubmissionThread::release_instance(); }
   TOverlappedSubmissionThread* operator->() { return p; }
 };
 }

--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -58,7 +58,7 @@ namespace thrift {
 struct TCriticalSection : apache::thrift::TNonCopyable {
   CRITICAL_SECTION cs;
   TCriticalSection() { InitializeCriticalSection(&cs); }
-  ~TCriticalSection() { DeleteCriticalSection(&cs); }
+  virtual ~TCriticalSection() { DeleteCriticalSection(&cs); }
 };
 
 class TAutoCrit : apache::thrift::TNonCopyable {
@@ -67,7 +67,7 @@ private:
 
 public:
   explicit TAutoCrit(TCriticalSection& cs) : cs_(&cs.cs) { EnterCriticalSection(cs_); }
-  ~TAutoCrit() { LeaveCriticalSection(cs_); }
+  virtual ~TAutoCrit() { LeaveCriticalSection(cs_); }
 };
 
 struct TAutoResetEvent : apache::thrift::TNonCopyable {
@@ -80,7 +80,7 @@ struct TAutoResetEvent : apache::thrift::TNonCopyable {
       throw apache::thrift::concurrency::SystemResourceException("CreateEvent failed");
     }
   }
-  ~TAutoResetEvent() { CloseHandle(h); }
+  virtual ~TAutoResetEvent() { CloseHandle(h); }
 };
 
 struct TManualResetEvent : apache::thrift::TNonCopyable {
@@ -93,7 +93,7 @@ struct TManualResetEvent : apache::thrift::TNonCopyable {
       throw apache::thrift::concurrency::SystemResourceException("CreateEvent failed");
     }
   }
-  ~TManualResetEvent() { CloseHandle(h); }
+  virtual ~TManualResetEvent() { CloseHandle(h); }
 };
 
 struct TAutoHandle : apache::thrift::TNonCopyable {

--- a/lib/cpp/src/thrift/windows/TWinsockSingleton.h
+++ b/lib/cpp/src/thrift/windows/TWinsockSingleton.h
@@ -54,7 +54,7 @@ private:
   TWinsockSingleton(void);
 
 public:
-  ~TWinsockSingleton(void);
+  virtual ~TWinsockSingleton(void);
 
 public:
   static void create(void);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->    
Commit 042580f53441efe1bc5c80c89351fcb30740659e removed the `virtual` keyword from the declaration of `~TConnectedClient()`.
    
While mostly benign, it does cause a warning in some versions  of GCC (non-virtual destructors can result in undefined behaviour), which can throw off CI sometimes when building with `-Werror`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
