### PR TITLE
THRIFT-4386 Add Lua 5.3/5.4 support

### DIFF
--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -206,8 +206,8 @@ RUN apt-get install -y --no-install-recommends \
 
 RUN apt-get install -y --no-install-recommends \
   `# Lua dependencies` \
-  lua5.2 \
-  lua5.2-dev
+  lua5.4 \
+  liblua5.4-dev
 # https://bugs.launchpad.net/ubuntu/+source/lua5.3/+bug/1707212
 # lua5.3 does not install alternatives!
 # need to update our luasocket code, lua doesn't have luaL_openlib any more

--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -273,6 +273,9 @@ string t_lua_generator::render_const_value(t_type* type, t_const_value* value) {
         out << value->get_double();
       }
       break;
+    case t_base_type::TYPE_UUID:
+      out << "TUUIDfromString(" << value->get_string() << ")";
+      break;
     default:
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
@@ -845,6 +848,9 @@ void t_lua_generator::generate_deserialize_field(ostream& out,
       case t_base_type::TYPE_DOUBLE:
         out << "readDouble()";
         break;
+      case t_base_type::TYPE_UUID:
+        out << "readUuid()";
+        break;
       default:
         throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase);
       }
@@ -1000,6 +1006,9 @@ void t_lua_generator::generate_serialize_field(ostream& out, t_field* tfield, st
       case t_base_type::TYPE_DOUBLE:
         out << "writeDouble(" << name << ")";
         break;
+      case t_base_type::TYPE_UUID:
+        out << "writeUuid(" << name << ")";
+        break;
       default:
         throw "compiler error: no PHP name for base type " + t_base_type::t_base_name(tbase);
       }
@@ -1151,6 +1160,8 @@ string t_lua_generator::type_to_enum(t_type* type) {
       return "TType.I64";
     case t_base_type::TYPE_DOUBLE:
       return "TType.DOUBLE";
+    case t_base_type::TYPE_UUID:
+      return "TType.UUID";
     default:
       throw "compiler error: unhandled type";
     }

