### PR TITLE
THRIFT-5756 Run php tests in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,62 @@ jobs:
           path: compiler/cpp/thrift
           retention-days: 3
 
+  lib-php:
+    needs: compiler
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, intl, xml
+
+      - name: Install Dependencies
+        run: composer install
+
+      - name: Backward compatibility for unit test in php greater then 7.1
+        if: matrix.php-version > 7.0
+        run: |
+          sed -i 's/setUp()/setUp():void/' lib/php/test/Unit/*Test.php
+          sed -i 's/setUpBeforeClass()/setUpBeforeClass():void/' lib/php/test/Unit/*Test.php
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Run configure
+        run: |
+          ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-php/with-php/' | sed 's/without-php_extension/with-php_extension/' )
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Run thrift-compiler
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+
+      - name: Build Thrift Classes
+        run: |
+          mkdir -p ./lib/php/test/Resources/packages/php
+          mkdir -p ./lib/php/test/Resources/packages/phpv
+          mkdir -p ./lib/php/test/Resources/packages/phpvo
+          mkdir -p ./lib/php/test/Resources/packages/phpjs
+          compiler/cpp/thrift --gen php              -r --out ./lib/php/test/Resources/packages/php    lib/php/test/Resources/ThriftTest.thrift
+          compiler/cpp/thrift --gen php:validate     -r --out ./lib/php/test/Resources/packages/phpv   lib/php/test/Resources/ThriftTest.thrift
+          compiler/cpp/thrift --gen php:validate,oop -r --out ./lib/php/test/Resources/packages/phpvo  lib/php/test/Resources/ThriftTest.thrift
+          compiler/cpp/thrift --gen php:json         -r --out ./lib/php/test/Resources/packages/phpjs  lib/php/test/Resources/ThriftTest.thrift
+
+      - name: Run Tests
+        run: vendor/bin/phpunit -c lib/php/phpunit.xml
+
   lib-go:
     needs: compiler
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -279,9 +279,8 @@ project.lock.json
 /lib/php/src/ext/thrift_protocol/run-tests.php
 /lib/php/src/ext/thrift_protocol/thrift_protocol.la
 /lib/php/src/ext/thrift_protocol/tmp-php.ini
-/lib/php/src/packages/
-/lib/php/test/TEST-*.xml
-/lib/php/test/packages/
+/lib/php/tests/Resources/packages/
+/lib/php/test/test-log-junit.xml
 /lib/py/dist/
 /lib/erl/logs/
 /lib/go/pkg

--- a/build/docker/ubuntu-bionic/Dockerfile
+++ b/build/docker/ubuntu-bionic/Dockerfile
@@ -216,8 +216,13 @@ RUN apt-get install -y --no-install-recommends \
       php-dev \
       php-json \
       php-pear \
+      php-mbstring \
+      php-xml \
       re2c \
       composer
+
+RUN pecl install xdebug-3.1.1 && \
+      echo "zend_extension=xdebug.so" > /etc/php/7.2/cli/conf.d/20-xdebug.ini
 
 RUN apt-get install -y --no-install-recommends \
       `# Python dependencies` \

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,10 @@
         "php": "^5.5 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.36",
-        "squizlabs/php_codesniffer": "3.*"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.3",
+        "squizlabs/php_codesniffer": "3.*",
+        "ext-json": "*",
+        "ext-xml": "*"
     },
     "autoload": {
         "psr-4": {"Thrift\\": "lib/php/lib/"}

--- a/lib/php/README.apache.md
+++ b/lib/php/README.apache.md
@@ -29,7 +29,7 @@ you must use a THttpClient transport.
 
 Sample Code
 ===========
-
+```php
 <?php
 
 namespace MyNamespace;
@@ -72,3 +72,4 @@ $protocol = new TBinaryProtocol($transport);
 $transport->open();
 $processor->process($protocol, $protocol);
 $transport->close();
+```

--- a/lib/php/phpunit.xml
+++ b/lib/php/phpunit.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="../../vendor/autoload.php"
          cacheResult="false"

--- a/lib/php/phpunit.xml
+++ b/lib/php/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="../../vendor/autoload.php"
+         cacheResult="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnWarning="true"
+         stopOnFailure="true"
+         processIsolation="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">./lib</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Thrift PHP Test Suite">
+            <directory>./test/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/lib/php/test/Fixtures/Fixtures.php
+++ b/lib/php/test/Fixtures/Fixtures.php
@@ -21,7 +21,7 @@
  * @package thrift.test
  */
 
-namespace Test\Thrift;
+namespace Test\Thrift\Fixtures;
 
 use ThriftTest\Xtruct;
 use ThriftTest\Xtruct2;

