### PR TITLE
THRIFT-5720: Encode binary args in Python remote

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1799,7 +1799,9 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
         first_arg = false;
       else
         f_remote << " ";
-      if (args[i]->get_type()->is_string()) {
+      if (args[i]->get_type()->is_binary()) {
+        f_remote << "args[" << i << "].encode('utf-8'),";
+      } else if (args[i]->get_type()->is_string()) {
         f_remote << "args[" << i << "],";
       } else {
         f_remote << "eval(args[" << i << "]),";


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Python generated "Service-remote" treats binary arguments as strings. This doesn't work in Python 3. We should introduce default encoding.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
