### PR TITLE
THRIFT-5794: Add tests

### DIFF
--- a/build/veralign.sh
+++ b/build/veralign.sh
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -71,6 +71,7 @@ FILES[lib/js/src/thrift.js]=simpleReplace
 FILES[lib/lua/Thrift.lua]=simpleReplace
 FILES[lib/netstd/Tests/Thrift.Tests/Thrift.Tests.csproj]=simpleReplace
 FILES[lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj]=simpleReplace
+FILES[lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj]=simpleReplace
 FILES[lib/netstd/Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj]=simpleReplace
 FILES[lib/netstd/Thrift/Properties/AssemblyInfo.cs]=simpleReplace
 FILES[lib/netstd/Thrift/Thrift.csproj]=simpleReplace

--- a/debian/copyright
+++ b/debian/copyright
@@ -74,6 +74,8 @@ under the Apache 2.0 License:
   lib/netstd/Thrift/Transport/TTransportFactory.cs
   lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Properties/AssemblyInfo.cs
   lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+  lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj
+  lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Properties/AssemblyInfo.cs
   lib/rb/lib/thrift.rb
   lib/st/README.md
   lib/st/thrift.st

--- a/lib/netstd/Makefile.am
+++ b/lib/netstd/Makefile.am
@@ -17,13 +17,14 @@
 # under the License.
 #
 
-SUBDIRS = . 
+SUBDIRS = .
 
 all-local:
 	$(DOTNETCORE) build -c Release
 
 check-local:
 	$(DOTNETCORE) test Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+	$(DOTNETCORE) test Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj
 	$(DOTNETCORE) test Tests/Thrift.Tests/Thrift.Tests.csproj
 	$(DOTNETCORE) test Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
 
@@ -38,6 +39,8 @@ clean-local:
 	$(RM) -r Tests/Thrift.IntegrationTests/obj
 	$(RM) -r Tests/Thrift.PublicInterfaces.Compile.Tests/bin
 	$(RM) -r Tests/Thrift.PublicInterfaces.Compile.Tests/obj
+	$(RM) -r Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/bin
+	$(RM) -r Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/obj
 
 distdir:
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am
@@ -53,6 +56,8 @@ EXTRA_DIST = \
 	Tests/Thrift.PublicInterfaces.Compile.Tests/optional_required_default.thrift \
 	Tests/Thrift.PublicInterfaces.Compile.Tests/Properties/AssemblyInfo.cs \
 	Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj \
+	Tests/Thrift.PublicInterfaces.Compile-C#12.Tests \
+	Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj \
 	Tests/Thrift.Tests/Collections \
 	Tests/Thrift.Tests/DataModel \
 	Tests/Thrift.Tests/Protocols \
@@ -77,4 +82,4 @@ EXTRA_DIST = \
 	build.sh \
 	runtests.cmd \
 	runtests.sh
-	
+

--- a/lib/netstd/README.md
+++ b/lib/netstd/README.md
@@ -5,7 +5,7 @@ Thrift client library for Microsoft .NET Standard
 # Build the library
 
 ## How to build on Windows
