### PR TITLE
THRIFT-5711: Fix FutureClient implementation when service extends from another service

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -3369,6 +3369,7 @@ void t_java_generator::generate_service_future_client(t_service* tservice) {
   string extends_client = "";
   if (tservice->get_extends() != nullptr) {
     extends_client = "extends " + type_name(tservice->get_extends()) + ".FutureClient ";
+  }
 
   static string adapter_class = "org.apache.thrift.async.AsyncMethodFutureAdapter";
   indent(f_service_) << "public static class FutureClient " << extends_client

--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -3366,8 +3366,13 @@ void t_java_generator::generate_service_client(t_service* tservice) {
 }
 
 void t_java_generator::generate_service_future_client(t_service* tservice) {
+  string extends_client = "";
+  if (tservice->get_extends() != nullptr) {
+    extends_client = "extends " + type_name(tservice->get_extends()) + ".FutureClient ";
+
   static string adapter_class = "org.apache.thrift.async.AsyncMethodFutureAdapter";
-  indent(f_service_) << "public static class FutureClient implements FutureIface {" << endl;
+  indent(f_service_) << "public static class FutureClient " << extends_client
+                     << "implements FutureIface {" << endl;
   indent_up();
   indent(f_service_) << "public FutureClient(AsyncIface delegate) {" << endl;
   indent_up();


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The `FutureClient` should extend the parent service `FutureClient` because the `FutureIface` does that too. Without this change the `FutureClient` will get a compilation error that does not implement all the methods. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
