### PR TITLE
[THRIFT-5752] Add TTransportFactoryInterface

### DIFF
--- a/lib/php/Makefile.am
+++ b/lib/php/Makefile.am
@@ -64,7 +64,9 @@ phpfactory_DATA = \
 	lib/Factory/TJSONProtocolFactory.php \
 	lib/Factory/TProtocolFactory.php \
 	lib/Factory/TStringFuncFactory.php \
+	lib/Factory/TTransportFactoryInterface.php
 	lib/Factory/TTransportFactory.php
+	lib/Factory/TFramedTransportFactory.php
 
 phpprotocoldir = $(phpdir)/Protocol
 phpprotocol_DATA = \

--- a/lib/php/lib/Factory/TFramedTransportFactory.php
+++ b/lib/php/lib/Factory/TFramedTransportFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Thrift\Factory;
+
+use Thrift\Transport\TFramedTransport;
+use Thrift\Transport\TTransport;
+
+class TFramedTransportFactory implements TTransportFactoryInterface
+{
+    public static function getTransport(TTransport $transport)
+    {
+        return new TFramedTransport($transport);
+    }
+}

--- a/lib/php/lib/Factory/TTransportFactoryInterface.php
+++ b/lib/php/lib/Factory/TTransportFactoryInterface.php
@@ -4,15 +4,12 @@ namespace Thrift\Factory;
 
 use Thrift\Transport\TTransport;
 
-class TTransportFactory implements TTransportFactoryInterface
+interface TTransportFactoryInterface
 {
     /**
      * @static
      * @param TTransport $transport
      * @return TTransport
      */
-    public static function getTransport(TTransport $transport)
-    {
-        return $transport;
-    }
+    public static function getTransport(TTransport $transport);
 }

--- a/lib/php/lib/Server/TServer.php
+++ b/lib/php/lib/Server/TServer.php
@@ -2,7 +2,7 @@
 
 namespace Thrift\Server;
 
-use Thrift\Factory\TTransportFactory;
+use Thrift\Factory\TTransportFactoryInterface;
 use Thrift\Factory\TProtocolFactory;
 
 /**
@@ -30,14 +30,14 @@ abstract class TServer
     /**
      * Input transport factory
      *
-     * @var TTransportFactory
+     * @var TTransportFactoryInterface
      */
     protected $inputTransportFactory_;
 
     /**
      * Output transport factory
      *
-     * @var TTransportFactory
+     * @var TTransportFactoryInterface
      */
     protected $outputTransportFactory_;
 
@@ -60,8 +60,8 @@ abstract class TServer
      *
      * @param object $processor
      * @param TServerTransport $transport
-     * @param TTransportFactory $inputTransportFactory
-     * @param TTransportFactory $outputTransportFactory
+     * @param TTransportFactoryInterface $inputTransportFactory
+     * @param TTransportFactoryInterface $outputTransportFactory
      * @param TProtocolFactory $inputProtocolFactory
      * @param TProtocolFactory $outputProtocolFactory
      * @return void
@@ -69,8 +69,8 @@ abstract class TServer
     public function __construct(
         $processor,
         TServerTransport $transport,
-        TTransportFactory $inputTransportFactory,
-        TTransportFactory $outputTransportFactory,
+        TTransportFactoryInterface $inputTransportFactory,
+        TTransportFactoryInterface $outputTransportFactory,
         TProtocolFactory $inputProtocolFactory,
         TProtocolFactory $outputProtocolFactory
     ) {


### PR DESCRIPTION
I'm offer to add TTransportFactoryInterface for having a possibility to use own implementation of TTransportFactory in TServer.

I have a problem when I'm tried to make a TSimpleServer for client who used a 
TFramedTransport. Current realization of TTransportFactory does not give me a possibility to add a TFramedTransport as  a decorator for use TTransport
  
- [x] https://issues.apache.org/jira/browse/THRIFT-5752
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
