### PR TITLE
THRIFT-5684 upgrade to net7.0

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -183,7 +183,7 @@ Last updated: October 1, 2017
 | java      | 1.8.0\_191     | 17           |       |
 | js        | Node.js 6.17.1, V8 5.1.281.111, npm 3.10.10 | Node.js 10.18.0, V8 6.8.275.32, npm 6.13.4 |     |
 | lua       |               | 5.2.4         | Lua 5.3: see THRIFT-4386 |
-| netstd    | 6.0           | 6.0           |       |
+| netstd    | 7.0           | 7.0           |       |
 | nodejs    | 6.16.0        | 10.16.0       |       |
 | ocaml     |               | 4.05.0        | THRIFT-4517: ocaml 4.02.3 on xenial appears broken |
 | perl      | 5.22.1        | 5.26.1        |       |

--- a/build/docker/old/debian-stretch/Dockerfile
+++ b/build/docker/old/debian-stretch/Dockerfile
@@ -102,10 +102,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 # project isn't ready for this quite yet:
 # RUN apt-get install -y --no-install-recommends \
 # `# dotnet core dependencies` \
-#       dotnet-sdk-6.0 \
-#       dotnet-runtime-6.0 \
-#       aspnetcore-runtime-6.0 \
-#       dotnet-apphost-pack-6.0
+#       dotnet-sdk-7.0 \
+#       dotnet-runtime-7.0 \
+#       aspnetcore-runtime-7.0 \
+#       dotnet-apphost-pack-7.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/old/ubuntu-artful/Dockerfile
+++ b/build/docker/old/ubuntu-artful/Dockerfile
@@ -120,10 +120,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
 `# dotnet core dependencies` \
-      dotnet-sdk-6.0 \
-      dotnet-runtime-6.0 \
-      aspnetcore-runtime-6.0 \
-      dotnet-apphost-pack-6.0
+      dotnet-sdk-7.0 \
+      dotnet-runtime-7.0 \
+      aspnetcore-runtime-7.0 \
+      dotnet-apphost-pack-7.0
 
 RUN apt-get install -y --no-install-recommends \
 `# Erlang dependencies` \

--- a/build/docker/old/ubuntu-disco/Dockerfile
+++ b/build/docker/old/ubuntu-disco/Dockerfile
@@ -126,10 +126,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
       `# dotnet core dependencies` \
-      dotnet-sdk-6.0 \
-      dotnet-runtime-6.0 \
-      aspnetcore-runtime-6.0 \
-      dotnet-apphost-pack-6.0
+      dotnet-sdk-7.0 \
+      dotnet-runtime-7.0 \
+      aspnetcore-runtime-7.0 \
+      dotnet-apphost-pack-7.0
 
 RUN apt-get install -y --no-install-recommends \
       `# Erlang dependencies` \

--- a/build/docker/old/ubuntu-xenial/Dockerfile
+++ b/build/docker/old/ubuntu-xenial/Dockerfile
@@ -115,10 +115,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
       `# dotnet core dependencies` \
-      dotnet-sdk-6.0 \
-      dotnet-runtime-6.0 \
-      aspnetcore-runtime-6.0 \
-      dotnet-apphost-pack-6.0
+      dotnet-sdk-7.0 \
+      dotnet-runtime-7.0 \
+      aspnetcore-runtime-7.0 \
+      dotnet-apphost-pack-7.0
 
 # Erlang dependencies
 ARG ERLANG_OTP_VERSION=18.3.4.11

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -124,10 +124,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
       `# dotnet core dependencies` \
-      dotnet-sdk-6.0 \
-      dotnet-runtime-6.0 \
-      aspnetcore-runtime-6.0 \
-      dotnet-apphost-pack-6.0
+      dotnet-sdk-7.0 \
+      dotnet-runtime-7.0 \
+      aspnetcore-runtime-7.0 \
+      dotnet-apphost-pack-7.0
 
 # Erlang dependencies
 ARG ERLANG_OTP_VERSION=23.3.4.11

--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -125,10 +125,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
       `# dotnet core dependencies` \
