### PR TITLE
Fix JS property/method collisions for fields named read/write

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -1061,10 +1061,10 @@ void t_js_generator::generate_js_struct_reader(ostream& out, t_struct* tstruct) 
   vector<t_field*>::const_iterator f_iter;
 
   if (gen_es6_) {
-    indent(out) << "read (input) {" << '\n';
+    indent(out) << "[Symbol.for(\"read\")] (input) {" << '\n';
   } else {
     indent(out) << js_namespace(tstruct->get_program()) << tstruct->get_name()
-        << ".prototype.read = function(input) {" << '\n';
+        << ".prototype[Symbol.for(\"read\")] = function(input) {" << '\n';
   }
 
   indent_up();
@@ -1151,10 +1151,10 @@ void t_js_generator::generate_js_struct_writer(ostream& out, t_struct* tstruct) 
   vector<t_field*>::const_iterator f_iter;
 
   if (gen_es6_) {
-    indent(out) << "write (output) {" << '\n';
+    indent(out) << "[Symbol.for(\"write\")] (output) {" << '\n';
   } else {
     indent(out) << js_namespace(tstruct->get_program()) << tstruct->get_name()
-        << ".prototype.write = function(output) {" << '\n';
+        << ".prototype[Symbol.for(\"write\")] = function(output) {" << '\n';
   }
 
   indent_up();
