### PR TITLE
Revert "go: Define a bytePool for TRichTransport"

### DIFF
--- a/lib/go/thrift/rich_transport.go
+++ b/lib/go/thrift/rich_transport.go
@@ -49,15 +49,9 @@ func (r *RichTransport) RemainingBytes() (num_bytes uint64) {
 	return r.TTransport.RemainingBytes()
 }
 
-var bytePool = newPool(nil, func(b *[1]byte) {
-	b[0] = 0
-})
-
 func readByte(r io.Reader) (c byte, err error) {
-	v := bytePool.get()
-	defer bytePool.put(&v)
-
-	n, err := r.Read(v[:])
+	v := [1]byte{0}
+	n, err := r.Read(v[0:1])
 	if n > 0 && (err == nil || errors.Is(err, io.EOF)) {
 		return v[0], nil
 	}
@@ -71,10 +65,7 @@ func readByte(r io.Reader) (c byte, err error) {
 }
 
 func writeByte(w io.Writer, c byte) error {
-	v := bytePool.get()
-	defer bytePool.put(&v)
-
-	v[0] = c
-	_, err := w.Write(v[:])
+	v := [1]byte{c}
+	_, err := w.Write(v[0:1])
 	return err
 }


### PR DESCRIPTION
This reverts commit 344498b67f42af38118cc250b0b1ec212f09d927.

In our extreme case this actually made things worse. On 30s cpu profiles, although mallocgc reduced from 27.13s to 26.30s, the byte pool itself costed 11.9s. Looking at writeByte and readByte, writeByte increased from 3.69s to 5.89s, and readByte increased from 11.36s to 16.09s.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
