### PR TITLE
THRIFT-5778 DRAFT/PROPOSAL: Thrift URI specification/implementation

### DIFF
--- a/doc/specs/thrift-uri.md
+++ b/doc/specs/thrift-uri.md
@@ -1,0 +1,155 @@
+Thrift URIs
+====================================================================
+
+Last Modified: 2024-APR-21
+
+<!--
+--------------------------------------------------------------------
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+--------------------------------------------------------------------
+-->
+
+# Motivation and use case
+
+Describing the endpoint specifics for a Thrift API today is a purely textual exercise, which leaves the client end with the task to set up and stack together a proper protocol/transport stack. That sometimes even leads to headaches, e.g. if the server requires e.g. framed protocol which might not be obvious. The use of a generally accepted, machine-readable and extensible Thrift URI format to describe client bindings could streamline that process.
+
+# Thrift URI general format
+
+Lets look at the general format:
+
+	"thrift://" <protocol> "/" <transport> ["/" <layer>]* "?" <transport-specific-data>
+
+The *scheme* of all Thrift URIs is "thrift://". Immediately followimng parts are the protocol being used and the endpoint transport.
+
+Optionally, more path segments may be added, each one describing a particular layered transport, e.g. "framed". 
+
+All query data (i.e. the part after the question mark) depend on the endpoint transport in the second segment, examples follow below. All data must be properly URL-encoded.
+
+# Predefined identifiers
+
+Each implementation shall register their implemented formats with the following keys internally:
+
+## Protocols
+|Code|Protocol|
+|-|-|
+|binary|Thrift Binary protocol|
+|compact|Thrift Compact protocol|
+|json|Standard Thrift JSON protocol|
+
+TODO: cover multiplex protocol
+
+## Endpoint Transports
+|Code|Transport|
+|-|-|
+|http|http(s) transport|
+|namedpipes|Named Pipes Transport|
+|pipes|Simple Pipes Transport (i.e. via STDIN,STDOUT)|
+|socket|Socket Transport|
+|tlssocket|TLS Sockets Transport|
+|file|File transport|
+|memory|Memory Buffer Transport|
+
+## Layered Transports
+|Code|Transport|
+|-|-|
+|framed|Framed transport|
+|buffered|Buffered transport|
+|zlib|ZLib transport|
+
+## TODO: multiplex protocol
+....
+
+
+# Extensibility
+
+Consistent with the open and extensible nature of Thrift, the registration mechanism outlined above is intentionally designed to be open to any user-defined protocols and transports. That way, future developments as well as proprietary developments can be covered by the same mechanism. It is also expected, that depending on the implemented set of features, different languages supported by Thrift might support a different set of Thrift URI components.
+
+
+# Transport specific data
+
+
+## http - http(s) transport
+
+The data part consists of the target URL. No other data are allowed.
+
+Examples:
+ * thrift://binary/http?https%3A%2F%2Fuser%3Apass%40example.com%2Fmyservice%3Farg%3Done%26arg%3Dtwo
+
+## namedpipes - Named Pipes Transport
+
+The data part consists of the target pipe, either name only or in full format:
+
+Examples:
+ * thrift://binary/namedpipes?mypipe
+ * thrift://binary/namedpipes?mypath%5Cmyname
+ * thrift://binary/namedpipes?%5C%5Cmyserver%5Cpipe%5Cmypath%5Cmyname
+
+## pipes - Simple Pipes Transport (i.e. via STDIN,STDOUT)
+....
+
+## socket - Socket Transport
+
+|key|argument|
+|-|-|
+|host|Host name or IP|
+|port|Host port|
+
+Examples:
+ * thrift://compact/socket/framed?host=localhost&port=8080
+
+## tlssocket - TLS Sockets Transport
+
+|key|argument|
+|-|-|
+|host|Host name or IP|
+|port|Host port|
+|cert|path to certificate file|
+
+Examples:
+ * thrift://binary/tlssocket?host=localhost&port=8080&cert=C%3A%5CTemp%5Cclient.p12
+
+
+## file - File transport
+
+|key|argument|
+|-|-|
+|infile|Input file name|
+|outfile|Output file name|
+
+Examples:
+ * thrift://json/file?infile=this.json&outfile=that.json
+
+
+## memory - Memory Buffer Transport
+
+No data expected.
+
+
+# Q&A
+
+## Is this a breaking change or not?
+
+No, it is an extension to the Thrift ecosystem, intended to make implementation of Thrift clients easier and faster.
+
+## Why are server transports not covered?
+
+The use case is about client connections. A server end usually requires somewhat more sophisticated implementation efforts, and constructing the transport/protocol stacks is just a small part of the whole. It also highly depends on the nature of the server. A Thrift URI would not add much value at the server end. That does not mean that the spec cannot be extended in the future.
+
+

