### PR TITLE
THRIFT-5715: Python non-user defined fields mutable with slots

### DIFF
--- a/test/py/TestClient.py
+++ b/test/py/TestClient.py
@@ -256,6 +256,35 @@ class AbstractTest(unittest.TestCase):
         y = self.client.testMultiException('success', 'foobar')
         self.assertEqual(y.string_thing, 'foobar')
 
+    def testException__traceback__(self):
+        print('testException__traceback__')
+        self.client.testException('Safe')
+        expect_slots = uses_slots = False
+        expect_dynamic = uses_dynamic = False
+        try:
+            self.client.testException('Xception')
+            self.fail("should have gotten exception")
+        except Xception as x:
+            uses_slots = hasattr(x, '__slots__')
+            uses_dynamic = (not isinstance(x, TException))
+            # We set expected values here so that we get clean tracebackes when
+            # the assertions fail.
+            try:
+                x.__traceback__ = x.__traceback__
+                # If `__traceback__` was set without errors than we expect that
+                # the slots option was used and that dynamic classes were not.
+                expect_slots = True
+                expect_dynamic = False
+            except Exception as e:
+                self.assertTrue(isinstance(e, TypeError))
+                # There are no other meaningful tests we can preform because we
+                # are unable to determine the desired state of either `__slots__`
+                # or `dynamic`.
+                return
+
+        self.assertEqual(expect_slots, uses_slots)
+        self.assertEqual(expect_dynamic, uses_dynamic)
+
     def testOneway(self):
         print('testOneway')
         start = time.time()


### PR DESCRIPTION
In Python 3.11 exceptions generated by the compiler can't be used with a
context manager because they are immutable. As of Python 3.11
`contextlib.contextmanager` sets `exc.__traceback__` in the event that
the code in the context manager errors.

As of Thrift v0.18.1 exceptions are generated as immutable by default.
See [PR#1835](https://github.com/apache/thrift/pull/1835) for more information about why exceptions were made
immutable by default.

This change makes all non-Thrift fields mutable when slots is used  without dynamic. This
will allow exceptions to be re-raised properly by the contextmanager in
Python 3.11.

With tutorial code generated from `head` this raises a `TypeError` not 
an `InvalidOperation`:

```
import contextlib
import sys

sys.path.append('gen-py')
from tutorial.ttypes import InvalidOperation

@contextlib.contextmanager
def example():
    yield
    return

def main():
    with example():
        raise InvalidOperation

if __name__ == "__main__":
    main()
```

It raises this error:

```
root@b81016c354b4:/src/thrift/tutorial/py# python3 contextmanager.py 
Traceback (most recent call last):
  File "/src/thrift/tutorial/py/contextmanager.py", line 5, in <module>
    from tutorial.ttypes import InvalidOperation
ModuleNotFoundError: No module named 'tutorial.ttypes'
root@b81016c354b4:/src/thrift/tutorial/py# python3 contextmanager.py 
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/src/thrift/tutorial/py/contextmanager.py", line 9, in example
    yield
  File "/src/thrift/tutorial/py/contextmanager.py", line 14, in main
    raise InvalidOperation
tutorial.ttypes.InvalidOperation: InvalidOperation(whatOp=None, why=None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/src/thrift/tutorial/py/contextmanager.py", line 17, in <module>
    main()
  File "/src/thrift/tutorial/py/contextmanager.py", line 13, in main
    with example():
  File "/usr/local/lib/python3.11/contextlib.py", line 188, in __exit__
    exc.__traceback__ = traceback
    ^^^^^^^^^^^^^^^^^
  File "/src/thrift/tutorial/py/gen-py/tutorial/ttypes.py", line 160, in __setattr__
    raise TypeError("can't modify immutable instance")
TypeError: can't modify immutable instance
```

The error after this change without slots, this error still happens:

```
root@daf9a41282a7:/src/thrift/tutorial/py# python3 ./contextmanager.py 
Traceback (most recent call last):
  File "/src/thrift/tutorial/py/./contextmanager.py", line 17, in <module>
    main()
  File "/src/thrift/tutorial/py/./contextmanager.py", line 14, in main
    raise InvalidOperation
tutorial.ttypes.InvalidOperation: InvalidOperation(whatOp=None, why=None)
root@daf9a41282a7:/src/thrift/tutorial/py# python3 ./contextmanager.py 
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/src/thrift/tutorial/py/./contextmanager.py", line 9, in example
    yield
  File "/src/thrift/tutorial/py/./contextmanager.py", line 14, in main
    raise InvalidOperation
tutorial.ttypes.InvalidOperation: InvalidOperation(whatOp=None, why=None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/src/thrift/tutorial/py/./contextmanager.py", line 17, in <module>
    main()
  File "/src/thrift/tutorial/py/./contextmanager.py", line 13, in main
    with example():
  File "/usr/local/lib/python3.11/contextlib.py", line 188, in __exit__
    exc.__traceback__ = traceback
    ^^^^^^^^^^^^^^^^^
  File "/src/thrift/tutorial/py/gen-py/tutorial/ttypes.py", line 160, in __setattr__
    raise TypeError("can't modify immutable instance")
TypeError: can't modify immutable instance
```

After change with slots:

```
root@b81016c354b4:/src/thrift/tutorial/py# python3 contextmanager.py 
Traceback (most recent call last):
  File "/src/thrift/tutorial/py/contextmanager.py", line 17, in <module>
    main()
  File "/src/thrift/tutorial/py/contextmanager.py", line 14, in main
    raise InvalidOperation
tutorial.ttypes.InvalidOperation: InvalidOperation(whatOp=None, why=None)
```

There is no diff in the generated code when slots is not used.

Here is the diff between `thrift` at head and this branch generating with `slots`:

```
src# diff -C 5 -r tutorial/gen-py-pr/head-slots/ tutorial/gen-py-pr/dev-slots/
diff -C 5 -r tutorial/gen-py-pr/head-slots/tutorial/ttypes.py tutorial/gen-py-pr/dev-slots/tutorial/ttypes.py
*** tutorial/gen-py-pr/head-slots/tutorial/ttypes.py    Thu Jun 29 16:03:16 2023
--- tutorial/gen-py-pr/dev-slots/tutorial/ttypes.py     Thu Jun 29 16:19:11 2023
***************
*** 174,186 ****
--- 174,192 ----
      def __init__(self, whatOp=None, why=None,):
          super(InvalidOperation, self).__setattr__('whatOp', whatOp)
          super(InvalidOperation, self).__setattr__('why', why)
  
      def __setattr__(self, *args):
+         if args[0] not in self.__slots__:
+             super().__setattr__(*args)
+             return
          raise TypeError("can't modify immutable instance")
  
      def __delattr__(self, *args):
+         if args[0] not in self.__slots__:
+             super().__delattr__(*args)
+             return
          raise TypeError("can't modify immutable instance")
  
      def __hash__(self):
          return hash(self.__class__) ^ hash((self.whatOp, self.why, ))
```

<!-- Explain the changes in the pull request below: -->
  


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
