### PR TITLE
ApacheThrift.nuspec: Updated to netstandard 2.1

### DIFF
--- a/ApacheThrift.nuspec
+++ b/ApacheThrift.nuspec
@@ -34,12 +34,12 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>Apache Thrift .NET Library</summary>
     <description>
-      Contains runtime libraries from lib/netstd for netstandard2.0 framework development.
+      Contains runtime libraries from lib/netstd for netstandard2.1 framework development.
     </description>
     <repository type="GitHub" url="https://github.com/apache/thrift" branch="release/0.20.0" />
     <tags>Apache Thrift RPC</tags>
   </metadata>
   <files>
-    <file src="lib\netstd\Thrift\bin\Release\netstandard2.0\*.*" target="lib\netstandard2.0" />
+    <file src="lib\netstd\Thrift\bin\*.*" target="lib\netstandard2.1" />
   </files>
 </package>


### PR DESCRIPTION
Currently the nuspec file is set to netstandard 2.0. As far as I know, the LTS version is netstandard 2.1. This PR increases the version to the LTS one.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
