### PR TITLE
py TSocket: Only disable socket.IPV6_V6ONLY when the family is AF_INET6

### DIFF
--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -228,13 +228,14 @@ class TServerSocket(TSocketBase, TServerTransportBase):
                 if eno == errno.ECONNREFUSED:
                     os.unlink(res[4])
 
-        self.handle = socket.socket(res[0], res[1])
-        self.handle.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-        self.handle.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if hasattr(self.handle, 'settimeout'):
-            self.handle.settimeout(None)
-        self.handle.bind(res[4])
-        self.handle.listen(self._backlog)
+        self.handle = s = socket.socket(res[0], res[1])
+        if s.family is socket.AF_INET6:
+            s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if hasattr(s, 'settimeout'):
+            s.settimeout(None)
+        s.bind(res[4])
+        s.listen(self._backlog)
 
     def accept(self):
         client, addr = self.handle.accept()


### PR DESCRIPTION
The changes introduced in 916ae8b8134630f49d32e47c3f0f3218f855a24c causes OSError when the socket is of IPv4 family.  This can be verified by the code snippet below (at least on RHEL 8 and RHEL 9 with Python 3.9):
```python
import socket
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
```
This will raise an exception `OSError: [Errno 92] Protocol not available`.

My fix is pretty simply: only set that IPv6 option when the socket family is IPv6.