### PR TITLE
THRIFT-5696: Allow custom TConfiguration for TByteBuffer.java

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/transport/TByteBuffer.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TByteBuffer.java
@@ -10,15 +10,27 @@ public final class TByteBuffer extends TEndpointTransport {
   private final ByteBuffer byteBuffer;
 
   /**
+   * Creates a new TByteBuffer wrapping a given NIO ByteBuffer and custom TConfiguration.
+   *
+   * @param configuration the custom TConfiguration.
+   * @param byteBuffer the NIO ByteBuffer to wrap.
+   * @throws TTransportException on error.
+   */
+  public TByteBuffer(TConfiguration configuration, ByteBuffer byteBuffer)
+      throws TTransportException {
+    super(configuration);
+    this.byteBuffer = byteBuffer;
+    updateKnownMessageSize(byteBuffer.capacity());
+  }
+
+  /**
    * Creates a new TByteBuffer wrapping a given NIO ByteBuffer.
    *
    * @param byteBuffer the NIO ByteBuffer to wrap.
    * @throws TTransportException on error.
    */
   public TByteBuffer(ByteBuffer byteBuffer) throws TTransportException {
-    super(new TConfiguration());
-    this.byteBuffer = byteBuffer;
-    updateKnownMessageSize(byteBuffer.capacity());
+    this(new TConfiguration(), byteBuffer);
   }
 
   @Override

--- a/lib/java/src/test/java/org/apache/thrift/transport/TestTByteBuffer.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/TestTByteBuffer.java
@@ -1,10 +1,12 @@
 package org.apache.thrift.transport;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import org.apache.thrift.TConfiguration;
 import org.junit.jupiter.api.Test;
 
 public class TestTByteBuffer {
@@ -38,5 +40,30 @@ public class TestTByteBuffer {
             TTransportException.class,
             () -> byteBuffer.write("Hello World".getBytes(StandardCharsets.UTF_8)));
     assertEquals("Not enough room in output buffer", e.getMessage());
+  }
+
+  @Test
+  public void testSmallTConfiguration() throws Exception {
+    // Test that TByteBuffer init fail with small max message size.
+    final TConfiguration configSmall =
+        new TConfiguration(
+            4, TConfiguration.DEFAULT_MAX_FRAME_SIZE, TConfiguration.DEFAULT_RECURSION_DEPTH);
+    TTransportException e =
+        assertThrows(
+            TTransportException.class,
+            () -> new TByteBuffer(configSmall, ByteBuffer.allocate(100)));
+    assertEquals("MaxMessageSize reached", e.getMessage());
+  }
+
+  @Test
+  public void testLargeTConfiguration() throws Exception {
+    // Test that TByteBuffer init pass with large max message size beyond
+    // TConfiguration.DEFAULT_MAX_MESSAGE_SIZE.
+    int maxSize = 101 * 1024 * 1024;
+    int bufferSize = (100 * 1024 + 512) * 1024;
+    final TConfiguration configLarge =
+        new TConfiguration(
+            maxSize, TConfiguration.DEFAULT_MAX_FRAME_SIZE, TConfiguration.DEFAULT_RECURSION_DEPTH);
+    assertDoesNotThrow(() -> new TByteBuffer(configLarge, ByteBuffer.allocate(bufferSize)));
   }
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Client: java

TByteBuffer.java does not allow passing custom TConfiguration into constructor
https://github.com/apache/thrift/blob/66aac4465926404c2bb0c450e80fac2c2824c04c/lib/java/src/main/java/org/apache/thrift/transport/TByteBuffer.java#L18-L22 

Default TConfiguration limit message size is 100MB maximum. TByteBuffer initialization will fail with "MaxMessageSize reached" error for ByteBuffer longer than 100MB.

```
org.apache.thrift.transport.TTransportException: MaxMessageSize reached
	at org.apache.thrift.transport.TEndpointTransport.resetConsumedMessageSize(TEndpointTransport.java:58)
	at org.apache.thrift.transport.TEndpointTransport.updateKnownMessageSize(TEndpointTransport.java:71)
	at org.apache.thrift.transport.TByteBuffer.<init>(TByteBuffer.java:24) 
```

This PR adds one more constructor in TByteBuffer.java that accept custom TConfiguration.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
