### PR TITLE
THRIFT-5725: Fix the comparison check for bio_get_fd

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -825,7 +825,7 @@ unsigned int TSSLSocket::waitForEvent(bool wantRead) {
     throw TSSLException("SSL_get_?bio returned nullptr");
   }
 
-  if (BIO_get_fd(bio, &fdSocket) <= 0) {
+  if (BIO_get_fd(bio, &fdSocket) < 0) {
     throw TSSLException("BIO_get_fd failed");
   }
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The routine _bio_get_fd_ checks for the validity of a file descriptor by comparing the fd to be less
than or equal to zero. The issue is that fd of 0 is a valid file descriptor. This PR changes the check
to be less than zero.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
