### PR TITLE
go: Proper indent in compiler

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.h
@@ -286,6 +286,10 @@ public:
 
   static bool is_pointer_field(t_field* tfield, bool in_container = false);
 
+  std::string indent_str() const {
+    return "\t";
+  }
+
 private:
   std::string gen_package_prefix_;
   std::string gen_thrift_import_;


### PR DESCRIPTION
This is a "trivial" change for go compiler to always use the combination of indent_up, indent_down, and indent, over manual indentation (by adding 2 spaces at the beginning of the string). Also change go compiler's indent_str to tab over 2 spaces.

While I'm here, also made a few minor tweaks on generated go code.
