### PR TITLE
Update Java lib gradle build script docs

### DIFF
--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -27,8 +27,8 @@
 // https://docs.gradle.org/current/userguide/toolchains.html
 //
 // The '--release' option added below makes sure that even if we are using
-// the toolchain version > 8, the final artifact is at version 8. There is
-// also a runtime CI that's based on Java 8 to ensure that.
+// the toolchain version > 11, the final artifact is at version 11. There is
+// also a runtime CI that's based on Java 11 to ensure that.
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)


### PR DESCRIPTION
It stated Java 8 but now we are on Java 11

<!-- Explain the changes in the pull request below: -->
Update Java lib gradle build script docs

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
