### PR TITLE
Resolve the occupation of java transmission object content

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -3328,6 +3328,7 @@ void t_java_generator::generate_service_client(t_service* tservice) {
       // Careful, only return _result if not a void function
       if (!(*f_iter)->get_returntype()->is_void()) {
         f_service_ << indent() << "if (result." << generate_isset_check("success") << ") {" << '\n'
+                   << indent() << "  after();" << '\n'
                    << indent() << "  return result.success;" << '\n'
                    << indent() << "}" << '\n';
       }

--- a/lib/java/src/main/java/org/apache/thrift/TServiceClient.java
+++ b/lib/java/src/main/java/org/apache/thrift/TServiceClient.java
@@ -22,6 +22,8 @@ package org.apache.thrift;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 /**
  * A TServiceClient is used to communicate with a TService implementation across protocols and
@@ -92,5 +94,12 @@ public abstract class TServiceClient {
     }
     result.read(iprot_);
     iprot_.readMessageEnd();
+  }
+
+  protected void after() {
+    TTransport transport = this.iprot_.getTransport();
+    if (transport instanceof TFramedTransport) {
+      ((TFramedTransport) transport).clear();
+    }
   }
 }

--- a/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -545,6 +545,9 @@ public abstract class AbstractNonblockingServer extends TServer {
       // get ready for another go-around
       buffer_ = ByteBuffer.allocate(4);
       state_ = FrameBufferState.READING_FRAME_SIZE;
+
+      // reset useless cache
+      response_.reset();
     }
 
     /**


### PR DESCRIPTION
The content of the transmitted object will not be immediately released after the request is processed. The object content will only be released in the next request. If the next request requires a long wait, the object will continue to occupy memory until a new request arrives.