--- a/lib/netstd/Tests/Thrift.Tests/UriFactory/TUriFactoryTests.cs
+++ b/lib/netstd/Tests/Thrift.Tests/UriFactory/TUriFactoryTests.cs
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.UriFactory
+{
+    [TestClass]
+    public class TUriFactoryTests
+    {
+        private enum BuiltinProtocols { binary, compact, json };
+        private enum BuiltinTransports { http, namedpipes, socket, tlssocket, file, memory };
+        private enum BuiltinLayered { framed, buffered };
+
+        private readonly string InputFile = Path.GetTempFileName();
+        private readonly string OutputFile = Path.GetTempFileName();
+
+        [TestMethod]
+        public void TFactory_Can_Parse_And_Construct_All_Builtin_Types()
+        {
+            // thrift://protocol/transport/layer/layer?data
+            foreach (var proto in Enum.GetValues<BuiltinProtocols>())
+            {
+                foreach (var trans in Enum.GetValues<BuiltinTransports>())
+                {
+                    var iTest = 0;
+                    while (InitializeTransportSpecificArgs(trans, iTest++, out var connection))
+                    {
+
+                        // test basic combination first
+                        var sData = MakeQueryString(connection);
+                        var sUri = TThriftUri.THRIFT_URI_SCHEME + proto + "/" + trans;
+                        TestUri(sUri + sData);
+
+                        // layers can be stacked upon each other, so lets do exactly that - just to test it
+                        foreach (var layer in Enum.GetValues<BuiltinLayered>())
+                        {
+                            sUri += "/" + layer;
+                            TestUri(sUri + sData);
+                        }
+                    }
+                }
+            }
+
+            File.Delete(InputFile);
+            File.Delete(OutputFile);
+        }
+
+        private bool InitializeTransportSpecificArgs(BuiltinTransports trans, int test, out Dictionary<string, string> connection)
+        {
+            if (test > 64)  // prevent against endless loops
+                throw new Exception("Internal test error");
+
+            connection = [];
+            switch (trans)
+            {
+                case BuiltinTransports.http:
+                    connection.Add("https://user:pass@example.com/myservice?arg=one&arg=two", string.Empty);
+                    return (test == 0);
+
+                case BuiltinTransports.namedpipes:
+                    switch (test)
+                    {
+                        case 0:  // full pipe name
+                            connection.Add(@"\\myserver\pipe\mypath\myname", string.Empty);
+                            return true;
+                        case 1: // pipe name w/o server part
+                            connection.Add(@"mypath\myname", string.Empty);
+                            return true;
+                        case 2: // simple pipe name w/o server part
+                            connection.Add(@"mypipe", string.Empty);
+                            return true;
+                        default:
+                            return false;
+                    };
+
+                case BuiltinTransports.file:
+                    switch (test)
+                    {
+                        case 0:  // no argument at all
+                            return true;
+                        case 1: // file stream
+                            connection.Add("infile", InputFile);
+                            return true;
+                        case 2: // file stream
+                            connection.Add("outfile", OutputFile);
+                            return true;
+                        default:
+                            return false;
+                    };
+
+                case BuiltinTransports.socket:
+                    connection.Add("host", "localhost");
+                    connection.Add("port", 8080.ToString());
+                    return (test == 0);
+
+                case BuiltinTransports.tlssocket:
+                    connection.Add("host", "localhost");
+                    connection.Add("port", 8080.ToString());
+                    connection.Add("cert", Path.Combine(Path.GetTempPath(), "client.p12"));
+                    return (test == 0);
+
+                case BuiltinTransports.memory:
+                    // none
+                    return (test == 0);
+
+                default:
+                    throw new NotImplementedException(trans.ToString());
+            };
+        }
+
+        private static string MakeQueryString(Dictionary<string, string> data)
+        {
+            if ((data == null) || (data.Count == 0))
+                return string.Empty;
+
+            var kvpair = new List<string>();
+            foreach (var pair in data)
+            {
+                var sTmp = Uri.EscapeDataString(pair.Key);
+                if (!string.IsNullOrEmpty(pair.Value))
+                    sTmp += "=" + Uri.EscapeDataString(pair.Value);
+                kvpair.Add(sTmp);
+            }
+            return "?" + string.Join("&", kvpair);
+        }
+
+        private static void TestUri(string sUri)
+        {
+            var parsed = new TThriftUri( sUri);
+            Assert.AreEqual(sUri, parsed.ToString());
+
+            try
+            {
+                var proto = TFactory.ConstructClientProtocolTransportStack(parsed, new(), out var trans);
+                try
+                {
+                    Assert.IsNotNull(proto);
+                    Assert.IsNotNull(trans);
+                }
+                finally
+                {
+                    trans?.Dispose();
+                    proto?.Dispose();
+                }
+            }
+            catch(System.Security.Cryptography.CryptographicException)
+            {
+                // that may happen, but is not relevant here
+            }
+            catch (TTransportException)
+            {
+                // that may happen, but is not relevant here
+            }
+        }
+    }
+}

