### PR TITLE
THRIFT-5723 Php8.1 fix warnings

### DIFF
--- a/lib/php/lib/Exception/TException.php
+++ b/lib/php/lib/Exception/TException.php
@@ -52,7 +52,7 @@ class TException extends \Exception
                 }
             }
         } else {
-            parent::__construct($p1, $p2);
+            parent::__construct((string)$p1, $p2);
         }
     }
 

--- a/lib/php/src/Thrift.php
+++ b/lib/php/src/Thrift.php
@@ -82,7 +82,7 @@ class TException extends Exception
         }
       }
     } else {
-      parent::__construct($p1, $p2);
+      parent::__construct((string)$p1, $p2);
     }
   }
 


### PR DESCRIPTION
In PHP 8.1 when creating new Exception with null message you will receive warning
E_DEPRECATED: Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated