### PR TITLE
THRIFT-5736: support http2 transport for thrift lib java

### DIFF
--- a/lib/java/build.gradle
+++ b/lib/java/build.gradle
@@ -32,6 +32,8 @@ buildscript {
 
     dependencies {
         classpath 'com.bmuschko:gradle-clover-plugin:2.2.1'
+        classpath 'com.squareup.okhttp3:okhttp3:3.14.0'
+        classpath 'org.mortbay.jetty.alpn:alpn-boot:8.1.13.v20181017'
     }
 }
 

--- a/lib/java/src/main/java/org/apache/thrift/transport/THttp2Client.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/THttp2Client.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift.transport;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class THttp2Client extends TEndpointTransport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(THttp2Client.class.getName());
+
+    private final ByteArrayOutputStream requestBuffer = new ByteArrayOutputStream();
+    private ResponseBody responseBody = null;
+    private Map<String, String> customHeaders = null;
+    private static final Map<String, String> defaultHeaders = getDefaultHeaders();
+
+    private OkHttpClient client;
+    private final SSLSocketFactory sslFactory;
+
+    private final TrustManager trustManager;
+    private final String url;
+    private int connectTimeout = 0;
+    private int readTimeout = 0;
+
+
+    public THttp2Client(String url) throws TTransportException {
+        this(url, null, null);
+    }
+
+    public THttp2Client(String url, SSLSocketFactory sslFactory, TrustManager trustManager) throws TTransportException {
+        this.url = url;
+        this.sslFactory = sslFactory;
+        this.trustManager = trustManager;
+    }
+
+    public THttp2Client setConnectTimeout(int timeout) {
+        connectTimeout = timeout;
+        return this;
+    }
+
+    public THttp2Client setReadTimeout(int timeout) {
+        readTimeout = timeout;
+        return this;
+    }
+
+    public THttp2Client setCustomHeaders(Map<String, String> headers) {
+        customHeaders = headers;
+        return this;
+    }
+
+    public THttp2Client setCustomHeader(String key, String value) {
+        if (customHeaders == null) {
+            customHeaders = new HashMap<>();
+        }
+        customHeaders.put(key, value);
+        return this;
+    }
+
+    public void open() {
+        client = OkHttp3Util.getClient(connectTimeout, readTimeout, sslFactory, trustManager);
+    }
+
+    public void close() {
+        try {
+            if (responseBody != null) {
+                responseBody.close();
+                responseBody = null;
+            }
+
+            requestBuffer.close();
+        } catch (IOException e) {
+            LOGGER.warn(e.getMessage());
+        }
+        OkHttp3Util.close();
+    }
+
+    public boolean isOpen() {
+        return client != null;
+    }
+
+    public int read(byte[] buf, int off, int len) throws TTransportException {
+        if (responseBody == null) {
+            throw new TTransportException("Response buffer is empty, no request.");
+        }
+        try {
+            int ret = responseBody.byteStream().read(buf, off, len);
+            if (ret == -1) {
+                throw new TTransportException("No more data available.");
+            }
+            return ret;
+        } catch (IOException iox) {
+            throw new TTransportException(iox);
+        }
+    }
+
+    public void write(byte[] buf, int off, int len) {
+        requestBuffer.write(buf, off, len);
+    }
+
+    public void flush() throws TTransportException {
+        if (null == client) {
+            throw new TTransportException("Null HttpClient, aborting.");
+        }
+
+        // Extract request and reset buffer
+        byte[] data = requestBuffer.toByteArray();
+        requestBuffer.reset();
+        try {
+
+            // Create request object
+            Request.Builder requestBuilder = new Request.Builder()
+                    .url(url)
+                    .post(RequestBody.create(MediaType.parse("application/x-thrift"), data));
+
+            defaultHeaders.forEach(requestBuilder::header);
+            if (customHeaders != null) {
+                customHeaders.forEach(requestBuilder::header);
+            }
+
+            Request request = requestBuilder.build();
+
+            // Make the request
+            Response response = client.newCall(request).execute();
+            if (!response.isSuccessful()) {
+                throw new TTransportException("HTTP Response code: " + response.code());
+            }
+
+            // Read the response
+            responseBody = response.body();
+        } catch (IOException iox) {
+            throw new TTransportException(iox);
+        }
+    }
+
+    private static Map<String, String> getDefaultHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/x-thrift");
+        headers.put("Accept", "application/x-thrift");
+        headers.put("User-Agent", "Java/THttpClient");
+        return headers;
+    }
+}
+

--- a/lib/java/src/main/java/org/apache/thrift/utils/OkHttp3Utils.java
+++ b/lib/java/src/main/java/org/apache/thrift/utils/OkHttp3Utils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift.utils;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+
+public class OkHttp3Utils {
+    private static OkHttpClient client;
+
+    private OkHttp3Util() {
+    }
+
+    public static OkHttpClient getClient(int connectTimeout, int readTimeout,
+                                         SSLSocketFactory sslFactory,
+                                         TrustManager trustManager) {
+        if (client == null) {
+            synchronized (OkHttp3Util.class) {
+                if (client == null) {
+                    // Create OkHttpClient builder
+                    OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
+                            .connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+                            .writeTimeout(readTimeout, TimeUnit.MILLISECONDS)
+                            .readTimeout(readTimeout, TimeUnit.MILLISECONDS);
+                    if (sslFactory != null) {
+                        clientBuilder.sslSocketFactory(sslFactory, (X509TrustManager) trustManager);
+                        clientBuilder.protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+                    } else {
+                        // config the http2 prior knowledge
+                        clientBuilder.protocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE));
+                    }
+                    client = clientBuilder.build();
+                }
+            }
+        }
+        return client;
+    }
+
+    public static void close() {
+        if (client != null) {
+            client.connectionPool().evictAll();
+            client.dispatcher().executorService().shutdown();
+            client = null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  Java 8 does not support HTTP2, and thrift java lib does not support HTTP2 too. In order to support HTTP2 for both thrift and java 8, we need to provide a new Transport to support HTTP2. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
