### PR TITLE
go: Fix indentation in compiler

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1209,19 +1209,25 @@ void t_go_generator::generate_go_struct_initializer(ostream& out,
                                                     t_struct* tstruct,
                                                     bool is_args_or_result) {
   out << publicize(type_name(tstruct), is_args_or_result) << "{";
+  indent_up();
   const vector<t_field*>& members = tstruct->get_members();
+  bool empty = true;
   for (auto member : members) {
     bool pointer_field = is_pointer_field(member);
     string publicized_name;
     t_const_value* def_value;
     get_publicized_name_and_def_value(member, &publicized_name, &def_value);
     if (!pointer_field && def_value != nullptr && !omit_initialization(member)) {
+      empty = false;
       out << '\n' << indent() << publicized_name << ": "
-          << render_field_initial_value(member, member->get_name(), pointer_field) << ","
-          << '\n';
+          << render_field_initial_value(member, member->get_name(), pointer_field) << ",";
     }
   }
 
+  indent_down();
+  if (!empty) {
+    out << '\n' << indent();
+  }
   out << "}" << '\n';
 }
 


### PR DESCRIPTION
This fixes a small case I missed in 4930caca.

Before:

    func NewFoo() *Foo {
        return &Foo{
        DefDef: 10,

        DefOpt: 11,
    }
    }

After:

    func NewFoo() *Foo {
        return &Foo{
            DefDef: 10,
            DefOpt: 11,
        }
    }

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
