### PR TITLE
Github Actions: Make java spotless step optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,11 +169,13 @@ jobs:
         run: |
           cd lib/java
           gradle spotlessCheck
+        continue-on-error: true
 
       - name: Run ktfmtCheck for Kotlin
         run: |
           cd lib/kotlin
           gradle ktfmtCheck
+        continue-on-error: true
 
       - name: Run bootstrap
         run: ./bootstrap.sh


### PR DESCRIPTION
Add `continue-on-error: true` so it does not block cross-tests from running.
