### PR TITLE
Fix VisualStudio project files and upgrade to VS2015

### DIFF
--- a/lib/cpp/libthrift.vcxproj
+++ b/lib/cpp/libthrift.vcxproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-mt|Win32">
       <Configuration>Debug-mt</Configuration>
@@ -35,41 +35,41 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\thrift\async\TAsyncChannel.cpp"/>
-    <ClCompile Include="src\thrift\async\TConcurrentClientSyncInfo.cpp"/>
-    <ClCompile Include="src\thrift\concurrency\BoostMonitor.cpp" />
-    <ClCompile Include="src\thrift\concurrency\BoostMutex.cpp" />
-    <ClCompile Include="src\thrift\concurrency\ThreadManager.cpp"/>
-    <ClCompile Include="src\thrift\concurrency\TimerManager.cpp"/>
-    <ClCompile Include="src\thrift\concurrency\Util.cpp"/>
-    <ClCompile Include="src\thrift\processor\PeekProcessor.cpp"/>
+    <ClCompile Include="src\thrift\async\TAsyncChannel.cpp" />
+    <ClCompile Include="src\thrift\async\TConcurrentClientSyncInfo.cpp" />
+    <ClCompile Include="src\thrift\concurrency\Monitor.cpp" />
+    <ClCompile Include="src\thrift\concurrency\Mutex.cpp" />
+    <ClCompile Include="src\thrift\concurrency\Thread.cpp" />
+    <ClCompile Include="src\thrift\concurrency\ThreadFactory.cpp" />
+    <ClCompile Include="src\thrift\concurrency\ThreadManager.cpp" />
+    <ClCompile Include="src\thrift\concurrency\TimerManager.cpp" />
+    <ClCompile Include="src\thrift\processor\PeekProcessor.cpp" />
     <ClCompile Include="src\thrift\protocol\TBase64Utils.cpp" />
-    <ClCompile Include="src\thrift\protocol\TDebugProtocol.cpp"/>
-    <ClCompile Include="src\thrift\protocol\TJSONProtocol.cpp"/>
-    <ClCompile Include="src\thrift\protocol\TProtocol.cpp"/>
-    <ClCompile Include="src\thrift\protocol\TMultiplexedProtocol.cpp"/>
-    <ClCompile Include="src\thrift\server\TSimpleServer.cpp"/>
-    <ClCompile Include="src\thrift\server\TThreadPoolServer.cpp"/>
-    <ClCompile Include="src\thrift\server\TThreadedServer.cpp"/>
-    <ClCompile Include="src\thrift\server\TConnectedClient.cpp"/>
-    <ClCompile Include="src\thrift\server\TNonblockingServer.cpp"/>
-    <ClCompile Include="src\thrift\server\TServerFramework.cpp"/>
-    <ClCompile Include="src\thrift\TApplicationException.cpp"/>
-    <ClCompile Include="src\thrift\TOutput.cpp"/>
-    <ClCompile Include="src\thrift\transport\TBufferTransports.cpp"/>
+    <ClCompile Include="src\thrift\protocol\TDebugProtocol.cpp" />
+    <ClCompile Include="src\thrift\protocol\TJSONProtocol.cpp" />
+    <ClCompile Include="src\thrift\protocol\TMultiplexedProtocol.cpp" />
+    <ClCompile Include="src\thrift\protocol\TProtocol.cpp" />
+    <ClCompile Include="src\thrift\server\TConnectedClient.cpp" />
+    <ClCompile Include="src\thrift\server\TServer.cpp" />
+    <ClCompile Include="src\thrift\server\TServerFramework.cpp" />
+    <ClCompile Include="src\thrift\server\TSimpleServer.cpp" />
+    <ClCompile Include="src\thrift\server\TThreadedServer.cpp" />
+    <ClCompile Include="src\thrift\server\TThreadPoolServer.cpp" />
+    <ClCompile Include="src\thrift\TApplicationException.cpp" />
+    <ClCompile Include="src\thrift\TOutput.cpp" />
+    <ClCompile Include="src\thrift\transport\SocketCommon.cpp" />
+    <ClCompile Include="src\thrift\transport\TBufferTransports.cpp" />
     <ClCompile Include="src\thrift\transport\TFDTransport.cpp" />
-    <ClCompile Include="src\thrift\transport\THttpClient.cpp" />
-    <ClCompile Include="src\thrift\transport\THttpServer.cpp" />
-    <ClCompile Include="src\thrift\transport\THttpTransport.cpp"/>
+    <ClCompile Include="src\thrift\transport\TFileTransport.cpp" />
+    <ClCompile Include="src\thrift\transport\THttpTransport.cpp" />
     <ClCompile Include="src\thrift\transport\TPipe.cpp" />
     <ClCompile Include="src\thrift\transport\TPipeServer.cpp" />
-    <ClCompile Include="src\thrift\transport\TServerSocket.cpp"/>
+    <ClCompile Include="src\thrift\transport\TServerSocket.cpp" />
     <ClCompile Include="src\thrift\transport\TSimpleFileTransport.cpp" />
