### PR TITLE
THRIFT-5753: PHP 8.1 deprecated warning about return type in jsonSerialize functions

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_php_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_php_generator.cc
@@ -1285,6 +1285,7 @@ void t_php_generator::generate_php_struct_required_validator(ostream& out,
 void t_php_generator::generate_php_struct_json_serialize(ostream& out,
                                                          t_struct* tstruct,
                                                          bool is_result) {
+  indent(out) << "#[\\ReturnTypeWillChange]" << endl;                                                          
   indent(out) << "public function jsonSerialize() {" << endl;
   indent_up();
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 In PHP 8.1 a "mixed" return type was added to the "JsonSerializable::jsonSerialize()" method.

This triggers a deprecation warning for generated PHP classes:

`Return type of TestClass::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...`

This will not affect previous versions of PHP, meaning these changes are backwards compatible.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
