### PR TITLE
THRIFT-5761 Lib/json tests fail

### DIFF
--- a/lib/json/schema.json
+++ b/lib/json/schema.json
@@ -64,7 +64,7 @@
       "required": [ "typeId", "keyTypeId", "valueTypeId" ]
     },
     "struct-type": {
-      "title": "Struct, union and exception schema",
+      "title": "Struct, union, enum and exception schema",
       "type": "object",
       "properties": {
         "typeId": {
@@ -145,9 +145,9 @@
       "type": "object",
       "allOf": [
         { "$ref": "#/definitions/name-and-doc" },
-        { "$ref": "#/definitions/type-desc" },
         {
           "properties": {
+            "type": { "$ref": "#/definitions/type-desc" },
             "value": {
               "oneOf": [
                 { "type": "string" },


### PR DESCRIPTION
Fix the test to expect `typeId` and `class` inside the `type` object instead of on the root level.
This is the way the compiler generates is.

Old output:
```json
  "constants": [
    {
      "name": "myNumberz",
      "typeId": "enum",
      "type": {
        "typeId": "enum",
        "class": "Numberz"
      },
      "value": 1
    }
  ],
```
New output:
```
  "constants": [
    {
      "name": "myNumberz",
      "typeId": "enum",
      "class": "Numberz",
      "value": 1
    }
  ],
```
