### PR TITLE
THRIFT-5716: lib: cpp: Fix crash in TMemoryBuffer due to uint32_t overflow

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -363,9 +363,9 @@ void TMemoryBuffer::ensureCanWrite(uint32_t len) {
     throw TTransportException("Insufficient space in external MemoryBuffer");
   }
 
-  // Grow the buffer as necessary.
-  const uint32_t current_used = bufferSize_ - avail;
-  const uint32_t required_buffer_size = len + current_used;
+  // Grow the buffer as necessary. Use uint64_t to avoid overflow.
+  const uint64_t current_used = bufferSize_ - avail;
+  const uint64_t required_buffer_size = len + current_used;
   if (required_buffer_size > maxBufferSize_) {
     throw TTransportException(TTransportException::BAD_ARGS,
                               "Internal buffer size overflow when requesting a buffer of size " + std::to_string(required_buffer_size));

--- a/lib/cpp/test/TMemoryBufferTest.cpp
+++ b/lib/cpp/test/TMemoryBufferTest.cpp
@@ -385,6 +385,14 @@ BOOST_AUTO_TEST_CASE(test_maximum_buffer_size)
   BOOST_CHECK_THROW(buf.write(&small_buff[0], 1), TTransportException);
 }
 
+BOOST_AUTO_TEST_CASE(test_buffer_overflow)
+{
+  TMemoryBuffer buf;
+  std::vector<uint8_t> small_buff(1);
+  buf.write(&small_buff[0], 1);
+  BOOST_CHECK_THROW(buf.getWritePtr(std::numeric_limits<uint32_t>::max()), TTransportException);
+}
+
 BOOST_AUTO_TEST_CASE(test_memory_buffer_to_get_sizeof_objects)
 {
   // This is a demonstration of how to use TMemoryBuffer to determine


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This fixes the overflow in `TMemoryBuffer::ensureCanWrite()` when the current usage plus the length of new content exceeds the max of uint32_t (e.g. 4GB). The buggy code is
```cpp
  const uint32_t current_used = bufferSize_ - avail;
  const uint32_t required_buffer_size = len + current_used;
  if (required_buffer_size > maxBufferSize_) {
    throw TTransportException(...)
  }
```
`len + current_used` could overflow in `uint32_t`, which results in not rejecting the write, i.e. not throwing TTransportException. The follow-up write on this TMemoryBuffer will write to invalid memory address and leads to a crash (e.g. [IMPALA-12223](https://issues.apache.org/jira/browse/IMPALA-12223))

We should define `current_used` as `uint64_t` so the result of the expression is also `uint64_t`. Changed the type of `required_buffer_size` to `uint64_t` as well.

Added a unit test for this.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
