### PR TITLE
THRIFT-5758 PHP 8.2 Deprecate dynamic properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl, xml
+          ini-values: "error_reporting=E_ALL"
 
       - name: Install Dependencies
         run: composer install

--- a/lib/php/lib/Base/TBase.php
+++ b/lib/php/lib/Base/TBase.php
@@ -31,6 +31,7 @@ use Thrift\Type\TType;
  * of PHP. Note that code is intentionally duplicated in here to avoid making
  * function calls for every field or member of a container..
  */
+#[\AllowDynamicProperties]
 abstract class TBase
 {
     public static $tmethod = array(

--- a/lib/php/lib/Exception/TException.php
+++ b/lib/php/lib/Exception/TException.php
@@ -38,6 +38,7 @@ use Thrift\Base\TBase;
  * @param mixed $p1 Message (string) or type-spec (array)
  * @param mixed $p2 Code (integer) or values (array)
  */
+#[\AllowDynamicProperties]
 class TException extends \Exception
 {
     public function __construct($p1 = null, $p2 = 0)

--- a/lib/php/src/Thrift.php
+++ b/lib/php/src/Thrift.php
@@ -68,6 +68,7 @@ class TMessageType
  * @param mixed $p1 Message (string) or type-spec (array)
  * @param mixed $p2 Code (integer) or values (array)
  */
+#[\AllowDynamicProperties]
 class TException extends Exception
 {
   public function __construct($p1=null, $p2=0)
@@ -419,6 +420,7 @@ class TException extends Exception
  * of PHP. Note that code is intentionally duplicated in here to avoid making
  * function calls for every field or member of a container..
  */
+#[\AllowDynamicProperties]
 abstract class TBase
 {
   static $tmethod = array(TType::BOOL   => 'Bool',

--- a/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
+++ b/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test\Thrift\Unit\Lib\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Thrift\Exception\TException;
+
+class TExceptionTest extends TestCase
+{
+    public function testExceptionWithMessageAndCode()
+    {
+        $message = 'Test exception message';
+        $code = 42;
+
+        $exception = new TException($message, $code);
+
+        $this->assertInstanceOf(TException::class, $exception);
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame($code, $exception->getCode());
+    }
+
+    public function testExceptionWithSpecAndVals()
+    {
+        $spec = [
+            ['var' => 'string'],
+            ['var' => 'int'],
+            ['var' => 'bool'],
+        ];
+
+        $vals = [
+            'string' => 'Test value',
+            'int' => 123456,
+            'bool' => true,
+        ];
+        $exception = new TException($spec, $vals);
+
+        $this->assertEquals('Test value', $exception->string);
+        $this->assertEquals(123456, $exception->int);
+        $this->assertEquals(true, $exception->bool);
+    }
+}


### PR DESCRIPTION
In php 8.2 dynamic properties will generate a deprecation

https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties

 

In Tbase and TException dynamic properties is used.

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([[Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)](https://issues.apache.org/jira/browse/THRIFT-5758)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