-- Get Thrift IDL compiler executable, add to some folder and add path to this folder into PATH variable
+- Get Thrift IDL compiler executable, add to some folder and add path to this folder into PATH variable. Or build from source by using the cmake target "copy-thrift-compiler", which places the binary to a place there it's found.
 - Open the Thrift.sln project with Visual Studio and build.
 or 
 - Build with scripts

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/GlobalSuppressions.cs
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/GlobalSuppressions.cs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1822", Justification = "<Ausstehend>", Scope = "module")]
+[assembly: SuppressMessage("Style", "IDE0090", Justification = "<Ausstehend>", Scope = "module")]

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Impl/Thrift5253/MyService.cs
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Impl/Thrift5253/MyService.cs
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift5253;
+
+namespace Thrift.PublicInterfaces.Compile.Tests.Impl.Thrift5253
+{
+    class MyServiceImpl : MyService.IAsync
+    {
+        public Task<AsyncProcessor> AsyncProcessor_(AsyncProcessor? input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new AsyncProcessor() { Foo = input?.Foo ?? 0 });
+        }
+
+        public Task<BrokenResult> Broken(BrokenArgs? input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new BrokenResult() { Foo = input?.Foo ?? 0 });
+        }
+
+        public Task<Client> Client_(Client? input, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            return Task.FromResult(new Client() { Foo = input?.Foo ?? 0 });
+        }
+
+        public Task<IAsync> IAsync_(IAsync? input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new IAsync() { Foo = input?.Foo ?? 0 });
+        }
+
+        public Task<InternalStructs> InternalStructs_(InternalStructs? input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new InternalStructs() { Foo = input?.Foo ?? 0 });
+        }
+
+        public Task TestAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task TestXsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<WorksRslt> Works(WorksArrrgs? input, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new WorksRslt() { Foo = input?.Foo ?? 0 });
+        }
+    }
+}

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Properties/AssemblyInfo.cs
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("The Apache Software Foundation")]
+[assembly: AssemblyProduct("Thrift")]
+[assembly: AssemblyCopyright("The Apache Software Foundation")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("d0d3706b-fed5-4cf5-b984-04f448de9d7b")]

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile-C#12.Tests/Thrift.PublicInterfaces.Compile-C#12.Tests.csproj
@@ -1,0 +1,85 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Licensed to the Apache Software Foundation(ASF) under one
+    or more contributor license agreements.See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+  	  http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+  -->
+
+  <PropertyGroup>
+    <ThriftVersion>0.21.0</ThriftVersion>
+    <ThriftVersionOutput>Thrift version $(ThriftVersion)</ThriftVersionOutput>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latestMajor</LangVersion>
+    <Version>$(ThriftVersion).0</Version>
+    <AssemblyName>Thrift.PublicInterfaces.Compile-C#12.Tests</AssemblyName>
+    <PackageId>Thrift.PublicInterfaces.Compile-C#12.Tests</PackageId>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Thrift/Thrift.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
+  </ItemGroup>
+
+  <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">
+    <CreateProperty Condition="'$(OS)' == 'Windows_NT'" Value=".exe">
+      <Output TaskParameter="Value" PropertyName="EXECUTABLE_SUFFIX" />
+    </CreateProperty>
+    <!-- Check on the path -->
+    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
+    </Exec>
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="which thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
+    </Exec>
+    <!-- Check in the current directory -->
+    <CreateProperty Condition="Exists('thrift$(EXECUTABLE_SUFFIX)')" Value="thrift$(EXECUTABLE_SUFFIX)">
+      <Output TaskParameter="Value" PropertyName="PathToThrift" />
+    </CreateProperty>
+    <!-- Check for the root projects output -->
+    <CreateProperty Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)')" Value="$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)">
+      <Output TaskParameter="Value" PropertyName="PathToThrift" />
+    </CreateProperty>
+    <Error Condition="!Exists('$(PathToThrift)')" Text="Thrift executable could not be found." />
+    <!-- Make sure the thrift version found is the same as the projects version -->
+    <Exec Command="$(PathToThrift) -version" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ThriftBinaryVersion" />
+    </Exec>
+    <Error Condition="$('$(ThriftBinaryVersion)'::StartsWith('$(ThriftVersionOutput)')) == true" Text="Thrift version returned: '$(ThriftBinaryVersion)' is not equal to the projects version '$(ThriftVersionOutput)'." />
+    <Message Importance="high" Text="Generating tests with thrift binary: '$(PathToThrift)'" />
+    <!-- Generate the thrift test files -->
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/CassandraTest.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/optional_required_default.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/name_conflicts.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../../../../test/ThriftTest.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../../../../contrib/fb303/if/fb303.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/Thrift5253.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/Thrift5320.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../Thrift.PublicInterfaces.Compile.Tests/Thrift5382.thrift" />
+  </Target>
+
+</Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -46,6 +46,9 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">
+    <CreateProperty Condition="'$(OS)' == 'Windows_NT'" Value=".exe">
+      <Output TaskParameter="Value" PropertyName="EXECUTABLE_SUFFIX" />
+    </CreateProperty>
     <!-- Check on the path -->
     <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
@@ -54,11 +57,11 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
     </Exec>
     <!-- Check in the current directory -->
-    <CreateProperty Condition="Exists('thrift')" Value="thrift">
+    <CreateProperty Condition="Exists('thrift$(EXECUTABLE_SUFFIX)')" Value="thrift$(EXECUTABLE_SUFFIX)">
       <Output TaskParameter="Value" PropertyName="PathToThrift" />
     </CreateProperty>
     <!-- Check for the root projects output -->
-    <CreateProperty Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift')" Value="$(ProjectDir)/../../../../compiler/cpp/thrift">
+    <CreateProperty Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)')" Value="$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)">
       <Output TaskParameter="Value" PropertyName="PathToThrift" />
     </CreateProperty>
     <Error Condition="!Exists('$(PathToThrift)')" Text="Thrift executable could not be found." />

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,10 +47,10 @@
 
   <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">
     <!-- Check on the path -->
