### PR TITLE
Use `outputVar` instead of hard coding `this.output` in JS codegen

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -919,9 +919,9 @@ void t_js_generator::generate_js_struct_definition(ostream& out,
 
       // Special case. Exceptions derive from Error, and error has a non optional message field.
       // Ignore the optional flag in this case, otherwise we will generate a incompatible field
-      // in the eyes of typescript. 
+      // in the eyes of typescript.
       string optional_flag = is_exception && member_name == "message" ? "" : ts_get_req(*m_iter);
- 
+
       f_types_ts_ << ts_indent() << ts_access << member_name << optional_flag << ": "
                   << ts_get_type((*m_iter)->get_type()) << ";" << endl;
     }
@@ -2019,23 +2019,23 @@ void t_js_generator::generate_service_client(t_service* tservice) {
 
     if (gen_node_) {
       if((*f_iter)->is_oneway()) {
-        f_service_ << indent() << "this.output.flush();" << endl;
+        f_service_ << indent() << outputVar << ".flush();" << endl;
         f_service_ << indent() << js_const_type_ << "callback = this._reqs[this.seqid()] || function() {};" << endl;
         f_service_ << indent() << "delete this._reqs[this.seqid()];" << endl;
         f_service_ << indent() << "callback(null);" << endl;
       } else {
-        f_service_ << indent() << "return this.output.flush();" << endl;
+        f_service_ << indent() << "return " << outputVar << ".flush();" << endl;
       }
     } else {
       if (gen_jquery_) {
-        f_service_ << indent() << "return this.output.getTransport().flush(callback);" << endl;
+        f_service_ << indent() << "return " << outputVar << ".getTransport().flush(callback);" << endl;
       } else if (gen_es6_) {
         f_service_ << indent() << js_const_type_ << "self = this;" << endl;
         if((*f_iter)->is_oneway()) {
-          f_service_ << indent() << "this.output.getTransport().flush(true, null);" << endl;
+          f_service_ << indent() << outputVar << ".getTransport().flush(true, null);" << endl;
           f_service_ << indent() << "callback();" << endl;
         } else {
-          f_service_ << indent() << "this.output.getTransport().flush(true, () => {" << endl;
+          f_service_ << indent() << outputVar << ".getTransport().flush(true, () => {" << endl;
           indent_up();
           f_service_ << indent() << js_let_type_ << "error = null, result = null;" << endl;
           f_service_ << indent() << "try {" << endl;
@@ -2051,11 +2051,11 @@ void t_js_generator::generate_service_client(t_service* tservice) {
         f_service_ << indent() << "if (callback) {" << endl;
         indent_up();
         if((*f_iter)->is_oneway()) {
-          f_service_ << indent() << "this.output.getTransport().flush(true, null);" << endl;
+          f_service_ << indent() << outputVar << ".getTransport().flush(true, null);" << endl;
           f_service_ << indent() << "callback();" << endl;
         } else {
           f_service_ << indent() << js_const_type_ << "self = this;" << endl;
-          f_service_ << indent() << "this.output.getTransport().flush(true, function() {" << endl;
+          f_service_ << indent() << outputVar << ".getTransport().flush(true, function() {" << endl;
           indent_up();
           f_service_ << indent() << js_let_type_ << "result = null;" << endl;
           f_service_ << indent() << "try {" << endl;
@@ -2069,7 +2069,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
         }
         indent_down();
         f_service_ << indent() << "} else {" << endl;
-        f_service_ << indent() << "  return this.output.getTransport().flush();" << endl;
+        f_service_ << indent() << "  return " << outputVar << ".getTransport().flush();" << endl;
         f_service_ << indent() << "}" << endl;
       }
     }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When generating the JS Thrift clients, it hard-codes `this.output` in a few places; however, if `gen_node_` is true, our variable should be `output` instead. We set a variable, `outputVar`, up on line 1968/1970 of the file, but don't use it everywhere. In NodeJS environment, this can lead to the wrong flush being called, which can lead to issues; for example, with the header transport protocol, the headers can either go missing or be sent incorrectly.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

I believe this is a trivial change not requiring a ticket.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] ~If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?~
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] ~If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.~

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
