### PR TITLE
Unsafe i32 to usize conversion from network data

### DIFF
--- a/lib/rs/src/lib.rs
+++ b/lib/rs/src/lib.rs
@@ -91,3 +91,48 @@ pub type Result<T> = std::result::Result<T, self::Error>;
 // Re-export ordered-float, since it is used by the generator
 // FIXME: check the guidance around type reexports
 pub use ordered_float::OrderedFloat;
+
+use std::io::{Error as IoErr, ErrorKind as IoErrKind};
+use std::ops::RangeBounds;
+
+/// A trait similar to try-from but with additional checks
+pub trait TryIntoRange<T>: TryInto<T> {
+    type ErrTy;
+
+    fn try_into_range(
+        self,
+        between: impl RangeBounds<Self>,
+    ) -> std::result::Result<T, Self::ErrTy>;
+}
+
+impl TryIntoRange<usize> for i32 {
+    type ErrTy = IoErr;
+
+    fn try_into_range(
+        self,
+        between: impl RangeBounds<Self>,
+    ) -> std::result::Result<usize, Self::ErrTy> {
+        if between.contains(&self) {
+            self.try_into()
+                .map_err(|_| IoErr::from(IoErrKind::InvalidData))
+        } else {
+            Err(IoErr::from(IoErrKind::InvalidData))
+        }
+    }
+}
+
+impl TryIntoRange<usize> for u32 {
+    type ErrTy = IoErr;
+
+    fn try_into_range(
+        self,
+        between: impl RangeBounds<Self>,
+    ) -> std::result::Result<usize, Self::ErrTy> {
+        if between.contains(&self) {
+            self.try_into()
+                .map_err(|_| IoErr::from(IoErrKind::InvalidData))
+        } else {
+            Err(IoErr::from(IoErrKind::InvalidData))
+        }
+    }
+}

--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -25,6 +25,7 @@ use super::{
 use super::{TOutputProtocol, TOutputProtocolFactory, TSetIdentifier, TStructIdentifier, TType};
 use crate::transport::{TReadTransport, TWriteTransport};
 use crate::{ProtocolError, ProtocolErrorKind};
+use crate::{TryIntoRange};
 
 const BINARY_PROTOCOL_VERSION_1: u32 = 0x8001_0000;
 
@@ -112,7 +113,8 @@ where
                 // in the non-strict version the first message field
                 // is the message name. strings (byte arrays) are length-prefixed,
                 // so we've just read the length in the first 4 bytes
-                let name_size = BigEndian::read_i32(&first_bytes) as usize;
+                let name_size = BigEndian::read_i32(&first_bytes)
+                                    .try_into_range(0..=i32::MAX)?;
                 let mut name_buf: Vec<u8> = vec![0; name_size];
                 self.transport.read_exact(&mut name_buf)?;
                 let name = String::from_utf8(name_buf)?;
@@ -154,7 +156,7 @@ where
     }
 
     fn read_bytes(&mut self) -> crate::Result<Vec<u8>> {
-        let num_bytes = self.transport.read_i32::<BigEndian>()? as usize;
+        let num_bytes = self.transport.read_i32::<BigEndian>()?.try_into_range(0..=i32::MAX)?;
         let mut buf = vec![0u8; num_bytes];
         self.transport
             .read_exact(&mut buf)


### PR DESCRIPTION
This patch fixes the problem with uncheckd data
conversion read from the network. Currently, code
reads data from the network, converts it to
i32, and then blindly converts it to usize (so -1
gets converted to -1_usize and causes panic in
debug build and huge memory use in release build). 
This could easily become a security vulnerability. 

The fix replaces all `as usize` casts to try_into
style casts.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