--- a/compiler/cpp/src/thrift/generate/t_lua_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_lua_generator.cc
@@ -730,6 +730,8 @@ void t_lua_generator::generate_process_function(ostream& out,
   if (!tfunction->is_oneway()) {
       out << indent() << "local result = " << resultname
           << ":new{}" << '\n';
+  } else {
+    out << indent() << "oprot.trans:flushOneway()" << '\n';
   }
 
   out <<  indent() << "local status, res = pcall(self.handler." << fn_name

--- a/lib/lua/TBinaryProtocol.lua
+++ b/lib/lua/TBinaryProtocol.lua
@@ -18,8 +18,8 @@
 --
 
 require 'TProtocol'
-require 'libluabpack'
-require 'libluabitwise'
+local libluabpack = require 'libluabpack'
+local libluabitwise = require 'libluabitwise'
 
 TBinaryProtocol = __TObject.new(TProtocolBase, {
   __type = 'TBinaryProtocol',

--- a/lib/lua/TBinaryProtocol.lua
+++ b/lib/lua/TBinaryProtocol.lua
@@ -111,6 +111,11 @@ function TBinaryProtocol:writeI32(i32)
   self.trans:write(buff)
 end
 
+function TBinaryProtocol:writeUI32(i32)
+  local buff = libluabpack.bpack('I', i32)
+  self.trans:write(buff)
+end
+
 function TBinaryProtocol:writeI64(i64)
   local buff = libluabpack.bpack('l', i64)
   self.trans:write(buff)
@@ -125,6 +130,13 @@ function TBinaryProtocol:writeString(str)
   -- Should be utf-8
   self:writeI32(string.len(str))
   self.trans:write(str)
+end
+
+function TBinaryProtocol:writeUuid(uuid)
+  self:writeUI32(uuid.two)
+  self:writeUI32(uuid.three)
+  self:writeUI32(uuid.zero)
+  self:writeUI32(uuid.one)
 end
 
 function TBinaryProtocol:readMessageBegin()
@@ -226,6 +238,12 @@ function TBinaryProtocol:readI32()
   return val
 end
 
+function TBinaryProtocol:readUI32()
+  local buff = self.trans:readAll(4)
+  local val = libluabpack.bunpack('I', buff)
+  return val
+end
+
 function TBinaryProtocol:readI64()
   local buff = self.trans:readAll(8)
   local val = libluabpack.bunpack('l', buff)
@@ -242,6 +260,19 @@ function TBinaryProtocol:readString()
   local len = self:readI32()
   local str = self.trans:readAll(len)
   return str
+end
+
+function TBinaryProtocol:readUuid()
+  local a = self:readUI32()
+  local b = self:readUI32()
+  local c = self:readUI32()
+  local d = self:readUI32()
+  return TUUID:new {
+    zero = c,
+    one = d,
+    two = a,
+    three = b
+  }
 end
 
 TBinaryProtocolFactory = TProtocolFactory:new{

--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -61,7 +61,8 @@ TCompactType = {
   COMPACT_LIST          = 0x09,
   COMPACT_SET           = 0x0A,
   COMPACT_MAP           = 0x0B,
-  COMPACT_STRUCT        = 0x0C
+  COMPACT_STRUCT        = 0x0C,
+  COMPACT_UUID          = 0x0D,
 }
 
 TTypeToCompactType = {}
@@ -77,21 +78,23 @@ TTypeToCompactType[TType.LIST]   = TCompactType.COMPACT_LIST
 TTypeToCompactType[TType.SET]    = TCompactType.COMPACT_SET
 TTypeToCompactType[TType.MAP]    = TCompactType.COMPACT_MAP
 TTypeToCompactType[TType.STRUCT] = TCompactType.COMPACT_STRUCT
+TTypeToCompactType[TType.UUID]   = TCompactType.COMPACT_UUID
 
 CompactTypeToTType = {}
-CompactTypeToTType[TType.STOP]                        = TType.STOP
-CompactTypeToTType[TCompactType.COMPACT_BOOLEAN_TRUE] = TType.BOOL
+CompactTypeToTType[TType.STOP]                         = TType.STOP
+CompactTypeToTType[TCompactType.COMPACT_BOOLEAN_TRUE]  = TType.BOOL
 CompactTypeToTType[TCompactType.COMPACT_BOOLEAN_FALSE] = TType.BOOL
-CompactTypeToTType[TCompactType.COMPACT_BYTE]         = TType.BYTE
-CompactTypeToTType[TCompactType.COMPACT_I16]          = TType.I16
-CompactTypeToTType[TCompactType.COMPACT_I32]          = TType.I32
-CompactTypeToTType[TCompactType.COMPACT_I64]          = TType.I64
-CompactTypeToTType[TCompactType.COMPACT_DOUBLE]       = TType.DOUBLE
-CompactTypeToTType[TCompactType.COMPACT_BINARY]       = TType.STRING
-CompactTypeToTType[TCompactType.COMPACT_LIST]         = TType.LIST
-CompactTypeToTType[TCompactType.COMPACT_SET]          = TType.SET
-CompactTypeToTType[TCompactType.COMPACT_MAP]          = TType.MAP
-CompactTypeToTType[TCompactType.COMPACT_STRUCT]       = TType.STRUCT
+CompactTypeToTType[TCompactType.COMPACT_BYTE]          = TType.BYTE
+CompactTypeToTType[TCompactType.COMPACT_I16]           = TType.I16
+CompactTypeToTType[TCompactType.COMPACT_I32]           = TType.I32
+CompactTypeToTType[TCompactType.COMPACT_I64]           = TType.I64
+CompactTypeToTType[TCompactType.COMPACT_DOUBLE]        = TType.DOUBLE
+CompactTypeToTType[TCompactType.COMPACT_BINARY]        = TType.STRING
+CompactTypeToTType[TCompactType.COMPACT_LIST]          = TType.LIST
+CompactTypeToTType[TCompactType.COMPACT_SET]           = TType.SET
+CompactTypeToTType[TCompactType.COMPACT_MAP]           = TType.MAP
+CompactTypeToTType[TCompactType.COMPACT_STRUCT]        = TType.STRUCT
+CompactTypeToTType[TCompactType.COMPACT_UUID]          = TType.UUID
 
 function TCompactProtocol:resetLastField()
   self.lastField = {}
@@ -197,6 +200,11 @@ function TCompactProtocol:writeI32(i32)
   self:writeVarint32(libluabpack.i32ToZigzag(i32))
 end
 
+function TCompactProtocol:writeUI32(i32)
+  local buff = libluabpack.bpack('I', i32)
+  self.trans:write(buff)
+end
+
 function TCompactProtocol:writeI64(i64)
   self:writeVarint64(libluabpack.i64ToZigzag(i64))
 end
@@ -209,6 +217,13 @@ end
 function TCompactProtocol:writeString(str)
   -- Should be utf-8
   self:writeBinary(str)
+end
+
+function TCompactProtocol:writeUuid(uuid)
+  self:writeUI32(uuid.two)
+  self:writeUI32(uuid.three)
+  self:writeUI32(uuid.zero)
+  self:writeUI32(uuid.one)
 end
 
 function TCompactProtocol:writeBinary(str)
@@ -385,6 +400,12 @@ function TCompactProtocol:readI32()
   return value
 end
 
+function TCompactProtocol:readUI32()
+  local buff = self.trans:readAll(4)
+  local val = libluabpack.bunpack('I', buff)
+  return val
+end
+
 function TCompactProtocol:readI64()
   local value = self:readVarint64()
   return value
@@ -398,6 +419,19 @@ end
 
 function TCompactProtocol:readString()
   return self:readBinary()
+end
+
+function TCompactProtocol:readUuid()
+  local a = self:readUI32()
+  local b = self:readUI32()
+  local c = self:readUI32()
+  local d = self:readUI32()
+  return TUUID:new {
+    zero = c,
+    one = d,
+    two = a,
+    three = b
+  }
 end
 
 function TCompactProtocol:readBinary()

--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -18,9 +18,9 @@
 --
 
 require 'TProtocol'
-require 'libluabpack'
-require 'libluabitwise'
-require 'liblualongnumber'
+local libluabpack = require 'libluabpack'
+local libluabitwise = require 'libluabitwise'
+local liblualongnumber = require 'liblualongnumber'
 
 TCompactProtocol = __TObject.new(TProtocolBase, {
   __type = 'TCompactProtocol',

--- a/lib/lua/TFramedTransport.lua
+++ b/lib/lua/TFramedTransport.lua
@@ -18,7 +18,7 @@
 --
 
 require 'TTransport'
-require 'libluabpack'
+local libluabpack = require 'libluabpack'
 
 TFramedTransport = TTransportBase:new{
   __type = 'TFramedTransport',

--- a/lib/lua/THttpTransport.lua
+++ b/lib/lua/THttpTransport.lua
@@ -160,12 +160,21 @@ function THttpTransport:writeHttpHeader(content_len)
   end
 end
 
+function THttpTransport:flushOneway()
+  self.wBuf = ''
+  self:writeHttpHeader(0)
+  self.trans:flush()
+end
+
 function THttpTransport:flush()
   -- If the write fails we still want wBuf to be clear
   local tmp = self.wBuf
   self.wBuf = ''
-  self:writeHttpHeader(string.len(tmp))
-  self.trans:write(tmp)
+  local dataLen = string.len(tmp)
+  self:writeHttpHeader(dataLen)
+  if dataLen > 0 then
+    self.trans:write(tmp)
+  end
   self.trans:flush()
 end
 

--- a/lib/lua/TJsonProtocol.lua
+++ b/lib/lua/TJsonProtocol.lua
@@ -405,7 +405,7 @@ function TJSONProtocol:writeI64(i64)
 end
 
 function TJSONProtocol:writeDouble(dub)
-  self:writeJSONDouble(string.format("%.16f", dub))
+  self:writeJSONDouble(string.format("%.20f", dub))
 end
 
 function TJSONProtocol:writeString(str)

--- a/lib/lua/TJsonProtocol.lua
+++ b/lib/lua/TJsonProtocol.lua
@@ -18,8 +18,9 @@
 --
 
 require 'TProtocol'
-require 'libluabpack'
-require 'libluabitwise'
+local libluabpack = require 'libluabpack'
+local libluabitwise = require 'libluabitwise'
+local liblualongnumber = require 'liblualongnumber'
 
 TJSONProtocol = __TObject.new(TProtocolBase, {
   __type = 'TJSONProtocol',

--- a/lib/lua/TJsonProtocol.lua
+++ b/lib/lua/TJsonProtocol.lua
@@ -43,6 +43,7 @@ TTypeToString[TType.STRUCT] = "rec"
 TTypeToString[TType.LIST]   = "lst"
 TTypeToString[TType.SET]    = "set"
 TTypeToString[TType.MAP]    = "map"
+TTypeToString[TType.UUID]   = "uid"
 
 StringToTType = {
   tf  = TType.BOOL,
@@ -55,7 +56,8 @@ StringToTType = {
   rec = TType.STRUCT,
   map = TType.MAP,
   set = TType.SET,
-  lst = TType.LIST
+  lst = TType.LIST,
+  uid = TType.UUID,
 }
 
 JSONNode = {
@@ -410,6 +412,10 @@ function TJSONProtocol:writeString(str)
   self:writeJSONString(str)
 end
 
+function TJSONProtocol:writeUuid(uuid)
+  self:writeJSONString(uuid:getString())
+end
+
 function TJSONProtocol:writeBinary(str)
   -- Should be utf-8
   self:writeJSONBase64(str)
@@ -705,6 +711,10 @@ end
 
 function TJSONProtocol:readString()
   return self:readJSONString()
+end
+
+function TJSONProtocol:readUuid()
+  return TUUIDfromString(self:readJSONString())
 end
 
 function TJSONProtocol:readBinary()

--- a/lib/lua/TProtocol.lua
+++ b/lib/lua/TProtocol.lua
@@ -86,6 +86,7 @@ function TProtocolBase:writeI32(i32) end
 function TProtocolBase:writeI64(i64) end
 function TProtocolBase:writeDouble(dub) end
 function TProtocolBase:writeString(str) end
+function TProtocolBase:writeUuid(uuid) end
 function TProtocolBase:readMessageBegin() end
 function TProtocolBase:readMessageEnd() end
 function TProtocolBase:readStructBegin() end
@@ -105,6 +106,7 @@ function TProtocolBase:readI32() end
 function TProtocolBase:readI64() end
 function TProtocolBase:readDouble() end
 function TProtocolBase:readString() end
+function TProtocolBase:readUuid() end
 
 function TProtocolBase:skip(ttype)
   if ttype == TType.BOOL then
@@ -151,6 +153,8 @@ function TProtocolBase:skip(ttype)
       self:skip(ettype)
     end
     self:readListEnd()
+  elseif ttype == TType.UUID then
+    self:readUuid()
   else
     terror(TProtocolException:new{
       message = 'Invalid data'

--- a/lib/lua/TSocket.lua
+++ b/lib/lua/TSocket.lua
@@ -17,7 +17,7 @@
 --
 
 require 'TTransport'
-require 'libluasocket'
+local luasocket = require 'libluasocket'
 
 -- TSocketBase
 TSocketBase = TTransportBase:new{

--- a/lib/lua/TTransport.lua
+++ b/lib/lua/TTransport.lua
@@ -76,6 +76,8 @@ function TTransportBase:readAll(len)
   return buf
 end
 function TTransportBase:write(buf) end
+-- flushOneway is a NOOP for most transport types.
+function TTransportBase:flushOneway() end
 function TTransportBase:flush() end
 
 TServerTransportBase = __TObject:new{

--- a/lib/lua/Thrift.lua
+++ b/lib/lua/Thrift.lua
@@ -23,6 +23,9 @@
 --setfenv(1, thrift)
 
 package.cpath = package.cpath .. ';bin/?.so' -- TODO FIX
+
+local libluabitwise = require 'libluabitwise'
+
 function ttype(obj)
   if type(obj) == 'table' and
     obj.__type and
@@ -66,8 +69,7 @@ TType = {
   MAP    = 13,
   SET    = 14,
   LIST   = 15,
-  UTF8   = 16,
-  UTF16  = 17
+  UUID   = 16
 }
 
 TMessageType = {
@@ -231,6 +233,35 @@ function TException:write(oprot)
   end
   oprot:writeFieldStop()
   oprot:writeStructEnd()
+end
+
+TUUID = {
+  zero,
+  one,
+  two,
+  three
+}
+
+TUUID = __TObject:new{
+  __type = 'TUUID'
+}
+
+function TUUIDfromString(str)
+  local iterator = string.gmatch(str, "[A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9]")
+  return TUUID:new {
+    zero = libluabitwise.buor(libluabitwise.ushiftl(tonumber(iterator(), 16), 16), tonumber(iterator(), 16)),
+    one = libluabitwise.buor(libluabitwise.ushiftl(tonumber(iterator(), 16), 16), tonumber(iterator(), 16)),
+    two = libluabitwise.buor(libluabitwise.ushiftl(tonumber(iterator(), 16), 16), tonumber(iterator(), 16)),
+    three = libluabitwise.buor(libluabitwise.ushiftl(tonumber(iterator(), 16), 16), tonumber(iterator(), 16))
+  }
+end
+
+function TUUID:getString()
+  return string.format("%08x-%04x-%04x-%04x-%04x%08x", self.zero, libluabitwise.ushiftr(self.one, 16), libluabitwise.buand(self.one, 0xFFFF), libluabitwise.ushiftr(self.two, 16), libluabitwise.buand(self.two, 0xFFFF), self.three)
+end
+
+function TUUID:__tostring()
+  return "<TUUID: " .. self:getString() .. ">"
 end
 
 -- Basic Client (used in generated lua code)

--- a/lib/lua/src/luabitwise.c
+++ b/lib/lua/src/luabitwise.c
@@ -27,6 +27,13 @@ static int l_not(lua_State *L) {
   return 1;
 }
 
+static int l_unot(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  a = ~a;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
 static int l_xor(lua_State *L) {
   int a = luaL_checkinteger(L, 1);
   int b = luaL_checkinteger(L, 2);
@@ -35,9 +42,26 @@ static int l_xor(lua_State *L) {
   return 1;
 }
 
+static int l_uxor(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  unsigned int b = luaL_checkinteger(L, 2);
+  a ^= b;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
+
 static int l_and(lua_State *L) {
   int a = luaL_checkinteger(L, 1);
   int b = luaL_checkinteger(L, 2);
+  a &= b;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
+static int l_uand(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  unsigned int b = luaL_checkinteger(L, 2);
   a &= b;
   lua_pushnumber(L, a);
   return 1;
@@ -51,9 +75,25 @@ static int l_or(lua_State *L) {
   return 1;
 }
 
+static int l_uor(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  unsigned int b = luaL_checkinteger(L, 2);
+  a |= b;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
 static int l_shiftr(lua_State *L) {
   int a = luaL_checkinteger(L, 1);
   int b = luaL_checkinteger(L, 2);
+  a = a >> b;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
+static int l_ushiftr(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  unsigned int b = luaL_checkinteger(L, 2);
   a = a >> b;
   lua_pushnumber(L, a);
   return 1;
@@ -67,13 +107,27 @@ static int l_shiftl(lua_State *L) {
   return 1;
 }
 
+static int l_ushiftl(lua_State *L) {
+  unsigned int a = luaL_checkinteger(L, 1);
+  unsigned int b = luaL_checkinteger(L, 2);
+  a = a << b;
+  lua_pushnumber(L, a);
+  return 1;
+}
+
 static const struct luaL_Reg funcs[] = {
   {"band", l_and},
+  {"buand", l_uand},
   {"bor", l_or},
+  {"buor", l_uor},
   {"bxor", l_xor},
+  {"buxor", l_uxor},
   {"bnot", l_not},
+  {"bunot", l_unot},
   {"shiftl", l_shiftl},
+  {"ushiftl", l_ushiftl},
   {"shiftr", l_shiftr},
+  {"ushiftr", l_ushiftr},
   {NULL, NULL}
 };
 

--- a/lib/lua/src/luabitwise.c
+++ b/lib/lua/src/luabitwise.c
@@ -78,6 +78,11 @@ static const struct luaL_Reg funcs[] = {
 };
 
 int luaopen_libluabitwise(lua_State *L) {
+#if LUA_VERSION_NUM >= 502
+    lua_newtable(L);
+    luaL_setfuncs(L, funcs, 0);
+#else
   luaL_register(L, "libluabitwise", funcs);
+#endif
   return 1;
 }

--- a/lib/lua/src/luabpack.c
+++ b/lib/lua/src/luabpack.c
@@ -303,6 +303,11 @@ static const struct luaL_Reg lua_bpack[] = {
 };
 
 int luaopen_libluabpack(lua_State *L) {
+#if LUA_VERSION_NUM >= 502
+    lua_newtable(L);
+    luaL_setfuncs(L, lua_bpack, 0);
+#else
   luaL_register(L, "libluabpack", lua_bpack);
+#endif
   return 1;
 }

--- a/lib/lua/src/luabpack.c
+++ b/lib/lua/src/luabpack.c
@@ -45,6 +45,7 @@ static int64_t T_ntohll(uint64_t data) {
  *  c - Signed Byte
  *  s - Signed Short
  *  i - Signed Int
+ *  I - Unsigned Int
  *  l - Signed Long
  *  d - Double
  */
@@ -69,6 +70,12 @@ static int l_bpack(lua_State *L) {
     case 'i': {
       int32_t data = luaL_checkinteger(L, 2);
       data = (int32_t)htonl(data);
+      luaL_addlstring(&buf, (void*)&data, sizeof(data));
+      break;
+    }
+    case 'I': {
+      uint32_t data = luaL_checkinteger(L, 2);
+      data = (uint32_t)htonl(data);
       luaL_addlstring(&buf, (void*)&data, sizeof(data));
       break;
     }
@@ -97,6 +104,7 @@ static int l_bpack(lua_State *L) {
  *  C - Unsigned Byte
  *  s - Signed Short
  *  i - Signed Int
+ *  I - Unsigned Int
  *  l - Signed Long
  *  d - Double
  */
@@ -141,6 +149,17 @@ static int l_bunpack(lua_State *L) {
       luaL_argcheck(L, len == sizeof(val), 1, "Invalid input string size.");
       memcpy(&val, data, sizeof(val));
       val = (int32_t)ntohl(val);
+      lua_pushnumber(L, val);
+      break;
+    }
+    /**
+     * unpack unsigned Int.
+     */
+    case 'I': {
+      uint32_t val;
+      luaL_argcheck(L, len == sizeof(val), 1, "Invalid input string size.");
+      memcpy(&val, data, sizeof(val));
+      val = (uint32_t)ntohl(val);
       lua_pushnumber(L, val);
       break;
     }

--- a/lib/lua/src/lualongnumber.c
+++ b/lib/lua/src/lualongnumber.c
@@ -223,6 +223,11 @@ LUALIB_API int luaopen_liblualongnumber(lua_State *L) {
   lua_pop(L, 1);
   set_methods(L, LONG_NUM_TYPE, methods);
 
+#if LUA_VERSION_NUM >= 502
+    lua_newtable(L);
+    luaL_setfuncs(L, funcs, 0);
+#else
   luaL_register(L, "liblualongnumber", funcs);
+#endif
   return 1;
 }

--- a/lib/lua/src/luasocket.c
+++ b/lib/lua/src/luasocket.c
@@ -185,8 +185,12 @@ int luaopen_libluasocket(lua_State *L) {
   set_methods(L, SOCKET_GENERIC, methods_generic);
   set_methods(L, SOCKET_CLIENT, methods_client);
   set_methods(L, SOCKET_SERVER, methods_server);
-
+#if LUA_VERSION_NUM >= 502
+    lua_newtable(L);
+    luaL_setfuncs(L, funcs_luasocket, 0);
+#else
   luaL_register(L, "luasocket", funcs_luasocket);
+#endif
   return 1;
 }
 

--- a/test/lua/Makefile.am
+++ b/test/lua/Makefile.am
@@ -19,11 +19,8 @@
 
 THRIFT = $(top_builddir)/compiler/cpp/thrift
 
-# Remove "MapType =" line to ignore some map bug for now
-stubs: ../v0.16/ThriftTest.thrift $(THRIFT)
-	$(THRIFT) --gen lua $<
-	$(SED) -i.bak 's/MapType =//g' gen-lua/ThriftTest_ttypes.lua
-	$(RM) gen-lua/ThriftTest_ttypes.lua.bak
+stubs: ../ThriftTest.thrift
+	$(THRIFT) --gen lua ../ThriftTest.thrift
 
 precross: stubs
 

--- a/test/lua/test_basic_client.lua
+++ b/test/lua/test_basic_client.lua
@@ -24,7 +24,7 @@ require('TCompactProtocol')
 require('TJsonProtocol')
 require('TBinaryProtocol')
 require('ThriftTest_ThriftTest')
-require('liblualongnumber')
+local liblualongnumber = require('liblualongnumber')
 
 local client
 

--- a/test/lua/test_basic_client.lua
+++ b/test/lua/test_basic_client.lua
@@ -98,6 +98,9 @@ function testBasicClient(rawArgs)
   assertEqual(client:testString('lala'),  'lala',  'Failed testString')
   assertEqual(client:testString('wahoo'), 'wahoo', 'Failed testString')
 
+  -- UUID
+  assertEqual(client:testUuid(TUUIDfromString('00112233-4455-6677-8899-aabbccddeeff')):getString(),  '00112233-4455-6677-8899-aabbccddeeff',  'Failed testUuid')
+
   -- Bool
   assertEqual(client:testBool(true), true, 'Failed testBool true')
   assertEqual(client:testBool(false), false, 'Failed testBool false')

--- a/test/lua/test_basic_server.lua
+++ b/test/lua/test_basic_server.lua
@@ -62,8 +62,111 @@ function TestHandler:testBinary(by)
   return by
 end
 
+function TestHandler:testUuid(uuid)
+  return uuid
+end
+
+function TestHandler:testNest(thing)
+  return thing
+end
+
 function TestHandler:testStruct(thing)
   return thing
+end
+
+function TestHandler:testMap(thing)
+  return thing
+end
+
+function TestHandler:testStringMap(thing)
+  return thing
+end
+
+function TestHandler:testSet(thing)
+  return thing
+end
+
+function TestHandler:testList(thing)
+  return thing
+end
+
+function TestHandler:testEnum(thing)
+  return thing
+end
+
+function TestHandler:testTypedef(thing)
+  return thing
+end
+
+function TestHandler:testMapMap(hello)
+  return {
+    ["-4"] = {
+      ["-4"] = -4,
+      ["-3"] = -3,
+      ["-2"] = -2,
+      ["-1"] = -1
+    },
+    ["4"] = {
+      ["1"] = 1,
+      ["2"] = 2,
+      ["3"] = 3,
+      ["4"] = 4
+    }
+  }
+end
+
+function TestHandler:testInsanity(argument)
+  local first_map = {
+    [Numberz.TWO] = argument,
+    [Numberz.THREE] = argument
+  };
+  local second_map = {
+    [Numberz.SIX] = Insanity:new {
+      userMap = {},
+      xtructs = {}
+    }
+  }
+
+  return {
+    ["1"] = first_map,
+    ["2"] = second_map
+  };
+end
+
+function TestHandler:testMulti(arg0, arg1, arg2, arg3, arg4, arg5)
+  return Xtruct:new {}
+end
+
+function TestHandler:testException(arg)
+  if arg == "Xception" then
+    return Xception:new {
+      errorCode = 1001,
+      message = arg
+    }
+  elseif arg == "TException" then
+    error("")
+  end
+end
+
+function TestHandler:testMultiException(arg0, arg1)
+  if arg0 == "Xception" then
+    return Xception:new {
+      errorCode = 1001,
+      message = "This is an Xception"
+    }
+  elseif arg0 == "Xception2" then
+    return Xception2:new {
+      errorCode = 2002,
+      struct_thing = Xtruct:new {
+        string_thing = "This is an Xception2"
+      }
+    }
+  elseif arg0 == "TException" then
+    error("")
+  end
+  return Xtruct:new {
+    string_thing = arg1
+  }
 end
 
 function TestHandler:testOneway(secondsToSleep)

--- a/test/lua/test_basic_server.lua
+++ b/test/lua/test_basic_server.lua
@@ -24,7 +24,7 @@ require('TCompactProtocol')
 require('TJsonProtocol')
 require('TBinaryProtocol')
 require('TServer')
-require('liblualongnumber')
+local liblualongnumber = require('liblualongnumber')
 
 --------------------------------------------------------------------------------
 -- Handler

--- a/test/tests.json
+++ b/test/tests.json
@@ -695,24 +695,31 @@
     },
     "client": {
       "timeout": 5,
-      "transports": [
-        "buffered",
-        "framed",
-        "http"
-      ],
-      "sockets": [
-        "ip"
-      ],
-      "protocols": [
-        "binary",
-        "compact",
-        "json"
-      ],
       "command": [
         "lua",
         "test_basic_client.lua"
       ]
     },
+    "server": {
+      "delay": 5,
+      "command": [
+        "lua",
+        "test_basic_server.lua"
+      ]
+    },
+    "transports": [
+      "buffered",
+      "framed",
+      "http"
+    ],
+    "sockets": [
+      "ip"
+    ],
+    "protocols": [
+      "binary",
+      "compact",
+      "json"
+    ],
     "workdir": "lua"
   },
   {


### PR DESCRIPTION
This PR adds support for running with Lua 5.3 and 5.4 while also keeping backwards compatibility with Lua 5.1.
Updated ubuntu-jammy dockerfile to install Lua 5.4 for testing.

Fixed cross-testing in a [follow up PR](https://github.com/thomasbruggink/thrift/commit/f42bc81f3945834531d8080bb941393d5717e643) to confirm this works with for both Lua versions with the Java client.