--- a/lib/php/test/Fixtures/TJSONProtocolFixtures.php
+++ b/lib/php/test/Fixtures/TJSONProtocolFixtures.php
@@ -21,7 +21,7 @@
  * @package thrift.test
  */
 
-namespace Test\Thrift\Protocol;
+namespace Test\Thrift\Fixtures;
 
 class TJSONProtocolFixtures
 {

--- a/lib/php/test/Fixtures/TSimpleJSONProtocolFixtures.php
+++ b/lib/php/test/Fixtures/TSimpleJSONProtocolFixtures.php
@@ -21,7 +21,7 @@
  * @package thrift.test
  */
 
-namespace test\Thrift\Protocol;
+namespace Test\Thrift\Fixtures;
 
 class TSimpleJSONProtocolFixtures
 {

--- a/lib/php/test/Makefile.am
+++ b/lib/php/test/Makefile.am
@@ -19,37 +19,26 @@
 
 PHPUNIT=php $(top_srcdir)/vendor/bin/phpunit
 
-stubs: ../../../test/v0.16/ThriftTest.thrift  TestValidators.thrift
-	mkdir -p ./packages/php
-	$(THRIFT) --gen php -r --out ./packages/php ../../../test/v0.16/ThriftTest.thrift
-	mkdir -p ./packages/phpv
-	mkdir -p ./packages/phpvo
-	mkdir -p ./packages/phpjs
-	$(THRIFT) --gen php:validate     -r --out ./packages/phpv   TestValidators.thrift
-	$(THRIFT) --gen php:validate,oop -r --out ./packages/phpvo  TestValidators.thrift
-	$(THRIFT) --gen php:json         -r --out ./packages/phpjs  TestValidators.thrift
+stubs: Resources/ThriftTest.thrift
+	mkdir -p ./Resources/packages/php
+	mkdir -p ./Resources/packages/phpv
+	mkdir -p ./Resources/packages/phpvo
+	mkdir -p ./Resources/packages/phpjs
+	$(THRIFT) --gen php              -r --out ./Resources/packages/php    Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:validate     -r --out ./Resources/packages/phpv   Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:validate,oop -r --out ./Resources/packages/phpvo  Resources/ThriftTest.thrift
+	$(THRIFT) --gen php:json         -r --out ./Resources/packages/phpjs  Resources/ThriftTest.thrift
 
 deps: $(top_srcdir)/composer.json
 	composer install --working-dir=$(top_srcdir)
 
 all-local: deps
 
-check-json-serializer: deps stubs
-	$(PHPUNIT) --log-junit=TEST-log-json-serializer.xml JsonSerialize/
-
-check-validator: deps stubs
-	$(PHPUNIT) --log-junit=TEST-log-validator.xml Validator/
-
-check-protocol:	deps stubs
-	$(PHPUNIT) --log-junit=TEST-log-protocol.xml Protocol/
-
-check: deps stubs \
-  check-protocol \
-  check-validator \
-  check-json-serializer
+check: deps stubs
+	$(PHPUNIT) --log-junit=test-log-junit.xml -c phpunit.xml /
 
 distclean-local:
 
 clean-local:
-	$(RM) -r ./packages
-	$(RM) TEST-*.xml
+	$(RM) -r ./Resources/packages
+	$(RM) test-log-junit.xml

--- a/lib/php/test/Resources/ThriftTest.thrift
+++ b/lib/php/test/Resources/ThriftTest.thrift
@@ -19,7 +19,7 @@
 
 namespace php TestValidators
 
-include "../../../test/v0.16/ThriftTest.thrift"
+include "../../../../test/v0.16/ThriftTest.thrift"
 
 union UnionOfStrings {
   1: string aa;

--- a/lib/php/test/Unit/BaseValidatorTest.php
+++ b/lib/php/test/Unit/BaseValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
@@ -18,7 +19,7 @@
  * under the License.
  */
 
-namespace Test\Thrift;
+namespace Test\Thrift\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Thrift\Exception\TProtocolException;
@@ -62,6 +63,7 @@ abstract class BaseValidatorTest extends TestCase
         $transport = new TMemoryBuffer("\000");
         $protocol = new TBinaryProtocol($transport);
         $bonk->read($protocol);
+        $this->assertTrue(true);
     }
 
     public function testWriteEmpty()
@@ -73,6 +75,8 @@ abstract class BaseValidatorTest extends TestCase
             $bonk->write($protocol);
             $this->fail('Bonk was able to write an empty object');
         } catch (TProtocolException $e) {
+            $this->expectExceptionMessage('Required field Bonk.message is unset!');
+            throw $e;
         }
     }
 
@@ -87,6 +91,8 @@ abstract class BaseValidatorTest extends TestCase
             $structa->write($protocol);
             $this->fail('StructA was able to write an empty object');
         } catch (TProtocolException $e) {
+            $this->expectExceptionMessage('Required field StructA.s is unset!');
+            throw $e;
         }
     }
 
