### PR TITLE
CI/appveyor: fix download location for flex-sdk

### DIFF
--- a/build/appveyor/MSVC-appveyor-full.bat
+++ b/build/appveyor/MSVC-appveyor-full.bat
@@ -137,7 +137,7 @@ pip.exe ^
 
 :: Adobe Flex SDK 4.6 for ActionScript
 MKDIR "C:\Adobe\Flex\SDK\4.6" || EXIT /B
-appveyor DownloadFile http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip -FileName C:\Adobe\Flex\SDK\4.6\SDK.zip || EXIT /B
+appveyor DownloadFile https://fpdownload.adobe.com/pub/flex/sdk/builds/flex4.6/flex_sdk_4.6.0.23201B.zip -FileName C:\Adobe\Flex\SDK\4.6\SDK.zip || EXIT /B
 CD "C:\Adobe\Flex\SDK\4.6" || EXIT /B
 7z x SDK.zip || EXIT /B
 SETX FLEX_HOME "C:\Adobe\Flex\SDK\4.6"


### PR DESCRIPTION
Current build seem to fail on downloading flex-SDK. Use new location according to https://stackoverflow.com/a/21269691/19761878