-      dotnet-sdk-6.0 \
-      dotnet-runtime-6.0 \
-      aspnetcore-runtime-6.0 \
-      dotnet-apphost-pack-6.0
+      dotnet-sdk-7.0 \
+      dotnet-runtime-7.0 \
+      aspnetcore-runtime-7.0 \
+      dotnet-apphost-pack-7.0
 
 # Erlang dependencies
 ARG ERLANG_OTP_VERSION=23.3.4.11

--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -125,10 +125,10 @@ ENV PATH /usr/lib/dart/bin:$PATH
 
 RUN apt-get install -y --no-install-recommends \
   `# dotnet core dependencies` \
-  dotnet-sdk-6.0 \
-  dotnet-runtime-6.0 \
-  aspnetcore-runtime-6.0 \
-  dotnet-apphost-pack-6.0
+  dotnet-sdk-7.0 \
+  dotnet-runtime-7.0 \
+  aspnetcore-runtime-7.0 \
+  dotnet-apphost-pack-7.0
 
 # Erlang dependencies
 ARG ERLANG_OTP_VERSION=23.3.4.11

--- a/configure.ac
+++ b/configure.ac
@@ -469,7 +469,7 @@ AX_THRIFT_LIB(netstd, [.NET Core], yes)
 if test "$with_netstd" = "yes";  then
   AC_PATH_PROG([DOTNETCORE], [dotnet])
   if [[ -x "$DOTNETCORE" ]] ; then
-    AX_PROG_DOTNETCORE_VERSION( [3.1.0], have_netstd="yes", have_netstd="no")
+    AX_PROG_DOTNETCORE_VERSION( [7.0.0], have_netstd="yes", have_netstd="no")
   fi
 fi
 AM_CONDITIONAL(WITH_DOTNET, [test "$have_netstd" = "yes"])

--- a/lib/netstd/Benchmarks/Thrift.Benchmarks/Thrift.Benchmarks.csproj
+++ b/lib/netstd/Benchmarks/Thrift.Benchmarks/Thrift.Benchmarks.csproj
@@ -20,14 +20,14 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TieredCompilation>false</TieredCompilation>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
+++ b/lib/netstd/Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Thrift.IntegrationTests</AssemblyName>
     <PackageId>Thrift.IntegrationTests</PackageId>
     <Version>0.19.0.0</Version>
@@ -34,11 +34,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.74.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.79.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Thrift\Thrift.csproj" />
@@ -47,7 +47,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <ThriftVersion>0.19.0</ThriftVersion>
     <ThriftVersionOutput>Thrift version $(ThriftVersion)</ThriftVersionOutput>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Version>$(ThriftVersion).0</Version>
     <AssemblyName>Thrift.PublicInterfaces.Compile.Tests</AssemblyName>
     <PackageId>Thrift.PublicInterfaces.Compile.Tests</PackageId>
@@ -37,11 +37,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">

--- a/lib/netstd/Tests/Thrift.Tests/Thrift.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.Tests/Thrift.Tests.csproj
@@ -19,17 +19,17 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Version>0.19.0.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.74.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="CompareNETObjects" Version="4.79.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,6 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 </Project>

--- a/lib/netstd/Thrift/Thrift.csproj
+++ b/lib/netstd/Thrift/Thrift.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>Thrift</AssemblyName>
     <PackageId>ApacheThrift</PackageId>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -57,12 +57,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="System.IO.Pipes" Version="[4.3,)" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
     <PackageReference Include="System.Net.NameResolution" Version="[4.3,)" />
     <PackageReference Include="System.Net.Requests" Version="[4.3,)" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
@@ -70,11 +70,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 	
   <Target Name="SetTFMAssemblyAttributesPath" BeforeTargets="GenerateTargetFrameworkMonikerAttribute">

