### PR TITLE
THRIFT-5768 Add missing test in configure.ac for kotlin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ if test "$with_kotlin" = "yes";  then
   AC_PATH_PROG([GRADLE], [gradle])
   AC_SUBST(CLASSPATH)
   AC_SUBST(GRADLE_OPTS)
-  if test "x$JAVA" != "x" && test "x$JAVAC" != "x" && "x$GRADLE" != "x" ; then
+  if test "x$JAVA" != "x" && test "x$JAVAC" != "x" && test "x$GRADLE" != "x" ; then
     have_kotlin="yes"
   fi
 fi


### PR DESCRIPTION
The Kotlin autoconfig script was missing a `test` causing it to try and execute `x/usr/local/bin/gradle` instead of test for its existence. This resulted in the following error:
```
./configure: line 15049: x/usr/local/bin/gradle: No such file or directory
```

Adding `test` results in the configuration succeeding. Configure output now:
```
thrift 0.21.0

Building C (GLib) Library .... : yes
Building C++ Library ......... : yes
Building Common Lisp Library.. : yes
Building D Library ........... : yes
Building Dart Library ........ : yes
Building .NET Standard Library : yes
Building Erlang Library ...... : yes
Building Go Library .......... : yes
Building Haxe Library ........ : yes
Building Java Library ........ : yes
Building Kotlin Library ...... : yes
Building Lua Library ......... : yes
Building NodeJS Library ...... : yes
Building Perl Library ........ : yes
Building PHP Library ......... : yes
Building Python Library ...... : yes
Building Py3 Library ......... : yes
Building Ruby Library ........ : yes
Building Rust Library ........ : yes
Building Swift Library ....... : yes
```
