### PR TITLE
Convert string types to Enums in Struct py:enum gen code

### DIFF
--- a/test/py/explicit_module/EnumSerializationTest.py
+++ b/test/py/explicit_module/EnumSerializationTest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import annotations
+
+import sys
+from shared_types.ttypes import SharedEnum
+from thrift.TSerialization import serialize, deserialize
+from thrift.protocol import TBinaryProtocol
+from thrift.transport import TTransport
+
+def deserialize_immutable(base,
+                buf,
+                protocol_factory=TBinaryProtocol.TBinaryProtocolFactory()):
+    transport = TTransport.TMemoryBuffer(buf)
+    protocol = protocol_factory.getProtocol(transport)
+    return base.read(protocol)
+
+def serialization_deserialization_struct_enum_test():
+    test_obj = TestStruct(param1="test_string", param2=TestEnum.TestEnum1, param3=SharedEnum.SharedEnum1)
+    test_obj_serialized = serialize(test_obj)
+    test_obj2 = deserialize(TestStruct(), test_obj_serialized)
+    assert test_obj.param1 == test_obj2.param1
+    assert test_obj.param2 == test_obj2.param2
+    assert test_obj.param3 == test_obj2.param3
+
+def serialization_deserialization_struct_enum_as_string_test():
+    test_obj = TestStruct(param1="test_string", param2=TestEnum.TestEnum1.name, param3=SharedEnum.SharedEnum1.name)
+    test_obj_serialized = serialize(test_obj)
+    test_obj2 = deserialize(TestStruct(), test_obj_serialized)
+    assert test_obj.param1 == test_obj2.param1
+    assert test_obj.param2 == test_obj2.param2
+    assert test_obj.param3 == test_obj2.param3
+
+def serialization_deserialization_exception_enum_as_string_test():
+    test_obj = TestException(whatOp=0, why=SharedEnum.SharedEnum0.name, who=TestEnum.TestEnum0.name)
+    test_obj_serialized = serialize(test_obj)
+    test_obj2 = deserialize_immutable(TestException, test_obj_serialized)
+    assert test_obj.whatOp == test_obj2.whatOp
+    assert test_obj.why == test_obj2.why
+    assert test_obj.who == test_obj2.who
+
+def serialization_deserialization_exception_enum_test():
+    test_obj = TestException(whatOp=0, why=SharedEnum.SharedEnum0, who=TestEnum.TestEnum0)
+    test_obj_serialized = serialize(test_obj)
+    test_obj2 = deserialize_immutable(TestException, test_obj_serialized)
+    assert test_obj.whatOp == test_obj2.whatOp
+    assert test_obj.why == test_obj2.why
+    assert test_obj.who == test_obj2.who
+
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if args:
+        from test5_slots.test5.ttypes import TestEnum, TestStruct, TestException
+    else:
+        from test5.ttypes import TestEnum, TestStruct, TestException
+    serialization_deserialization_struct_enum_test()
+    serialization_deserialization_struct_enum_as_string_test()
+    serialization_deserialization_exception_enum_as_string_test()
+    serialization_deserialization_exception_enum_test()

--- a/test/py/explicit_module/runtest.sh
+++ b/test/py/explicit_module/runtest.sh
@@ -25,10 +25,15 @@ rm -rf gen-py
 ../../../compiler/cpp/thrift --gen py test3.thrift && exit 1  # Fail since test3.thrift has python keywords
 ../../../compiler/cpp/thrift --gen py:enum shared_types.thrift || exit 1
 ../../../compiler/cpp/thrift --gen py:enum test4.thrift || exit 1
+../../../compiler/cpp/thrift --gen py:enum test5.thrift || exit 1
+mkdir -p ./gen-py/test5_slots
+../../../compiler/cpp/thrift --gen py:enum,slots -out ./gen-py/test5_slots test5.thrift || exit 1
 PYTHONPATH=./gen-py python -c 'import foo.bar.baz' || exit 1
 PYTHONPATH=./gen-py python -c 'import test2' || exit 1
 PYTHONPATH=./gen-py python -c 'import test1' &>/dev/null && exit 1  # Should fail.
 PYTHONPATH=./gen-py python -c 'import test4.constants' || exit 1
