### PR TITLE
Fix ambigous typescript definitions

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -2851,12 +2851,12 @@ std::string t_js_generator::ts_function_signature(t_function* tfunction, bool in
         }
       }
       if (exception_types == "") {
-        str += "callback?: (error: void, response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+        str += "callback: (error: void, response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
       } else {
-        str += "callback?: (error: " + exception_types + ", response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+        str += "callback: (error: " + exception_types + ", response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
       }
     } else {
-      str += "callback?: (data: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+      str += "callback: (data: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
     }
 
     if (gen_jquery_) {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
The generated typescript client includes type definitions like this:

```typescript
    addProfile(profile: types_ttypes.Profile): Promise<types_ttypes.Profile>;

    addProfile(profile: types_ttypes.Profile, callback?: (error: void, response: types_ttypes.Profile)=>void): void;
```

This is ambigous as the second definition overrides the first one since callback is optional. And is in fact not how the client works.

The correct types should be:

```typescript
    addProfile(profile: types_ttypes.Profile): Promise<types_ttypes.Profile>;

    addProfile(profile: types_ttypes.Profile, callback: (error: void, response: types_ttypes.Profile)=>void): void;
```

My current workaround is to run this nasty sed, so it would be nice to get this fix in. 😄 

```bash
find "$out_dir" -name '*.d.ts' -type f -exec sed -i '' -e '/.*callback\?:.*/d' {} \;
```

In my understanding, this should always be the case, as the older synchronous+callback API would be:

```typescript
    addProfile(profile: types_ttypes.Profile): types_ttypes.Profile;

    addProfile(profile: types_ttypes.Profile, callback: (error: void, response: types_ttypes.Profile)=>void): void;
```

So I don't really see a scenario where the callback would be optional without also changing the return type.

Regarding this being a breaking change, as long as a function signature with an optional callback and one without a callback are available, only the callback style function signature will be valid. So I don't think this is a breaking change.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
