### PR TITLE
go: Use new atomic types introduced in go1.19

### DIFF
--- a/lib/go/thrift/serializer_test.go
+++ b/lib/go/thrift/serializer_test.go
@@ -243,7 +243,7 @@ func TestSerializer(t *testing.T) {
 
 func TestSerializerPoolAsync(t *testing.T) {
 	var wg sync.WaitGroup
-	var counter int64
+	var counter atomic.Int64
 	s := NewTSerializerPool(NewTSerializer)
 	d := NewTDeserializerPool(NewTDeserializer)
 	f := func(i int64) bool {
@@ -251,7 +251,7 @@ func TestSerializerPoolAsync(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			t.Run(
-				fmt.Sprintf("#%d-%d", atomic.AddInt64(&counter, 1), i),
+				fmt.Sprintf("#%d-%d", counter.Add(1), i),
 				func(t *testing.T) {
 					m := MyTestStruct{
 						Int64: i,

--- a/lib/go/thrift/socket_conn.go
+++ b/lib/go/thrift/socket_conn.go
@@ -30,7 +30,7 @@ type socketConn struct {
 	net.Conn
 
 	buffer [1]byte
-	closed int32
+	closed atomic.Int32
 }
 
 var _ net.Conn = (*socketConn)(nil)
@@ -67,7 +67,7 @@ func wrapSocketConn(conn net.Conn) *socketConn {
 // It's the same as the previous implementation of TSocket.IsOpen and
 // TSSLSocket.IsOpen before we added connectivity check.
 func (sc *socketConn) isValid() bool {
-	return sc != nil && sc.Conn != nil && atomic.LoadInt32(&sc.closed) == 0
+	return sc != nil && sc.Conn != nil && sc.closed.Load() == 0
 }
 
 // IsOpen checks whether the connection is open.
@@ -119,6 +119,6 @@ func (sc *socketConn) Close() error {
 		// Already closed
 		return net.ErrClosed
 	}
-	atomic.StoreInt32(&sc.closed, 1)
+	sc.closed.Store(1)
 	return sc.Conn.Close()
 }


### PR DESCRIPTION
Those come with nocopy protection, so they can prevent bugs like people passing the types by value instead of by pointer from the compiler.
