### PR TITLE
Separated MSVC and clang-cl settings for Windows

### DIFF
--- a/build/cmake/DefinePlatformSpecifc.cmake
+++ b/build/cmake/DefinePlatformSpecifc.cmake
@@ -25,8 +25,12 @@ set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix")
 
 # basic options
 foreach(lang IN ITEMS C CXX)
-  if("CMAKE_${lang}_COMPILER_ID" STREQUAL "MSVC" OR "${CMAKE_${lang}_SIMULATE_ID}" STREQUAL "MSVC")
+  if("CMAKE_${lang}_COMPILER_ID" STREQUAL "MSVC")
+    # These flags are not supported (or needed) with Clang-Cl on Windows:
     set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} /MP") # parallel build
+  endif()
+
+  if("CMAKE_${lang}_COMPILER_ID" STREQUAL "MSVC" OR "${CMAKE_${lang}_SIMULATE_ID}" STREQUAL "MSVC")
     set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} /W3") # warning level 3
     include(CheckCXXCompilerFlag)
     set(CMAKE_REQUIRED_QUIET ON)


### PR DESCRIPTION
This PR makes a minor improvement when building with LLVM clang-cl on Windows. One of the compile flags is not needed by clang-cl and should only be used with MSVC compilers.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
