### PR TITLE
THRIFT-5709: Drastically improve to_string() performance.

### DIFF
--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -35,7 +35,8 @@ namespace thrift {
 template <typename T>
 std::string to_string(const T& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  const static auto locale = std::locale("C");
+  o.imbue(locale);
   o << t;
   return o.str();
 }
@@ -44,7 +45,8 @@ std::string to_string(const T& t) {
 // is enabled.
 inline std::string to_string(const float& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  const static auto locale = std::locale("C");
+  o.imbue(locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<float>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -52,7 +54,8 @@ inline std::string to_string(const float& t) {
 
 inline std::string to_string(const double& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  const static auto locale = std::locale("C");
+  o.imbue(locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -60,7 +63,8 @@ inline std::string to_string(const double& t) {
 
 inline std::string to_string(const long double& t) {
   std::ostringstream o;
-  o.imbue(std::locale("C"));
+  const static auto locale = std::locale("C");
+  o.imbue(locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<long double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();

--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -32,11 +32,15 @@
 namespace apache {
 namespace thrift {
 
+// unnamed namespace to enforce internal linkage - could be done with 'inline' when once have C++17
+namespace {
+const auto default_locale = std::locale("C");
+}
+
 template <typename T>
 std::string to_string(const T& t) {
   std::ostringstream o;
-  const static auto locale = std::locale("C");
-  o.imbue(locale);
+  o.imbue(default_locale);
   o << t;
   return o.str();
 }
@@ -45,8 +49,7 @@ std::string to_string(const T& t) {
 // is enabled.
 inline std::string to_string(const float& t) {
   std::ostringstream o;
-  const static auto locale = std::locale("C");
-  o.imbue(locale);
+  o.imbue(default_locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<float>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -54,8 +57,7 @@ inline std::string to_string(const float& t) {
 
 inline std::string to_string(const double& t) {
   std::ostringstream o;
-  const static auto locale = std::locale("C");
-  o.imbue(locale);
+  o.imbue(default_locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();
@@ -63,8 +65,7 @@ inline std::string to_string(const double& t) {
 
 inline std::string to_string(const long double& t) {
   std::ostringstream o;
-  const static auto locale = std::locale("C");
-  o.imbue(locale);
+  o.imbue(default_locale);
   o.precision(static_cast<std::streamsize>(std::ceil(static_cast<double>(std::numeric_limits<long double>::digits * std::log10(2.0f) + 1))));
   o << t;
   return o.str();


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Currently, the `to_string()` overloads in `TToString.h` call the `std::locale` constructor for every single call. Creating locales is surprisingly expensive. We have an application where we - especially during tests - write large amounts of Thrift dumps to disk, and is this application we currently spend around 17% of total CPU time in std::locale's constructor (building with MSVC, in a Release build - other compilers might optimize this away?). With this change, it's basically down to zero.

Since we always create the exact same locale anyways, using a `const static` one does not hurt.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
