### PR TITLE
fix: make timeouterror more compatible with future versions of Python

### DIFF
--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -151,7 +151,8 @@ class TSocket(TSocketBase):
     def read(self, sz):
         try:
             buff = self.handle.recv(sz)
-        except socket.timeout as e:
+        # TODO: remove socket.timeout when 3.10 becomes the earliest version of python supported.
+        except (socket.timeout, TimeoutError) as e:
             raise TTransportException(type=TTransportException.TIMED_OUT, message="read timeout", inner=e)
         except socket.error as e:
             if (e.args[0] == errno.ECONNRESET and


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

see reason in https://github.com/apache/thrift/pull/2961

> starting from python 3.10, this is a deprecated alias to TimeoutError: https://docs.python.org/3.12/library/socket.html#socket.timeout
> while TimeoutError also exists in 3.8 (the earliest version of python still supported): https://docs.python.org/3.8/library/exceptions.html#TimeoutError
> so I wonder if we should be more future proof and handle both socket.timeout and TimeoutError here, and then we can drop socket.timeout when 3.10 becomes the earliest version of python supported.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