@@ -114,6 +120,8 @@ abstract class BaseValidatorTest extends TestCase
     {
         if (!static::hasReadValidator($class)) {
             static::fail($class . ' class should have a read validator');
+        } else {
+            static::assertTrue(true);
         }
     }
 
@@ -121,6 +129,8 @@ abstract class BaseValidatorTest extends TestCase
     {
         if (static::hasReadValidator($class)) {
             static::fail($class . ' class should not have a write validator');
+        } else {
+            static::assertTrue(true);
         }
     }
 
@@ -128,6 +138,8 @@ abstract class BaseValidatorTest extends TestCase
     {
         if (!static::hasWriteValidator($class)) {
             static::fail($class . ' class should have a write validator');
+        } else {
+            static::assertTrue(true);
         }
     }
 
@@ -135,6 +147,8 @@ abstract class BaseValidatorTest extends TestCase
     {
         if (static::hasWriteValidator($class)) {
             static::fail($class . ' class should not have a write validator');
+        } else {
+            static::assertTrue(true);
         }
     }
 

--- a/lib/php/test/Unit/BinarySerializerTest.php
+++ b/lib/php/test/Unit/BinarySerializerTest.php
@@ -17,33 +17,26 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * @package thrift.test
  */
 
-namespace Test\Thrift\Protocol;
+namespace Test\Thrift\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Thrift\ClassLoader\ThriftClassLoader;
 use Thrift\Serializer\TBinarySerializer;
 