@@ -1395,7 +1395,7 @@ void t_js_generator::generate_service_processor(t_service* tservice) {
                 "Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN_METHOD, "
                 "'Unknown function ' + r.fname);" << '\n' << indent()
              << "  output.writeMessageBegin(r.fname, Thrift.MessageType.EXCEPTION, r.rseqid);"
-             << '\n' << indent() << "  x.write(output);" << '\n' << indent()
+             << '\n' << indent() << "  x[Symbol.for(\"write\")](output);" << '\n' << indent()
              << "  output.writeMessageEnd();" << '\n' << indent() << "  output.flush();" << '\n'
              << indent() << "}" << '\n';
 
@@ -1447,7 +1447,7 @@ void t_js_generator::generate_process_function(t_service* tservice, t_function* 
                       + "_result";
 
   indent(f_service_) << js_const_type_ << "args = new " << argsname << "();" << '\n' << indent()
-             << "args.read(input);" << '\n' << indent() << "input.readMessageEnd();" << '\n';
+             << "args[Symbol.for(\"read\")](input);" << '\n' << indent() << "input.readMessageEnd();" << '\n';
 
   // Generate the function call
   t_struct* arg_struct = tfunction->get_arglist();
@@ -1509,7 +1509,7 @@ void t_js_generator::generate_process_function(t_service* tservice, t_function* 
   f_service_ << indent() << js_const_type_ << "result_obj = new " << resultname << "({success: result});" << '\n'
              << indent() << "output.writeMessageBegin(\"" << tfunction->get_name()
              << "\", Thrift.MessageType.REPLY, seqid);" << '\n' << indent()
-             << "result_obj.write(output);" << '\n' << indent() << "output.writeMessageEnd();" << '\n'
+             << "result_obj[Symbol.for(\"write\")](output);" << '\n' << indent() << "output.writeMessageEnd();" << '\n'
              << indent() << "output.flush();" << '\n';
   indent_down();
 
@@ -1562,7 +1562,7 @@ void t_js_generator::generate_process_function(t_service* tservice, t_function* 
     indent(f_service_) << "}" << '\n';
   }
 
-  f_service_ << indent() << "result.write(output);" << '\n' << indent()
+  f_service_ << indent() << "result[Symbol.for(\"write\")](output);" << '\n' << indent()
              << "output.writeMessageEnd();" << '\n' << indent() << "output.flush();" << '\n';
   indent_down();
   indent(f_service_) << "});" << '\n';
@@ -1610,7 +1610,7 @@ void t_js_generator::generate_process_function(t_service* tservice, t_function* 
                             " err.message);" << '\n' << indent() << "output.writeMessageBegin(\""
              << tfunction->get_name() << "\", Thrift.MessageType.EXCEPTION, seqid);" << '\n';
   indent_down();
-  f_service_ << indent() << "}" << '\n' << indent() << "result_obj.write(output);" << '\n' << indent()
+  f_service_ << indent() << "}" << '\n' << indent() << "result_obj[Symbol.for(\"write\")](output);" << '\n' << indent()
              << "output.writeMessageEnd();" << '\n' << indent() << "output.flush();" << '\n';
 
   indent_down();
@@ -2013,7 +2013,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
 
 
     // Write to the stream
-    f_service_ << indent() << "args.write(" << outputVar << ");" << '\n' << indent() << outputVar
+    f_service_ << indent() << "args[Symbol.for(\"write\")](" << outputVar << ");" << '\n' << indent() << outputVar
                << ".writeMessageEnd();" << '\n';
 
     if (gen_node_) {
@@ -2152,13 +2152,13 @@ void t_js_generator::generate_service_client(t_service* tservice) {
 
       indent_up();
       f_service_ << indent() << js_const_type_ << "x = new Thrift.TApplicationException();" << '\n'
-                 << indent() << "x.read(" << inputVar << ");" << '\n'
+                 << indent() << "x[Symbol.for(\"read\")](" << inputVar << ");" << '\n'
                  << indent() << inputVar << ".readMessageEnd();" << '\n'
                  << indent() << render_recv_throw("x") << '\n';
       scope_down(f_service_);
 
       f_service_ << indent() << js_const_type_ << "result = new " << resultname << "();" << '\n' << indent()
-                 << "result.read(" << inputVar << ");" << '\n';
+                 << "result[Symbol.for(\"read\")](" << inputVar << ");" << '\n';
 
       f_service_ << indent() << inputVar << ".readMessageEnd();" << '\n' << '\n';
 
@@ -2299,7 +2299,7 @@ void t_js_generator::generate_deserialize_field(ostream& out,
  */
 void t_js_generator::generate_deserialize_struct(ostream& out, t_struct* tstruct, string prefix) {
   out << indent() << prefix << " = new " << js_type_namespace(tstruct->get_program())
-      << tstruct->get_name() << "();" << '\n' << indent() << prefix << ".read(input);" << '\n';
+      << tstruct->get_name() << "();" << '\n' << indent() << prefix << "[Symbol.for(\"read\")](input);" << '\n';
 }
 
 void t_js_generator::generate_deserialize_container(ostream& out, t_type* ttype, string prefix) {
@@ -2482,7 +2482,7 @@ void t_js_generator::generate_serialize_field(ostream& out, t_field* tfield, str
  */
 void t_js_generator::generate_serialize_struct(ostream& out, t_struct* tstruct, string prefix) {
   (void)tstruct;
-  indent(out) << prefix << ".write(output);" << '\n';
+  indent(out) << prefix << "[Symbol.for(\"write\")](output);" << '\n';
 }
 
 /**


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
If a thrift struct has a member named `read`, it causes a naming collision. This change renames `read` to `thriftRead` and `write` to `thriftWrite` on generated JavaScript classes.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

I reviewed the NodeJS library code to see if read or write was called directly on the generated classes:

<details>
<summary>`read` calls in NodeJS library</summary>

```
❯ rg '\.read\('
binary_protocol.js
193:    name = this.trans.read(sz);
271:  var buff = this.trans.read(8);
288:  return this.trans.read(len);

compact_protocol.js
727:  var buff = this.trans.read(8);
769:  return this.trans.read(size);

header_transport.js
280:  this.read(endOfHeaders);
```
</details>

So `.read` is only called on the transports.

<details>
<summary>write calls in NodeJS library</summary>

```
server.js
49:            stream.write(buf); // TCP connection

connection.js
187:    self.write(data);
^ Connection.prototype
196:  this.connection.write(data);
^ Connection.prototype
387:    self.write(data);
^ StdIOConnection.prototype
396:  this.connection.write(data);
^ StdIOConnection.prototype

http_connection.js
227:  req.write(data);
^ The http request

multiplexed_protocol.js
56:    connection.write(buf,seqid);
^ Third argument `connection` on Multiplexer.prototype.createClient. Assume this is Connection

compact_protocol.js
353:  this.trans.write(new Buffer([b]));
428:  this.trans.write(buff);
434:    this.trans.write(new Buffer(arg, encoding));
441:    this.trans.write(arg);
505:  this.trans.write(wbuf);
539:  this.trans.write(wbuf);
^ Transport only

header_transport.js
89:  this.transport.write(str);
316:  varintWriter.write(paddingBuffer);
^ Transport and VarIntHelper

binary_protocol.js
130:  this.trans.write(new Buffer([b]));
134:  this.trans.write(binary.writeI16(new Buffer(2), i16));
138:  this.trans.write(binary.writeI32(new Buffer(4), i32));
143:    this.trans.write(i64.buffer);
145:    this.trans.write(new Int64(i64).buffer);
150:  this.trans.write(binary.writeDouble(new Buffer(8), dub));
156:    this.trans.write(new Buffer(arg, encoding));
163:    this.trans.write(arg);
^ Transport only

create_client.js
47:    connection.write(buf, seqid);
^ Connection

web_server.js
453:        response.write(file, "binary");
^ Http response
468:          socket.write(frame);
^ Websocket
518:      socket.write("HTTP/1.1 403 No Apache Thrift Service available\r\n\r\n");
^ Http socket
524:    socket.write("HTTP/1.1 101 Switching Protocols\r\n" +
^ Http socket

json_protocol.js
99:    this.trans.write(this.tstack.pop());
125:  this.trans.write(this.wbuf);
^ Transport
```
</details>

So `.write` is not called on generated classes here either.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
