### PR TITLE
THRIFT-5731: Handle ErrAbandonRequest automatically

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -108,13 +108,19 @@ The context object passed into the server handler function will be canceled when
 the client closes the connection (this is a best effort check, not a guarantee
 -- there's no guarantee that the context object is always canceled when client
 closes the connection, but when it's canceled you can always assume the client
-closed the connection). When implementing Go Thrift server, you can take
-advantage of that to abandon requests that's no longer needed:
+closed the connection). The cause of the cancellation (via `context.Cause(ctx)`)
+would also be set to `thrift.ErrAbandonRequest`.
+
+When implementing Go Thrift server, you can take advantage of that to abandon
+requests that's no longer needed by returning `thrift.ErrAbandonRequest`:
 
     func MyEndpoint(ctx context.Context, req *thriftRequestType) (*thriftResponseType, error) {
         ...
         if ctx.Err() == context.Canceled {
             return nil, thrift.ErrAbandonRequest
+            // Or just return ctx.Err(), compiler generated processor code will
+            // handle it for you automatically:
+            // return nil, ctx.Err()
         }
         ...
     }

--- a/lib/go/test/tests/server_connectivity_check_test.go
+++ b/lib/go/test/tests/server_connectivity_check_test.go
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/test/gopath/src/clientmiddlewareexceptiontest"
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func TestServerConnectivityCheck(t *testing.T) {
+	const (
+		// Server will sleep for longer than client is willing to wait
+		// so client will close the connection.
+		serverSleep         = 50 * time.Millisecond
+		clientSocketTimeout = time.Millisecond
+	)
+	serverSocket, err := thrift.NewTServerSocket(":0")
+	if err != nil {
+		t.Fatalf("failed to create server socket: %v", err)
+	}
+	processor := clientmiddlewareexceptiontest.NewClientMiddlewareExceptionTestProcessor(fakeClientMiddlewareExceptionTestHandler(
+		func(ctx context.Context) (*clientmiddlewareexceptiontest.FooResponse, error) {
+			time.Sleep(serverSleep)
+			err := ctx.Err()
+			if err == nil {
+				t.Error("Expected server ctx to be cancelled, did not happen")
+				return new(clientmiddlewareexceptiontest.FooResponse), nil
+			}
+			return nil, err
+		},
+	))
+	server := thrift.NewTSimpleServer2(processor, serverSocket)
+	if err := server.Listen(); err != nil {
+		t.Fatalf("failed to listen server: %v", err)
+	}
+	server.SetLogger(func(msg string) {
+		t.Errorf("Server logger called with %q", msg)
+		t.Errorf("Server logger callstack:\n%s", debug.Stack())
+	})
+	addr := serverSocket.Addr().String()
+	go server.Serve()
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	cfg := &thrift.TConfiguration{
+		SocketTimeout: clientSocketTimeout,
+	}
+	socket := thrift.NewTSocketConf(addr, cfg)
+	if err := socket.Open(); err != nil {
+		t.Fatalf("failed to create client connection: %v", err)
+	}
+	t.Cleanup(func() {
+		socket.Close()
+	})
+	inProtocol := thrift.NewTBinaryProtocolConf(socket, cfg)
+	outProtocol := thrift.NewTBinaryProtocolConf(socket, cfg)
+	client := thrift.NewTStandardClient(inProtocol, outProtocol)
+	ctx, cancel := context.WithTimeout(context.Background(), clientSocketTimeout)
+	defer cancel()
+	_, err = clientmiddlewareexceptiontest.NewClientMiddlewareExceptionTestClient(client).Foo(ctx)
+	socket.Close()
+	if err == nil {
+		t.Error("Expected client to time out, did not happen")
+	}
+}


### PR DESCRIPTION
Also add a test to verify the behavior.

The test helped me to found a bug in TSimpleServer that didn't handle the ErrAbandonRequest case correctly, so fix the bug as well.

client: go

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
