### PR TITLE
THRIFT-5754: Fix PHP 8.1 deprecates passing null to non-nullable internal function parameters

### DIFF
--- a/lib/php/lib/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Protocol/TJSONProtocol.php
@@ -108,7 +108,7 @@ class TJSONProtocol extends TProtocol
     {
         $result = TType::STOP;
 
-        if (strlen($name) > 1) {
+        if (strlen((string) $name) > 1) {
             switch (substr($name, 0, 1)) {
                 case 'd':
                     $result = TType::DOUBLE;

--- a/lib/php/lib/StringFunc/Core.php
+++ b/lib/php/lib/StringFunc/Core.php
@@ -27,14 +27,14 @@ class Core implements TStringFunc
     {
         // specifying a null $length would return an empty string
         if ($length === null) {
-            return substr($str, $start);
+            return substr((string) $str, $start);
         }
 
-        return substr($str, $start, $length);
+        return substr((string) $str, $start, $length);
     }
 
     public function strlen($str)
     {
-        return strlen($str);
+        return strlen((string) $str);
     }
 }

--- a/lib/php/lib/StringFunc/Mbstring.php
+++ b/lib/php/lib/StringFunc/Mbstring.php
@@ -36,11 +36,11 @@ class Mbstring implements TStringFunc
             $length = $this->strlen($str) - $start;
         }
 
-        return mb_substr($str, $start, $length, '8bit');
+        return mb_substr((string) $str, $start, $length, '8bit');
     }
 
     public function strlen($str)
     {
-        return mb_strlen($str, '8bit');
+        return mb_strlen((string) $str, '8bit');
     }
 }

--- a/lib/php/lib/TMultiplexedProcessor.php
+++ b/lib/php/lib/TMultiplexedProcessor.php
@@ -97,7 +97,7 @@ class TMultiplexedProcessor
         }
 
         // Extract the service name and the new Message name.
-        if (strpos($fname, TMultiplexedProtocol::SEPARATOR) === false) {
+        if (strpos((string) $fname, TMultiplexedProtocol::SEPARATOR) === false) {
             throw new TException("Service name not found in message name: {$fname}. Did you " .
                 "forget to use a TMultiplexProtocol in your client?");
         }

--- a/lib/php/src/TStringUtils.php
+++ b/lib/php/src/TStringUtils.php
@@ -12,15 +12,15 @@ implements TStringFunc {
     {
         // specifying a null $length would return an empty string
         if ($length === null) {
-            return substr($str, $start);
+            return substr((string) $str, $start);
         }
 
-        return substr($str, $start, $length);
+        return substr((string) $str, $start, $length);
     }
 
     public function strlen($str)
     {
-        return strlen($str);
+        return strlen((string) $str);
     }
 }
 
@@ -39,12 +39,12 @@ implements TStringFunc {
             $length = $this->strlen($str) - $start;
         }
 
-        return mb_substr($str, $start, $length, '8bit');
+        return mb_substr((string) $str, $start, $length, '8bit');
     }
 
     public function strlen($str)
     {
-        return mb_strlen($str, '8bit');
+        return mb_strlen((string) $str, '8bit');
     }
 }
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
PHP 8.1 has deprecated passing null values to non-nullable internal function parameters:
https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

This can lead to deprecation warnings and potential errors in future versions.

Example of a deprecation warning:
`PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in Thrift/StringFunc/Core.php on line 38`

The changes in this PR will not affect previous versions of PHP, meaning these changes are backwards compatible.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
