### PR TITLE
Apply trivial formatting improvements to kotlin

### DIFF
--- a/lib/kotlin/cross-test-server/src/main/kotlin/org/apache/thrift/test/TestHandler.kt
+++ b/lib/kotlin/cross-test-server/src/main/kotlin/org/apache/thrift/test/TestHandler.kt
@@ -104,7 +104,8 @@ class TestHandler : ThriftTest {
     override suspend fun testNest(thing: Xtruct2): Xtruct2 {
         val thing2: Xtruct = thing.struct_thing!!
         logger.info(
-            """testNest({${thing.byte_thing}, {"${thing2.string_thing}", ${thing2.byte_thing}, ${thing2.i32_thing}, ${thing2.i64_thing}}, ${thing.i32_thing}})""".trimIndent()
+            """testNest({${thing.byte_thing}, {"${thing2.string_thing}", ${thing2.byte_thing}, ${thing2.i32_thing}, ${thing2.i64_thing}}, ${thing.i32_thing}})"""
+                .trimIndent()
         )
         return thing
     }

--- a/lib/kotlin/cross-test-server/src/main/kotlin/org/apache/thrift/test/TestServer.kt
+++ b/lib/kotlin/cross-test-server/src/main/kotlin/org/apache/thrift/test/TestServer.kt
@@ -96,6 +96,7 @@ object TestServer {
 
     internal class TestServerEventHandler() : TServerEventHandler {
         private var nextConnectionId = 1
+
         override fun preServe() {
             println(
                 "TServerEventHandler.preServe - called only once before server starts accepting connections"


### PR DESCRIPTION
This applies trivial formatting requirements for ktfmt 0.13.0 from abandoned PR #2837, but does not bump ktfmt to 0.13.0, due to bugs in that version. These formatting improvements should be suitable for the current 0.12.0 version of ktfmt, but will avoid needing to re-apply these changes when ktfmt is eventually updated.
