### PR TITLE
THRIFT-5703 Haxe 4.30 emits "Local variable retval used without being initialized" on generated code

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
@@ -2521,7 +2521,6 @@ void t_haxe_generator::generate_serialize_struct(ostream& out, t_struct* tstruct
  * @param prefix String prefix for fields
  */
 void t_haxe_generator::generate_serialize_container(ostream& out, t_type* ttype, string prefix) {
-  scope_up(out);
 
   if (ttype->is_map()) {
     string iter = tmp("_key");
@@ -2572,7 +2571,6 @@ void t_haxe_generator::generate_serialize_container(ostream& out, t_type* ttype,
     indent(out) << "oprot.writeListEnd();" << endl;
   }
 
-  scope_down(out);
 }
 
 /**

--- a/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_haxe_generator.cc
@@ -201,6 +201,7 @@ public:
   std::string type_name(t_type* ttype, bool in_container = false, bool in_init = false);
   std::string base_type_name(t_base_type* tbase, bool in_container = false);
   std::string declare_field(t_field* tfield, bool init = false);
+  std::string render_default_value_for_type(t_type* type, bool allow_null);
   std::string function_signature_combined(t_function* tfunction);
   std::string function_signature_normal(t_function* tfunction);
   std::string argument_list(t_struct* tstruct);
@@ -1878,8 +1879,9 @@ void t_haxe_generator::generate_service_client(t_service* tservice) {
 
     string retval = tmp("retval");
     if (!((*f_iter)->is_oneway() || (*f_iter)->get_returntype()->is_void())) {
-      f_service_ << indent() << "var " << retval << " : " << type_name((*f_iter)->get_returntype()) << ";"
-                 << endl;
+      f_service_ << indent() << "var " << retval << " : " << type_name((*f_iter)->get_returntype())
+                 << " = " << render_default_value_for_type((*f_iter)->get_returntype(),true) 
+                 << ";" << endl;
     }
 
     if ((*f_iter)->is_oneway()) {
@@ -2736,48 +2738,49 @@ string t_haxe_generator::base_type_name(t_base_type* type, bool in_container) {
  * @param ttype The type
  */
 string t_haxe_generator::declare_field(t_field* tfield, bool init) {
-  // TODO(mcslee): do we ever need to initialize the field?
   string result = "var " + tfield->get_name() + " : " + type_name(tfield->get_type());
   if (init) {
     t_type* ttype = get_true_type(tfield->get_type());
     if (ttype->is_base_type() && tfield->get_value() != nullptr) {
       result += " = " + render_const_value_str( ttype, tfield->get_value());
-    } else if (ttype->is_base_type()) {
-      t_base_type::t_base tbase = ((t_base_type*)ttype)->get_base();
-      switch (tbase) {
-      case t_base_type::TYPE_VOID:
-        throw "NO T_VOID CONSTRUCT";
-      case t_base_type::TYPE_STRING:
-        result += " = null";
-        break;
-      case t_base_type::TYPE_UUID:
-        result += " = uuid.Uuid.NIL";
-        break;
-      case t_base_type::TYPE_BOOL:
-        result += " = false";
-        break;
-      case t_base_type::TYPE_I8:
-      case t_base_type::TYPE_I16:
-      case t_base_type::TYPE_I32:
-      case t_base_type::TYPE_I64:
-        result += " = 0";
-        break;
-      case t_base_type::TYPE_DOUBLE:
-        result += " = (double)0";
-        break;
-      default:
-        throw "unhandled type";
-      }
-
-    } else if (ttype->is_enum()) {
-      result += " = 0";
-    } else if (ttype->is_container()) {
-      result += " = new " + type_name(ttype, false, true) + "()";
     } else {
-      result += " = new " + type_name(ttype, false, true) + "()";
+      result += " = " + render_default_value_for_type( ttype, false);
     }
   }
   return result + ";";
+}
+
+string t_haxe_generator::render_default_value_for_type( t_type* type, bool allow_null) {
+  t_type* ttype = get_true_type(type);
+
+  if (ttype->is_base_type()) {
+    t_base_type::t_base tbase = ((t_base_type*)ttype)->get_base();
+    switch (tbase) {
+    case t_base_type::TYPE_VOID:
+      throw "NO T_VOID CONSTRUCT";
+    case t_base_type::TYPE_STRING:
+      return "null";
+    case t_base_type::TYPE_UUID:
+      return "uuid.Uuid.NIL";
+    case t_base_type::TYPE_BOOL:
+      return "false";
+    case t_base_type::TYPE_I8:
+    case t_base_type::TYPE_I16:
+    case t_base_type::TYPE_I32:
+    case t_base_type::TYPE_I64:
+      return "0";
+    case t_base_type::TYPE_DOUBLE:
+      return "0.0";
+    default:
+      throw "unhandled type";
+    }
+  } else if (ttype->is_enum()) {
+    return "0";
+  } else if (ttype->is_container()) {
+    return allow_null ? "null" : "new " + type_name(ttype, false, true) + "()";
+  } else {
+    return allow_null ? "null" : "new " + type_name(ttype, false, true) + "()";
+  }
 }
 
 /**


### PR DESCRIPTION
plus THRIFT-5704 Superfluous block scope in generated write() code