-    <ClCompile Include="src\thrift\transport\TFileTransport.cpp" />
-    <ClCompile Include="src\thrift\transport\TSocket.cpp"/>
-    <ClCompile Include="src\thrift\transport\TSSLSocket.cpp"/>
-    <ClCompile Include="src\thrift\transport\TTransportException.cpp"/>
-    <ClCompile Include="src\thrift\transport\TTransportUtils.cpp"/>
+    <ClCompile Include="src\thrift\transport\TSocket.cpp" />
+    <ClCompile Include="src\thrift\transport\TSocketPool.cpp" />
+    <ClCompile Include="src\thrift\transport\TTransportException.cpp" />
+    <ClCompile Include="src\thrift\transport\TTransportUtils.cpp" />
     <ClCompile Include="src\thrift\windows\GetTimeOfDay.cpp" />
     <ClCompile Include="src\thrift\windows\OverlappedSubmissionThread.cpp" />
     <ClCompile Include="src\thrift\windows\SocketPair.cpp" />
@@ -99,15 +99,12 @@
     <ClInclude Include="src\thrift\transport\TBufferTransports.h" />
     <ClInclude Include="src\thrift\transport\TFDTransport.h" />
     <ClInclude Include="src\thrift\transport\TFileTransport.h" />
-    <ClInclude Include="src\thrift\transport\THttpClient.h" />
-    <ClInclude Include="src\thrift\transport\THttpServer.h" />
     <ClInclude Include="src\thrift\transport\TPipe.h" />
     <ClInclude Include="src\thrift\transport\TPipeServer.h" />
     <ClInclude Include="src\thrift\transport\TServerSocket.h" />
     <ClInclude Include="src\thrift\transport\TServerTransport.h" />
     <ClInclude Include="src\thrift\transport\TSimpleFileTransport.h" />
     <ClInclude Include="src\thrift\transport\TSocket.h" />
-    <ClInclude Include="src\thrift\transport\TSSLSocket.h" />
     <ClInclude Include="src\thrift\transport\TTransport.h" />
     <ClInclude Include="src\thrift\transport\TTransportException.h" />
     <ClInclude Include="src\thrift\transport\TTransportUtils.h" />
@@ -134,45 +131,53 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-mt|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-mt|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-mt|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-mt|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -239,7 +244,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthrift.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
@@ -253,7 +258,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthrift.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
     </ClCompile>
@@ -295,7 +300,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthrift.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
     </ClCompile>
@@ -313,7 +318,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthrift.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
     </ClCompile>

--- a/lib/cpp/libthrift.vcxproj.filters
+++ b/lib/cpp/libthrift.vcxproj.filters
@@ -6,9 +6,6 @@
     </ClCompile>
     <ClCompile Include="src\thrift\TOutput.cpp" />
     <ClCompile Include="src\thrift\TApplicationException.cpp" />
-    <ClCompile Include="src\thrift\windows\StdAfx.cpp">
-      <Filter>windows</Filter>
-    </ClCompile>
     <ClCompile Include="src\thrift\transport\TTransportException.cpp">
       <Filter>transport</Filter>
     </ClCompile>
@@ -19,9 +16,6 @@
       <Filter>concurrency</Filter>
     </ClCompile>
     <ClCompile Include="src\thrift\concurrency\TimerManager.cpp">
-      <Filter>concurrency</Filter>
-    </ClCompile>
-    <ClCompile Include="src\thrift\concurrency\Util.cpp">
       <Filter>concurrency</Filter>
     </ClCompile>
     <ClCompile Include="src\thrift\protocol\TDebugProtocol.cpp">
@@ -46,15 +40,6 @@
       <Filter>transport</Filter>
     </ClCompile>
     <ClCompile Include="src\thrift\transport\THttpTransport.cpp">
-      <Filter>transport</Filter>
-    </ClCompile>
-    <ClCompile Include="src\thrift\transport\THttpClient.cpp">
-      <Filter>transport</Filter>
-    </ClCompile>
-    <ClCompile Include="src\thrift\transport\THttpServer.cpp">
-      <Filter>transport</Filter>
-    </ClCompile>
-    <ClCompile Include="src\thrift\transport\TSSLSocket.cpp">
       <Filter>transport</Filter>
     </ClCompile>
     <ClCompile Include="src\thrift\transport\TTransportUtils.cpp">
@@ -90,12 +75,6 @@
     <ClCompile Include="src\thrift\windows\SocketPair.cpp">
       <Filter>windows</Filter>
     </ClCompile>
-    <ClCompile Include="src\thrift\concurrency\BoostMonitor.cpp">
-      <Filter>concurrency</Filter>
-    </ClCompile>
-    <ClCompile Include="src\thrift\concurrency\BoostMutex.cpp">
-      <Filter>concurrency</Filter>
-    </ClCompile>
     <ClCompile Include="src\thrift\windows\WinFcntl.cpp">
       <Filter>windows</Filter>
     </ClCompile>
@@ -105,6 +84,17 @@
     <ClCompile Include="src\thrift\transport\TPipeServer.cpp">
       <Filter>transport</Filter>
     </ClCompile>