--- a/lib/netstd/Tests/Thrift.Tests/UriFactory/TUriFactoryTests.cs
+++ b/lib/netstd/Tests/Thrift.Tests/UriFactory/TUriFactoryTests.cs
@@ -38,10 +38,10 @@ namespace Thrift.Tests.UriFactory
         private static HashSet<BuiltinTransports> GetAllSocketTransports()
         {
             // these are known to slow down the test
-            return new HashSet<BuiltinTransports> {
+            return [
                 BuiltinTransports.socket,
                 BuiltinTransports.tlssocket,
-            };
+            ];
         }
 
         [TestMethod]
@@ -78,8 +78,8 @@ namespace Thrift.Tests.UriFactory
         private void InternalTestMethodImplementation(IEnumerable<BuiltinProtocols> protocols, IEnumerable<BuiltinTransports> transports, IEnumerable<BuiltinProtocolDecorators> decorators, IEnumerable<BuiltinLayeredTransports> layeredTransports)
         {
             // those must not be empty to have at least one test run
-            Assert.IsTrue(protocols.Count() > 0);
-            Assert.IsTrue(transports.Count() > 0);
+            Assert.IsTrue(protocols.Any());
+            Assert.IsTrue(transports.Any());
 
             // "none" should always be included and should be first
             Assert.IsTrue(decorators.FirstOrDefault() == BuiltinProtocolDecorators.none);
@@ -126,7 +126,7 @@ namespace Thrift.Tests.UriFactory
             File.Delete(OutputFile);
         }
 
-        private string MakeLayeredTransportString(BuiltinLayeredTransports layer)
+        private static string MakeLayeredTransportString(BuiltinLayeredTransports layer)
         {
             return layer switch
             {

--- a/lib/netstd/Thrift/Protocol/TMultiplexedProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TMultiplexedProtocol.cs
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Thrift.Protocol.Entities;
+using Thrift.Transport;
 
 #pragma warning disable IDE0079 // net20 - unneeded suppression
 #pragma warning disable IDE0290 // net8 - primary CTOR
@@ -88,6 +91,15 @@ namespace Thrift.Protocol
                 default:
                     await base.WriteMessageBeginAsync(message, cancellationToken);
                     break;
+            }
+        }
+
+        internal class Factory : TProtocolDecoratorFactory
+        {
+            public override TProtocol GetProtocol(TProtocol proto, Dictionary<string, string> arguments)
+            {
+                var sService = arguments?.FirstOrDefault().Key ?? string.Empty;
+                return new TMultiplexedProtocol(proto, sService);
             }
         }
     }

