### PR TITLE
THRIFT-5750 deprecate "ansistr_binary_" option

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_delphi_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_delphi_generator.cc
@@ -80,6 +80,7 @@ public:
     for( iter = parsed_options.begin(); iter != parsed_options.end(); ++iter) {
       if( iter->first.compare("ansistr_binary") == 0) {
         ansistr_binary_ = true;
+        pwarning(0, "The 'ansistr_binary' option is deprecated.");
       } else if( iter->first.compare("register_types") == 0) {
         register_types_ = true;
       } else if( iter->first.compare("old_names") == 0) {


### PR DESCRIPTION
Client: delphi
Patch: Jens Geyer

This patch is just the deprecation notice, feature will be removed in 0.21.0