### PR TITLE
Remove py2 from github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -84,6 +85,7 @@ jobs:
         go:
           - '1.19'
           - '1.20'
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
@@ -349,7 +351,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.x", "3.x"]
+        python-version:
+          - "3.x"
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
@@ -370,21 +374,11 @@ jobs:
           python --version
           pip --version
 
-      - name: Python 2.x backport setup
-        if: matrix.python-version == '2.x'
-        run: |
-          python -m pip install --upgrade ipaddress backports.ssl_match_hostname
-
       - name: Run bootstrap
         run: ./bootstrap.sh
 
-      - name: Run configure 2.x
-        if: matrix.python-version == '2.x'
-        run: |
-          ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-python/with-python/')
-
       - name: Run configure 3.x
-        if: matrix.python-version != '2.x'
+        if: matrix.python-version == '3.x'
         run: |
           ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-py3/with-py3/')
 

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -553,6 +553,7 @@ public class TBinaryProtocol extends TProtocol {
         throw new TTransportException(TTransportException.UNKNOWN, "unrecognized type code");
     }
   }
+
   // -----------------------------------------------------------------
   // Additional methods to improve performance.
 

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
@@ -940,6 +940,7 @@ public class TCompactProtocol extends TProtocol {
         throw new TTransportException(TTransportException.UNKNOWN, "unrecognized type code");
     }
   }
+
   // -----------------------------------------------------------------
   // Additional methods to improve performance.
 

--- a/lib/java/src/main/java/org/apache/thrift/server/TThreadedSelectorServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/TThreadedSelectorServer.java
@@ -65,18 +65,22 @@ public class TThreadedSelectorServer extends AbstractNonblockingServer {
 
     /** The number of threads for selecting on already-accepted connections */
     public int selectorThreads = 2;
+
     /**
      * The size of the executor service (if none is specified) that will handle invocations. This
      * may be set to 0, in which case invocations will be handled directly on the selector threads
      * (as is in TNonblockingServer)
      */
     private int workerThreads = 5;
+
     /** Time to wait for server to stop gracefully */
     private int stopTimeoutVal = 60;
 
     private TimeUnit stopTimeoutUnit = TimeUnit.SECONDS;
+
     /** The ExecutorService for handling dispatched requests */
     private ExecutorService executorService = null;
+
     /**
      * The size of the blocking queue per selector thread for passing accepted connections to the
      * selector thread

--- a/lib/java/src/main/java/org/apache/thrift/transport/TIOStreamTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TIOStreamTransport.java
@@ -68,6 +68,7 @@ public class TIOStreamTransport extends TEndpointTransport {
     super(config);
     inputStream_ = is;
   }
+
   /**
    * Input stream constructor, constructs an input only transport.
    *


### PR DESCRIPTION
Although we haven't removed py2 support yet, it's no longer available in github actions so it's been consistently failing in recent github action runs.

Also add `fail-fast: false` to all matrices in github actions.
