### PR TITLE
THRIFT-5699: java lib and build tool chain: gradle 8.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 19
+          java-version: 17
           cache: "gradle"
 
       - name: Install dependencies
@@ -431,7 +431,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          # here we intentionally use an older version so that we also verify java 19 compiles to it
+          # here we intentionally use an older version so that we also verify Java 17 compiles to it
           java-version: 11
           cache: "gradle"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 19
           cache: "gradle"
 
       - name: Install dependencies
@@ -431,7 +431,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          # here we intentionally use an older version so that we also verify java 17 compiles to it
+          # here we intentionally use an older version so that we also verify java 19 compiles to it
           java-version: 11
           cache: "gradle"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Setup gradle
         run: |
           wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip
-          (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -)
+          (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -)
           unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip
           sudo mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle
           sudo ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
     needs: compiler
     runs-on: ubuntu-20.04
     env:
-      GRADLE_VERSION: "7.6"
+      GRADLE_VERSION: "8.0.2"
     steps:
       - uses: actions/checkout@v3
 

--- a/build/docker/old/ubuntu-disco/Dockerfile
+++ b/build/docker/old/ubuntu-disco/Dockerfile
@@ -160,7 +160,7 @@ RUN apt-get install -y --no-install-recommends \
       haxelib setup --always /usr/share/haxe/lib && \
       haxelib install --always hxcpp 2>&1 > /dev/null
 
-ENV GRADLE_VERSION="7.6"
+ENV GRADLE_VERSION="8.0.2"
 RUN apt-get install -y --no-install-recommends \
       `# Java dependencies` \
       ant \
@@ -169,7 +169,7 @@ RUN apt-get install -y --no-install-recommends \
       openjdk-11-jdk-headless && \
       `# Gradle` \
       wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip && \
