### PR TITLE
fix(php): TProtocol::skip fix parameter type

### DIFF
--- a/lib/php/lib/Protocol/TProtocol.php
+++ b/lib/php/lib/Protocol/TProtocol.php
@@ -181,7 +181,7 @@ abstract class TProtocol
      * The skip function is a utility to parse over unrecognized date without
      * causing corruption.
      *
-     * @param TType $type What type is it
+     * @param int $type What type is it
      */
     public function skip($type)
     {


### PR DESCRIPTION


<!-- Explain the changes in the pull request below: -->
We can't use `TType` as a type by itself, because it isn't enum, so the type of parameter should be `int`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

[skip ci]