### PR TITLE
Switch from `logger.warn` to `logger.warning`

### DIFF
--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -397,8 +397,8 @@ class TSSLServerSocket(TSocket.TServerSocket, TSSLBase):
                 self._validate_callback(client.peercert, addr[0])
                 client.is_valid = True
             except Exception:
-                logger.warn('Failed to validate client certificate address: %s',
-                            addr[0], exc_info=True)
+                logger.warning('Failed to validate client certificate address: %s',
+                               addr[0], exc_info=True)
                 client.close()
                 plain_client.close()
                 return None

--- a/lib/py/src/transport/TSocket.py
+++ b/lib/py/src/transport/TSocket.py
@@ -208,7 +208,7 @@ class TServerSocket(TSocketBase, TServerTransportBase):
         else:
             # We cann't update backlog when it is already listening, since the
             # handle has been created.
-            logger.warn('You have to set backlog before listen.')
+            logger.warning('You have to set backlog before listen.')
 
     def listen(self):
         res0 = self._resolveAddr()

--- a/lib/py/src/transport/sslcompat.py
+++ b/lib/py/src/transport/sslcompat.py
@@ -70,7 +70,7 @@ def _optional_dependencies():
         logger.debug('ipaddress module is available')
         ipaddr = True
     except ImportError:
-        logger.warn('ipaddress module is unavailable')
+        logger.warning('ipaddress module is unavailable')
         ipaddr = False
 
     if sys.hexversion < 0x030500F0:
@@ -82,17 +82,17 @@ def _optional_dependencies():
             if ver[0] * 10 + ver[1] >= 35:
                 return ipaddr, match
             else:
-                logger.warn('backports.ssl_match_hostname module is too old')
+                logger.warning('backports.ssl_match_hostname module is too old')
                 ipaddr = False
         except ImportError:
-            logger.warn('backports.ssl_match_hostname is unavailable')
+            logger.warning('backports.ssl_match_hostname is unavailable')
             ipaddr = False
     try:
         from ssl import match_hostname
         logger.debug('ssl.match_hostname is available')
         match = match_hostname
     except ImportError:
-        logger.warn('using legacy validation callback')
+        logger.warning('using legacy validation callback')
         match = legacy_validate_callback
     return ipaddr, match
 


### PR DESCRIPTION
Need for Python 3.13

https://github.com/python/cpython/issues/105376: Remove undocumented and untested Logger.warn() and LoggerAdapter.warn() methods and logging.warn() function.