+    <ClCompile Include="src\thrift\concurrency\Monitor.cpp" />
+    <ClCompile Include="src\thrift\concurrency\Mutex.cpp" />
+    <ClCompile Include="src\thrift\concurrency\Thread.cpp" />
+    <ClCompile Include="src\thrift\concurrency\ThreadFactory.cpp" />
+    <ClCompile Include="src\thrift\protocol\TProtocol.cpp" />
+    <ClCompile Include="src\thrift\server\TConnectedClient.cpp" />
+    <ClCompile Include="src\thrift\server\TServer.cpp" />
+    <ClCompile Include="src\thrift\server\TServerFramework.cpp" />
+    <ClCompile Include="src\thrift\transport\SocketCommon.cpp" />
+    <ClCompile Include="src\thrift\transport\TSocketPool.cpp" />
+    <ClCompile Include="src\thrift\windows\OverlappedSubmissionThread.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\thrift\transport\TBufferTransports.h">
@@ -119,12 +109,6 @@
     <ClInclude Include="src\thrift\Thrift.h" />
     <ClInclude Include="src\thrift\TProcessor.h" />
     <ClInclude Include="src\thrift\TApplicationException.h" />
-    <ClInclude Include="src\thrift\windows\StdAfx.h">
-      <Filter>windows</Filter>
-    </ClInclude>
-    <ClInclude Include="src\thrift\windows\TargetVersion.h">
-      <Filter>windows</Filter>
-    </ClInclude>
     <ClInclude Include="src\thrift\concurrency\Exception.h">
       <Filter>concurrency</Filter>
     </ClInclude>
@@ -182,15 +166,6 @@
     <ClInclude Include="src\thrift\transport\TFileTransport.h">
       <Filter>transport</Filter>
     </ClInclude>
-    <ClInclude Include="src\thrift\transport\THttpClient.h">
-      <Filter>transport</Filter>
-    </ClInclude>
-    <ClInclude Include="src\thrift\transport\THttpServer.h">
-      <Filter>transport</Filter>
-    </ClInclude>
-    <ClInclude Include="src\thrift\transport\TSSLSocket.h">
-      <Filter>transport</Filter>
-    </ClInclude>
     <ClInclude Include="src\thrift\transport\TTransportUtils.h">
       <Filter>transport</Filter>
     </ClInclude>
@@ -218,9 +193,6 @@
     <ClInclude Include="src\thrift\windows\SocketPair.h">
       <Filter>windows</Filter>
     </ClInclude>
-    <ClInclude Include="src\thrift\windows\force_inc.h">
-      <Filter>windows</Filter>
-    </ClInclude>
     <ClInclude Include="src\thrift\windows\WinFcntl.h">
       <Filter>windows</Filter>
     </ClInclude>
@@ -230,6 +202,8 @@
     <ClInclude Include="src\thrift\transport\TPipeServer.h">
       <Filter>transport</Filter>
     </ClInclude>
+    <ClInclude Include="src\thrift\TOutput.h" />
+    <ClInclude Include="src\thrift\windows\OverlappedSubmissionThread.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="protocol">
@@ -260,9 +234,6 @@
   <ItemGroup>
     <None Include="src\thrift\protocol\TBinaryProtocol.tcc">
       <Filter>protocol</Filter>
-    </None>
-    <None Include="src\thrift\windows\tr1\functional">
-      <Filter>windows\tr1</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/lib/cpp/libthriftnb.vcxproj
+++ b/lib/cpp/libthriftnb.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-mt|Win32">
       <Configuration>Debug-mt</Configuration>
@@ -64,45 +64,53 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-mt|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-mt|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-mt|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-mt|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -170,7 +178,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthriftnb.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
     </ClCompile>
@@ -185,7 +193,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthriftnb.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
     </ClCompile>
@@ -230,7 +238,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthriftnb.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
     </ClCompile>
@@ -249,7 +257,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_CONFIG_H=1;WIN32;thrift_EXPORTS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)libthriftnb.pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
     </ClCompile>

--- a/lib/cpp/libthriftnb.vcxproj.filters
+++ b/lib/cpp/libthriftnb.vcxproj.filters
@@ -27,9 +27,6 @@
     <ClCompile Include="src\thrift\async\TAsyncProtocolProcessor.cpp">
       <Filter>async</Filter>
     </ClCompile>
-    <ClCompile Include="src\thrift\windows\StdAfx.cpp">
-      <Filter>windows</Filter>
-    </ClCompile>
     <ClCompile Include="src\thrift\transport\TNonblockingServerSocket.cpp">
       <Filter>transport</Filter>
     </ClCompile>
@@ -51,9 +48,6 @@
       <Filter>async</Filter>
     </ClInclude>
     <ClInclude Include="src\thrift\windows\config.h">
-      <Filter>windows</Filter>
-    </ClInclude>
-    <ClInclude Include="src\thrift\windows\StdAfx.h">
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="src\thrift\windows\TargetVersion.h">


### PR DESCRIPTION
The VisualStudio project files in lib/cpp are completely outdated.
This PR:
* Upgrades the project files to VisualStudio 2015.
* Fixes wrong source filenames in the project files.
* Adds thrift_EXPORTS symbol.