### PR TITLE
THRIFT-5706: lib/cpp Fix the Security tests on openssl 1.1 and 3.0

### DIFF
--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -109,7 +109,13 @@ struct SecurityFromBufferFixture {
       shared_ptr<TSSLServerSocket> pServerSocket;
 
       pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
-      pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+      #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+          // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+          // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+          pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
+      #else
+          pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+      #endif
       pServerSocketFactory->loadCertificateFromBuffer(certString("server.crt").c_str());
       pServerSocketFactory->loadPrivateKeyFromBuffer(certString("server.key").c_str());
       pServerSocketFactory->server(true);
@@ -155,6 +161,11 @@ struct SecurityFromBufferFixture {
       try {
         pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
         pClientSocketFactory->authenticate(true);
+        #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+            // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+            // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+            pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
+        #endif
         pClientSocketFactory->loadCertificateFromBuffer(certString("client.crt").c_str());
         pClientSocketFactory->loadPrivateKeyFromBuffer(certString("client.key").c_str());
         pClientSocketFactory->loadTrustedCertificatesFromBuffer(certString("CA.pem").c_str());
@@ -199,16 +210,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
   try {
     // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = (OPENSSL_VERSION_NUMBER < 0x30000000L);
+        bool ossl1x = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
+    /* SSLTLS  */  { true,    false,   false,   ossl1x,  ossl1x,  true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
-    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
+    /* TLSv1_0 */  { ossl1x,  false,   false,   ossl1x,  false,   false   },
+    /* TLSv1_1 */  { ossl1x,  false,   false,   false,   ossl1x,  false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 

--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -109,7 +109,7 @@ struct SecurityFromBufferFixture {
       shared_ptr<TSSLServerSocket> pServerSocket;
 
       pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
-      #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+      #if OPENSSL_VERSION_NUMBER >= 0x10100000L
           // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
           // to @SECLEVEL=0 or 1, so specify it to test all combinations.
           pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
@@ -161,7 +161,7 @@ struct SecurityFromBufferFixture {
       try {
         pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
         pClientSocketFactory->authenticate(true);
-        #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+        #if OPENSSL_VERSION_NUMBER >= 0x10100000L
             // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
             // to @SECLEVEL=0 or 1, so specify it to test all combinations.
             pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
@@ -210,16 +210,15 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
   try {
     // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1x = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1x,  ossl1x,  true    },
+    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1x,  false,   false,   ossl1x,  false,   false   },
-    /* TLSv1_1 */  { ossl1x,  false,   false,   false,   ossl1x,  false   },
+    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
+    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -108,7 +108,13 @@ struct SecurityFixture
             shared_ptr<TSSLServerSocket> pServerSocket;
 
             pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
-            pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+            #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+                // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+                // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+                pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
+            #else
+                pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+            #endif
             pServerSocketFactory->loadCertificate(certFile("server.crt").string().c_str());
             pServerSocketFactory->loadPrivateKey(certFile("server.key").string().c_str());
             pServerSocketFactory->server(true);
@@ -162,6 +168,11 @@ struct SecurityFixture
             {
                 pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
                 pClientSocketFactory->authenticate(true);
+                #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+                    // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
+                    // to @SECLEVEL=0 or 1, so specify it to test all combinations.
+                    pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
+                #endif
                 pClientSocketFactory->loadCertificate(certFile("client.crt").string().c_str());
                 pClientSocketFactory->loadPrivateKey(certFile("client.key").string().c_str());
                 pClientSocketFactory->loadTrustedCertificates(certFile("CA.pem").string().c_str());
@@ -221,16 +232,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
     {
         // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1 = (OPENSSL_VERSION_NUMBER < 0x30000000L);
+        bool ossl1x = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1,   ossl1,   true    },
+    /* SSLTLS  */  { true,    false,   false,   ossl1x,  ossl1x,  true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1,   false,   false,   ossl1,   false,   false   },
-    /* TLSv1_1 */  { ossl1,   false,   false,   false,   ossl1,   false   },
+    /* TLSv1_0 */  { ossl1x,  false,   false,   ossl1x,  false,   false   },
+    /* TLSv1_1 */  { ossl1x,  false,   false,   false,   ossl1x,  false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -108,7 +108,7 @@ struct SecurityFixture
             shared_ptr<TSSLServerSocket> pServerSocket;
 
             pServerSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
-            #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+            #if OPENSSL_VERSION_NUMBER >= 0x10100000L
                 // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
                 // to @SECLEVEL=0 or 1, so specify it to test all combinations.
                 pServerSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0:@STRENGTH");
@@ -168,7 +168,7 @@ struct SecurityFixture
             {
                 pClientSocketFactory.reset(new TSSLSocketFactory(static_cast<apache::thrift::transport::SSLProtocol>(protocol)));
                 pClientSocketFactory->authenticate(true);
-                #if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x30000000L
+                #if OPENSSL_VERSION_NUMBER >= 0x10100000L
                     // OpenSSL 1.1.0 introduced @SECLEVEL. Modern distributions limit TLS 1.0/1.1
                     // to @SECLEVEL=0 or 1, so specify it to test all combinations.
                     pClientSocketFactory->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@SECLEVEL=0");
@@ -232,16 +232,15 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
     {
         // matrix of connection success between client and server with different SSLProtocol selections
         static_assert(apache::thrift::transport::LATEST == 5, "Mismatch in assumed number of ssl protocols");
-        bool ossl1x = (OPENSSL_VERSION_NUMBER < 0x30000000L);
         bool matrix[apache::thrift::transport::LATEST + 1][apache::thrift::transport::LATEST + 1] =
         {
     //   server    = SSLTLS   SSLv2    SSLv3    TLSv1_0  TLSv1_1  TLSv1_2
     // client
-    /* SSLTLS  */  { true,    false,   false,   ossl1x,  ossl1x,  true    },
+    /* SSLTLS  */  { true,    false,   false,   true,    true,    true    },
     /* SSLv2   */  { false,   false,   false,   false,   false,   false   },
     /* SSLv3   */  { false,   false,   true,    false,   false,   false   },
-    /* TLSv1_0 */  { ossl1x,  false,   false,   ossl1x,  false,   false   },
-    /* TLSv1_1 */  { ossl1x,  false,   false,   false,   ossl1x,  false   },
+    /* TLSv1_0 */  { true,    false,   false,   true,    false,   false   },
+    /* TLSv1_1 */  { true,    false,   false,   false,   true,    false   },
     /* TLSv1_2 */  { true,    false,   false,   false,   false,   true    }
         };
 


### PR DESCRIPTION
This PR fixes the Security tests to build on a clean install of ubuntu
20.04 and ubuntu 22.04 without modifications to the systems openssl
configuration.

    * Enable TLS 1.0 and TLS 1.1 on OpenSSL 1.1 with the seclevel=0 flag
    * Disable TLS 1.0 and TLS 1.1 on OpenSSL 3.0

While its technically possible to enable it on OpenSSL 3 I think because
of all the issues with these old TLS versions dropping support for it is
better.

This PR builds forth on the work done here: https://github.com/apache/thrift/pull/2811

Tested with the ubuntu 20.04 (OpenSSL 1.1) and 22.04 (OpenSSL 3.0) docker containers.
All lib/cpp tests succeed in both.