### PR TITLE
THRIFT-5653: Fix Java UUID typeid

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/protocol/TType.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TType.java
@@ -34,6 +34,8 @@ public final class TType {
   public static final byte MAP = 13;
   public static final byte SET = 14;
   public static final byte LIST = 15;
-  public static final byte ENUM = 16;
-  public static final byte UUID = 17;
+  public static final byte UUID = 16;
+
+  /** This is not part of the TBinaryProtocol spec but Java specific implementation detail */
+  public static final byte ENUM = -1;
 }


### PR DESCRIPTION
It should be 16 not 17 according to the spec.

Currently ENUM holds 16, it's not in TBinaryProtocol spec and seems to be a Java implementation detail somehow got mixed inside TType, move that to ~255~ -1 (java's byte is signed) for now. Someone more familiar with Java can probably remove it from TType completely in the future.

client: java
