### PR TITLE
THRIFT-5738: Unused variable fails mac builds

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -5756,7 +5756,6 @@ void t_java_generator::generate_java_struct_tuple_writer(ostream& out, t_struct*
     }
 
     indent(out) << "oprot.writeBitSet(optionals, " << optional_count << ");" << endl;
-    int j = 0;
     for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
       if ((*f_iter)->get_req() == t_field::T_OPTIONAL
           || (*f_iter)->get_req() == t_field::T_OPT_IN_REQ_OUT) {
@@ -5765,7 +5764,6 @@ void t_java_generator::generate_java_struct_tuple_writer(ostream& out, t_struct*
         generate_serialize_field(out, (*f_iter), "struct.", "", false);
         indent_down();
         indent(out) << "}" << endl;
-        j++;
       }
     }
   }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Building 0.19.0 on Mac OS Ventura 13.6 (`Darwin J59JPHTWW7 22.6.0 Darwin Kernel Version 22.6.0: Fri Sep 15 13:41:28 PDT 2023; root:xnu-8796.141.3.700.8~1/RELEASE_ARM64_T6000 arm64`) yields this error:

```
src/thrift/generate/t_java_generator.cc:5759:9: error: variable 'j' set but not used [-Werror,-Wunused-but-set-variable]
    int j = 0;
        ^
1 error generated.
make[1]: *** [src/thrift/generate/thrift-t_java_generator.o] Error 1
```

It's a pretty easy excision.

```
% gcc --version
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

With this change only, the compiler `make` succeeds.

```
% cd compiler/cpp
% make -j3 >&/dev/null
% ./thrift --version
Thrift version 0.19.0
% file thrift
thrift: Mach-O 64-bit executable arm64
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) https://issues.apache.org/jira/browse/THRIFT-5738
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- n/a If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
