### PR TITLE
Setting TCP_ NODELAY option for rust server

### DIFF
--- a/lib/rs/src/server/threaded.rs
+++ b/lib/rs/src/server/threaded.rs
@@ -183,6 +183,7 @@ where
         for stream in listener.incoming() {
             match stream {
                 Ok(s) => {
+                    s.set_nodelay(true).ok();
                     let channel = TTcpChannel::with_stream(s);
                     self.handle_stream(channel)?;
                 }


### PR DESCRIPTION
Resolve TFramedWriteTransport write message size 4 bytes causing approximately 40 milliseconds delay.