### PR TITLE
Do not install `FindLibevent.cmake` when libevent is disabled

### DIFF
--- a/build/cmake/GenerateConfigModule.cmake
+++ b/build/cmake/GenerateConfigModule.cmake
@@ -40,6 +40,9 @@ if (NOT CYGWIN)
 
 		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ThriftConfig.cmake"
 						"${CMAKE_CURRENT_BINARY_DIR}/ThriftConfigVersion.cmake"
-						"${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/FindLibevent.cmake"
 						DESTINATION "${CMAKE_INSTALL_DIR}/thrift")
+        if(WITH_LIBEVENT)
+            install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/FindLibevent.cmake"
+                            DESTINATION "${CMAKE_INSTALL_DIR}/thrift")
+        endif()
 endif()


### PR DESCRIPTION
When libevent is not used, the script `FindLibevent.cmake` may be confusing to downstream projects. Do not install it.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
