### PR TITLE
Fix NewTZlibTransportFactoryWithFactory comment

### DIFF
--- a/lib/go/thrift/zlib_transport.go
+++ b/lib/go/thrift/zlib_transport.go
@@ -56,7 +56,7 @@ func NewTZlibTransportFactory(level int) *TZlibTransportFactory {
 	return &TZlibTransportFactory{level: level, factory: nil}
 }
 
-// NewTZlibTransportFactory constructs a new instance of TZlibTransportFactory
+// NewTZlibTransportFactoryWithFactory constructs a new instance of TZlibTransportFactory
 // as a wrapper over existing transport factory
 func NewTZlibTransportFactoryWithFactory(level int, factory TTransportFactory) *TZlibTransportFactory {
 	return &TZlibTransportFactory{level: level, factory: factory}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

There is a bad name in the NewTZlibTransportFactoryWithFactory function comment.
Found here: https://github.com/open-telemetry/opentelemetry-go/pull/4020
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
