### PR TITLE
THRIFT-5810: install static MSVC libraries to lib/

### DIFF
--- a/build/cmake/DefineInstallationPaths.cmake
+++ b/build/cmake/DefineInstallationPaths.cmake
@@ -20,7 +20,9 @@
 
 # Define the default install paths
 set(BIN_INSTALL_DIR "bin" CACHE PATH "The binary install dir (default: bin)")
-if(MSVC)
+# For MSVC builds, install shared libs to bin/, while keeping the install
+# dir for static libs as lib/.
+if(MSVC AND BUILD_SHARED_LIBS)
     set(LIB_INSTALL_DIR "bin${LIB_SUFFIX}" CACHE PATH "The library install dir (default: bin${LIB_SUFFIX})")
 else()
     set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")


### PR DESCRIPTION
With THRIFT-5109 the LIB_INSTALL_DIR for MSVC libs chanaged from lib/ to bin/ which makes sense for shared libs but is not consistent with the usual treatment of static libs.
Install the static libs to lib/, similar to other platforms and projects.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