--- a/lib/netstd/Thrift/Protocol/TProtocolDecoratorFactory.cs
+++ b/lib/netstd/Thrift/Protocol/TProtocolDecoratorFactory.cs
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+using System.Collections.Generic;
+
+namespace Thrift.Protocol
+{
+    // ReSharper disable once InconsistentNaming
+    public abstract class TProtocolDecoratorFactory
+    {
+        public abstract TProtocol GetProtocol(TProtocol proto, Dictionary<string, string> arguments);
+    }
+}

--- a/lib/netstd/Thrift/TFactory.cs
+++ b/lib/netstd/Thrift/TFactory.cs
@@ -23,7 +23,8 @@ using Thrift.Protocol;
 using Thrift.Transport;
 using Thrift.Transport.Client;
 
-#pragma warning disable IDE0028  // collection init is net8 only
+#pragma warning disable IDE0079  // unneeded suppression -> all except net8
+#pragma warning disable IDE0028  // simplify collection init -> net8 only
 
 namespace Thrift
 {

--- a/lib/netstd/Thrift/TFactory.cs
+++ b/lib/netstd/Thrift/TFactory.cs
@@ -17,20 +17,40 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
+using System.Reflection.Emit;
+using System.Xml.Linq;
 using Thrift.Protocol;
 using Thrift.Transport;
 using Thrift.Transport.Client;
-using Thrift.Transport.Server;
-using static System.Net.WebRequestMethods;
+
+#pragma warning disable IDE0028  // collection init is net8 only
 
 namespace Thrift
 {
     public static class TFactory
     {
+        private class LayerFactory
+        {
+            // its either one or the other, can't be both
+            public readonly TProtocolDecoratorFactory ProtocolDecorator;
+            public readonly TTransportFactory LayeredTransport;
+
+            public LayerFactory(TProtocolDecoratorFactory factory)
+            {
+                ProtocolDecorator = factory;
+            }
+
+            public LayerFactory(TTransportFactory factory)
+            {
+                LayeredTransport = factory;
+            }
+        }
+
+
         private static readonly Dictionary<string, TProtocolFactory> RegisteredProtocols = new Dictionary<string, TProtocolFactory>();
-        private static readonly Dictionary<string, TTransportFactory> RegisteredLayeredTransports = new Dictionary<string, TTransportFactory>();
         private static readonly Dictionary<string, TEndpointTransportFactory> RegisteredEndpointTransports = new Dictionary<string, TEndpointTransportFactory>();
+        private static readonly Dictionary<string, LayerFactory> RegisteredLayers = new Dictionary<string, LayerFactory>();
+
 
         static TFactory()
         {
@@ -38,6 +58,9 @@ namespace Thrift
             Register("binary", new TBinaryProtocol.Factory());
             Register("compact", new TCompactProtocol.Factory());
             Register("json", new TJsonProtocol.Factory());
+
+            // protocol decorators
+            Register("mplex", new TMultiplexedProtocol.Factory());
 
             // layered transports
             Register("framed", new TFramedTransport.Factory());
@@ -56,20 +79,30 @@ namespace Thrift
 
         public static void Register(string name, TProtocolFactory factory)
         {
+            // throws intentionally if name is already used
             lock (RegisteredProtocols)
-                RegisteredProtocols.Add(name, factory);  // throws intentionally if name is already used
-        }
-
-        public static void Register(string name, TTransportFactory factory)
-        {
-            lock (RegisteredLayeredTransports)
-                RegisteredLayeredTransports.Add(name, factory);  // throws intentionally if name is already used
+                RegisteredProtocols.Add(name, factory);
         }
 
         public static void Register(string name, TEndpointTransportFactory factory)
         {
+            // throws intentionally if name is already used
             lock (RegisteredEndpointTransports)
-                RegisteredEndpointTransports.Add(name, factory);  // throws intentionally if name is already used
+                RegisteredEndpointTransports.Add(name, factory);
+        }
+
+        public static void Register(string name, TTransportFactory factory)
+        {
+            // throws intentionally if name is already used
+            lock (RegisteredLayers)
+                RegisteredLayers.Add(name, new LayerFactory(factory));  
+        }
+
+        public static void Register(string name, TProtocolDecoratorFactory factory)
+        {
+            // throws intentionally if name is already used
+            lock (RegisteredLayers)
+                RegisteredLayers.Add(name, new LayerFactory(factory));
         }
 
 
@@ -82,31 +115,49 @@ namespace Thrift
 
         public static TProtocol ConstructClientProtocolTransportStack(TThriftUri uri, TConfiguration config, out TTransport transport)
         {
-            transport = CreateEndpointTransport(uri.EndpointTransport, config, uri.QueryData);
-            foreach (var layer in uri.LayeredTransports)
-                transport = CreateLayeredTransport(layer, transport);
-            return CreateProtocol(uri.Protocol, transport);
+            transport = CreateEndpointTransport(uri.Transport, config, uri.QueryData);
+            foreach (var layer in uri.Layers)
+                transport = AddLayeredTransport(transport, layer.Key);
+
+            var protocol = CreateProtocol(uri.Protocol, transport);
+            foreach (var layer in uri.Layers)
+                protocol = AddProtocolDecorator(protocol, layer.Key, layer.Value);
+
+            return protocol;
         }
 
         private static TEndpointTransport CreateEndpointTransport(string name, TConfiguration config, Dictionary<string, string> args)
         {
             if (RegisteredEndpointTransports.TryGetValue(name, out var factory))
                 return factory.GetTransport(config, args);
-            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Endpoint transport '" + name + "' not registered");
-        }
 
-        private static TTransport CreateLayeredTransport(string name, TTransport transport)
-        {
-            if (RegisteredLayeredTransports.TryGetValue(name, out var factory))
-                return factory.GetTransport(transport);
-            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "layered transport '" + name + "' not registered");
+            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Endpoint transport '" + name + "' not registered");
         }
 
         private static TProtocol CreateProtocol(string name, TTransport transport)
         {
             if (RegisteredProtocols.TryGetValue(name, out var factory))
                 return factory.GetProtocol(transport);
+
             throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Protocol '" + name + "' not registered");
+        }
+
+        private static TProtocol AddProtocolDecorator(TProtocol protocol, string name, Dictionary<string, string> args)
+        {
+            if (!RegisteredLayers.TryGetValue(name, out var factory))
+                throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Thrift protocol/transport layer '" + name + "' not registered");
+            if (factory.ProtocolDecorator != null)
+                return factory.ProtocolDecorator.GetProtocol(protocol, args);
+            return protocol;
+        }
+
+        private static TTransport AddLayeredTransport(TTransport transport, string name)
+        {
+            if (!RegisteredLayers.TryGetValue(name, out var factory))
+                throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Thrift protocol/transport layer '" + name + "' not registered");
+            if (factory.LayeredTransport != null)
+                return factory.LayeredTransport.GetTransport(transport);
+            return transport;
         }
     }
 }

--- a/lib/netstd/Thrift/TFactory.cs
+++ b/lib/netstd/Thrift/TFactory.cs
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+using Thrift.Transport.Server;
+using static System.Net.WebRequestMethods;
+
+namespace Thrift
+{
+    public static class TFactory
+    {
+        private static readonly Dictionary<string, TProtocolFactory> RegisteredProtocols = new Dictionary<string, TProtocolFactory>();
+        private static readonly Dictionary<string, TTransportFactory> RegisteredLayeredTransports = new Dictionary<string, TTransportFactory>();
+        private static readonly Dictionary<string, TEndpointTransportFactory> RegisteredEndpointTransports = new Dictionary<string, TEndpointTransportFactory>();
+
+        static TFactory()
+        {
+            // protocol
+            Register("binary", new TBinaryProtocol.Factory());
+            Register("compact", new TCompactProtocol.Factory());
+            Register("json", new TJsonProtocol.Factory());
+
+            // layered transports
+            Register("framed", new TFramedTransport.Factory());
+            Register("buffered", new TBufferedTransport.Factory());
+
+            // common endpoint transports
+            Register("file", new TStreamTransport.Factory());
+            Register("memory", new TMemoryBufferTransport.Factory());
+
+            // client endpoint transports
+            Register("socket", new TSocketTransport.Factory());
+            Register("tlssocket", new TTlsSocketTransport.Factory());
+            Register("http", new THttpTransport.Factory());
+            Register("namedpipes", new TNamedPipeTransport.Factory());
+        }
+
+        public static void Register(string name, TProtocolFactory factory)
+        {
+            lock (RegisteredProtocols)
+                RegisteredProtocols.Add(name, factory);  // throws intentionally if name is already used
+        }
+
+        public static void Register(string name, TTransportFactory factory)
+        {
+            lock (RegisteredLayeredTransports)
+                RegisteredLayeredTransports.Add(name, factory);  // throws intentionally if name is already used
+        }
+
+        public static void Register(string name, TEndpointTransportFactory factory)
+        {
+            lock (RegisteredEndpointTransports)
+                RegisteredEndpointTransports.Add(name, factory);  // throws intentionally if name is already used
+        }
+
+
+        public static TProtocol ConstructClientProtocolTransportStack(string sThriftUri, TConfiguration config, out TTransport transport)
+        {
+            var uri = new TThriftUri(sThriftUri);
+            return ConstructClientProtocolTransportStack(uri, config, out transport);
+        }
+
+
+        public static TProtocol ConstructClientProtocolTransportStack(TThriftUri uri, TConfiguration config, out TTransport transport)
+        {
+            transport = CreateEndpointTransport(uri.EndpointTransport, config, uri.QueryData);
+            foreach (var layer in uri.LayeredTransports)
+                transport = CreateLayeredTransport(layer, transport);
+            return CreateProtocol(uri.Protocol, transport);
+        }
+
+        private static TEndpointTransport CreateEndpointTransport(string name, TConfiguration config, Dictionary<string, string> args)
+        {
+            if (RegisteredEndpointTransports.TryGetValue(name, out var factory))
+                return factory.GetTransport(config, args);
+            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Endpoint transport '" + name + "' not registered");
+        }
+
+        private static TTransport CreateLayeredTransport(string name, TTransport transport)
+        {
+            if (RegisteredLayeredTransports.TryGetValue(name, out var factory))
+                return factory.GetTransport(transport);
+            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "layered transport '" + name + "' not registered");
+        }
+
+        private static TProtocol CreateProtocol(string name, TTransport transport)
+        {
+            if (RegisteredProtocols.TryGetValue(name, out var factory))
+                return factory.GetProtocol(transport);
+            throw new TApplicationException(TApplicationException.ExceptionType.Unknown, "Protocol '" + name + "' not registered");
+        }
+    }
+}

