### PR TITLE
THRIFT-5272 printTo does not properly handle i8 datatypes

### DIFF
--- a/lib/cpp/src/thrift/TToString.h
+++ b/lib/cpp/src/thrift/TToString.h
@@ -45,6 +45,14 @@ std::string to_string(const T& t) {
   return o.str();
 }
 
+// special handling of i8 datatypes (THRIFT-5272)
+inline std::string to_string(const int8_t& t) {
+  std::ostringstream o;
+  o.imbue(default_locale);
+  o << static_cast<int>(t);
+  return o.str();
+}
+
 // TODO: replace the computations below with std::numeric_limits::max_digits10 once C++11
 // is enabled.
 inline std::string to_string(const float& t) {

--- a/lib/cpp/src/thrift/TUuid.h
+++ b/lib/cpp/src/thrift/TUuid.h
@@ -27,6 +27,7 @@
 #endif // THRIFT_TUUID_SUPPORT_BOOST_UUID
 
 #include <algorithm>
+#include <sstream>
 
 namespace apache {
 namespace thrift {

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -47,6 +47,8 @@ set(testgencpp_SOURCES
     gen-cpp/OneWayService.h
     gen-cpp/TypedefTest_types.cpp
     gen-cpp/TypedefTest_types.h
+    gen-cpp/Thrift5272_types.cpp
+    gen-cpp/Thrift5272_types.h
     ThriftTest_extras.cpp
     DebugProtoTest_extras.cpp
 )
@@ -83,6 +85,7 @@ set(UnitTest_SOURCES
     TServerTransportTest.cpp
     ThrifttReadCheckTests.cpp
     TUuidTest.cpp
+    Thrift5272.cpp
 )
 
 add_executable(UnitTests ${UnitTest_SOURCES})
@@ -369,6 +372,8 @@ endif()
 #
 # Common thrift code generation rules
 #
+# files from /test
+#
 
 add_custom_command(OUTPUT gen-cpp/AnnotationTest_constants.cpp
                           gen-cpp/AnnotationTest_constants.h
@@ -407,8 +412,14 @@ add_custom_command(OUTPUT gen-cpp/SecondService.cpp gen-cpp/ThriftTest_constants
     COMMAND ${THRIFT_COMPILER} --gen cpp ${PROJECT_SOURCE_DIR}/test/ThriftTest.thrift
 )
 
+# files from /lib/cpp/test
+
 add_custom_command(OUTPUT gen-cpp/OneWayService.cpp gen-cpp/OneWayTest_types.h gen-cpp/OneWayService.h
     COMMAND ${THRIFT_COMPILER} --gen cpp ${CMAKE_CURRENT_SOURCE_DIR}/OneWayTest.thrift
+)
+
+add_custom_command(OUTPUT gen-cpp/Thrift5272_types.cpp gen-cpp/Thrift5272_types.h
+    COMMAND ${THRIFT_COMPILER} --gen cpp ${CMAKE_CURRENT_SOURCE_DIR}/Thrift5272.thrift
 )
 
 add_custom_command(OUTPUT gen-cpp/ChildService.cpp gen-cpp/ChildService.h gen-cpp/ParentService.cpp gen-cpp/ParentService.h gen-cpp/proc_types.cpp gen-cpp/proc_types.h

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -24,12 +24,13 @@ BUILT_SOURCES = gen-cpp/AnnotationTest_types.h \
                 gen-cpp/OptionalRequiredTest_types.h \
                 gen-cpp/Recursive_types.h \
                 gen-cpp/ThriftTest_types.h \
+                gen-cpp/Thrift5272_types.h \
                 gen-cpp/TypedefTest_types.h \
                 gen-cpp/ChildService.h \
                 gen-cpp/EmptyService.h \
                 gen-cpp/ParentService.h \
-		gen-cpp/OneWayTest_types.h \
-		gen-cpp/OneWayService.h \
+                gen-cpp/OneWayTest_types.h \
+                gen-cpp/OneWayService.h \
                 gen-cpp/proc_types.h
 
 noinst_LTLIBRARIES = libtestgencpp.la libprocessortest.la
@@ -50,6 +51,8 @@ nodist_libtestgencpp_la_SOURCES = \
 	gen-cpp/ThriftTest_types.h \
 	gen-cpp/ThriftTest_constants.cpp \
 	gen-cpp/ThriftTest_constants.h \
+	gen-cpp/Thrift5272_types.cpp \
+	gen-cpp/Thrift5272_types.h \
 	gen-cpp/TypedefTest_types.cpp \
 	gen-cpp/TypedefTest_types.h \
 	gen-cpp/OneWayService.cpp \
@@ -104,7 +107,7 @@ check_PROGRAMS = \
 	OpenSSLManualInitTest \
 	EnumTest \
 	RenderedDoubleConstantsTest \
-        AnnotationTest
+	AnnotationTest
 
 if AMX_HAVE_LIBEVENT
 noinst_PROGRAMS += \
@@ -134,6 +137,7 @@ UnitTests_SOURCES = \
 	TServerTransportTest.cpp \
 	TTransportCheckThrow.h \
 	ThrifttReadCheckTests.cpp \
+	Thrift5272.cpp \
 	TUuidTest.cpp
 
 UnitTests_LDADD = \
@@ -409,6 +413,8 @@ OpenSSLManualInitTest_LDADD = \
 #
 # Common thrift code generation rules
 #
+# files from /test
+#
 
 gen-cpp/AnnotationTest_constants.cpp gen-cpp/AnnotationTest_constants.h gen-cpp/AnnotationTest_types.cpp gen-cpp/AnnotationTest_types.h: $(top_srcdir)/test/AnnotationTest.thrift
 	$(THRIFT) --gen cpp $<
@@ -418,7 +424,6 @@ gen-cpp/DebugProtoTest_types.cpp gen-cpp/DebugProtoTest_types.h gen-cpp/EmptySer
 
 gen-cpp/DoubleConstantsTest_constants.cpp gen-cpp/DoubleConstantsTest_constants.h: $(top_srcdir)/test/DoubleConstantsTest.thrift
 	$(THRIFT) --gen cpp $<
-
 
 gen-cpp/EnumTest_types.cpp gen-cpp/EnumTest_types.h: $(top_srcdir)/test/EnumTest.thrift
 	$(THRIFT) --gen cpp $<
@@ -438,7 +443,12 @@ gen-cpp/Service.cpp gen-cpp/StressTest_types.cpp: $(top_srcdir)/test/StressTest.
 gen-cpp/SecondService.cpp gen-cpp/ThriftTest_constants.cpp gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_types.h: $(top_srcdir)/test/ThriftTest.thrift
 	$(THRIFT) --gen cpp $<
 
+# files from /lib/cpp/test
+
 gen-cpp/OneWayService.cpp gen-cpp/OneWayTest_types.h gen-cpp/OneWayService.h: OneWayTest.thrift
+	$(THRIFT) --gen cpp $<
+
+gen-cpp/Thrift5272_types.cpp gen-cpp/Thrift5272_types.h: Thrift5272.thrift
 	$(THRIFT) --gen cpp $<
 
 gen-cpp/ChildService.cpp gen-cpp/ChildService.h gen-cpp/ParentService.cpp gen-cpp/ParentService.h gen-cpp/proc_types.cpp gen-cpp/proc_types.h: processor/proc.thrift

--- a/lib/cpp/test/Thrift5272.cpp
+++ b/lib/cpp/test/Thrift5272.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <sstream>
+#include "gen-cpp/Thrift5272_types.h"
+
+BOOST_AUTO_TEST_SUITE(Thrift5272Test)
+
+namespace utf = boost::unit_test;
+
+// Define this env var to enable some logging (in case you need to debug)
+#undef ENABLE_STDERR_LOGGING
+
+using namespace thrift5272;
+
+
+BOOST_AUTO_TEST_CASE( printTo )
+{
+  std::stringstream ss;
+  std::string text;
+  Meta a = Meta();
+
+  a.printTo(ss);
+  text = ss.str();
+  BOOST_TEST(text == "Meta(byte_type=0, i8_type=0, i16_type=0, i32_type=0, i64_type=0)");
+
+  ss.clear();
+  ss.str("");
+  a.byte_type = 50;
+  a.i8_type = 50;
+  a.i16_type = 50;
+  a.i32_type = 50;
+  a.i64_type = 50;
+  a.printTo(ss);
+  text = ss.str();
+  BOOST_TEST(text == "Meta(byte_type=50, i8_type=50, i16_type=50, i32_type=50, i64_type=50)");
+
+  ss.clear();
+  ss.str("");
+  a.byte_type = 127;
+  a.i8_type = 127;
+  a.i16_type = 127;
+  a.i32_type = 127;
+  a.i64_type = 127;
+  a.printTo(ss);
+  text = ss.str();
+  BOOST_TEST(text == "Meta(byte_type=127, i8_type=127, i16_type=127, i32_type=127, i64_type=127)");
+}
+
+BOOST_AUTO_TEST_CASE( ostream_handle_int8_to_str )
+{
+  int8_t t = 65;
+  std::ostringstream o;
+  o << t;
+  BOOST_TEST(o.str() != "65", "ostingstream handles int8 correctly. let's drop specialization for Thrift5272 from TToString.h.");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/Thrift5272.thrift
+++ b/lib/cpp/test/Thrift5272.thrift
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp thrift5272
+
+// a minimal Thrift struct, to test Trift5272.cpp
+struct Meta
+{
+  1: byte byte_type,  // keep using byte, even it'S just an alias for i8 (THRIFT-5153)
+  2: i8   i8_type,
+  3: i16  i16_type,
+  4: i32  i32_type,
+  5: i64  i64_type,
+}

--- a/lib/cpp/test/ThrifttReadCheckTests.cpp
+++ b/lib/cpp/test/ThrifttReadCheckTests.cpp
@@ -19,7 +19,6 @@
 
 #define  MAX_MESSAGE_SIZE  2
 
-#include <boost/test/auto_unit_test.hpp>
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <climits>


### PR DESCRIPTION
This fixes [Thift5272](https://issues.apache.org/jira/browse/THRIFT-5272). Using the patch provided with the issue and adding a test for it.
  
There is one commit for the test, which includes related build-files (Makefile + CMake). So you can see the test is actually detecting the issue.
There is 2nd commit for the fix, this also makes the test pass.
The 3rd commit is just updating a deprecated and a missing header

If needed I can squash commits of test and fix.