### PR TITLE
THRIFT-5795 namespace not properly escaped

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -314,7 +314,20 @@ void t_netstd_generator::start_netstd_namespace(ostream& out)
 {
     if (!namespace_name_.empty())
     {
-        out << "namespace " << namespace_name_ << '\n';
+        std::string normalized;
+        
+        const char* delim = ".";
+        char* str = strdup(namespace_name_.c_str());
+        char* next = strtok(str, delim);
+        while( next != NULL) {
+            if( normalized.length() > 0) {
+                normalized += ".";
+            }
+            normalized += normalize_name(next,false);
+            next = strtok(NULL, delim);
+        }
+        
+        out << "namespace " << normalized << '\n';
         scope_up(out);
     }
 }

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -77,6 +77,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5253.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5382.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ./Thrift5795.thrift" />
   </Target>
 
 </Project>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5795.thrift
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift5795.thrift
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-5795 namespace not properly escaped
+
+namespace * Thrift5795.default
+
+
+struct foo {
+  1: double bar;
+}
+


### PR DESCRIPTION
Client: netstd
Patch: Jens Geyer
