### PR TITLE
Fix Security Tests for OpenSSLv3

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -198,15 +198,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
   try {
     // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
+        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
+    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
-    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
+    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
+    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -220,15 +220,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
     {
         // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
+        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
+    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
-    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
+    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
+    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 


### PR DESCRIPTION
OpenSSLv3 does stricter protocol matching in the handshake.

This change adapts the test matrix to work with either both widespread versions of OpenSSL.

Partially fixes [THRIFT-5672](https://issues.apache.org/jira/browse/THRIFT-5672).
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.