### PR TITLE
THRIFT-5747 warning: The macro `AC_HELP_STRING' is obsolete. You should run autoupdate.

### DIFF
--- a/aclocal/ax_thrift_internal.m4
+++ b/aclocal/ax_thrift_internal.m4
@@ -18,7 +18,7 @@ dnl notice and this notice are preserved.
 AC_DEFUN([AX_THRIFT_LIB],
          [
           AC_ARG_WITH($1,
-                      AC_HELP_STRING([--with-$1], [build the $2 library @<:@default=$3@:>@]),
+                      AS_HELP_STRING([--with-$1], [build the $2 library @<:@default=$3@:>@]),
                       [with_$1="$withval"],
                       [with_$1=$3]
                       )

--- a/configure.ac
+++ b/configure.ac
@@ -311,9 +311,9 @@ AX_THRIFT_LIB(perl, [Perl], yes)
 if test "$with_perl" = "yes"; then
   AC_PATH_PROG([PERL], [perl])
   if test -n "$PERL" ; then
-    AC_PROG_PERL_MODULES([Bit::Vector], success="yes", success="no")
+    AX_PROG_PERL_MODULES([Bit::Vector],[success="yes"],[success="no"])
     have_perl_bit_vector="$success"
-    AC_PROG_PERL_MODULES([Class::Accessor], success="yes", success="no")
+    AX_PROG_PERL_MODULES([Class::Accessor],[success="yes"],[success="no"])
     have_perl_class_accessor="$success"
   fi
   if test -n "$PERL" -a "$have_perl_bit_vector" = "yes" ; then
@@ -589,13 +589,14 @@ case "${host_os}" in
   AM_CONDITIONAL(MINGW, true)
   ;;
 *)
-  AC_ISC_POSIX
+  AC_SEARCH_LIBS([strerror],[cposix])
   ;;
 esac
 
 AC_C_CONST
 AC_C_INLINE
 AC_C_VOLATILE
+AC_C_RESTRICT
 
 AC_HEADER_STDBOOL
 AC_HEADER_STDC

--- a/contrib/fb303/aclocal/ax_thrift_internal.m4
+++ b/contrib/fb303/aclocal/ax_thrift_internal.m4
@@ -18,7 +18,7 @@ dnl notice and this notice are preserved.
 AC_DEFUN([AX_THRIFT_LIB],
          [
           AC_ARG_WITH($1,
-                      AC_HELP_STRING([--with-$1], [build the $2 library @<:@default=$3@:>@]),
+                      AS_HELP_STRING([--with-$1], [build the $2 library @<:@default=$3@:>@]),
                       [with_$1="$withval"],
                       [with_$1=$3]
                       )


### PR DESCRIPTION
Patch: Jens Geyer