--- a/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
@@ -32,13 +32,6 @@ using System.Diagnostics;
 
 namespace Thrift.Transport.Server
 {
-    [Obsolete("NamedPipeClientFlags is deprecated, use NamedPipeServerFlags instead.")]
-    [Flags]
-    public enum NamedPipeClientFlags {  // bad name
-        None = 0x00,
-        OnlyLocalClients = 0x01
-    };
-
     [Flags]
     public enum NamedPipeServerFlags
     {
@@ -81,18 +74,6 @@ namespace Thrift.Transport.Server
 
             _pipeAddress = pipeAddress;
             _onlyLocalClients = flags.HasFlag(NamedPipeServerFlags.OnlyLocalClients);
-            _numListenPipes = (byte)numListenPipes;
-        }
-
-        [Obsolete("NamedPipeClientFlags is deprecated, use NamedPipeServerFlags instead.")]
-        public TNamedPipeServerTransport(string pipeAddress, TConfiguration config, NamedPipeClientFlags flags, int numListenPipes = 1)
-            : base(config)
-        {
-            if ((numListenPipes < 1) || (numListenPipes > 254))
-                throw new ArgumentOutOfRangeException(nameof(numListenPipes), "Value must be in the range of [1..254]");
-
-            _pipeAddress = pipeAddress;
-            _onlyLocalClients = flags.HasFlag(NamedPipeClientFlags.OnlyLocalClients);
             _numListenPipes = (byte)numListenPipes;
         }
 

--- a/test/netstd/Client/Client.csproj
+++ b/test/netstd/Client/Client.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
@@ -35,9 +35,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="[4.3,)" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="System.Threading" Version="[4.3,)" />
   </ItemGroup>
 

--- a/test/netstd/Client/TestClient.cs
+++ b/test/netstd/Client/TestClient.cs
@@ -257,7 +257,7 @@ namespace ThriftTest
                         trans = new TTlsSocketTransport(host, port, Configuration, 0,
                             cert,
                             (sender, certificate, chain, errors) => true,
-                            null, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12);
+                            null, SslProtocols.Tls12);
                         break;
 
                     case TransportChoice.Socket:

--- a/test/netstd/Server/Server.csproj
+++ b/test/netstd/Server/Server.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
@@ -37,9 +37,9 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="[4.3,)" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
     <PackageReference Include="System.Threading" Version="[4.3,)" />
   </ItemGroup>
 

--- a/test/netstd/Server/TestServer.cs
+++ b/test/netstd/Server/TestServer.cs
@@ -606,7 +606,7 @@ namespace ThriftTest
                             trans = new TTlsServerSocketTransport(param.port, Configuration,
                                 cert,
                                 (sender, certificate, chain, errors) => true,
-                                null, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12);
+                                null, SslProtocols.Tls12);
                             break;
 
                         case TransportChoice.Socket:

--- a/tutorial/netstd/Client/Client.csproj
+++ b/tutorial/netstd/Client/Client.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tutorial/netstd/Interfaces/Interfaces.csproj
+++ b/tutorial/netstd/Interfaces/Interfaces.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Interfaces</AssemblyName>
     <PackageId>Interfaces</PackageId>
     <Version>0.19.0.0</Version>
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.0" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">

--- a/tutorial/netstd/Server/Program.cs
+++ b/tutorial/netstd/Server/Program.cs
@@ -191,7 +191,7 @@ Sample:
             TServerTransport serverTransport = transport switch
             {
                 Transport.Tcp => new TServerSocketTransport(9090, Configuration),
-                Transport.NamedPipe => new TNamedPipeServerTransport(".test", Configuration, NamedPipeClientFlags.None),
+                Transport.NamedPipe => new TNamedPipeServerTransport(".test", Configuration, NamedPipeServerFlags.None, 64),
                 Transport.TcpTls => new TTlsServerSocketTransport(9090, Configuration, GetCertificate(), ClientCertValidator, LocalCertificateSelectionCallback),
                 _ => throw new ArgumentException("unsupported value $transport", nameof(transport)),
             };

--- a/tutorial/netstd/Server/Server.csproj
+++ b/tutorial/netstd/Server/Server.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
@@ -40,6 +40,6 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer

* Upgrade to net7.0 incl net7.0 library target
*  prevent against new warning [CS8981](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves?f1url=%3FappId%3Droslyn%26k%3Dk(CS8981)#cs8981---the-type-name-only-contains-lower-cased-ascii-characters)"The type name only contains lower-cased ascii characters" that comes alomng with it,
*  also remove the already deprecated NamedPipeClientFlags enum for good.