### PR TITLE
THRIFT-5787: restoring binary compatibility of Factory constructor

### DIFF
--- a/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
@@ -475,7 +475,13 @@ namespace Thrift.Protocol
             protected readonly bool StrictRead;
             protected readonly bool StrictWrite;
 
-            public Factory(bool strictRead = false, bool strictWrite = true)
+            // emtpy constructor preserves binary compatibility with v19.0 and lower versions of this class
+            public Factory()
+                : this(false, true)
+            {
+            }
+
+            public Factory(bool strictRead, bool strictWrite)
             {
                 StrictRead = strictRead;
                 StrictWrite = strictWrite;


### PR DESCRIPTION
The factory constructor needs to have an addition method to maintain binary compatibility as the runtime still sees the parameters added to the constructor

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
