### PR TITLE
THRIFT-5139/THRIFT-4181: Python3 type hints

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -17,21 +17,21 @@
  * under the License.
  */
 
+#include <string>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <limits>
-#include <string>
 #include <vector>
 
-#include "thrift/generate/t_generator.h"
-#include "thrift/platform.h"
-#include "thrift/version.h"
-#include <algorithm>
-#include <sstream>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sstream>
+#include <algorithm>
+#include "thrift/platform.h"
+#include "thrift/version.h"
+#include "thrift/generate/t_generator.h"
 
 using std::map;
 using std::ostream;
@@ -49,7 +49,7 @@ public:
   t_py_generator(t_program* program,
                  const std::map<std::string, std::string>& parsed_options,
                  const std::string& option_string)
-    : t_generator(program) {
+    : t_generator (program) {
     update_keywords_for_validation();
 
     std::map<std::string, std::string>::const_iterator iter;
@@ -71,70 +71,66 @@ public:
     gen_dynbaseclass_frozen_ = "";
     import_dynbase_ = "";
     package_prefix_ = "";
-    for (iter = parsed_options.begin(); iter != parsed_options.end(); ++iter) {
-      if (iter->first.compare("enum") == 0) {
+    for( iter = parsed_options.begin(); iter != parsed_options.end(); ++iter) {
+      if( iter->first.compare("enum") == 0) {
         gen_enum_ = true;
-      } else if (iter->first.compare("new_style") == 0) {
-        pwarning(
-            0,
-            "new_style is enabled by default, so the option will be removed in the near future.\n");
-      } else if (iter->first.compare("old_style") == 0) {
+      } else if( iter->first.compare("new_style") == 0) {
+        pwarning(0, "new_style is enabled by default, so the option will be removed in the near future.\n");
+      } else if( iter->first.compare("old_style") == 0) {
         gen_newstyle_ = false;
         pwarning(0, "old_style is deprecated and may be removed in the future.\n");
-      } else if (iter->first.compare("utf8strings") == 0) {
-        pwarning(0,
-                 "utf8strings is enabled by default, so the option will be removed in the near "
-                 "future.\n");
-      } else if (iter->first.compare("no_utf8strings") == 0) {
+      } else if( iter->first.compare("utf8strings") == 0) {
+        pwarning(0, "utf8strings is enabled by default, so the option will be removed in the near future.\n");
+      } else if( iter->first.compare("no_utf8strings") == 0) {
         gen_utf8strings_ = false;
-      } else if (iter->first.compare("slots") == 0) {
+      } else if( iter->first.compare("slots") == 0) {
         gen_slots_ = true;
-      } else if (iter->first.compare("package_prefix") == 0) {
+      } else if( iter->first.compare("package_prefix") == 0) {
         package_prefix_ = iter->second;
-      } else if (iter->first.compare("dynamic") == 0) {
+      } else if( iter->first.compare("dynamic") == 0) {
         gen_dynamic_ = true;
         gen_newstyle_ = false; // dynamic is newstyle
-        if (gen_dynbaseclass_.empty()) {
+        if( gen_dynbaseclass_.empty()) {
           gen_dynbaseclass_ = "TBase";
         }
-        if (gen_dynbaseclass_frozen_.empty()) {
+        if( gen_dynbaseclass_frozen_.empty()) {
           gen_dynbaseclass_frozen_ = "TFrozenBase";
         }
-        if (gen_dynbaseclass_exc_.empty()) {
+        if( gen_dynbaseclass_exc_.empty()) {
           gen_dynbaseclass_exc_ = "TExceptionBase";
         }
-        if (gen_dynbaseclass_frozen_exc_.empty()) {
+        if( gen_dynbaseclass_frozen_exc_.empty()) {
           gen_dynbaseclass_frozen_exc_ = "TFrozenExceptionBase";
         }
-        if (import_dynbase_.empty()) {
-          import_dynbase_
-              = "from thrift.protocol.TBase import TBase, TFrozenBase, TExceptionBase, "
-                "TFrozenExceptionBase, TTransport\n";
+        if( import_dynbase_.empty()) {
+          import_dynbase_ = "from thrift.protocol.TBase import TBase, TFrozenBase, TExceptionBase, TFrozenExceptionBase, TTransport\n";
         }
-      } else if (iter->first.compare("dynbase") == 0) {
+      } else if( iter->first.compare("dynbase") == 0) {
         gen_dynbase_ = true;
         gen_dynbaseclass_ = (iter->second);
-      } else if (iter->first.compare("dynfrozen") == 0) {
+      } else if( iter->first.compare("dynfrozen") == 0) {
         gen_dynbaseclass_frozen_ = (iter->second);
-      } else if (iter->first.compare("dynexc") == 0) {
+      } else if( iter->first.compare("dynexc") == 0) {
         gen_dynbaseclass_exc_ = (iter->second);
-      } else if (iter->first.compare("dynfrozenexc") == 0) {
+      } else if( iter->first.compare("dynfrozenexc") == 0) {
         gen_dynbaseclass_frozen_exc_ = (iter->second);
-      } else if (iter->first.compare("dynimport") == 0) {
+      } else if( iter->first.compare("dynimport") == 0) {
         gen_dynbase_ = true;
         import_dynbase_ = (iter->second);
-      } else if (iter->first.compare("zope.interface") == 0) {
+      } else if( iter->first.compare("zope.interface") == 0) {
         gen_zope_interface_ = true;
-      } else if (iter->first.compare("twisted") == 0) {
+      } else if( iter->first.compare("twisted") == 0) {
         gen_twisted_ = true;
         gen_zope_interface_ = true;
-      } else if (iter->first.compare("tornado") == 0) {
+      } else if( iter->first.compare("tornado") == 0) {
         gen_tornado_ = true;
-      } else if (iter->first.compare("coding") == 0) {
+      } else if( iter->first.compare("coding") == 0) {
         coding_ = iter->second;
       } else if (iter->first.compare("type_hints") == 0) {
+        if (!gen_enum_) {
+          throw "the type_hints py option requires the enum py option";
+        }
         gen_type_hints_ = true;
-        gen_enum_ = true;
       } else {
         throw "unknown option py:" + iter->first;
       }
@@ -155,7 +151,9 @@ public:
     }
   }
 
-  std::string indent_str() const override { return "    "; }
+  std::string indent_str() const override {
+    return "    ";
+  }
 
   /**
    * Init and close methods
@@ -208,7 +206,9 @@ public:
    * Serialization constructs
    */
 
-  void generate_deserialize_field(std::ostream& out, t_field* tfield, std::string prefix = "");
+  void generate_deserialize_field(std::ostream& out,
+                                  t_field* tfield,
+                                  std::string prefix = "");
 
   void generate_deserialize_struct(std::ostream& out, t_struct* tstruct, std::string prefix = "");
 
@@ -218,7 +218,9 @@ public:
 
   void generate_deserialize_map_element(std::ostream& out, t_map* tmap, std::string prefix = "");
 
-  void generate_deserialize_list_element(std::ostream& out, t_list* tlist, std::string prefix = "");
+  void generate_deserialize_list_element(std::ostream& out,
+                                         t_list* tlist,
+                                         std::string prefix = "");
 
   void generate_serialize_field(std::ostream& out, t_field* tfield, std::string prefix = "");
 
@@ -256,9 +258,7 @@ public:
   std::string declare_argument(t_field* tfield);
   std::string render_field_default_value(t_field* tfield);
   std::string type_name(t_type* ttype);
-  std::string function_signature(t_function* tfunction,
-                                 bool interface = false,
-                                 bool send_part = false);
+  std::string function_signature(t_function* tfunction, bool interface = false, bool send_part = false);
   std::string argument_list(t_struct* tstruct,
                             std::vector<std::string>* pre = nullptr,
                             std::vector<std::string>* post = nullptr);
@@ -273,9 +273,7 @@ public:
     return sub_namespace == "twisted";
   }
 
-  static std::string get_real_py_module(const t_program* program,
-                                        bool gen_twisted,
-                                        std::string package_dir = "") {
+  static std::string get_real_py_module(const t_program* program, bool gen_twisted, std::string package_dir="") {
     if (gen_twisted) {
       std::string twisted_module = program->get_namespace("py.twisted");
       if (!twisted_module.empty()) {
@@ -291,8 +289,7 @@ public:
   }
 
   static bool is_immutable(t_type* ttype) {
-    std::map<std::string, std::vector<std::string>>::iterator it
-        = ttype->annotations_.find("python.immutable");
+    std::map<std::string, std::vector<std::string>>::iterator it = ttype->annotations_.find("python.immutable");
 
     if (it == ttype->annotations_.end()) {
       // Exceptions are immutable by default.
@@ -305,6 +302,7 @@ public:
   }
 
 private:
+
   /**
    * True if we should generate new-style classes.
    */
@@ -312,8 +310,8 @@ private:
   bool gen_enum_;
 
   /**
-   * True if we should generate dynamic style classes.
-   */
+  * True if we should generate dynamic style classes.
+  */
   bool gen_dynamic_;
 
   bool gen_dynbase_;
@@ -327,8 +325,8 @@ private:
   bool gen_slots_;
 
   /**
-   * True if we should generate classes type hints and type checks in write methods.
-   */
+  * True if we should generate classes type hints and type checks in write methods.
+  */
   bool gen_type_hints_;
 
   std::string copy_options_;
@@ -374,13 +372,11 @@ private:
 
 protected:
   std::set<std::string> lang_keywords_for_validation() const override {
-    std::string keywords[]
-        = {"False", "None",     "True",   "and",      "as",     "assert", "break",
-           "class", "continue", "def",    "del",      "elif",   "else",   "except",
-           "exec",  "finally",  "for",    "from",     "global", "if",     "import",
-           "in",    "is",       "lambda", "nonlocal", "not",    "or",     "pass",
-           "print", "raise",    "return", "try",      "while",  "with",   "yield"};
-    return std::set<std::string>(keywords, keywords + sizeof(keywords) / sizeof(keywords[0]));
+    std::string keywords[] = { "False", "None", "True", "and", "as", "assert", "break", "class",
+          "continue", "def", "del", "elif", "else", "except", "exec", "finally", "for", "from",
+          "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "print",
+          "raise", "return", "try", "while", "with", "yield" };
+    return std::set<std::string>(keywords, keywords + sizeof(keywords)/sizeof(keywords[0]) );
   }
 };
 
@@ -443,9 +439,10 @@ void t_py_generator::init_generator() {
 
   f_types_ << "all_structs = []" << '\n';
 
-  f_consts_ << py_autogen_comment() << '\n'
-            << py_imports() << '\n'
-            << "from .ttypes import *" << '\n';
+  f_consts_ <<
+    py_autogen_comment() << '\n' <<
+    py_imports() << '\n' <<
+    "from .ttypes import *" << '\n';
 }
 
 /**
@@ -466,11 +463,11 @@ string t_py_generator::render_includes() {
 string t_py_generator::py_autogen_comment() {
   string coding;
   if (!coding_.empty()) {
-    coding = "# -*- coding: " + coding_ + " -*-\n";
+      coding = "# -*- coding: " + coding_ + " -*-\n";
   }
-  return coding + std::string("#\n") + "# Autogenerated by Thrift Compiler (" + THRIFT_VERSION
-         + ")\n" + "#\n" + "# DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING\n"
-         + "#\n" + "#  options string: " + copy_options_ + "\n" + "#\n";
+  return coding + std::string("#\n") + "# Autogenerated by Thrift Compiler (" + THRIFT_VERSION + ")\n"
+         + "#\n" + "# DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING\n" + "#\n"
+         + "#  options string: " + copy_options_ + "\n" + "#\n";
 }
 
 /**
@@ -485,9 +482,12 @@ string t_py_generator::py_imports() {
   ss << "from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, "
         "TApplicationException"
      << '\n'
-     << "from thrift.protocol.TProtocol import TProtocolException" << '\n'
-     << "from thrift.TRecursive import fix_spec" << '\n'
-     << "from uuid import UUID" << '\n';
+     << "from thrift.protocol.TProtocol import TProtocolException"
+     << '\n'
+     << "from thrift.TRecursive import fix_spec"
+     << '\n'
+     << "from uuid import UUID"
+     << '\n';
   if (gen_enum_) {
     ss << "from enum import IntEnum" << '\n';
   }
@@ -540,8 +540,10 @@ void t_py_generator::generate_enum(t_enum* tenum) {
 
   f_types_ << '\n'
            << '\n'
-           << "class " << tenum->get_name() << (base_class.empty() ? "" : "(" + base_class + ")")
-           << ":" << '\n';
+           << "class " << tenum->get_name()
+           << (base_class.empty() ? "" : "(" + base_class + ")")
+           << ":"
+           << '\n';
   indent_up();
   generate_python_docstring(f_types_, tenum);
 
@@ -649,7 +651,7 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
         throw "type error: " + type->get_name() + " has no field " + v_iter->first->get_string();
       }
       indent(out) << render_const_value(g_type_string, v_iter->first) << ": "
-                  << render_const_value(field_type, v_iter->second) << "," << '\n';
+          << render_const_value(field_type, v_iter->second) << "," << '\n';
     }
     indent_down();
     indent(out) << "})";
@@ -665,7 +667,7 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
     map<t_const_value*, t_const_value*, t_const_value::value_compare>::const_iterator v_iter;
     for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
       indent(out) << render_const_value(ktype, v_iter->first) << ": "
-                  << render_const_value(vtype, v_iter->second) << "," << '\n';
+          << render_const_value(vtype, v_iter->second) << "," << '\n';
     }
     indent_down();
     indent(out) << "}";
@@ -719,7 +721,7 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
  * definitions are grouped at the end of the file to enable co-recursive structs.
  */
 void t_py_generator::generate_forward_declaration(t_struct* tstruct) {
-  generate_py_struct(tstruct, tstruct->is_xception());
+    generate_py_struct(tstruct, tstruct->is_xception());
 }
 
 /**
@@ -745,6 +747,7 @@ void t_py_generator::generate_xception(t_struct* txception) {
 void t_py_generator::generate_py_struct(t_struct* tstruct, bool is_exception) {
   generate_py_struct_definition(f_types_, tstruct, is_exception);
 }
+
 
 /**
  * Generate the thrift_spec for a struct
@@ -819,7 +822,7 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
   } else if (gen_dynamic_) {
     if (is_immutable(tstruct)) {
       out << "(" << gen_dynbaseclass_frozen_ << ")";
-    } else {
+    } else  {
       out << "(" << gen_dynbaseclass_ << ")";
     }
   } else if (gen_newstyle_) {
@@ -892,9 +895,9 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
       if (is_immutable(tstruct)) {
         if (gen_enum_ && type->is_enum()) {
           indent(out) << "super(" << tstruct->get_name() << ", self).__setattr__('"
-                      << (*m_iter)->get_name() << "', " << (*m_iter)->get_name() << " if hasattr("
-                      << (*m_iter)->get_name() << ", 'value') else " << type_name(type)
-                      << ".__members__.get(" << (*m_iter)->get_name() << "))" << '\n';
+                      << (*m_iter)->get_name() << "', " << (*m_iter)->get_name()
+                      << " if hasattr("  << (*m_iter)->get_name() << ", 'value') else "
+                      << type_name(type) << ".__members__.get(" << (*m_iter)->get_name() << "))" << '\n';
         } else if (gen_newstyle_ || gen_dynamic_) {
           indent(out) << "super(" << tstruct->get_name() << ", self).__setattr__('"
                       << (*m_iter)->get_name() << "', " << (*m_iter)->get_name() << ")" << '\n';
@@ -923,10 +926,11 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
     // trivial because we know which fields are user-provided, without slots we need to build a
     // way to know which fields are user-provided.
     if (gen_slots_ && !gen_dynamic_) {
-      out << indent() << "if args[0] not in self.__slots__:" << '\n';
-      indent_up();
-      out << indent() << "super().__setattr__(*args)" << '\n' << indent() << "return" << '\n';
-      indent_down();
+        out << indent() << "if args[0] not in self.__slots__:" << '\n';
+        indent_up();
+        out << indent() << "super().__setattr__(*args)" << '\n'
+            << indent() << "return" << '\n';
+        indent_down();
     }
     out << indent() << "raise TypeError(\"can't modify immutable instance\")" << '\n';
     indent_down();
@@ -940,10 +944,11 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
     // trivial because we know which fields are user-provided, without slots we need to build a
     // way to know which fields are user-provided.
     if (gen_slots_ && !gen_dynamic_) {
-      out << indent() << "if args[0] not in self.__slots__:" << '\n';
-      indent_up();
-      out << indent() << "super().__delattr__(*args)" << '\n' << indent() << "return" << '\n';
-      indent_down();
+        out << indent() << "if args[0] not in self.__slots__:" << '\n';
+        indent_up();
+        out << indent() << "super().__delattr__(*args)" << '\n'
+            << indent() << "return" << '\n';
+        indent_down();
     }
     out << indent() << "raise TypeError(\"can't modify immutable instance\")" << '\n';
     indent_down();
@@ -977,8 +982,7 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
         t_type* type = (*m_iter)->get_type();
         if (type->is_enum()) {
           out << indent() << "if name == \"" << (*m_iter)->get_name() << "\":" << '\n'
-              << indent() << indent_str()
-              << "super().__setattr__(name, value if hasattr(value, 'value') else "
+              << indent() << indent_str() << "super().__setattr__(name, value if hasattr(value, 'value') else "
               << type_name(type) << ".__members__.get(value))" << '\n'
               << indent() << indent_str() << "return" << '\n';
         }
@@ -1018,10 +1022,8 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
     // Equality and inequality methods that compare by value
     out << indent() << "def __eq__(self, other):" << '\n';
     indent_up();
-    out << indent()
-        << "return isinstance(other, self.__class__) and "
-           "self.__dict__ == other.__dict__"
-        << '\n';
+    out << indent() << "return isinstance(other, self.__class__) and "
+                       "self.__dict__ == other.__dict__" << '\n';
     indent_down();
     out << '\n';
 
@@ -1105,7 +1107,7 @@ void t_py_generator::generate_py_struct_reader(ostream& out, t_struct* tstruct) 
         result << "None";
       }
       indent(out) << result.str() << '\n';
-    }
+     }
   }
 
   // Loop over reading in fields
@@ -1181,8 +1183,9 @@ void t_py_generator::generate_py_struct_writer(ostream& out, t_struct* tstruct) 
   indent(out) << "if oprot._fast_encode is not None and self.thrift_spec is not None:" << '\n';
   indent_up();
 
-  indent(out) << "oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))"
-              << '\n';
+  indent(out)
+      << "oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))"
+      << '\n';
   indent(out) << "return" << '\n';
   indent_down();
 
@@ -1206,8 +1209,8 @@ void t_py_generator::generate_py_struct_writer(ostream& out, t_struct* tstruct) 
   }
 
   // Write the struct map
-  out << indent() << "oprot.writeFieldStop()" << '\n'
-      << indent() << "oprot.writeStructEnd()" << '\n';
+  out << indent() << "oprot.writeFieldStop()" << '\n' << indent() << "oprot.writeStructEnd()"
+      << '\n';
 
   out << '\n';
 
@@ -1251,9 +1254,8 @@ void t_py_generator::generate_service(t_service* tservice) {
 
   if (tservice->get_extends() != nullptr) {
     f_service_ << "import "
-               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_,
-                                     package_prefix_)
-               << "." << tservice->get_extends()->get_name() << '\n';
+               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_, package_prefix_) << "."
+               << tservice->get_extends()->get_name() << '\n';
   }
 
   f_service_ << "import logging" << '\n'
@@ -1283,7 +1285,8 @@ void t_py_generator::generate_service(t_service* tservice) {
   generate_service_remote(tservice);
 
   // Close service file
-  f_service_ << "fix_spec(all_structs)" << '\n' << "del all_structs" << '\n';
+  f_service_ << "fix_spec(all_structs)" << '\n'
+             << "del all_structs" << '\n';
   f_service_.close();
 }
 
@@ -1442,8 +1445,8 @@ void t_py_generator::generate_service_client(t_service* tservice) {
     }
   } else {
     if (gen_twisted_) {
-      f_service_ << indent() << extends << ".Client.__init__(self, transport, oprot_factory)"
-                 << '\n';
+      f_service_ << indent() << extends
+                 << ".Client.__init__(self, transport, oprot_factory)" << '\n';
     } else if (gen_tornado_) {
       f_service_ << indent() << extends
                  << ".Client.__init__(self, transport, iprot_factory, oprot_factory)" << '\n';
@@ -1454,9 +1457,9 @@ void t_py_generator::generate_service_client(t_service* tservice) {
   indent_down();
 
   if (gen_tornado_ && extends.empty()) {
-    f_service_ << '\n'
-               << indent() << "@gen.engine" << '\n'
-               << indent() << "def _start_receiving(self):" << '\n';
+    f_service_ << '\n' <<
+      indent() << "@gen.engine" << '\n' <<
+      indent() << "def _start_receiving(self):" << '\n';
     indent_up();
     indent(f_service_) << "while True:" << '\n';
     indent_up();
@@ -1553,10 +1556,9 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << "d.addCallbacks(" << '\n';
 
       indent_up();
-      f_service_ << indent() << "callback=self.cb_send_" << funname << "," << '\n'
-                 << indent() << "callbackArgs=(seqid,)," << '\n'
-                 << indent() << "errback=self.eb_send_" << funname << "," << '\n'
-                 << indent() << "errbackArgs=(seqid,))" << '\n';
+      f_service_ << indent() << "callback=self.cb_send_" << funname << "," << '\n' << indent()
+                 << "callbackArgs=(seqid,)," << '\n' << indent() << "errback=self.eb_send_"
+                 << funname << "," << '\n' << indent() << "errbackArgs=(seqid,))" << '\n';
       indent_down();
 
       indent(f_service_) << "return d" << '\n';
@@ -1567,9 +1569,8 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       indent_up();
       if ((*f_iter)->is_oneway()) {
         // if one-way, fire the deferred & remove it from _reqs
-        f_service_ << indent() << "d = self._reqs.pop(seqid)" << '\n'
-                   << indent() << "d.callback(None)" << '\n'
-                   << indent() << "return d" << '\n';
+        f_service_ << indent() << "d = self._reqs.pop(seqid)" << '\n' << indent()
+                   << "d.callback(None)" << '\n' << indent() << "return d" << '\n';
       } else {
         f_service_ << indent() << "return self._reqs[seqid]" << '\n';
       }
@@ -1579,9 +1580,8 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       // add an errback to fail the request if the call to send_<> raised an exception
       indent(f_service_) << "def eb_send_" << funname << "(self, f, seqid):" << '\n';
       indent_up();
-      f_service_ << indent() << "d = self._reqs.pop(seqid)" << '\n'
-                 << indent() << "d.errback(f)" << '\n'
-                 << indent() << "return d" << '\n';
+      f_service_ << indent() << "d = self._reqs.pop(seqid)" << '\n' << indent() << "d.errback(f)"
+                 << '\n' << indent() << "return d" << '\n';
       indent_down();
     }
 
@@ -1611,13 +1611,12 @@ void t_py_generator::generate_service_client(t_service* tservice) {
 
     // Write to the stream
     if (gen_twisted_ || gen_tornado_) {
-      f_service_ << indent() << "args.write(oprot)" << '\n'
-                 << indent() << "oprot.writeMessageEnd()" << '\n'
-                 << indent() << "oprot.trans.flush()" << '\n';
+      f_service_ << indent() << "args.write(oprot)" << '\n' << indent() << "oprot.writeMessageEnd()"
+                 << '\n' << indent() << "oprot.trans.flush()" << '\n';
     } else {
-      f_service_ << indent() << "args.write(self._oprot)" << '\n'
-                 << indent() << "self._oprot.writeMessageEnd()" << '\n'
-                 << indent() << "self._oprot.trans.flush()" << '\n';
+      f_service_ << indent() << "args.write(self._oprot)" << '\n' << indent()
+                 << "self._oprot.writeMessageEnd()" << '\n' << indent()
+                 << "self._oprot.trans.flush()" << '\n';
     }
 
     indent_down();
@@ -1632,7 +1631,8 @@ void t_py_generator::generate_service_client(t_service* tservice) {
       } else {
         t_struct noargs(program_);
         t_function recv_function((*f_iter)->get_returntype(),
-                                 string("recv_") + (*f_iter)->get_name(), &noargs);
+                                 string("recv_") + (*f_iter)->get_name(),
+                                 &noargs);
         f_service_ << indent() << "def " << function_signature(&recv_function) << ":" << '\n';
       }
       indent_up();
@@ -1643,27 +1643,23 @@ void t_py_generator::generate_service_client(t_service* tservice) {
         f_service_ << indent() << "d = self._reqs.pop(rseqid)" << '\n';
       } else if (gen_tornado_) {
       } else {
-        f_service_ << indent() << "iprot = self._iprot" << '\n'
-                   << indent() << "(fname, mtype, rseqid) = iprot.readMessageBegin()" << '\n';
+        f_service_ << indent() << "iprot = self._iprot" << '\n' << indent()
+                   << "(fname, mtype, rseqid) = iprot.readMessageBegin()" << '\n';
       }
 
       f_service_ << indent() << "if mtype == TMessageType.EXCEPTION:" << '\n'
                  << indent() << indent_str() << "x = TApplicationException()" << '\n';
 
       if (gen_twisted_) {
-        f_service_ << indent() << indent_str() << "x.read(iprot)" << '\n'
-                   << indent() << indent_str() << "iprot.readMessageEnd()" << '\n'
-                   << indent() << indent_str() << "return d.errback(x)" << '\n'
-                   << indent() << "result = " << resultname << "()" << '\n'
-                   << indent() << "result.read(iprot)" << '\n'
-                   << indent() << "iprot.readMessageEnd()" << '\n';
+        f_service_ << indent() << indent_str() << "x.read(iprot)" << '\n' << indent()
+                   << indent_str() << "iprot.readMessageEnd()" << '\n' << indent() << indent_str() << "return d.errback(x)"
+                   << '\n' << indent() << "result = " << resultname << "()" << '\n' << indent()
+                   << "result.read(iprot)" << '\n' << indent() << "iprot.readMessageEnd()" << '\n';
       } else {
-        f_service_ << indent() << indent_str() << "x.read(iprot)" << '\n'
-                   << indent() << indent_str() << "iprot.readMessageEnd()" << '\n'
-                   << indent() << indent_str() << "raise x" << '\n'
-                   << indent() << "result = " << resultname << "()" << '\n'
-                   << indent() << "result.read(iprot)" << '\n'
-                   << indent() << "iprot.readMessageEnd()" << '\n';
+        f_service_ << indent() << indent_str() << "x.read(iprot)" << '\n' << indent()
+                   << indent_str() << "iprot.readMessageEnd()" << '\n' << indent() << indent_str() << "raise x" << '\n'
+                   << indent() << "result = " << resultname << "()" << '\n' << indent()
+                   << "result.read(iprot)" << '\n' << indent() << "iprot.readMessageEnd()" << '\n';
       }
 
       // Careful, only return _result if not a void function
@@ -1738,31 +1734,28 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
   ofstream_with_content_based_conditional_update f_remote;
   f_remote.open(f_remote_name.c_str());
 
-  f_remote << "#!/usr/bin/env python" << '\n'
-           << py_autogen_comment() << '\n'
-           << "import sys" << '\n'
-           << "import pprint" << '\n'
-           << "if sys.version_info[0] > 2:" << '\n'
-           << indent_str() << "from urllib.parse import urlparse" << '\n'
-           << "else:" << '\n'
-           << indent_str() << "from urlparse import urlparse" << '\n'
-           << "from thrift.transport import TTransport, TSocket, TSSLSocket, THttpClient" << '\n'
-           << "from thrift.protocol.TBinaryProtocol import TBinaryProtocol" << '\n'
-           << '\n';
+  f_remote <<
+    "#!/usr/bin/env python" << '\n' <<
+    py_autogen_comment() << '\n' <<
+    "import sys" << '\n' <<
+    "import pprint" << '\n' <<
+    "if sys.version_info[0] > 2:" << '\n' <<
+    indent_str() << "from urllib.parse import urlparse" << '\n' <<
+    "else:" << '\n' <<
+    indent_str() << "from urlparse import urlparse" << '\n' <<
+    "from thrift.transport import TTransport, TSocket, TSSLSocket, THttpClient" << '\n' <<
+    "from thrift.protocol.TBinaryProtocol import TBinaryProtocol" << '\n' << '\n';
 
-  f_remote << "from " << module_ << " import " << service_name_ << '\n'
-           << "from " << module_ << ".ttypes import *" << '\n'
-           << '\n';
+  f_remote <<
+    "from " << module_ << " import " << service_name_ << '\n' <<
+    "from " << module_ << ".ttypes import *" << '\n' << '\n';
 
-  f_remote << "if len(sys.argv) <= 1 or sys.argv[1] == '--help':" << '\n'
-           << indent_str() << "print('')" << '\n'
-           << indent_str()
-           << "print('Usage: ' + sys.argv[0] + ' [-h host[:port]] [-u url] [-f[ramed]] [-s[sl]] "
-              "[-novalidate] [-ca_certs certs] [-keyfile keyfile] [-certfile certfile] function "
-              "[arg1 [arg2...]]')"
-           << '\n'
-           << indent_str() << "print('')" << '\n'
-           << indent_str() << "print('Functions:')" << '\n';
+  f_remote <<
+    "if len(sys.argv) <= 1 or sys.argv[1] == '--help':" << '\n' <<
+    indent_str() << "print('')" << '\n' <<
+    indent_str() << "print('Usage: ' + sys.argv[0] + ' [-h host[:port]] [-u url] [-f[ramed]] [-s[sl]] [-novalidate] [-ca_certs certs] [-keyfile keyfile] [-certfile certfile] function [arg1 [arg2...]]')" << '\n' <<
+    indent_str() << "print('')" << '\n' <<
+    indent_str() << "print('Functions:')" << '\n';
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
     f_remote << indent_str() << "print('  " << (*f_iter)->get_returntype()->get_name() << " "
              << (*f_iter)->get_name() << "(";
@@ -1847,18 +1840,15 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
            << indent_str() << "transport = THttpClient.THttpClient(host, port, uri)" << '\n'
            << "else:" << '\n'
            << indent_str() << "if ssl:" << '\n'
-           << indent_str() << indent_str()
-           << "socket = TSSLSocket.TSSLSocket(host, port, "
+           << indent_str() << indent_str() << "socket = TSSLSocket.TSSLSocket(host, port, "
               "validate=validate, ca_certs=ca_certs, keyfile=keyfile, certfile=certfile)"
            << '\n'
            << indent_str() << "else:" << '\n'
            << indent_str() << indent_str() << "socket = TSocket.TSocket(host, port)" << '\n'
            << indent_str() << "if framed:" << '\n'
-           << indent_str() << indent_str() << "transport = TTransport.TFramedTransport(socket)"
-           << '\n'
+           << indent_str() << indent_str() << "transport = TTransport.TFramedTransport(socket)" << '\n'
            << indent_str() << "else:" << '\n'
-           << indent_str() << indent_str() << "transport = TTransport.TBufferedTransport(socket)"
-           << '\n'
+           << indent_str() << indent_str() << "transport = TTransport.TBufferedTransport(socket)" << '\n'
            << "protocol = TBinaryProtocol(transport)" << '\n'
            << "client = " << service_name_ << ".Client(protocol)" << '\n'
            << "transport.open()" << '\n'
@@ -1881,8 +1871,8 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
     f_remote << "if cmd == '" << (*f_iter)->get_name() << "':" << '\n';
     indent_up();
     f_remote << indent() << "if len(args) != " << num_args << ":" << '\n'
-             << indent() << indent_str() << "print('" << (*f_iter)->get_name() << " requires "
-             << num_args << " args')" << '\n'
+             << indent() << indent_str() << "print('" << (*f_iter)->get_name() << " requires " << num_args
+             << " args')" << '\n'
              << indent() << indent_str() << "sys.exit(1)" << '\n'
              << indent() << "pp.pprint(client." << (*f_iter)->get_name() << "(";
     indent_down();
@@ -1918,11 +1908,12 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
 #ifndef _MSC_VER
 
   // Make file executable, love that bitwise OR action
-  chmod(f_remote_name.c_str(), S_IRUSR | S_IWUSR | S_IXUSR
+  chmod(f_remote_name.c_str(),
+        S_IRUSR | S_IWUSR | S_IXUSR
 #ifndef _WIN32
-                                   | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
+        | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
 #endif
-  );
+        );
 
 #endif // _MSC_VER
 }
@@ -1983,7 +1974,7 @@ void t_py_generator::generate_service_server(t_service* tservice) {
 
   f_service_ << indent() << "def on_message_begin(self, func):" << '\n';
   indent_up();
-  f_service_ << indent() << "self._on_message_begin = func" << '\n';
+    f_service_ << indent() << "self._on_message_begin = func" << '\n';
   indent_down();
   f_service_ << '\n';
 
@@ -1994,7 +1985,7 @@ void t_py_generator::generate_service_server(t_service* tservice) {
   f_service_ << indent() << "(name, type, seqid) = iprot.readMessageBegin()" << '\n';
   f_service_ << indent() << "if self._on_message_begin:" << '\n';
   indent_up();
-  f_service_ << indent() << "self._on_message_begin(name, type, seqid)" << '\n';
+    f_service_ << indent() << "self._on_message_begin(name, type, seqid)" << '\n';
   indent_down();
 
   // TODO(mcslee): validate message
@@ -2053,9 +2044,8 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
   (void)tservice;
   // Open function
   if (gen_tornado_) {
-    f_service_ << indent() << "@gen.coroutine" << '\n'
-               << indent() << "def process_" << tfunction->get_name()
-               << "(self, seqid, iprot, oprot):" << '\n';
+    f_service_ << indent() << "@gen.coroutine" << '\n' << indent() << "def process_"
+               << tfunction->get_name() << "(self, seqid, iprot, oprot):" << '\n';
   } else {
     f_service_ << indent() << "def process_" << tfunction->get_name()
                << "(self, seqid, iprot, oprot):" << '\n';
@@ -2066,9 +2056,8 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
   string argsname = tfunction->get_name() + "_args";
   string resultname = tfunction->get_name() + "_result";
 
-  f_service_ << indent() << "args = " << argsname << "()" << '\n'
-             << indent() << "args.read(iprot)" << '\n'
-             << indent() << "iprot.readMessageEnd()" << '\n';
+  f_service_ << indent() << "args = " << argsname << "()" << '\n' << indent() << "args.read(iprot)"
+             << '\n' << indent() << "iprot.readMessageEnd()" << '\n';
 
   t_struct* xs = tfunction->get_xceptions();
   const std::vector<t_field*>& xceptions = xs->get_members();
@@ -2173,8 +2162,8 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
                  << indent() << "oprot.trans.flush()" << '\n';
     } else {
       f_service_ << indent() << "except Exception:" << '\n'
-                 << indent() << indent_str() << "logging.exception('Exception in oneway handler')"
-                 << '\n';
+                 << indent() << indent_str()
+                 << "logging.exception('Exception in oneway handler')" << '\n';
     }
     indent_down();
 
@@ -2232,8 +2221,8 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
                  << '\n';
     } else {
       f_service_ << indent() << "except Exception:" << '\n'
-                 << indent() << indent_str() << "logging.exception('Exception in oneway handler')"
-                 << '\n';
+                 << indent() << indent_str()
+                 << "logging.exception('Exception in oneway handler')" << '\n';
     }
 
     if (!tfunction->is_oneway()) {
@@ -2278,7 +2267,8 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
     }
 
     indent_down();
-    f_service_ << indent() << "except TTransport.TTransportException:" << '\n'
+    f_service_ << indent()
+               << "except TTransport.TTransportException:" << '\n'
                << indent() << indent_str() << "raise" << '\n';
 
     if (!tfunction->is_oneway()) {
@@ -2312,8 +2302,7 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
                  << indent() << "oprot.trans.flush()" << '\n';
     } else {
       f_service_ << indent() << "except Exception:" << '\n'
-                 << indent() << indent_str() << "logging.exception('Exception in oneway handler')"
-                 << '\n';
+                 << indent() << indent_str() << "logging.exception('Exception in oneway handler')" << '\n';
     }
 
     // Close function
@@ -2324,7 +2313,9 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
 /**
  * Deserializes a field of any type.
  */
-void t_py_generator::generate_deserialize_field(ostream& out, t_field* tfield, string prefix) {
+void t_py_generator::generate_deserialize_field(ostream& out,
+                                                t_field* tfield,
+                                                string prefix) {
   t_type* type = get_true_type(tfield->get_type());
 
   if (type->is_void()) {
@@ -2348,11 +2339,10 @@ void t_py_generator::generate_deserialize_field(ostream& out, t_field* tfield, s
       case t_base_type::TYPE_STRING:
         if (type->is_binary()) {
           out << "readBinary()";
-        } else if (!gen_utf8strings_) {
+        } else if(!gen_utf8strings_) {
           out << "readString()";
         } else {
-          out << "readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else "
-                 "iprot.readString()";
+          out << "readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()";
         }
         break;
       case t_base_type::TYPE_BOOL:
@@ -2389,7 +2379,8 @@ void t_py_generator::generate_deserialize_field(ostream& out, t_field* tfield, s
     }
     out << '\n';
   } else {
-    printf("DO NOT KNOW HOW TO DESERIALIZE FIELD '%s' TYPE '%s'\n", tfield->get_name().c_str(),
+    printf("DO NOT KNOW HOW TO DESERIALIZE FIELD '%s' TYPE '%s'\n",
+           tfield->get_name().c_str(),
            type->get_name().c_str());
   }
 }
@@ -2423,20 +2414,20 @@ void t_py_generator::generate_deserialize_container(ostream& out, t_type* ttype,
 
   // Declare variables, read header
   if (ttype->is_map()) {
-    out << indent() << prefix << " = {}" << '\n'
-        << indent() << "(" << ktype << ", " << vtype << ", " << size << ") = iprot.readMapBegin()"
-        << '\n';
+    out << indent() << prefix << " = {}" << '\n' << indent() << "(" << ktype << ", " << vtype
+        << ", " << size << ") = iprot.readMapBegin()" << '\n';
   } else if (ttype->is_set()) {
-    out << indent() << prefix << " = set()" << '\n'
-        << indent() << "(" << etype << ", " << size << ") = iprot.readSetBegin()" << '\n';
+    out << indent() << prefix << " = set()" << '\n' << indent() << "(" << etype << ", " << size
+        << ") = iprot.readSetBegin()" << '\n';
   } else if (ttype->is_list()) {
-    out << indent() << prefix << " = []" << '\n'
-        << indent() << "(" << etype << ", " << size << ") = iprot.readListBegin()" << '\n';
+    out << indent() << prefix << " = []" << '\n' << indent() << "(" << etype << ", " << size
+        << ") = iprot.readListBegin()" << '\n';
   }
 
   // For loop iterates over elements
   string i = tmp("_i");
-  indent(out) << "for " << i << " in range(" << size << "):" << '\n';
+  indent(out) <<
+    "for " << i << " in range(" << size << "):" << '\n';
 
   indent_up();
 
@@ -2499,7 +2490,9 @@ void t_py_generator::generate_deserialize_set_element(ostream& out, t_set* tset,
 /**
  * Write a list element
  */
-void t_py_generator::generate_deserialize_list_element(ostream& out, t_list* tlist, string prefix) {
+void t_py_generator::generate_deserialize_list_element(ostream& out,
+                                                       t_list* tlist,
+                                                       string prefix) {
   string elem = tmp("_elem");
   t_field felem(tlist->get_elem_type(), elem);
 
@@ -2544,8 +2537,7 @@ void t_py_generator::generate_serialize_field(ostream& out, t_field* tfield, str
         } else if (!gen_utf8strings_) {
           out << "writeString(" << name << ")";
         } else {
-          out << "writeString(" << name << ".encode('utf-8') if sys.version_info[0] == 2 else "
-              << name << ")";
+          out << "writeString(" << name << ".encode('utf-8') if sys.version_info[0] == 2 else " << name << ")";
         }
         break;
       case t_base_type::TYPE_BOOL:
@@ -2573,7 +2565,7 @@ void t_py_generator::generate_serialize_field(ostream& out, t_field* tfield, str
         throw "compiler error: no Python name for base type " + t_base_type::t_base_name(tbase);
       }
     } else if (type->is_enum()) {
-      if (gen_enum_) {
+      if (gen_enum_){
         out << "writeI32(" << name << ".value)";
       } else {
         out << "writeI32(" << name << ")";
@@ -2581,8 +2573,10 @@ void t_py_generator::generate_serialize_field(ostream& out, t_field* tfield, str
     }
     out << '\n';
   } else {
-    printf("DO NOT KNOW HOW TO SERIALIZE FIELD '%s%s' TYPE '%s'\n", prefix.c_str(),
-           tfield->get_name().c_str(), type->get_name().c_str());
+    printf("DO NOT KNOW HOW TO SERIALIZE FIELD '%s%s' TYPE '%s'\n",
+           prefix.c_str(),
+           tfield->get_name().c_str(),
+           type->get_name().c_str());
   }
 }
 
@@ -2749,7 +2743,6 @@ string t_py_generator::declare_argument(t_field* tfield) {
   } else {
     result << "None";
   }
-
   return result.str();
 }
 
@@ -2842,8 +2835,7 @@ string t_py_generator::type_name(t_type* ttype) {
     return get_real_py_module(program, gen_twisted_, package_prefix_) + "." + ttype->get_name();
   }
   if (program != nullptr && program != program_) {
-    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes."
-           + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes." + ttype->get_name();
   }
   return ttype->get_name();
 }
@@ -2970,12 +2962,12 @@ string t_py_generator::type_to_spec_args(t_type* ttype) {
   }
 
   if (ttype->is_binary()) {
-    return "'BINARY'";
+    return  "'BINARY'";
   } else if (gen_utf8strings_ && ttype->is_base_type()
              && reinterpret_cast<t_base_type*>(ttype)->is_string()) {
     return "'UTF8'";
   } else if (ttype->is_base_type() || ttype->is_enum()) {
-    return "None";
+    return  "None";
   } else if (ttype->is_struct() || ttype->is_xception()) {
     return "[" + type_name(ttype) + ", None]";
   } else if (ttype->is_map()) {
@@ -3009,22 +3001,19 @@ THRIFT_REGISTER_GENERATOR(
     "    zope.interface:  Generate code for use with zope.interface.\n"
     "    twisted:         Generate Twisted-friendly RPC services.\n"
     "    tornado:         Generate code for use with Tornado.\n"
-    "    no_utf8strings:  Do not Encode/decode strings using utf8 in the generated code. Basically "
-    "no effect for Python 3.\n"
+    "    no_utf8strings:  Do not Encode/decode strings using utf8 in the generated code. Basically no effect for Python 3.\n"
     "    coding=CODING:   Add file encoding declare in generated file.\n"
     "    slots:           Generate code using slots for instance members.\n"
     "    dynamic:         Generate dynamic code, less code generated but slower.\n"
     "    dynbase=CLS      Derive generated classes from class CLS instead of TBase.\n"
-    "    dynfrozen=CLS    Derive generated immutable classes from class CLS instead of "
-    "TFrozenBase.\n"
+    "    dynfrozen=CLS    Derive generated immutable classes from class CLS instead of TFrozenBase.\n"
     "    dynexc=CLS       Derive generated exceptions from CLS instead of TExceptionBase.\n"
-    "    dynfrozenexc=CLS Derive generated immutable exceptions from CLS instead of "
-    "TFrozenExceptionBase.\n"
+    "    dynfrozenexc=CLS Derive generated immutable exceptions from CLS instead of TFrozenExceptionBase.\n"
     "    dynimport='from foo.bar import CLS'\n"
     "                     Add an import line to generated code to find the dynbase class.\n"
     "    package_prefix='top.package.'\n"
     "                     Package prefix for generated files.\n"
     "    old_style:       Deprecated. Generate old-style classes.\n"
-    "    enum:            Generates Python's IntEnum, connects thrift to python enums. Python 3.4 "
-    "and higher.\n"
-    "    type_hints:      Generate type hints in write method, including IntEnum generation.\n")
+    "    enum:            Generates Python's IntEnum, connects thrift to python enums. Python 3.4 and higher.\n"
+    "    type_hints:      Generate type hints and type checks in write method, including IntEnum generation.\n"
+)

--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -831,6 +831,8 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
   out << ":" << '\n';
   indent_up();
   generate_python_docstring(out, tstruct);
+  std::string thrift_spec_type = gen_type_hints_ ? ": typing.Any" : "";
+  out << indent() << "thrift_spec" << thrift_spec_type << " = None" << '\n';
 
   out << '\n';
 

--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -3015,5 +3015,5 @@ THRIFT_REGISTER_GENERATOR(
     "                     Package prefix for generated files.\n"
     "    old_style:       Deprecated. Generate old-style classes.\n"
     "    enum:            Generates Python's IntEnum, connects thrift to python enums. Python 3.4 and higher.\n"
-    "    type_hints:      Generate type hints and type checks in write method, including IntEnum generation.\n"
+    "    type_hints:      Generate type hints and type checks in write method. Requires the enum option.\n"
 )

--- a/test/py/Makefile.am
+++ b/test/py/Makefile.am
@@ -52,7 +52,11 @@ thrift_gen =                                    \
         gen-py-enum/ThriftTest/__init__.py \
         gen-py-enum/DebugProtoTest/__init__.py \
         gen-py-enum/DoubleConstantsTest/__init__.py \
-        gen-py-enum/Recursive/__init__.py
+        gen-py-enum/Recursive/__init__.py \
+        gen-py-type_hints/ThriftTest/__init__.py \
+        gen-py-type_hints/DebugProtoTest/__init__.py \
+        gen-py-type_hints/DoubleConstantsTest/__init__.py \
+        gen-py-type_hints/Recursive/__init__.py
 
 distdir:
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am
@@ -118,6 +122,12 @@ gen-py-enum/%/__init__.py: ../%.thrift $(THRIFT)
 	test ../v0.16/$(notdir $<) \
 	&& $(THRIFT) --gen py:enum -out gen-py-enum ../v0.16/$(notdir $<) \
 	|| $(THRIFT) --gen py:enum -out gen-py-enum $<
+
+gen-py-type_hints/%/__init__.py: ../%.thrift $(THRIFT)
+	test -d gen-py-type_hints || $(MKDIR_P) gen-py-type_hints
+	test ../v0.16/$(notdir $<) \
+	&& $(THRIFT) --gen py:type_hints -out gen-py-type_hints ../v0.16/$(notdir $<) \
+	|| $(THRIFT) --gen py:type_hints -out gen-py-type_hints $<
 
 clean-local:
 	$(RM) -r build

--- a/test/py/Makefile.am
+++ b/test/py/Makefile.am
@@ -125,9 +125,9 @@ gen-py-enum/%/__init__.py: ../%.thrift $(THRIFT)
 
 gen-py-type_hints/%/__init__.py: ../%.thrift $(THRIFT)
 	test -d gen-py-type_hints || $(MKDIR_P) gen-py-type_hints
-	test ../v0.16/$(notdir $<) \
-	&& $(THRIFT) --gen py:type_hints -out gen-py-type_hints ../v0.16/$(notdir $<) \
-	|| $(THRIFT) --gen py:type_hints -out gen-py-type_hints $<
+	test ../$(notdir $<) \
+	&& $(THRIFT) --gen py:type_hints,enum -out gen-py-type_hints ../$(notdir $<) \
+	|| $(THRIFT) --gen py:type_hints,enum -out gen-py-type_hints $<
 
 clean-local:
 	$(RM) -r build

--- a/test/py/RunClientServer.py
+++ b/test/py/RunClientServer.py
@@ -259,7 +259,7 @@ def main():
     parser = OptionParser()
     parser.add_option('--all', action="store_true", dest='all')
     parser.add_option('--genpydirs', type='string', dest='genpydirs',
-                      default='default,slots,oldstyle,no_utf8strings,dynamic,dynamicslots,enum',
+                      default='default,slots,oldstyle,no_utf8strings,dynamic,dynamicslots,enum,type_hints',
                       help='directory extensions for generated code, used as suffixes for \"gen-py-*\" added sys.path for individual tests')
     parser.add_option("--port", type="int", dest="port", default=9090,
                       help="port number for server to listen on")

--- a/test/py/RunClientServer.py
+++ b/test/py/RunClientServer.py
@@ -44,6 +44,7 @@ SCRIPTS = [
     'TestEof.py',
     'TestSyntax.py',
     'TestSocket.py',
+    'TestTypes.py'
 ]
 FRAMED = ["TNonblockingServer"]
 SKIP_ZLIB = ['TNonblockingServer', 'THttpServer']

--- a/test/py/TestTypes.py
+++ b/test/py/TestTypes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from ThriftTest import ThriftTest
+from ThriftTest.ThriftTest import Client
+from ThriftTest.ttypes import Xtruct
+
+import unittest
+
+# only run this test if the string 'options string: py:type_hints' esxists in the file 
+def has_type_hints_option():
+    with open(ThriftTest.__file__) as f:
+        return 'options string: py:type_hints' in f.read()
+
+@unittest.skipUnless(has_type_hints_option(), "type hints not enabled")
+class TypeAnnotationsTest(unittest.TestCase):
+
+    def test_void(self):
+        self.assertEqual(Client.testVoid.__annotations__, {'return': None})
+
+    def test_string(self):
+        self.assertEqual(Client.testString.__annotations__, {'return': str, 'thing': str})
+
+    def test_byte(self):
+        self.assertEqual(Client.testByte.__annotations__, {'return': int, 'thing': int})
+
+    def test_i32(self):
+        self.assertEqual(Client.testI32.__annotations__, {'return': int, 'thing': int})
+
+    def test_i64(self):
+        self.assertEqual(Client.testI64.__annotations__, {'return': int, 'thing': int})
+
+    def test_double(self):
+        self.assertEqual(Client.testDouble.__annotations__, {'return': float, 'thing': float})
+
+    def test_binary(self):
+        self.assertEqual(Client.testBinary.__annotations__, {'return': bytes, 'thing': bytes})
+
+    def test_struct(self):
+        self.assertEqual(Client.testStruct.__annotations__, {'return': Xtruct, 'thing': Xtruct})
+
+    def test_map(self):
+        self.assertEqual(Client.testMap.__annotations__, {'return': dict[int, int], 'thing': dict[int, int]})
+    
+    def test_list(self):
+        self.assertEqual(Client.testList.__annotations__, {'return': list[int], 'thing': list[int]})
+
+    def test_set(self):
+        self.assertEqual(Client.testSet.__annotations__, {'return': set[int], 'thing': set[int]})

--- a/test/py/generate.cmake
+++ b/test/py/generate.cmake
@@ -14,6 +14,7 @@ generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:no_utf8strings gen-py
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:enum gen-py-enum)
+generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:type_hints gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:slots gen-py-slots)
@@ -22,6 +23,7 @@ generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:no_utf8strings ge
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:enum gen-py-enum)
+generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:type_hints gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:slots gen-py-slots)
@@ -30,6 +32,7 @@ generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:no_utf8strings gen
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:enum gen-py-enum)
+generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:type_hints gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:slots gen-py-slots)
@@ -38,3 +41,4 @@ generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:no_utf8strings gen-py-no_utf
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:enum gen-py-enum)
+generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:type_hints gen-py-type_hints)

--- a/test/py/generate.cmake
+++ b/test/py/generate.cmake
@@ -14,7 +14,7 @@ generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:no_utf8strings gen-py
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:enum gen-py-enum)
-generate(${MY_PROJECT_DIR}/test/v0.16/ThriftTest.thrift py:type_hints gen-py-type_hints)
+generate(${MY_PROJECT_DIR}/test/ThriftTest.thrift py:type_hints,enum gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:slots gen-py-slots)
@@ -23,7 +23,7 @@ generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:no_utf8strings ge
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:enum gen-py-enum)
-generate(${MY_PROJECT_DIR}/test/v0.16/DebugProtoTest.thrift py:type_hints gen-py-type_hints)
+generate(${MY_PROJECT_DIR}/test/DebugProtoTest.thrift py:type_hints,enum gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:slots gen-py-slots)
@@ -32,7 +32,7 @@ generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:no_utf8strings gen
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:enum gen-py-enum)
-generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:type_hints gen-py-type_hints)
+generate(${MY_PROJECT_DIR}/test/DoubleConstantsTest.thrift py:type_hints,enum gen-py-type_hints)
 
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py gen-py-default)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:slots gen-py-slots)
@@ -41,4 +41,4 @@ generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:no_utf8strings gen-py-no_utf
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:dynamic gen-py-dynamic)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:dynamic,slots gen-py-dynamicslots)
 generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:enum gen-py-enum)
-generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:type_hints gen-py-type_hints)
+generate(${MY_PROJECT_DIR}/test/Recursive.thrift py:type_hints,enum gen-py-type_hints)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Add type hinting (with native enums (IntEnum)) for python generated code

  1. Squashed and rebased changes from [stale PR](https://github.com/apache/thrift/pull/2523)
  2. Removed the controversial runtime type check as it goes beyond strictly annotations
  3. Added type_hints as a default option to `RunClientServer.py` and `generate.cmake`. 
  4. Enabled testing against thrift test suite
  5. Made enum regeneration explicitly required instead of implied when this flag is provided
  6. Added python tests to verify basic annotations are getting added
  7. Generate a thrift_spec attribute variable declaration for all generated thrift structures and optionally type hint it if type_hints are enabled
Note: Appveyor x86 / Python 3.5 build is failing since this PR generates variable type hints (`x: int = 1`), which are only[ python 3.6 and up](https://peps.python.org/pep-0526/). Do we have any patterns established for skipping tests based on platform/python version? 
  
Example difference in generated code after running `thrift --gen py:type_hints` against:
```
struct OneOfEachZZ {
  1: required bool im_true,
  2: bool im_false,
  3: byte a_bite,
  4: i16 integer16,
  5: i32 integer32,
  6: i64 integer64,
  7: double double_precision,
  8: string some_characters,
  9: string zomg_unicode,
  10: optional bool what_who
}

service UnderscoreSrv {
  i64 some_rpc_call(1: string message, 2: OneOfEachZZ sample_struct)
}
```

<details><summary>ttypes.py</summary>
<p>

```
root@37314fef4537:/thrift/src/test# diff gen-py/FullCamelTest/ttypes.py gen-py-old/FullCamelTest/ttypes.py 
6c6
< #  options string: py
---
> #  options string: py:type_hints
8a9,10
> from __future__ import annotations
> import typing
12a15
> from enum import IntEnum
37,47c40,50
<     def __init__(self, im_true = None, im_false = None, a_bite = None, integer16 = None, integer32 = None, integer64 = None, double_precision = None, some_characters = None, zomg_unicode = None, what_who = None,):
<         self.im_true = im_true
<         self.im_false = im_false
<         self.a_bite = a_bite
<         self.integer16 = integer16
<         self.integer32 = integer32
<         self.integer64 = integer64
<         self.double_precision = double_precision
<         self.some_characters = some_characters
<         self.zomg_unicode = zomg_unicode
<         self.what_who = what_who
---
>     def __init__(self, im_true: bool = None, im_false: typing.Optional[bool] = None, a_bite: typing.Optional[int] = None, integer16: typing.Optional[int] = None, integer32: typing.Optional[int] = None, integer64: typing.Optional[int] = None, double_precision: typing.Optional[float] = None, some_characters: typing.Optional[str] = None, zomg_unicode: typing.Optional[str] = None, what_who: typing.Optional[bool] = None,):
>         self.im_true: bool = im_true
>         self.im_false: typing.Optional[bool] = im_false
>         self.a_bite: typing.Optional[int] = a_bite
>         self.integer16: typing.Optional[int] = integer16
>         self.integer32: typing.Optional[int] = integer32
>         self.integer64: typing.Optional[int] = integer64
>         self.double_precision: typing.Optional[float] = double_precision
>         self.some_characters: typing.Optional[str] = some_characters
>         self.zomg_unicode: typing.Optional[str] = zomg_unicode
>         self.what_who: typing.Optional[bool] = what_who
```

</p>
</details> 

<details><summary>UnderscoreSrv.py</summary>
<p>

```
root@37314fef4537:/thrift/src/test# diff gen-py/FullCamelTest/UnderscoreSrv.py gen-py-old/FullCamelTest/UnderscoreSrv.py 
6c6
< #  options string: py
---
> #  options string: py:type_hints
8a9,10
> from __future__ import annotations
> import typing
12a15
> from enum import IntEnum
23c26
<     def some_rpc_call(self, message, sample_struct):
---
>     def some_rpc_call(self, message: str, sample_struct: OneOfEachZZ) -> int:
40c43
<     def some_rpc_call(self, message, sample_struct):
---
>     def some_rpc_call(self, message: str, sample_struct: OneOfEachZZ) -> int:
50c53
<     def send_some_rpc_call(self, message, sample_struct):
---
>     def send_some_rpc_call(self, message: str, sample_struct: OneOfEachZZ):
59c62
<     def recv_some_rpc_call(self):
---
>     def recv_some_rpc_call(self) -> int:
137,139c140,142
<     def __init__(self, message = None, sample_struct = None,):
<         self.message = message
<         self.sample_struct = sample_struct
---
>     def __init__(self, message: typing.Optional[str] = None, sample_struct: typing.Optional[OneOfEachZZ] = None,):
>         self.message: typing.Optional[str] = message
>         self.sample_struct: typing.Optional[OneOfEachZZ] = sample_struct
212,213c215,216
<     def __init__(self, success = None,):
<         self.success = success
---
>     def __init__(self, success: typing.Optional[int] = None,):
>         self.success: typing.Optional[int] = success

```

</p>
</details> 


Unrelated to these changes, I noticed that even if a field is marked as required, `declare_argument` generates a default value in the function arguments of None. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

Open questions: Since the original PR opened, 
- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
