### PR TITLE
fix(php): exclude most part of the repo for php package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,19 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
+    },
+    "archive": {
+        "exclude": [
+            "*",
+            ".*",
+            "!/CHANGES.md",
+            "!/LICENSE",
+            "!/NOTICE",
+            "!/README.md",
+            "!/composer.json",
+            "!/lib/php/README.apache.md",
+            "!/lib/php/README.md",
+            "!/lib/php/lib"
+        ]
     }
 }


### PR DESCRIPTION
This change excludes different languages from composer package, that will results in decrease of package size:
 - packed .zip: from 4.8M to 0.2M (less traffic, faster installs)
 - unpacked (in vendor directory): 22M->0.2M (smaller application dependencies, faster deploys)

What will be excluded from final package:
 - other languages
 - helpful repository files (.gitignore/.editorconfig/etc)
 - compiler
 - tests
 - tutorial
 - PHP sources/tests

What will final package contain of:
 - README/LICENSE/CHANGES
 - PHP library itself
 - composer.json

There is no code change so [skip ci]

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.


