### PR TITLE
Add NewTServerSocketUnix() and NewTServerSocketTimeoutUnix()

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -52,6 +52,18 @@ func NewTServerSocketFromAddrTimeout(addr net.Addr, clientTimeout time.Duration)
 	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}
 }
 
+func NewTServerSocketUnix(listenAddr string) (*TServerSocket, error) {
+	return NewTServerSocketTimeoutUnix(listenAddr, 0)
+}
+
+func NewTServerSocketTimeoutUnix(listenAddr string, clientTimeout time.Duration) (*TServerSocket, error) {
+	addr, err := net.ResolveUnixAddr("unix", listenAddr)
+	if err != nil {
+		return nil, err
+	}
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
+}
+
 func (p *TServerSocket) Listen() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The change adds ability to create servers that are listening on local unix domain sockets. We cannot implement it via existing API since necessary members of the TServerSocket() struct are not public (addr & clientTimeout).

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