-      (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
+      (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
       unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip && \
       mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle && \
       ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/build/docker/old/ubuntu-xenial/Dockerfile
+++ b/build/docker/old/ubuntu-xenial/Dockerfile
@@ -155,7 +155,7 @@ RUN apt-get install -y --no-install-recommends \
       haxelib install --always hxcpp 3.4.64 2>&1 > /dev/null
 # note: hxcpp 3.4.185 (latest) no longer ships static libraries, and caused a build failure
 
-ENV GRADLE_VERSION="7.6"
+ENV GRADLE_VERSION="8.0.2"
 RUN apt-get install -y --no-install-recommends \
       `# Java dependencies` \
       ant \
@@ -165,7 +165,7 @@ RUN apt-get install -y --no-install-recommends \
       unzip && \
       `# Gradle` \
       wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip && \
-      (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
+      (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
       unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip && \
       mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle && \
       ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -161,7 +161,7 @@ RUN apt-get install -y --no-install-recommends \
       haxelib setup --always /usr/share/haxe/lib && \
       haxelib install --always hxcpp 2>&1 > /dev/null
 
-ENV GRADLE_VERSION="7.6"
+ENV GRADLE_VERSION="8.0.2"
 RUN apt-get install -y --no-install-recommends \
       `# Java dependencies` \
       ant \
@@ -170,7 +170,7 @@ RUN apt-get install -y --no-install-recommends \
       openjdk-17-jdk-headless && \
       `# Gradle` \
       wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip && \
-      (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
+      (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
       unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip && \
       mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle && \
       ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -162,7 +162,7 @@ RUN apt-get install -y --no-install-recommends \
       haxelib setup --always /usr/share/haxe/lib && \
       haxelib install --always hxcpp 2>&1 > /dev/null
 
-ENV GRADLE_VERSION="7.6"
+ENV GRADLE_VERSION="8.0.2"
 RUN apt-get install -y --no-install-recommends \
       `# Java dependencies` \
       ant \
@@ -171,7 +171,7 @@ RUN apt-get install -y --no-install-recommends \
       openjdk-17-jdk-headless && \
       `# Gradle` \
       wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip && \
-      (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
+      (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
       unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip && \
       mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle && \
       ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -162,7 +162,7 @@ RUN apt-get install -y --no-install-recommends \
   haxelib setup --always /usr/share/haxe/lib && \
   haxelib install --always hxcpp 2>&1 > /dev/null
 
-ENV GRADLE_VERSION="7.6"
+ENV GRADLE_VERSION="8.0.2"
 RUN apt-get install -y --no-install-recommends \
   `# Java dependencies` \
   ant \
@@ -171,7 +171,7 @@ RUN apt-get install -y --no-install-recommends \
   openjdk-11-jdk-headless && \
   `# Gradle` \
   wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip && \
-  (echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
+  (echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -) && \
   unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip && \
   mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle && \
   ln -s /usr/local/gradle/bin/gradle /usr/local/bin

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -29,7 +29,7 @@ These are only required if you choose to build the libraries for the given langu
     * Qt (optional)
 * Java
     * Java 17
-    * Gradle 7.6
+    * Gradle 8.0.2
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)
 * PHP 5.0 (optionally including header files for extension modules)

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -28,7 +28,7 @@ These are only required if you choose to build the libraries for the given langu
     * zlib (optional)
     * Qt (optional)
 * Java
-    * Java 17
+    * Java 19
     * Gradle 8.0.2
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -28,7 +28,7 @@ These are only required if you choose to build the libraries for the given langu
     * zlib (optional)
     * Qt (optional)
 * Java
-    * Java 19
+    * Java 17 (latest LTS)
     * Gradle 8.0.2
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)

--- a/doc/install/debian.md
+++ b/doc/install/debian.md
@@ -18,7 +18,7 @@ Debian 7/Ubuntu 12 users need to manually install a more recent version of autom
 If you would like to build Apache Thrift libraries for other programming languages you may need to install additional packages. The following languages require the specified additional packages:
 
  * Java
-	* packages: gradle (version 7.6)
+	* packages: gradle (version 8.0.2)
 	* You will also need Java JDK v1.8 or higher. Type **javac** to see a list of available packages, pick the one you prefer and **apt-get install** it (e.g. default-jdk).
  * Ruby
 	* ruby-full ruby-dev ruby-rspec rake rubygems bundler

--- a/lib/java/README.md
+++ b/lib/java/README.md
@@ -42,7 +42,7 @@ The Thrift Java source is not build using the GNU tools, but rather uses
 the Gradle build system, which tends to be predominant amongst Java
 developers.
 
-Currently we use gradle 7.6 to build the Thrift Java source. The usual way to setup gradle
+Currently we use gradle 8.0 to build the Thrift Java source. The usual way to setup gradle
 project is to include the gradle-wrapper.jar in the project and then run the gradle wrapper to
 bootstrap setting up gradle binaries. However to avoid putting binary files into the source tree we
 have ignored the gradle wrapper files. You are expected to install it manually, as described in
@@ -50,13 +50,13 @@ the [gradle documentation](https://docs.gradle.org/current/userguide/installatio
 following this step (which is also done in the travis CI docker images):
 
 ```bash
-export GRADLE_VERSION="7.6"
+export GRADLE_VERSION="8.0.2"
 # install dependencies
 apt-get install -y --no-install-recommends openjdk-17-jdk-headless wget unzip
 # download gradle distribution
 wget https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q -O /tmp/gradle-$GRADLE_VERSION-bin.zip
 # check binary integrity
-echo "7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -
+echo "ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7  /tmp/gradle-$GRADLE_VERSION-bin.zip" | sha256sum -c -
 # unzip and install
 unzip -d /tmp /tmp/gradle-$GRADLE_VERSION-bin.zip
 mv /tmp/gradle-$GRADLE_VERSION /usr/local/gradle

--- a/lib/java/build.gradle
+++ b/lib/java/build.gradle
@@ -40,7 +40,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'pmd'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id "com.github.spotbugs" version "4.7.1"
     id "com.diffplug.spotless" version "6.5.2"
 }

--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -21,7 +21,7 @@
 // ----------------------------------------------------------------------------
 // Compiler configuration details
 
-// We are using Java 17 toolchain to compile.
+// We are using Java 19 toolchain to compile.
 // This enables decoupling from the Java version that gradle runs, from
 // the actual JDK version for the project. For more details, see
 // https://docs.gradle.org/current/userguide/toolchains.html
@@ -31,7 +31,7 @@
 // also a runtime CI that's based on Java 11 to ensure that.
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(19)
     }
 }
 

--- a/lib/java/gradle/sourceConfiguration.gradle
+++ b/lib/java/gradle/sourceConfiguration.gradle
@@ -21,7 +21,7 @@
 // ----------------------------------------------------------------------------
 // Compiler configuration details
 
-// We are using Java 19 toolchain to compile.
+// We are using Java 17 (latest LTS) toolchain to compile.
 // This enables decoupling from the Java version that gradle runs, from
 // the actual JDK version for the project. For more details, see
 // https://docs.gradle.org/current/userguide/toolchains.html
@@ -31,7 +31,7 @@
 // also a runtime CI that's based on Java 11 to ensure that.
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/lib/java/gradle/unitTests.gradle
+++ b/lib/java/gradle/unitTests.gradle
@@ -24,7 +24,7 @@ task testJar(type: Jar, group: 'Build') {
     description = 'Assembles a jar archive containing the test classes.'
     project.test.dependsOn it
 
-    classifier 'test'
+    archiveClassifier = 'test'
     from sourceSets.test.output
 }
 

--- a/lib/java/gradle/unitTests.gradle
+++ b/lib/java/gradle/unitTests.gradle
@@ -65,7 +65,7 @@ test {
         outputs.upToDateWhen { false }
     }
 
-    // This is required for Mockito to run under Java 17
+    // This is required for Mockito to run under Java 19
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     include '**/Test*.class'
     exclude '**/Test*\$*.class'

--- a/lib/java/gradle/unitTests.gradle
+++ b/lib/java/gradle/unitTests.gradle
@@ -65,7 +65,7 @@ test {
         outputs.upToDateWhen { false }
     }
 
-    // This is required for Mockito to run under Java 19
+    // This is required for Mockito to run under Java 17
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     include '**/Test*.class'
     exclude '**/Test*\$*.class'


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
- upgrade gradle to version 8
- ~upgrade toolchain java version to 19~
- upgrade shadow plugin due to incompatible gradle dependency

note this does not change built java library version which is pinned to 11

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
