### PR TITLE
Fix: fix python readMessageBegin return value type error

### DIFF
--- a/lib/py/src/protocol/TBinaryProtocol.py
+++ b/lib/py/src/protocol/TBinaryProtocol.py
@@ -18,6 +18,7 @@
 #
 
 from .TProtocol import TType, TProtocolBase, TProtocolException, TProtocolFactory
+from ..compat import binary_to_str
 from struct import pack, unpack
 
 
@@ -145,7 +146,7 @@ class TBinaryProtocol(TProtocolBase):
             if self.strictRead:
                 raise TProtocolException(type=TProtocolException.BAD_VERSION,
                                          message='No protocol version header')
-            name = self.trans.readAll(sz)
+            name = binary_to_str(self.trans.readAll(sz))
             type = self.readByte()
             seqid = self.readI32()
         return (name, type, seqid)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

## What did this PR do?

In the function `transport.TTransport.readAll`, when the `sz<0`, the type of name is `str`.

But when the `sz>0`, the type of name is `bytes`.

They should return the same types.

I use the `binary_to_str` to convert the type of `name`

## Test

I write a unittest method `test_TBinaryProtocol_no_strict_write_read` to test my changes. It passed.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
