### PR TITLE
THRIFT-5706: lib: cpp: Fix C++ SecurityTest compilation on OpenSSL1.x

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -109,7 +109,13 @@ struct SecurityFromBufferFixture {
       shared_ptr<TSSLServerSocket> pServerSocket;
 
       pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+      // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+      // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+      pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
+#else
       pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+#endif
       pServerSocketFactory->loadCertificateFromBuffer(certString("server.crt").c_str());
       pServerSocketFactory->loadPrivateKeyFromBuffer(certString("server.key").c_str());
       pServerSocketFactory->server(true);
@@ -154,6 +160,11 @@ struct SecurityFromBufferFixture {
 
       try {
         pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+        // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+        pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
+#endif
         pClientSocketFactory->authenticate(true);
         pClientSocketFactory->loadCertificateFromBuffer(certString("client.crt").c_str());
         pClientSocketFactory->loadPrivateKeyFromBuffer(certString("client.key").c_str());
@@ -199,16 +210,15 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
   try {
     // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
+    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
-    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
+    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
+    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -108,7 +108,13 @@ struct SecurityFixture
             shared_ptr<TSSLServerSocket> pServerSocket;
 
             pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+            // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+            // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+            pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
+#else
             pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+#endif
             pServerSocketFactory->loadCertificate(certFile("server.crt").string().c_str());
             pServerSocketFactory->loadPrivateKey(certFile("server.key").string().c_str());
             pServerSocketFactory->server(true);
@@ -161,6 +167,11 @@ struct SecurityFixture
             try
             {
                 pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+                // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+                // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+                pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
+#endif
                 pClientSocketFactory->authenticate(true);
                 pClientSocketFactory->loadCertificate(certFile("client.crt").string().c_str());
                 pClientSocketFactory->loadPrivateKey(certFile("client.key").string().c_str());
@@ -221,16 +232,15 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
     {
         // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
+    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
-    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
+    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
+    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 


### PR DESCRIPTION
A recent change modified SecurityTest.cpp/SecurityFromBufferTest.cpp to handle OpenSSL3 by using OPENSSL_VERSION_MAJOR to detect the different OpenSSL versions. OPENSSL_VERSION_MAJOR is not available on OpenSSL 1.x, so these tests no longer compile on Ubuntu 20, etc.

The underlying reason for the OpenSSL3 change is that older versions of TLS (1.0, 1.1) are only accessible when specifying @SECLEVEL=0. Some distributions with OpenSSL 1.1.1 (Ubuntu 20) make them accessible at @SECLEVEL=1, so the tests can also fail in that circumstance.

This removes the reference to OPENSSL_VERSION_MAJOR and changes the test to specify @SECLEVEL=0 for OpenSSL versions that have @SECLEVEL support (> 1.1.0).

Testing:
 - Tested SecurityTest/SecurityFromBufferTest on Ubuntu 20 and 22
 - Tested with OpenSSL 1.0.2

<!-- Explain the changes in the pull request below: -->
 This fixes the build/functionality for SecurityTest/SecurityFromBufferTest after the changes in https://github.com/apache/thrift/commit/05604e261455f1d85a5d04c4364a21d2a7e417b2

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
