### PR TITLE
make GitHubActions also run tests for netstd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-php/with-php/' | sed 's/without-php_extension/with-php_extension/' )
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: thrift-compiler
           path: compiler/cpp


### PR DESCRIPTION
Add a job to build and run tests for netstd. Also upload the binaries as artifact.
This gives basic testing, but leaves including to cross-test for the future.

Most job-steps are copied from the other jobs.

In relation to #2994 it already uses artifact-action v4 and ubuntu-22.04 (ubuntu-20.04 has issues with dotnet-support).