--- a/lib/netstd/Thrift/TThriftUri.cs
+++ b/lib/netstd/Thrift/TThriftUri.cs
@@ -21,8 +21,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
-#pragma warning disable IDE0028  // net8 only
-#pragma warning disable IDE0074  // net8 only
+//#pragma warning disable IDE0028  // net8 only
+//#pragma warning disable IDE0074  // net8 only
 
 namespace Thrift
 {
@@ -32,7 +32,7 @@ namespace Thrift
         // must either be empty or begin with a slash("/") character.If a URI
         // does not contain an authority component, then the path cannot begin
         // with two slash characters("//").  
-        public const string THRIFT_URI_SCHEME = "thrift:/";
+        public const string THRIFT_URI_SCHEME = "thrift:";
 
         public readonly string Protocol;
         public readonly string Transport;

--- a/lib/netstd/Thrift/TThriftUri.cs
+++ b/lib/netstd/Thrift/TThriftUri.cs
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Thrift
+{
+    public class TThriftUri
+    {
+        public const string THRIFT_URI_SCHEME = "thrift://";
+
+        public readonly string Protocol;
+        public readonly string EndpointTransport;
+        public readonly List<string> LayeredTransports = new List<string>();
+        public readonly Dictionary<string,string> QueryData = new Dictionary<string, string>();
+
+        public TThriftUri(string protocol, string endpointTransport, Dictionary<string, string> data)
+        {
+            Protocol = (protocol ?? "").Trim();
+            EndpointTransport = (endpointTransport ?? "").Trim();
+            if(data!=null)
+                foreach (var pair in data)
+                    QueryData.Add(pair.Key, pair.Value);
+        }
+
+        public TThriftUri(string sThriftUri)
+        {
+            if (!sThriftUri.StartsWith(THRIFT_URI_SCHEME))
+                throw new TApplicationException(TApplicationException.ExceptionType.ProtocolError, "Invalid URI: " + THRIFT_URI_SCHEME + " expected");
+
+            // split path and query
+            sThriftUri = sThriftUri.Remove(0, THRIFT_URI_SCHEME.Length);
+            var pieces = sThriftUri.Split('?');
+            var sPath = pieces[0];
+            var sQuery = string.Join("?", pieces.Skip(1).ToArray());
+
+            // analyze path
+            // thrift://protocol/transport/layer/layer?data
+            pieces = sPath.Split('/');
+            if (pieces.Length < 2)
+                throw new TApplicationException(TApplicationException.ExceptionType.ProtocolError, "Invalid URI: not enough data");
+            Protocol = pieces[0].Trim();
+            EndpointTransport = pieces[1].Trim();
+            for (int i = 2; i < pieces.Length; i++)
+                LayeredTransports.Add(pieces[i].Trim());
+
+            // analyze query data
+            if (!string.IsNullOrEmpty(sQuery))
+            {
+                pieces = sQuery.Split('&');
+                foreach (var piece in pieces)
+                {
+                    var pair = piece.Split('=');
+                    var sKey = Uri.UnescapeDataString(pair[0]);
+                    var sValue = Uri.UnescapeDataString(string.Join("=", pair.Skip(1).ToArray()));
+                    QueryData.Add(sKey, sValue);
+                }
+            }
+
+            Validate();
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(THRIFT_URI_SCHEME);
+            sb.Append(Protocol);
+            sb.Append('/');
+            sb.Append(EndpointTransport);
+
+            foreach (var layer in LayeredTransports)
+            {
+                sb.Append('/');
+                sb.Append(layer.Trim());
+            }
+
+            if (QueryData.Count > 0)
+            {
+                var kvpair = new List<string>();
+                foreach (var pair in QueryData)
+                {
+                    var sTmp = Uri.EscapeDataString(pair.Key);
+                    if (!string.IsNullOrEmpty(pair.Value))
+                        sTmp += "=" + Uri.EscapeDataString(pair.Value);
+                    kvpair.Add(sTmp);
+                }
+                sb.Append('?');
+                sb.Append(string.Join("&", kvpair));
+            }
+
+            return sb.ToString();
+        }
+
+
+        internal void Validate()
+        {
+            if (string.IsNullOrEmpty(Protocol))
+                throw new TApplicationException(TApplicationException.ExceptionType.ProtocolError, "Invalid URI: Protocol missing");
+            if (string.IsNullOrEmpty(EndpointTransport))
+                throw new TApplicationException(TApplicationException.ExceptionType.ProtocolError, "Invalid URI: Endpoint transport missing");
+        }
+    }
+
+}

--- a/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
@@ -293,5 +293,15 @@ namespace Thrift.Transport.Client
             }
             _isDisposed = true;
         }
