### PR TITLE
Update supported go versions to 1.20 and 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.19'
           - '1.20'
+          - '1.21'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
         run: make -C test/go precross
 
       - name: Upload go precross artifacts
-        if: matrix.go == '1.20'
+        if: matrix.go == '1.21'
         uses: actions/upload-artifact@v3
         with:
           name: go-precross

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -163,7 +163,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.19.5</td><td>1.20</td>
+<!-- Language Levels -------><td>1.20</td><td>1.21</td>
 <!-- Field types -----------><td><img src="/doc/images/cred.png" alt=""/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/apache/thrift
 
-go 1.19
+go 1.20

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.19
+go 1.20
 
 replace github.com/apache/thrift => ../../../../
 

--- a/lib/go/test/go.mod
+++ b/lib/go/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test
 
-go 1.19
+go 1.20
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/test/go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
Getting the PR ready to be merged once go 1.21 releases.