### PR TITLE
Add missing include for the security tests

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <fstream>
 #include <memory>
+#include <openssl/opensslv.h>
 #include <thrift/transport/TSSLServerSocket.h>
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TTransport.h>

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -24,6 +24,7 @@
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <memory>
+#include <openssl/opensslv.h>
 #include <thrift/transport/TSSLServerSocket.h>
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TTransport.h>


### PR DESCRIPTION
Fixes a build error on msvc that was introduced with #2760.