+
+        public class Factory : TEndpointTransportFactory
+        {
+            public override TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection)
+            {
+                // connection is simply the server name
+                var server = connection.First().Key;
+                return new THttpTransport(new Uri(server), config);
+            }
+        }
     }
 }

--- a/lib/netstd/Thrift/Transport/Client/TMemoryBufferTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TMemoryBufferTransport.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -173,6 +174,15 @@ namespace Thrift.Transport.Client
                 }
             }
             IsDisposed = true;
+        }
+
+        internal class Factory : TEndpointTransportFactory
+        {
+            public override TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection)
+            {
+                Debug.Assert((connection?.Count ?? 0) == 0);  // unused data
+                return new TMemoryBufferTransport(config);
+            }
         }
     }
 }

--- a/lib/netstd/Thrift/Transport/Client/TSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TSocketTransport.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -224,6 +225,16 @@ namespace Thrift.Transport.Client
                 }
             }
             _isDisposed = true;
+        }
+
+        new internal class Factory : TEndpointTransportFactory
+        {
+            public override TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection)
+            {
+                var sHost = connection["host"];
+                var sPort = connection["port"];
+                return new TSocketTransport(sHost, int.Parse(sPort), config);
+            }
         }
     }
 }

--- a/lib/netstd/Thrift/Transport/Client/TStreamTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TStreamTransport.cs
@@ -16,9 +16,12 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Thrift.Protocol;
 
 namespace Thrift.Transport.Client
 {
@@ -122,6 +125,27 @@ namespace Thrift.Transport.Client
                 }
             }
             _isDisposed = true;