-    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true">
+    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
     </Exec>
-    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="which thrift || true" ConsoleToMSBuild="true">
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="which thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
     </Exec>
     <!-- Check in the current directory -->

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -72,14 +72,14 @@
     <Error Condition="$('$(ThriftBinaryVersion)'::StartsWith('$(ThriftVersionOutput)')) == true" Text="Thrift version returned: '$(ThriftBinaryVersion)' is not equal to the projects version '$(ThriftVersionOutput)'." />
     <Message Importance="high" Text="Generating tests with thrift binary: '$(PathToThrift)'" />
     <!-- Generate the thrift test files -->
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./CassandraTest.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./optional_required_default.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./name_conflicts.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../../../../test/ThriftTest.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./../../../../contrib/fb303/if/fb303.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5253.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5320.thrift" />
-    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5382.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./CassandraTest.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./optional_required_default.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./name_conflicts.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./../../../../test/ThriftTest.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./../../../../contrib/fb303/if/fb303.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5253.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5320.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial -r ./Thrift5382.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Thrift.sln
+++ b/lib/netstd/Thrift.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29905.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{ED5A45B0-07D1-4507-96B7-83FBD3D031CA}"
 EndProject
@@ -11,6 +11,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Thrift.Tests", "Tests\Thrift.Tests\Thrift.Tests.csproj", "{0790D388-1A3C-4423-8CF2-C97074A8B68B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Thrift.PublicInterfaces.Compile.Tests", "Tests\Thrift.PublicInterfaces.Compile.Tests\Thrift.PublicInterfaces.Compile.Tests.csproj", "{A6AE021D-61CB-4D84-A103-0B663C62AE2C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Thrift.PublicInterfaces.Compile-C#12.Tests", "Tests\Thrift.PublicInterfaces.Compile-C#12.Tests\Thrift.PublicInterfaces.Compile-C#12.Tests.csproj", "{A47C249D-3CE9-417E-A3BF-B45B90C12989}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{BF7B896B-8BB6-447C-84F8-26871882A14A}"
 EndProject
@@ -86,6 +88,18 @@ Global
 		{D0559DFF-6632-446C-9EFC-C750DA20B1D9}.Release|x64.Build.0 = Release|Any CPU
 		{D0559DFF-6632-446C-9EFC-C750DA20B1D9}.Release|x86.ActiveCfg = Release|Any CPU
 		{D0559DFF-6632-446C-9EFC-C750DA20B1D9}.Release|x86.Build.0 = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|x64.Build.0 = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Debug|x86.Build.0 = Debug|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|x64.ActiveCfg = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|x64.Build.0 = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|x86.ActiveCfg = Release|Any CPU
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -95,6 +109,7 @@ Global
 		{0790D388-1A3C-4423-8CF2-C97074A8B68B} = {ED5A45B0-07D1-4507-96B7-83FBD3D031CA}
 		{A6AE021D-61CB-4D84-A103-0B663C62AE2C} = {ED5A45B0-07D1-4507-96B7-83FBD3D031CA}
 		{D0559DFF-6632-446C-9EFC-C750DA20B1D9} = {BF7B896B-8BB6-447C-84F8-26871882A14A}
+		{A47C249D-3CE9-417E-A3BF-B45B90C12989} = {ED5A45B0-07D1-4507-96B7-83FBD3D031CA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FD20BC4A-0109-41D8-8C0C-893E784D7EF9}


### PR DESCRIPTION
Based on Thrift5794 I worked on improving CI-testing for netstd. As sideeffect I found, that the thrift-exe is not found on windows, which is fixed by commit
* "make MSBuild ignore errors when thrift-binary is not found and continue search"
* "include .exe extension, when looking for compiler"

To address Thrift5794 this PR  switches to use default C# languagelevel for the `Thrift.PublicInterfaces.Compile.Tests`  (dropping "net8" option from calling the compiler). To keep testing with "net8 / C#12" a 2nd project `Thrift.PublicInterfaces.Compile-C#12.Tests` is added, which keeps using the "net8" option.
The Thrift-files are shared between both projects, to reduce amount of duplicated code.

--- 
Alternative ways I tried/had in mind:
* generating code for all language-levels inside one project (generate to different folders inside the project): will not work, as it causes double definitions of generated symbols
* having the test-job changing the code to run for all language-levels: feels ugly and hard to follow. Github tests can for sure do this way, but might be pain when testing locally. (something like "for {default|net6|net8} in LANG: sed /var/$LANG/ *.cssproj")