### PR TITLE
lib: py: remove distutils in favor of setuptools

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -25,8 +25,8 @@ try:
 except Exception:
     from distutils.core import setup, Extension
 
-from distutils.command.build_ext import build_ext
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+from setuptools.command.build_ext import build_ext
+from setuptools.errors import CCompilerError, ExecError, PlatformError
 
 # Fix to build sdist under vagrant
 import os
@@ -41,7 +41,7 @@ if sys.platform == 'win32':
     include_dirs.append('compat/win32')
     ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError, IOError)
 else:
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+    ext_errors = (CCompilerError, ExecError, PlatformError)
 
 
 class BuildFailed(Exception):
@@ -52,7 +52,7 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError:
+        except PlatformError:
             raise BuildFailed()
 
     def build_extension(self, ext):


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
As distutils is removed in python 3.12, and setuptools provides the same interface, it can be switched in place with only minor changes. This allows using the thrift bindings on versions of Python 3.12 or greater, and in python environments without distutils installed(such as NixOS, which does not expose setuptools' internal distutils distribution)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ x Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.