+        }
+
+        internal class Factory : TEndpointTransportFactory
+        {
+            public override TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection)
+            {
+                // optionally we can pass in a file name for read/write
+                Stream input = null;
+                Stream output = null;
+
+                if (connection != null)
+                {
+                    if (connection.TryGetValue("infile", out var sValue))
+                        input = new FileStream(sValue, FileMode.Open, FileAccess.Read);
+
+                    if (connection.TryGetValue("outfile", out sValue))
+                        output = new FileStream(sValue, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+                }
+
+                return new TStreamTransport(input, output, config);
+            }
         }
     }
 }

--- a/lib/netstd/Thrift/Transport/Client/TTlsSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/TTlsSocketTransport.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
@@ -282,6 +283,17 @@ namespace Thrift.Transport.Client
             }
         }
 
+        new internal class Factory : TEndpointTransportFactory
+        {
+            public override TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection)
+            {
+                var sHost = connection["host"];
+                var sPort = connection["port"];
+                var sCert = connection["cert"];
+                var certificate = new X509Certificate2(sCert);
+                return new TTlsSocketTransport(sHost, int.Parse(sPort), config, 0, certificate);
+            }
+        }
 
     }
 }

--- a/lib/netstd/Thrift/Transport/Layered/TBufferedTransport.cs
+++ b/lib/netstd/Thrift/Transport/Layered/TBufferedTransport.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;

--- a/lib/netstd/Thrift/Transport/TEndpointTransportFactory.cs
+++ b/lib/netstd/Thrift/Transport/TEndpointTransportFactory.cs
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+
+namespace Thrift.Transport
+{
+    /// <summary>
+    ///     Factory class used to create wrapped instance of TEndpointTransports.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public abstract class TEndpointTransportFactory
+    {
+        public abstract TEndpointTransport GetTransport(TConfiguration config, Dictionary<string, string> connection);
+    }
+}


### PR DESCRIPTION
Describing the endpoint specifics for a Thrift API today is a purely textual exercise, which leaves the client end with the task to set up and stack together a proper protocol/transport stack. That sometimes even leads to headaches, e.g. if the server requires e.g. framed protocol which might not be obvious. The use of a generally accepted, machine-readable and extensible Thrift URI format to describe client bindings could streamline that process.

Details see https://github.com/Jens-G/thrift/blob/thrift-uri/doc/specs/thrift-uri.md 