### PR TITLE
THRIFT-5745: Implement slog.LogValuer on go TStructs

### DIFF
--- a/lib/go/test/tests/slog_tstruct_wrapper_test.go
+++ b/lib/go/test/tests/slog_tstruct_wrapper_test.go
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/test/gopath/src/forwardtypetest"
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func dropTime(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 && a.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return a
+}
+
+func TestSlogTStructWrapperJSON(t *testing.T) {
+	for _, c := range []struct {
+		label string
+		value thrift.TStruct
+		want  string
+	}{
+		{
+			label: "struct",
+			value: &forwardtypetest.Struct{
+				Foo: &forwardtypetest.Exc{
+					Code: thrift.Int32Ptr(10),
+				},
+			},
+			want: `{"level":"INFO","msg":"bar","struct":{"type":"*forwardtypetest.Struct","value":{"foo":{"code":10}}}}`,
+		},
+		{
+			label: "exception",
+			value: &forwardtypetest.Exc{
+				Code: thrift.Int32Ptr(10),
+			},
+			want: `{"level":"INFO","msg":"bar","struct":{"type":"*forwardtypetest.Exc","value":{"code":10}}}`,
+		},
+		{
+			label: "nil-struct",
+			value: (*forwardtypetest.Struct)(nil),
+			want:  `{"level":"INFO","msg":"bar","struct":null}`,
+		},
+		{
+			label: "nil-exception",
+			value: (*forwardtypetest.Exc)(nil),
+			want:  `{"level":"INFO","msg":"bar","struct":null}`,
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			var sb strings.Builder
+			logger := slog.New(slog.NewJSONHandler(&sb, &slog.HandlerOptions{
+				AddSource:   false,
+				ReplaceAttr: dropTime,
+			}))
+
+			logger.Info("bar", "struct", c.value)
+			if got := strings.TrimSuffix(sb.String(), "\n"); got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSlogTStructWrapperText(t *testing.T) {
+	for _, c := range []struct {
+		label string
+		value thrift.TStruct
+		want  string
+	}{
+		{
+			label: "struct",
+			value: &forwardtypetest.Struct{
+				Foo: &forwardtypetest.Exc{
+					Code: thrift.Int32Ptr(10),
+				},
+			},
+			want: `level=INFO msg=bar struct="*forwardtypetest.Struct{\"foo\":{\"code\":10}}"`,
+		},
+		{
+			label: "exception",
+			value: &forwardtypetest.Exc{
+				Code: thrift.Int32Ptr(10),
+			},
+			want: `level=INFO msg=bar struct="*forwardtypetest.Exc{\"code\":10}"`,
+		},
+		{
+			label: "nil-struct",
+			value: (*forwardtypetest.Struct)(nil),
+			want:  `level=INFO msg=bar struct=<nil>`,
+		},
+		{
+			label: "nil-exception",
+			value: (*forwardtypetest.Exc)(nil),
+			want:  `level=INFO msg=bar struct=<nil>`,
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			var sb strings.Builder
+			logger := slog.New(slog.NewTextHandler(&sb, &slog.HandlerOptions{
+				AddSource:   false,
+				ReplaceAttr: dropTime,
+			}))
+
+			logger.Info("bar", "struct", c.value)
+			if got := strings.TrimSuffix(sb.String(), "\n"); got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/lib/go/thrift/slog.go
+++ b/lib/go/thrift/slog.go
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// SlogTStructWrapper is a wrapper used by the compiler to wrap TStruct and
+// TException to be better logged by slog.
+type SlogTStructWrapper struct {
+	Type  string  `json:"type"`
+	Value TStruct `json:"value"`
+}
+
+var (
+	_ fmt.Stringer   = SlogTStructWrapper{}
+	_ json.Marshaler = SlogTStructWrapper{}
+)
+
+func (w SlogTStructWrapper) MarshalJSON() ([]byte, error) {
+	// Use an alias to avoid infinite recursion
+	type alias SlogTStructWrapper
+	return json.Marshal(alias(w))
+}
+
+func (w SlogTStructWrapper) String() string {
+	var sb strings.Builder
+	sb.WriteString(w.Type)
+	if err := json.NewEncoder(&sb).Encode(w.Value); err != nil {
+		// Should not happen, but just in case
+		return fmt.Sprintf("%s: %v", w.Type, w.Value)
+	}
+	// json encoder will write an additional \n at the end, get rid of it
+	return strings.TrimSuffix(sb.String(), "\n")
+}

--- a/lib/go/thrift/slog_test.go
+++ b/lib/go/thrift/slog_test.go
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSlogTStructWrapperJSON(t *testing.T) {
+	// This test just ensures that we don't have infinite recursion when
+	// json encoding it. More comprehensive tests are under lib/go/test.
+	v := SlogTStructWrapper{Type: "foo"}
+	var sb strings.Builder
+	if err := json.NewEncoder(&sb).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+	t.Log(strings.TrimSuffix(sb.String(), "\n"))
+}


### PR DESCRIPTION
Client: go

Implement slog.LogValuer for all TStruct and TException generated by the compiler for go code. Also add SlogTStructWrapper in the library so we don't have to repeat it in the compiler generated go code.