+PYTHONPATH=./gen-py python EnumSerializationTest.py || exit 1
+PYTHONPATH=./gen-py python EnumSerializationTest.py slot|| exit 1
 cp -r gen-py simple
 ../../../compiler/cpp/thrift -r --gen py test2.thrift || exit 1
 PYTHONPATH=./gen-py python -c 'import test2' || exit 1

--- a/test/py/explicit_module/test5.thrift
+++ b/test/py/explicit_module/test5.thrift
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace py test5
+
+include "shared_types.thrift"
+
+enum TestEnum {
+  TestEnum0 = 0,
+  TestEnum1 = 1,
+}
+
+struct TestStruct {
+    1: optional string param1
+    2: optional TestEnum param2
+    3: optional shared_types.SharedEnum param3
+}
+
+/**
+ * Structs can also be exceptions, if they are nasty.
+ */
+exception TestException {
+  1: i32 whatOp,
+  2: shared_types.SharedEnum why
+  3: TestEnum who
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When serializing and deserializing Enums for Structs, the current code expects Enum member variables to be a string instead of an Enum. What this means is that the thrift file shows that an Enum is passed in the struct, when actually a string is passed in. This is very confusing can arbitrarily lead to KeyError in the deserialization logic.

However, changing this behavior is potentially breaking. To avoid breaking existing users, check if the type is an Enum when setting the member variable and convert the type to an Enum if it is a string. This allows the actual type to be an Enum and simplifies the serialization/deserialization logic to use Enums instead of converting strings.

Given a thrift file like the following:
```python
enum TestEnum {
  TestEnum0 = 0,
  TestEnum1 = 1,
}

struct TestStruct {
    1: optional string param1
    2: optional TestEnum param2
}
```

this is how you would create a struct before and after the change but both are valid.
```python
# Before
TestStruct(param1="test_string", param2=TestEnum.TestEnum1.name) # or pass in "TestEnum1"

# After
TestStruct(param1="test_string", param2=TestEnum.TestEnum1)
```

Serialization/Deserialization Code Change Example- 
```python
class TestStruct(object):
    """
    Attributes:
     - param1
     - param2

    """


    def __init__(self, param1=None, param2=None,):
        self.param1 = param1
        self.param2 = param2

++    def __setattr__(self, name, value):
++		if name == "param2":
++	        super().__setattr__(name, value if hasattr(value, 'value') else TestEnum.__members__.get(value))
++			return
++        super().__setattr__(name, value)

    def read(self, iprot):
        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
            return
        iprot.readStructBegin()
        while True:
            (fname, ftype, fid) = iprot.readFieldBegin()
            if ftype == TType.STOP:
                break
            if fid == 1:
                if ftype == TType.STRING:
                    self.param1 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                else:
                    iprot.skip(ftype)
            elif fid == 2:
                if ftype == TType.I32:
--                    self.param2 = TestEnum(iprot.readI32()).name
++                    self.param2 = TestEnum(iprot.readI32())
                else:
                    iprot.skip(ftype)
            else:
                iprot.skip(ftype)
            iprot.readFieldEnd()
        iprot.readStructEnd()

    def write(self, oprot):
        if oprot._fast_encode is not None and self.thrift_spec is not None:
            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
            return
        oprot.writeStructBegin('TestStruct')
        if self.param1 is not None:
            oprot.writeFieldBegin('param1', TType.STRING, 1)
            oprot.writeString(self.param1.encode('utf-8') if sys.version_info[0] == 2 else self.param1)
            oprot.writeFieldEnd()
        if self.param2 is not None:
            oprot.writeFieldBegin('param2', TType.I32, 2)
--            oprot.writeI32(TestEnum[self.param2].value)
++           oprot.writeI32(self.param2.value)
            oprot.writeFieldEnd()
        oprot.writeFieldStop()
        oprot.writeStructEnd()

    def validate(self):
        return

    def __repr__(self):
        L = ['%s=%r' % (key, value)
             for key, value in self.__dict__.items()]
        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))

    def __eq__(self, other):
        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

    def __ne__(self, other):
        return not (self == other)
all_structs.append(TestStruct)
TestStruct.thrift_spec = (
    None,  # 0
    (1, TType.STRING, 'param1', 'UTF8', None, ),  # 1
    (2, TType.I32, 'param2', None, None, ),  # 2
)
fix_spec(all_structs)
del all_structs
```

  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
