### PR TITLE
THRIFT-5760 Update minimal version of php

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        php-version: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -94,12 +94,6 @@ jobs:
 
       - name: Install Dependencies
         run: composer install
-
-      - name: Backward compatibility for unit test in php greater then 7.1
-        if: matrix.php-version > 7.0
-        run: |
-          sed -i 's/setUp()/setUp():void/' lib/php/test/Unit/*Test.php
-          sed -i 's/setUpBeforeClass()/setUpBeforeClass():void/' lib/php/test/Unit/*Test.php
 
       - name: Run bootstrap
         run: ./bootstrap.sh

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "issues": "https://issues.apache.org/jira/browse/THRIFT"
     },
     "require": {
-        "php": "^5.5 || ^7.0 || ^8.0"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.3",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "squizlabs/php_codesniffer": "3.*",
         "ext-json": "*",
         "ext-xml": "*"

--- a/doc/install/README.md
+++ b/doc/install/README.md
@@ -32,7 +32,7 @@ These are only required if you choose to build the libraries for the given langu
     * Gradle 8.4
 * C#: Mono 1.2.4 (and pkg-config to detect it) or Visual Studio 2005+
 * Python 2.6 (including header files for extension modules)
-* PHP 5.0 (optionally including header files for extension modules)
+* PHP 7.1 (optionally including header files for extension modules)
 * Ruby 1.8
     * bundler gem
 * Erlang R12 (R11 works but not recommended)

--- a/lib/php/README.md
+++ b/lib/php/README.md
@@ -21,7 +21,7 @@ under the License.
 
 # Using Thrift with PHP
 
-Thrift requires PHP 5. Thrift makes as few assumptions about your PHP
+Thrift requires PHP 7.1 Thrift makes as few assumptions about your PHP
 environment as possible while trying to make some more advanced PHP
 features (i.e. APCu cacheing using asbolute path URLs) as simple as possible.
 

--- a/lib/php/test/Unit/BinarySerializerTest.php
+++ b/lib/php/test/Unit/BinarySerializerTest.php
@@ -31,7 +31,7 @@ use Thrift\Serializer\TBinarySerializer;
  */
 class BinarySerializerTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');

--- a/lib/php/test/Unit/JsonSerializeTest.php
+++ b/lib/php/test/Unit/JsonSerializeTest.php
@@ -31,7 +31,7 @@ use Thrift\ClassLoader\ThriftClassLoader;
  */
 class JsonSerializeTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpjs');

--- a/lib/php/test/Unit/TJSONProtocolTest.php
+++ b/lib/php/test/Unit/TJSONProtocolTest.php
@@ -37,7 +37,7 @@ class TJSONProtocolTest extends TestCase
     private $transport;
     private $protocol;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');
@@ -48,7 +48,7 @@ class TJSONProtocolTest extends TestCase
         TJSONProtocolFixtures::populateTestArgsJSON();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->transport = new TMemoryBuffer();
         $this->protocol = new TJSONProtocol($this->transport);

--- a/lib/php/test/Unit/TSimpleJSONProtocolTest.php
+++ b/lib/php/test/Unit/TSimpleJSONProtocolTest.php
@@ -37,7 +37,7 @@ class TSimpleJSONProtocolTest extends TestCase
     private $transport;
     private $protocol;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/php');
@@ -48,7 +48,7 @@ class TSimpleJSONProtocolTest extends TestCase
         TSimpleJSONProtocolFixtures::populateTestArgsSimpleJSON();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->transport = new TMemoryBuffer();
         $this->protocol = new TSimpleJSONProtocol($this->transport);

--- a/lib/php/test/Unit/ValidatorTest.php
+++ b/lib/php/test/Unit/ValidatorTest.php
@@ -29,7 +29,7 @@ use Thrift\ClassLoader\ThriftClassLoader;
  */
 class ValidatorTest extends BaseValidatorTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpv');

--- a/lib/php/test/Unit/ValidatorTestOop.php
+++ b/lib/php/test/Unit/ValidatorTestOop.php
@@ -29,7 +29,7 @@ use Thrift\ClassLoader\ThriftClassLoader;
  */
 class ValidatorTestOop extends BaseValidatorTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $loader = new ThriftClassLoader();
         $loader->registerNamespace('ThriftTest', __DIR__ . '/../Resources/packages/phpvo');


### PR DESCRIPTION
Update minimal version of php to 7.1

I know that currently 8.* is main version, but current code has to much dependencies on version 5, so let's move step by step.

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? https://issues.apache.org/jira/browse/THRIFT-5760
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