-require __DIR__ . '/../../../../vendor/autoload.php';
-
 /***
- * This test suite depends on running the compiler against the
- * standard ThriftTest.thrift file:
- *
- * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r \
- *   --out ./packages ../../../test/ThriftTest.thrift
- *
- * @runTestsInSeparateProcesses
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r  --out ./Resources/packages/php ./Resources/ThriftTest.thrift
  */
 class BinarySerializerTest extends TestCase
 {
     public function setUp()
     {
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/php');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->register();
     }
 
     /**

--- a/lib/php/test/Unit/JsonSerializeTest.php
+++ b/lib/php/test/Unit/JsonSerializeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
@@ -18,26 +19,24 @@
  * under the License.
  */
 
-namespace Test\Thrift\JsonSerialize;
+namespace Test\Thrift\Unit;
 
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Thrift\ClassLoader\ThriftClassLoader;
 
-require __DIR__ . '/../../../../vendor/autoload.php';
-
-/**
- * @runTestsInSeparateProcesses
+/***
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php:json -r  --out ./Resources/packages/phpjs ./Resources/ThriftTest.thrift
  */
 class JsonSerializeTest extends TestCase
 {
     protected function setUp()
     {
-        if (version_compare(phpversion(), '5.4', '<')) {
-            $this->markTestSkipped('Requires PHP 5.4 or newer!');
-        }
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/phpjs');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpjs');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/phpjs');
+        $loader->register();
     }
 
     public function testEmptyStruct()

--- a/lib/php/test/Unit/TJSONProtocolTest.php
+++ b/lib/php/test/Unit/TJSONProtocolTest.php
@@ -17,27 +17,20 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * @package thrift.test
  */
 
-namespace Test\Thrift\Protocol;
+namespace Test\Thrift\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Test\Thrift\Fixtures;
+use Test\Thrift\Fixtures\Fixtures;
+use Test\Thrift\Fixtures\TJSONProtocolFixtures;
+use Thrift\ClassLoader\ThriftClassLoader;
 use Thrift\Protocol\TJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
 
-require __DIR__ . '/../../../../vendor/autoload.php';
-
 /***
- * This test suite depends on running the compiler against the
- * standard ThriftTest.thrift file:
- *
- * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r \
- *   --out ./packages ../../../test/ThriftTest.thrift
- *
- * @runTestsInSeparateProcesses
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r  --out ./Resources/packages/php ./Resources/ThriftTest.thrift
  */
 class TJSONProtocolTest extends TestCase
 {
@@ -46,9 +39,10 @@ class TJSONProtocolTest extends TestCase
 
     public static function setUpBeforeClass()
     {
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/php');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->register();
 
         Fixtures::populateTestArgs();
         TJSONProtocolFixtures::populateTestArgsJSON();
@@ -265,7 +259,9 @@ class TJSONProtocolTest extends TestCase
             TJSONProtocolFixtures::$testArgsJSON['testVoid']
         );
         $args = new \ThriftTest\ThriftTest_testVoid_args();
-        $args->read($this->protocol);
+        $result = $args->read($this->protocol);
+
+        $this->assertEquals(0, $result);
     }
 
     public function testString1Read()

--- a/lib/php/test/Unit/TSimpleJSONProtocolTest.php
+++ b/lib/php/test/Unit/TSimpleJSONProtocolTest.php
@@ -17,27 +17,20 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * @package thrift.test
  */
 
-namespace Test\Thrift\Protocol;
+namespace Test\Thrift\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Test\Thrift\Fixtures;
+use Test\Thrift\Fixtures\Fixtures;
+use Test\Thrift\Fixtures\TSimpleJSONProtocolFixtures;
+use Thrift\ClassLoader\ThriftClassLoader;
 use Thrift\Protocol\TSimpleJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
 
-require __DIR__ . '/../../../../vendor/autoload.php';
-
 /***
- * This test suite depends on running the compiler against the
- * standard ThriftTest.thrift file:
- *
- * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r \
- *   --out ./packages ../../../test/ThriftTest.thrift
- *
- * @runTestsInSeparateProcesses
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php -r  --out ./Resources/packages/php ./Resources/ThriftTest.thrift
  */
 class TSimpleJSONProtocolTest extends TestCase
 {
@@ -46,10 +39,10 @@ class TSimpleJSONProtocolTest extends TestCase
 
     public static function setUpBeforeClass()
     {
-
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/php');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/php');
+        $loader->register();
 
         Fixtures::populateTestArgs();
         TSimpleJSONProtocolFixtures::populateTestArgsSimpleJSON();

--- a/lib/php/test/Unit/ValidatorTest.php
+++ b/lib/php/test/Unit/ValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
@@ -18,24 +19,23 @@
  * under the License.
  */
 
-namespace Test\Thrift;
-
-require_once __DIR__ . '/../../../../vendor/autoload.php';
+namespace Test\Thrift\Unit;
 
 use Thrift\ClassLoader\ThriftClassLoader;
 
-/**
- * Class TestValidatorsOop
- * @package Test\Thrift
- *
- * @runTestsInSeparateProcesses
+/***
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php:validate -r  --out ./Resources/packages/phpv ./Resources/ThriftTest.thrift
  */
-class ValidatorTestOop extends BaseValidatorTest
+class ValidatorTest extends BaseValidatorTest
 {
     public function setUp()
     {
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/phpvo');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpv');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/phpv');
+        $loader->registerNamespace('TestValidators', __DIR__ . '/../Resources/packages/phpv');
+        $loader->registerDefinition('TestValidators', __DIR__ . '/../Resources/packages/phpv');
+        $loader->register();
     }
 }

--- a/lib/php/test/Unit/ValidatorTestOop.php
+++ b/lib/php/test/Unit/ValidatorTestOop.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
@@ -18,24 +19,23 @@
  * under the License.
  */
 
-namespace Test\Thrift;
-
-require __DIR__ . '/../../../../vendor/autoload.php';
+namespace Test\Thrift\Unit;
 
 use Thrift\ClassLoader\ThriftClassLoader;
 
-/**
- * Class TestValidators
- * @package Test\Thrift
- *
- * @runTestsInSeparateProcesses
+/***
+ * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
+ * lib/php/test$ ../../../compiler/cpp/thrift --gen php:validate,oop -r --out ./Resources/packages/phpvo ./Resources/ThriftTest.thrift
  */
-class ValidatorTest extends BaseValidatorTest
+class ValidatorTestOop extends BaseValidatorTest
 {
     public function setUp()
     {
-        /** @var \Composer\Autoload\ClassLoader $loader */
-        $loader = require __DIR__ . '/../../../../vendor/autoload.php';
-        $loader->addPsr4('', __DIR__ . '/../packages/phpv');
+        $loader = new ThriftClassLoader();
+        $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpvo');
+        $loader->registerDefinition('ThriftTest', __DIR__ . '/../Resources/packages/phpvo');
+        $loader->registerNamespace('TestValidators', __DIR__ . '/../Resources/packages/phpvo');
+        $loader->registerDefinition('TestValidators', __DIR__ . '/../Resources/packages/phpvo');
+        $loader->register();
     }
 }


### PR DESCRIPTION
Before updating minimum version of php to 7.4 or 8.0 we should start running php tests on every pull request.
In this pull request i also maid such things:
- add xdebug to Docker instance ubuntu-bionic
- combine all php tests in one folder and add configuration file for running them
- add to github action running of tests for php versions 5.6 - 8.3
- for versions php greater than 7.1 in github action using dirty hack with update code of php tests, due to the BC in php
- modify README for better view

Next steps:
- increase code coverage for php code
- update min version of php to 7.4
- update generation of php code for 7.4


Also it will be great to update code style to PSR-12 and add code style check to github actions

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? https://issues.apache.org/jira/browse/THRIFT-5756
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
