### PR TITLE
optimizing performance issues under large-scale connection

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <string>
 #include <cstdlib>
+#include <unordered_set>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -259,7 +260,7 @@ private:
    * which in turn allows their transports, protocols, processors and handlers
    * to deallocate and clean up correctly.
    */
-  std::vector<TConnection*> activeConnections_;
+  std::unordered_set<TConnection*> activeConnections_;
 
   /*
   */


### PR DESCRIPTION
When the number of client connection exceeds 100000, especially when it reaches 500000, there will be serious performance issues if thousands of level links are constantly created and deleted.
