### PR TITLE
lib/cpp/test/Security*Test.cpp: Fix the check for OpenSSL version macro

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
   try {
     // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
+        bool ossl1 = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
     {
         // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = OPENSSL_VERSION_MAJOR == 1;
+        bool ossl1 = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2


### PR DESCRIPTION
This commit fixes the current build problem on MSVC (see i.e. https://ci.appveyor.com/project/ApacheSoftwareFoundation/thrift/builds/48238772/job/cyh9vdh0xsiadd01)
```
C:\projects\thrift\lib\cpp\test\SecurityFromBufferTest.cpp(202): error C2065: 'OPENSSL_VERSION_MAJOR': undeclared identifier [C:\projects\build\MSVC2017\x64\lib\cpp\test\SecurityFromBufferTest.vcxproj]
C:\projects\thrift\lib\cpp\test\SecurityTest.cpp(224): error C2065: 'OPENSSL_VERSION_MAJOR': undeclared identifier 
```

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
