### PR TITLE
THRIFT-5794 testcase 

### DIFF
--- a/lib/netstd/Makefile.am
+++ b/lib/netstd/Makefile.am
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-SUBDIRS = . 
+SUBDIRS = .
 
 all-local:
 	$(DOTNETCORE) build -c Release
@@ -77,4 +77,3 @@ EXTRA_DIST = \
 	build.sh \
 	runtests.cmd \
 	runtests.sh
-	

--- a/lib/netstd/README.md
+++ b/lib/netstd/README.md
@@ -5,13 +5,14 @@ Thrift client library for Microsoft .NET Standard
 # Build the library
 
 ## How to build on Windows
-- Get Thrift IDL compiler executable, add to some folder and add path to this folder into PATH variable
+- Get Thrift IDL compiler executable, add to some folder and add path to this folder into PATH variable. 
+- Alternatively, build from source by using the cmake target "copy-thrift-compiler", which places the binary to a suitable place.
 - Open the Thrift.sln project with Visual Studio and build.
 or 
 - Build with scripts
 
 ## How to build on Unix/Linux
-- Ensure you have .NET Core SDK 3.1 (LTS) installed, or use the [Ubuntu docker image](../../build/docker/README.md)
+- Ensure you have a suitable .NET Core SDK installed, or use the [Ubuntu docker image](../../build/docker/README.md)
 - Follow common automake build practice: `./ bootstrap && ./ configure && make`
 
 ## Known issues

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,19 +46,22 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="_GenerateRestoreProjectSpec;Restore;Compile">
+    <CreateProperty Condition="'$(OS)' == 'Windows_NT'" Value=".exe">
+      <Output TaskParameter="Value" PropertyName="EXECUTABLE_SUFFIX" />
+    </CreateProperty>
     <!-- Check on the path -->
-    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true">
+    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="where thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
     </Exec>
-    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="which thrift || true" ConsoleToMSBuild="true">
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="which thrift" ConsoleToMSBuild="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PathToThrift" />
     </Exec>
     <!-- Check in the current directory -->
-    <CreateProperty Condition="Exists('thrift')" Value="thrift">
+    <CreateProperty Condition="Exists('thrift$(EXECUTABLE_SUFFIX)')" Value="thrift$(EXECUTABLE_SUFFIX)">
       <Output TaskParameter="Value" PropertyName="PathToThrift" />
     </CreateProperty>
     <!-- Check for the root projects output -->
-    <CreateProperty Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift')" Value="$(ProjectDir)/../../../../compiler/cpp/thrift">
+    <CreateProperty Condition="Exists('$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)')" Value="$(ProjectDir)/../../../../compiler/cpp/thrift$(EXECUTABLE_SUFFIX)">
       <Output TaskParameter="Value" PropertyName="PathToThrift" />
     </CreateProperty>
     <Error Condition="!Exists('$(PathToThrift)')" Text="Thrift executable could not be found." />
@@ -78,6 +81,10 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5795.thrift" />
+    <!-- special options (see ticket) -->
+    <Exec Command="$(PathToThrift) -gen netstd                       -r ./Thrift5794-netstd.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:net6                  -r ./Thrift5794-net6.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:net8                  -r ./Thrift5794-net8.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-net6.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-net6.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-5794 uncompilable code generated w/o net8 option
+
+namespace * Thrift5794.net6
+
+struct foo {
+  1: double a;
+  2: double b;
+  3: double c;
+}
+
+struct bar {
+  1: required double a;
+  2: required double b;
+  3: double c;
+}
+

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-net8.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-net8.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-5794 uncompilable code generated w/o net8 option
+
+namespace * Thrift5794.net8
+
+struct foo {
+  1: double a;
+  2: double b;
+  3: double c;
+}
+
+struct bar {
+  1: required double a;
+  2: required double b;
+  3: double c;
+}
+

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-netstd.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5794-netstd.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-5794 uncompilable code generated w/o net8 option
+
+namespace * Thrift5794.netstd
+
+struct foo {
+  1: double a;
+  2: double b;
+  3: double c;
+}
+
+struct bar {
+  1: required double a;
+  2: required double b;
+  3: double c;
+}
+

--- a/lib/netstd/Thrift.sln
+++ b/lib/netstd/Thrift.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29905.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{ED5A45B0-07D1-4507-96B7-83FBD3D031CA}"
 EndProject


### PR DESCRIPTION
* JensG: added testcase for THRIFT-5794 + reverted most of the changes

----
### from https://github.com/apache/thrift/pull/2999:

netstd: tests: also run tests with "net8" option of thrift-compiler

Add a project which is a copy of the PublicInterfaces.Compile.Tests, but use the "net8" compiler option to generate code that uses C#12-features.
Use the thrift-files from the existing test, to avoid code-duplication.
This is effectively the tests that are run till v0.20.0.

netstd: use default CSharp-language level of compiler instead of using Net8/C#12 for PublicInterfaces.Compile.Tests

netstd: update readme for local building

netstd: tests: include .exe extension, when looking for compiler

It will not be found without this and causes na error and abort.

netstd: tests: make MSBuild ignore errors when thrift-binary is not found and continue search

Windows copmmand "where" errors when thrift-binary is not found in PATH. This will cause MSBuild to abort instead of searching in alternative paths.
So just ignore potential erros and make it go on. Adapt this also for Unix "which", so we don't need to suppress the returncode.
