### PR TITLE
THRIFT-5688: Add PyPI publishing github actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,32 @@
+name: "PyPI publishing"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Build
+        run: |
+          cd lib/py
+          python setup.py sdist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: lib/py/dist/


### PR DESCRIPTION
This is tested with https://github.com/apache/thrift/pull/2927, which published to https://test.pypi.org/project/thrift-test/. I tested locally with:

    (venv) fishy@penguin:~/work/test$ pip install -i https://test.pypi.org/simple/ thrift-test
    Looking in indexes: https://test.pypi.org/simple/
    Collecting thrift-test
      Downloading https://test-files.pythonhosted.org/packages/e6/02/5885ea1406f560d0a23351f68acc2892d7f6495b16bfc2eeee8de4649777/thrift-test-0.21.0.tar.gz (62 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.3/62.3 kB 1.4 MB/s eta 0:00:00
      Preparing metadata (setup.py) ... done
    Collecting six>=1.7.2 (from thrift-test)
      Downloading https://test-files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz (29 kB)
      Preparing metadata (setup.py) ... done
    Building wheels for collected packages: thrift-test, six
      Building wheel for thrift-test (setup.py) ... done
      Created wheel for thrift-test: filename=thrift_test-0.21.0-cp311-cp311-linux_x86_64.whl size=416914 sha256=3a972bc562be7ed19cb37399e444ed0d373cde5319023974080b625e550901d4
      Stored in directory: /home/fishy/.cache/pip/wheels/45/20/1f/d3e1b869ac068d63ca2b2c13a2f4e33a80b360fae7091c8a9b
      Building wheel for six (setup.py) ... done
      Created wheel for six: filename=six-1.10.0-py2.py3-none-any.whl size=9942 sha256=74014380446ccf331366316cec0b1aaf40e0162e70307622b493e38e8451115f
      Stored in directory: /home/fishy/.cache/pip/wheels/e4/18/d0/e02474c90dcf14c511c0f52145d7e72e41ff3fb80b330ba58e
    Successfully built thrift-test six
    Installing collected packages: six, thrift-test
    Successfully installed six-1.10.0 thrift-test-0.21.0
    (venv) fishy@penguin:~/work/test$ python3
    Python 3.11.7 (main, Dec  8 2023, 14:22:46) [GCC 13.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from thrift.transport import TSocket
    >>> transport = TSocket.TSocket('localhost', 9090)
    >>> transport
    <thrift.transport.TSocket.TSocket object at 0x785b18d83690>
    >>> transport.open()
    Could not connect to any of [('::1', 9090, 0, 0), ('127.0.0.1', 9090)]
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/fishy/work/test/venv/lib/python3.11/site-packages/thrift/transport/TSocket.py", line 149, in open
        raise TTransportException(type=TTransportException.NOT_OPEN, message=msg)
    thrift.transport.TTransport.TTransportException: Could not connect to any of [('::1', 9090, 0, 0), ('127.0.0.1', 9090)]
    >>>

I think the current version doesn't do any c compilation (e.g. it only publishes the pure python version), which will cause it to lack fastbinary optimizations. To add those we'll likely need github action workers to build the c extension in all the platforms we want to support.

If we want to merge this version, I'll enable pending publishing with `pypi.yml` from this repo on pypi [1].

[1]: https://pypi.org/manage/account/publishing/
