### PR TITLE
Fix building with gcc 13

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <unordered_map>
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sstream>


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 
    This fixes the following compiler error.

    t_js_generator.cc:48:14: error: 'int64_t' does not name a type
       48 | static const int64_t max_safe_integer = 0x1fffffffffffff;
          |              ^~~~~~~
    t_js_generator.cc:50:14: error: 'int64_t' does not name a type
       50 | static const int64_t min_safe_integer = -max_safe_integer;
          |              ^~~~~~~

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
