### PR TITLE
Remove deprecated has_rdoc from gemspec

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
   s.extensions  = ['ext/extconf.rb']
 
-  s.has_rdoc      = true
   s.rdoc_options  = %w[--line-numbers --inline-source --title Thrift --main README]
 
   s.rubyforge_project = 'thrift'


### PR DESCRIPTION
This change simply removes the deprecated `has_rdoc` usage from the gemspec. Due to this deprecated usage end users will see the following message in their console at times. Would be ideal if we can remove this noise.

```console
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /Users/larouxn/.gem/ruby/ruby-3.3.0/bundler/gems/thrift-b109bdd1a4aa/lib/rb/thrift.gemspec:15.
```

Looks like it has been deprecated for at least 5 years based on tickets raised about this back in ~2018.

<img width="1017" alt="Screenshot 2024-05-17 at 11 08 56" src="https://github.com/apache/thrift/assets/1557529/0f70e5eb-d1c5-4bc7-bc52-dcb26f963a92">

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) - I did not create a ticket.
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"? - N/A, see above.
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.