### PR TITLE
THRIFT-5769: fix invalid size error on large messages

### DIFF
--- a/lib/nodejs/lib/thrift/framed_transport.js
+++ b/lib/nodejs/lib/thrift/framed_transport.js
@@ -35,30 +35,27 @@ function TFramedTransport(buffer, callback) {
 Object.setPrototypeOf(TFramedTransport.prototype, THeaderTransport.prototype);
 
 TFramedTransport.receiver = function(callback, seqid) {
-  var residual = [];
+  var residual = new Buffer(0);
 
   return function(data) {
-    // push received data to residual
-    for(var i = 0; i < data.length; ++i) {
-      residual.push(data[i])
-    }
+    residual = Buffer.concat([residual, Buffer.from(data)]);
 
     while (residual.length > 0) {
       if (residual.length < 4) {
         // Not enough bytes to continue, save and resume on next packet
         return;
       }
-      // get single package sieze
-      var frameSize = binary.readI32(Buffer.from(residual.slice(0, 4)), 0);
+      // Get single package size
+      var frameSize = binary.readI32(residual, 0);
       // Not enough bytes to continue, save and resume on next packet
       if (residual.length < 4 + frameSize) {
         return;
       }
 
-      // splice first 4 bytes
-      residual.splice(0, 4)
-      // get package data
-      var frame = Buffer.from(residual.splice(0, frameSize));
+      // Get package data
+      var frame = residual.subarray(4, 4 + frameSize);
+      // Remove processed data from residual
+      residual = residual.subarray(4 + frameSize);
       callback(new TFramedTransport(frame), seqid);
     }
   };

--- a/lib/nodejs/test/header.test.js
+++ b/lib/nodejs/test/header.test.js
@@ -100,6 +100,18 @@ const cases = {
     assert.equals(otherHeaders.foo, undefined);
     assert.equals(otherHeaders.otherfoo, "baz");
     assert.end();
+  },
+  "Should handle large messages without crashing": function(assert) {
+    const callback = function() {};
+    const onData = TFramedTransport.receiver(callback);
+
+    const largeChunkSize = 2 * 100 * 1024 * 1024;
+    const largeChunk = Buffer.alloc(largeChunkSize, "A");
+    const sizeBuffer = new Buffer(4);
+    sizeBuffer.writeInt32BE(largeChunkSize + 4, 0);
+    onData(Buffer.concat([sizeBuffer, largeChunk]));
+
+    assert.end();
   }
 };
 

--- a/lib/nodejs/test/testAll.sh
+++ b/lib/nodejs/test/testAll.sh
@@ -118,6 +118,7 @@ fi
 # unit tests
 
 node ${DIR}/binary.test.js || TESTOK=1
+node ${DIR}/header.test.js || TESTOK=1
 node ${DIR}/int64.test.js || TESTOK=1
 node ${DIR}/deep-constructor.test.js || TESTOK=1
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Fixes https://issues.apache.org/jira/browse/THRIFT-5769.

Replaces `residual` `Array` with `Buffer` to fix crash caused by large messages.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
