### PR TITLE
THRIFT-5698: remove use of deprecated std::iterator

### DIFF
--- a/lib/cpp/src/thrift/Thrift.h
+++ b/lib/cpp/src/thrift/Thrift.h
@@ -50,9 +50,11 @@
 namespace apache {
 namespace thrift {
 
-class TEnumIterator
-    : public std::iterator<std::forward_iterator_tag, std::pair<int, const char*> > {
+class TEnumIterator {
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = std::pair<int, const char*>;
+
   TEnumIterator(int n, int* enums, const char** names)
     : ii_(0), n_(n), enums_(enums), names_(names) {}
 

--- a/lib/cpp/src/thrift/transport/TSocketUtils.h
+++ b/lib/cpp/src/thrift/transport/TSocketUtils.h
@@ -62,7 +62,10 @@ private:
 public:
   using PtrOwnedList = std::unique_ptr<addrinfo, addrinfo_deleter>;
 
-  struct Iter : std::iterator<std::forward_iterator_tag, const addrinfo*> {
+  struct Iter {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const addrinfo*;
+
     value_type ptr = nullptr;
 
     Iter() = default;


### PR DESCRIPTION
C++17 deprecated std::iterator.

See
https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

Prior to this change, compiling while targeting C++17 or higher results
in warnings.