### PR TITLE
Use Bmi2 instrunction to optmize compact protocol int64 code and deco…

### DIFF
--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -124,6 +124,58 @@ if(UNIX)
     endif()
 endif()
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+  set(PREV_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mbmi2 -mbmi -mlzcnt -msse3 -mavx512bw -mavx512vl")
+  check_cxx_source_compiles(
+  "
+  #include <immintrin.h>
+  int main(){unsigned int a,b;_pdep_u32(a,b); return 0;}
+  "
+  HAVE_BMI2)
+  check_cxx_source_compiles(
+  "
+  #include <immintrin.h>
+  int main(){unsigned int a; _tzcnt_u32(a); return 0;}
+  "
+  HAVE_BMI)
+  check_cxx_source_compiles(
+  "
+  #include <immintrin.h>
+  int main(){unsigned int c;_lzcnt_u32(c); return 0;}
+  "
+  HAVE_LZCNT)
+  check_cxx_source_compiles(
+  "
+  #include <immintrin.h>
+  int main(){const __m128i* p;_mm_lddqu_si128(p); return 0;}
+  "
+  HAVE_SSE3)
+  check_cxx_source_compiles(
+  "
+  #include <immintrin.h>
+  int main(){__m128i a,b;_mm_mask_cmp_epi8_mask(0x3ff,a,b,_MM_CMPINT_NLT); return 0;}
+  "
+  HAVE_AVX512BW_AVX512VL)
+
+  if (HAVE_BMI2)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2")
+  endif()
+  if (HAVE_BMI)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi")
+  endif()
+  if (HAVE_LZCNT)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlzcnt")
+  endif()
+  if (HAVE_SSE3)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse3")
+  endif()
+  if (HAVE_AVX512BW_AVX512VL)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512bw -mavx512vl")
+  endif()
+  set(CMAKE_REQUIRED_FLAGS ${PREV_CMAKE_REQUIRED_FLAGS})
+endif ()
+
 set(thriftcpp_threads_SOURCES
     src/thrift/concurrency/ThreadFactory.cpp
     src/thrift/concurrency/Thread.cpp

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -167,7 +167,14 @@ public:
   uint32_t writeListEnd() { return 0; }
   uint32_t writeSetEnd() { return 0; }
   uint32_t writeFieldEnd() { return 0; }
+private:
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t writeVarint64NoneBMI2(uint64_t n);
 
+#if defined(__BMI2__) && defined(__LZCNT__)
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t writeVarint64BMI2(uint64_t n);
+#endif
 protected:
   int32_t writeFieldBeginInternal(const char* name,
                                   const TType fieldType,
@@ -222,6 +229,19 @@ public:
   uint32_t readMapEnd() { return 0; }
   uint32_t readListEnd() { return 0; }
   uint32_t readSetEnd() { return 0; }
+
+private:
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t readVarint64FastPathNoneAVX(const uint8_t* buf,const std::size_t bufsz,int64_t& i64);
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t readVarint64SlowPathNoneAVX(uint8_t* buf,const std::size_t bufsz,int64_t& i64);
+  #if defined(__SSE3__) && defined(__AVX512BW__) && defined(__AVX512VL__) && \
+  defined(__BMI2__) && defined(__BMI__)
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t readVarint64FastPathAVX(const uint8_t* buf,const std::size_t bufsz,int64_t& i64);
+  template<bool needConsume=true>
+  inline __attribute__((always_inline)) uint32_t readVarint64SlowPathAVX(uint8_t* buf,const std::size_t bufsz,int64_t& i64);
+  #endif
 
 protected:
   uint32_t readVarint32(int32_t& i32);


### PR DESCRIPTION
…de,in our unit

test.It show that code has 30% performance boost, and in decode it show 5% performance boost.
origin bench:
$ ./GbenchMarkForCompactProtocol
2023-04-10T00:56:33+08:00
Running ./GbenchMarkForCompactProtocol
Run on (128 X 3300 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 49152 KiB (x2)
Load Average: 0.71, 0.57, 0.24
-------------------------------------------------------------
Benchmark                   Time             CPU   Iterations
-------------------------------------------------------------
BM_Int64_Encode_1        22.1 ns         22.1 ns     31677633
BM_Int64_Encode_2        23.7 ns         23.7 ns     29457528
BM_Int64_Encode_3        26.1 ns         26.1 ns     26844781
BM_Int64_Encode_4        27.1 ns         27.1 ns     25705377
BM_Int64_Encode_5        30.0 ns         29.9 ns     23345095
BM_Int64_Encode_6        32.3 ns         32.3 ns     21658363
BM_Int64_Encode_7        34.5 ns         34.5 ns     20256118
BM_Int64_Encode_8        36.3 ns         36.3 ns     19234451
BM_Int64_Encode_9        37.8 ns         37.8 ns     18510508
BM_Int64_Encode_10       39.8 ns         39.8 ns     17531197
BM_Int64_Decode_1         485 ns          486 ns      1439281
BM_Int64_Decode_2         489 ns          491 ns      1424556
BM_Int64_Decode_3         493 ns          495 ns      1413917
BM_Int64_Decode_4         491 ns          493 ns      1421200
BM_Int64_Decode_5         495 ns          497 ns      1408950
BM_Int64_Decode_6         496 ns          498 ns      1406069
BM_Int64_Decode_7         504 ns          506 ns      1383636
BM_Int64_Decode_8         507 ns          509 ns      1374477
BM_Int64_Decode_9         505 ns          507 ns      1380481
BM_Int64_Decode_10        503 ns          505 ns      1386843

optimized bench:
$ ./GbenchMarkForCompactProtocol
2023-04-10T01:09:25+08:00
Running ./GbenchMarkForCompactProtocol
Run on (128 X 3300 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 49152 KiB (x2)
Load Average: 0.00, 0.24, 0.31
-------------------------------------------------------------
Benchmark                   Time             CPU   Iterations
-------------------------------------------------------------
BM_Int64_Encode_1        21.0 ns         21.0 ns     30414973
BM_Int64_Encode_2        22.3 ns         22.2 ns     28778678
BM_Int64_Encode_3        25.6 ns         25.6 ns     27278662
BM_Int64_Encode_4        29.1 ns         29.1 ns     23984143
BM_Int64_Encode_5        29.3 ns         29.2 ns     23856317
BM_Int64_Encode_6        29.6 ns         29.6 ns     23585080
BM_Int64_Encode_7        29.9 ns         29.8 ns     23423250
BM_Int64_Encode_8        29.7 ns         29.7 ns     23496002
BM_Int64_Encode_9        28.9 ns         28.9 ns     24128142
BM_Int64_Encode_10       28.9 ns         28.8 ns     24132967
BM_Int64_Decode_1         480 ns          480 ns      1430995
BM_Int64_Decode_2         481 ns          481 ns      1390746
BM_Int64_Decode_3         490 ns          492 ns      1395035
BM_Int64_Decode_4         495 ns          496 ns      1409327
BM_Int64_Decode_5         500 ns          501 ns      1398344
BM_Int64_Decode_6         495 ns          497 ns      1408096
BM_Int64_Decode_7         499 ns          501 ns      1398316
BM_Int64_Decode_8         496 ns          497 ns      1409067
BM_Int64_Decode_9         501 ns          503 ns      1392703
BM_Int64_Decode_10        500 ns          502 ns      1395121

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
