### PR TITLE
netstd: fix syntax error in deepcopy() method for v0.20.0

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -1103,7 +1103,7 @@ void t_netstd_generator::generate_netstd_deepcopy_method(ostream& out, t_struct*
       out << endl << indent() << "{" << endl;
       indent_up();
     } else {
-      out << endl;
+      out << ";" << endl;
     }
 
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -77,6 +77,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5253.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5382.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./git-pr2993.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -77,7 +77,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5253.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5382.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./git-pr2993.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd -r ./git-pr2993.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/git-pr2993.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/git-pr2993.thrift
@@ -1,0 +1,8 @@
+namespace * deepcopy_syntax
+
+struct CIELab
+{
+  1: double L;
+  2: double a;
+  3: double b;
+}


### PR DESCRIPTION
The ending ";" was missing when creating instance of class which caused a syntax error.

This was introduced when adding .net8 support ([4115e952b5bed2887113af053b63acd3a03c6e19](https://github.com/apache/thrift/commit/4115e952b5bed2887113af053b63acd3a03c6e19#diff-171cba564f81e70ad05350c5b6be4131a21c4a4c0b1f608954d9cb3f55ffc6deR1100))

example of generated broken code

~~~
    public CIELab DeepCopy()
    {
      var tmp5 = new CIELab()    // <----- here the closing ";" is missing
      if(__isset.L)
      {
        tmp5.L = this.L;
      }
~~~

This issue was fixed in master inside 4f1839575f3af168f960110414114255bd344203. This PR only picks the relevant fix into v0.20.0 without adding the feature of this commit. 