### PR TITLE
Update supported go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.21'
           - '1.22'
+          - '1.23'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
         run: make -C test/go precross
 
       - name: Upload go precross artifacts
-        if: matrix.go == '1.22'
+        if: matrix.go == '1.23'
         uses: actions/upload-artifact@v4
         with:
           name: go-precross

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -163,9 +163,9 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.21</td><td>1.22</td>
+<!-- Language Levels -------><td>1.22</td><td>1.23</td>
 <!-- Field types -----------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
-<!-- Low-Level Transports --><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
+<!-- Low-Level Transports --><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Protocols -------------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Servers ---------------><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/apache/thrift
 
-go 1.21
+go 1.22.0

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.21
+go 1.22.0
 
 require github.com/apache/thrift v0.0.0-00010101000000-000000000000
 

--- a/lib/go/test/go.mod
+++ b/lib/go/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/lib/go/test/tests/equals_test.go
+++ b/lib/go/test/tests/equals_test.go
@@ -255,7 +255,7 @@ func genMapFoo() *equalstest.MapEqualsFoo {
 
 func genInt64Slice(length int) []int64 {
 	ret := make([]int64, length)
-	for i := 0; i < length; i++ {
+	for i := range ret {
 		ret[i] = int64(length - i)
 	}
 	return ret
@@ -263,7 +263,7 @@ func genInt64Slice(length int) []int64 {
 
 func genStringSlice(length int) []string {
 	ret := make([]string, length)
-	for i := 0; i < length; i++ {
+	for i := range ret {
 		ret[i] = strconv.Itoa(length - i)
 	}
 	return ret
@@ -271,7 +271,7 @@ func genStringSlice(length int) []string {
 
 func genBytesSlice(length int) [][]byte {
 	ret := make([][]byte, length)
-	for i := 0; i < length; i++ {
+	for i := range ret {
 		ret[i] = []byte(strconv.Itoa(length - i))
 	}
 	return ret
@@ -279,7 +279,7 @@ func genBytesSlice(length int) [][]byte {
 
 func genInt64StringMap(length int) map[int64]string {
 	ret := make(map[int64]string, length)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		ret[int64(i)] = strconv.Itoa(i)
 	}
 	return ret

--- a/lib/go/test/tests/string_parse_allocation_test.go
+++ b/lib/go/test/tests/string_parse_allocation_test.go
@@ -42,7 +42,7 @@ func BenchmarkSimpleJsonStringParse_Allocations(b *testing.B) {
 	b.StopTimer()
 	numEscapedQuotes := 1000
 	var sb strings.Builder
-	for i := 0; i < numEscapedQuotes; i++ {
+	for range numEscapedQuotes {
 		sb.WriteString(`\"`)
 	}
 
@@ -51,7 +51,7 @@ func BenchmarkSimpleJsonStringParse_Allocations(b *testing.B) {
 	transport := thrift.NewTMemoryBuffer()
 	p := thrift.NewTJSONProtocol(transport)
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		transport.Reset()
 		transport.WriteString(testString)
 		transport.Flush(context.Background())

--- a/lib/go/test/tests/validate_test.go
+++ b/lib/go/test/tests/validate_test.go
@@ -107,7 +107,7 @@ func TestBasicValidator(t *testing.T) {
 	}
 	bt = validatetest.NewBasicTest()
 	bt.Map1 = make(map[string]string)
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		bt.Map1[strconv.Itoa(i)] = strconv.Itoa(i)
 	}
 	if err := bt.Validate(); err == nil {
@@ -149,7 +149,7 @@ func TestBasicValidator(t *testing.T) {
 		t.Errorf("Error cannot be unwrapped into *ValidationError: %v", err)
 	}
 	bt = validatetest.NewBasicTest()
-	for i := 0; i < 11; i++ {
+	for range 11 {
 		bt.Set1 = append(bt.Set1, "0")
 	}
 	if err := bt.Validate(); err == nil {
@@ -272,7 +272,7 @@ func TestFieldReference(t *testing.T) {
 	frt = validatetest.NewFieldReferenceTest()
 	frt.MaxSize = 8
 	frt.Map0 = make(map[string]string)
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		frt.Map0[strconv.Itoa(i)] = strconv.Itoa(i)
 	}
 	if err := frt.Validate(); err == nil {
@@ -289,7 +289,7 @@ func TestFieldReference(t *testing.T) {
 	}
 	frt = validatetest.NewFieldReferenceTest()
 	frt.MaxSize = 8
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		frt.List0 = append(frt.List0, "0")
 	}
 	if err := frt.Validate(); err == nil {
@@ -306,7 +306,7 @@ func TestFieldReference(t *testing.T) {
 	}
 	frt = validatetest.NewFieldReferenceTest()
 	frt.MaxSize = 8
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		frt.Set0 = append(frt.Set0, "0")
 	}
 	if err := frt.Validate(); err == nil {

--- a/lib/go/thrift/binary_protocol_test.go
+++ b/lib/go/thrift/binary_protocol_test.go
@@ -112,7 +112,7 @@ func generateSafeReadBytesBenchmark(askedSize int32, dataSize int) func(b *testi
 	return func(b *testing.B) {
 		data := make([]byte, dataSize)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			safeReadBytes(askedSize, bytes.NewReader(data))
 		}
 	}

--- a/lib/go/thrift/exception.go
+++ b/lib/go/thrift/exception.go
@@ -121,20 +121,20 @@ var _ TException = wrappedTException{}
 //
 // For a endpoint defined in thrift IDL like this:
 //
-//     service MyService {
-//       FooResponse foo(1: FooRequest request) throws (
-//         1: Exception1 error1,
-//         2: Exception2 error2,
-//       )
-//     }
+//	service MyService {
+//	  FooResponse foo(1: FooRequest request) throws (
+//	    1: Exception1 error1,
+//	    2: Exception2 error2,
+//	  )
+//	}
 //
 // The thrift compiler generated go code for the result TStruct would be like:
 //
-//     type MyServiceFooResult struct {
-//       Success *FooResponse `thrift:"success,0" db:"success" json:"success,omitempty"`
-//       Error1 *Exception1 `thrift:"error1,1" db:"error1" json:"error1,omitempty"`
-//       Error2 *Exception2 `thrift:"error2,2" db:"error2" json:"error2,omitempty"`
-//     }
+//	type MyServiceFooResult struct {
+//	  Success *FooResponse `thrift:"success,0" db:"success" json:"success,omitempty"`
+//	  Error1 *Exception1 `thrift:"error1,1" db:"error1" json:"error1,omitempty"`
+//	  Error2 *Exception2 `thrift:"error2,2" db:"error2" json:"error2,omitempty"`
+//	}
 //
 // And this function extracts the first non-nil exception out of
 // *MyServiceFooResult.
@@ -144,7 +144,7 @@ func ExtractExceptionFromResult(result TStruct) error {
 		return nil
 	}
 	typ := v.Type()
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		if typ.Field(i).Name == "Success" {
 			continue
 		}

--- a/lib/go/thrift/framed_transport_test.go
+++ b/lib/go/thrift/framed_transport_test.go
@@ -42,7 +42,7 @@ func TestTFramedTransportReuseTransport(t *testing.T) {
 	writer := NewTFramedTransport(trans)
 
 	t.Run("pair", func(t *testing.T) {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			// write
 			if _, err := io.Copy(writer, strings.NewReader(content)); err != nil {
 				t.Fatalf("Failed to write on #%d: %v", i, err)
@@ -64,7 +64,7 @@ func TestTFramedTransportReuseTransport(t *testing.T) {
 
 	t.Run("batched", func(t *testing.T) {
 		// write
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if _, err := io.Copy(writer, strings.NewReader(content)); err != nil {
 				t.Fatalf("Failed to write on #%d: %v", i, err)
 			}
@@ -74,7 +74,7 @@ func TestTFramedTransportReuseTransport(t *testing.T) {
 		}
 
 		// read
-		for i := 0; i < n; i++ {
+		for i := range n {
 			const (
 				size = len(content)
 			)

--- a/lib/go/thrift/header_transport.go
+++ b/lib/go/thrift/header_transport.go
@@ -494,7 +494,7 @@ func (t *THeaderTransport) parseHeaders(ctx context.Context, frameSize uint32) e
 		)
 		t.frameReader = reader
 		transformIDs := make([]THeaderTransformID, transformCount)
-		for i := 0; i < int(transformCount); i++ {
+		for i := range int(transformCount) {
 			id, err := hp.readVarint32()
 			if err != nil {
 				return err
@@ -536,7 +536,7 @@ func (t *THeaderTransport) parseHeaders(ctx context.Context, frameSize uint32) e
 			if err != nil {
 				return err
 			}
-			for i := 0; i < int(count); i++ {
+			for range int(count) {
 				key, err := hp.ReadString(ctx)
 				if err != nil {
 					return err

--- a/lib/go/thrift/header_transport_test.go
+++ b/lib/go/thrift/header_transport_test.go
@@ -316,7 +316,7 @@ func TestTHeaderTransportReuseTransport(t *testing.T) {
 	writer := NewTHeaderTransport(trans)
 
 	t.Run("pair", func(t *testing.T) {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			// write
 			if _, err := io.Copy(writer, strings.NewReader(content)); err != nil {
 				t.Fatalf("Failed to write on #%d: %v", i, err)
@@ -338,7 +338,7 @@ func TestTHeaderTransportReuseTransport(t *testing.T) {
 
 	t.Run("batched", func(t *testing.T) {
 		// write
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if _, err := io.Copy(writer, strings.NewReader(content)); err != nil {
 				t.Fatalf("Failed to write on #%d: %v", i, err)
 			}
@@ -348,7 +348,7 @@ func TestTHeaderTransportReuseTransport(t *testing.T) {
 		}
 
 		// read
-		for i := 0; i < n; i++ {
+		for i := range n {
 			const (
 				size = len(content)
 			)

--- a/lib/go/thrift/json_protocol_test.go
+++ b/lib/go/thrift/json_protocol_test.go
@@ -451,7 +451,7 @@ func TestReadJSONProtocolBinary(t *testing.T) {
 	if len(v) != len(value) {
 		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
 	}
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		if v[i] != value[i] {
 			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
 		}

--- a/lib/go/thrift/lowlevel_benchmarks_test.go
+++ b/lib/go/thrift/lowlevel_benchmarks_test.go
@@ -41,7 +41,7 @@ func BenchmarkBinaryBool_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -52,7 +52,7 @@ func BenchmarkBinaryByte_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -63,7 +63,7 @@ func BenchmarkBinaryI16_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -74,7 +74,7 @@ func BenchmarkBinaryI32_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -84,7 +84,7 @@ func BenchmarkBinaryI64_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -94,7 +94,7 @@ func BenchmarkBinaryDouble_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -104,7 +104,7 @@ func BenchmarkBinaryString_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -114,7 +114,7 @@ func BenchmarkBinaryBinary_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }
@@ -125,7 +125,7 @@ func BenchmarkBinaryBool_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -136,7 +136,7 @@ func BenchmarkBinaryByte_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -147,7 +147,7 @@ func BenchmarkBinaryI16_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -158,7 +158,7 @@ func BenchmarkBinaryI32_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -168,7 +168,7 @@ func BenchmarkBinaryI64_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -178,7 +178,7 @@ func BenchmarkBinaryDouble_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -188,7 +188,7 @@ func BenchmarkBinaryString_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -198,7 +198,7 @@ func BenchmarkBinaryBinary_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }
@@ -209,7 +209,7 @@ func BenchmarkBinaryBool_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -220,7 +220,7 @@ func BenchmarkBinaryByte_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -231,7 +231,7 @@ func BenchmarkBinaryI16_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -242,7 +242,7 @@ func BenchmarkBinaryI32_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -252,7 +252,7 @@ func BenchmarkBinaryI64_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -262,7 +262,7 @@ func BenchmarkBinaryDouble_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -272,7 +272,7 @@ func BenchmarkBinaryString_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -282,7 +282,7 @@ func BenchmarkBinaryBinary_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := binaryProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }
@@ -293,7 +293,7 @@ func BenchmarkCompactBool_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -304,7 +304,7 @@ func BenchmarkCompactByte_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -315,7 +315,7 @@ func BenchmarkCompactI16_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -326,7 +326,7 @@ func BenchmarkCompactI32_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -336,7 +336,7 @@ func BenchmarkCompactI64_0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -346,7 +346,7 @@ func BenchmarkCompactDouble0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -356,7 +356,7 @@ func BenchmarkCompactString0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -366,7 +366,7 @@ func BenchmarkCompactBinary0(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }
@@ -377,7 +377,7 @@ func BenchmarkCompactBool_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -388,7 +388,7 @@ func BenchmarkCompactByte_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -399,7 +399,7 @@ func BenchmarkCompactI16_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -410,7 +410,7 @@ func BenchmarkCompactI32_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -420,7 +420,7 @@ func BenchmarkCompactI64_1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -430,7 +430,7 @@ func BenchmarkCompactDouble1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -440,7 +440,7 @@ func BenchmarkCompactString1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -450,7 +450,7 @@ func BenchmarkCompactBinary1(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }
@@ -461,7 +461,7 @@ func BenchmarkCompactBool_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBool(b, p, trans)
 	}
 }
@@ -472,7 +472,7 @@ func BenchmarkCompactByte_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteByte(b, p, trans)
 	}
 }
@@ -483,7 +483,7 @@ func BenchmarkCompactI16_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI16(b, p, trans)
 	}
 }
@@ -494,7 +494,7 @@ func BenchmarkCompactI32_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI32(b, p, trans)
 	}
 }
@@ -504,7 +504,7 @@ func BenchmarkCompactI64_2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteI64(b, p, trans)
 	}
 }
@@ -514,7 +514,7 @@ func BenchmarkCompactDouble2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteDouble(b, p, trans)
 	}
 }
@@ -524,7 +524,7 @@ func BenchmarkCompactString2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteString(b, p, trans)
 	}
 }
@@ -534,7 +534,7 @@ func BenchmarkCompactBinary2(b *testing.B) {
 		b.Fatal(err)
 	}
 	p := compactProtoF.GetProtocol(trans)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ReadWriteBinary(b, p, trans)
 	}
 }

--- a/lib/go/thrift/protocol.go
+++ b/lib/go/thrift/protocol.go
@@ -146,7 +146,7 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 		if err != nil {
 			return err
 		}
-		for i := 0; i < size; i++ {
+		for range size {
 			err := Skip(ctx, self, keyType, maxDepth-1)
 			if err != nil {
 				return err
@@ -163,7 +163,7 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 		if err != nil {
 			return err
 		}
-		for i := 0; i < size; i++ {
+		for range size {
 			err := Skip(ctx, self, elemType, maxDepth-1)
 			if err != nil {
 				return err
@@ -175,7 +175,7 @@ func Skip(ctx context.Context, self TProtocol, fieldType TType, maxDepth int) (e
 		if err != nil {
 			return err
 		}
-		for i := 0; i < size; i++ {
+		for range size {
 			err := Skip(ctx, self, elemType, maxDepth-1)
 			if err != nil {
 				return err

--- a/lib/go/thrift/protocol_test.go
+++ b/lib/go/thrift/protocol_test.go
@@ -45,7 +45,7 @@ var (
 
 func init() {
 	protocol_bdata = make([]byte, PROTOCOL_BINARY_DATA_SIZE)
-	for i := 0; i < PROTOCOL_BINARY_DATA_SIZE; i++ {
+	for i := range PROTOCOL_BINARY_DATA_SIZE {
 		protocol_bdata[i] = byte((i + 'a') % 255)
 	}
 	BOOL_VALUES = []bool{false, true, false, false, true}
@@ -531,7 +531,7 @@ func ReadWriteBinary(t testing.TB, p TProtocol, trans TTransport) {
 	if len(v) != len(value) {
 		t.Errorf("%s: %T %T len(v) != len(value)... %d != %d", "ReadWriteBinary", p, trans, len(v), len(value))
 	} else {
-		for i := 0; i < len(v); i++ {
+		for i := range v {
 			if v[i] != value[i] {
 				t.Errorf("%s: %T %T %s != %s", "ReadWriteBinary", p, trans, v, value)
 			}

--- a/lib/go/thrift/serializer_test.go
+++ b/lib/go/thrift/serializer_test.go
@@ -328,7 +328,7 @@ func BenchmarkSerializer(b *testing.B) {
 		b.Run(
 			c.Label,
 			func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
+				for range b.N {
 					s := c.Serializer()
 					m := MyTestStruct{}
 					str, _ := s.WriteString(context.Background(), &m)

--- a/lib/go/thrift/serializer_types_test.go
+++ b/lib/go/thrift/serializer_types_test.go
@@ -319,7 +319,7 @@ func (p *MyTestStruct) readField9(ctx context.Context, iprot TProtocol) error {
 	}
 	tMap := make(map[string]string, size)
 	p.StringMap = tMap
-	for i := 0; i < size; i++ {
+	for range size {
 		var _key0 string
 		if v, err := iprot.ReadString(ctx); err != nil {
 			return PrependError("error reading field 0: ", err)
@@ -347,7 +347,7 @@ func (p *MyTestStruct) readField10(ctx context.Context, iprot TProtocol) error {
 	}
 	tSlice := make([]string, 0, size)
 	p.StringList = tSlice
-	for i := 0; i < size; i++ {
+	for range size {
 		var _elem2 string
 		if v, err := iprot.ReadString(ctx); err != nil {
 			return PrependError("error reading field 0: ", err)
@@ -369,7 +369,7 @@ func (p *MyTestStruct) readField11(ctx context.Context, iprot TProtocol) error {
 	}
 	tSet := make(map[string]struct{}, size)
 	p.StringSet = tSet
-	for i := 0; i < size; i++ {
+	for range size {
 		var _elem3 string
 		if v, err := iprot.ReadString(ctx); err != nil {
 			return PrependError("error reading field 0: ", err)

--- a/lib/go/thrift/simple_json_protocol.go
+++ b/lib/go/thrift/simple_json_protocol.go
@@ -1306,7 +1306,7 @@ func (p *TSimpleJSONProtocol) readNumeric() (Numeric, error) {
 
 // Safely peeks into the buffer, reading only what is necessary
 func (p *TSimpleJSONProtocol) safePeekContains(b []byte) bool {
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		a, _ := p.reader.Peek(i + 1)
 		if len(a) < (i+1) || a[i] != b[i] {
 			return false

--- a/lib/go/thrift/simple_json_protocol_test.go
+++ b/lib/go/thrift/simple_json_protocol_test.go
@@ -497,7 +497,7 @@ func TestReadSimpleJSONProtocolBinary(t *testing.T) {
 	if len(v) != len(value) {
 		t.Fatalf("Bad value for %s value length %v, wrote: %v, received length: %v", thetype, len(value), s, len(v))
 	}
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		if v[i] != value[i] {
 			t.Fatalf("Bad value for %s at index %d value %v, wrote: %v, received: %v", thetype, i, value[i], s, v[i])
 		}

--- a/lib/go/thrift/ssl_server_socket.go
+++ b/lib/go/thrift/ssl_server_socket.go
@@ -93,6 +93,9 @@ func (p *TSSLServerSocket) Open() error {
 }
 
 func (p *TSSLServerSocket) Addr() net.Addr {
+	if p.listener != nil {
+		return p.listener.Addr()
+	}
 	return p.addr
 }
 

--- a/lib/go/thrift/transport_test.go
+++ b/lib/go/thrift/transport_test.go
@@ -36,7 +36,7 @@ var (
 
 func init() {
 	transport_bdata = make([]byte, TRANSPORT_BINARY_DATA_SIZE)
-	for i := 0; i < TRANSPORT_BINARY_DATA_SIZE; i++ {
+	for i := range TRANSPORT_BINARY_DATA_SIZE {
 		transport_bdata[i] = byte((i + 'a') % 255)
 	}
 	transport_header = map[string]string{"key": "User-Agent",

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/test/go
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/go/src/bin/stress/main.go
+++ b/test/go/src/bin/stress/main.go
@@ -133,7 +133,7 @@ func main() {
 	if *clients != 0 {
 		ready.Add(*clients + 1)
 		done.Add(*clients)
-		for i := 0; i < *clients; i++ {
+		for range *clients {
 			go client(protocolFactory)
 		}
 		ready.Done()
@@ -170,45 +170,45 @@ func client(protocolFactory thrift.TProtocolFactory) {
 	ready.Wait()
 	switch callType {
 	case echoVoid:
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoVoid(ctx)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoByte:
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoByte(ctx, 42)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoI32:
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoI32(ctx, 4242)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoI64:
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoI64(ctx, 424242)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoString:
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoString(ctx, "TestString")
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echiList:
 		l := []int8{-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8}
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoList(ctx, l)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoSet:
 		s := []int8{-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8}
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoSet(ctx, s)
 			atomic.AddInt64(&clicounter, 1)
 		}
 	case echoMap:
 		m := map[int8]int8{-10: 10, -9: 9, -8: 8, -7: 7, -6: 6, -5: 5, -4: 4, -3: 3, -2: 2, -1: 1, 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8}
-		for i := 0; i < *loop; i++ {
+		for range *loop {
 			client.EchoMap(ctx, m)
 			atomic.AddInt64(&clicounter, 1)
 		}

--- a/test/go/src/bin/testserver/main.go
+++ b/test/go/src/bin/testserver/main.go
@@ -41,7 +41,7 @@ var certPath = flag.String("certPath", "keys", "Directory that contains SSL cert
 func main() {
 	flag.Parse()
 
-	processor, serverTransport, transportFactory, protocolFactory, err := common.GetServerParams(*host, *port, *domain_socket, *transport, *protocol, *ssl, *certPath, common.PrintingHandler)
+	processor, serverTransport, transportFactory, protocolFactory, _, err := common.GetServerParams(*host, *port, *domain_socket, *transport, *protocol, *ssl, *certPath, common.PrintingHandler)
 
 	if err != nil {
 		log.Fatalf("Unable to process server params: %v", err)

--- a/test/go/src/common/client.go
+++ b/test/go/src/common/client.go
@@ -37,14 +37,11 @@ func init() {
 }
 
 func StartClient(
-	host string,
-	port int64,
-	domain_socket string,
+	addr string,
 	transport string,
 	protocol string,
 	ssl bool,
 ) (client *thrifttest.ThriftTestClient, trans thrift.TTransport, err error) {
-	hostPort := fmt.Sprintf("%s:%d", host, port)
 	cfg := &thrift.TConfiguration{
 		TLSConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -70,13 +67,9 @@ func StartClient(
 		protocolFactory = thrift.NewTDebugProtocolFactoryWithLogger(protocolFactory, "client:", thrift.StdLogger(nil))
 	}
 	if ssl {
-		trans = thrift.NewTSSLSocketConf(hostPort, cfg)
+		trans = thrift.NewTSSLSocketConf(addr, cfg)
 	} else {
-		if domain_socket != "" {
-			trans = thrift.NewTSocketConf(domain_socket, nil)
-		} else {
-			trans = thrift.NewTSocketConf(hostPort, nil)
-		}
+		trans = thrift.NewTSocketConf(addr, nil)
 	}
 	if err != nil {
 		return nil, nil, err
@@ -88,10 +81,9 @@ func StartClient(
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			client := &http.Client{Transport: tr}
-			trans, err = thrift.NewTHttpClientWithOptions(fmt.Sprintf("https://%s/", hostPort), thrift.THttpClientOptions{Client: client})
-			fmt.Println(hostPort)
+			trans, err = thrift.NewTHttpClientWithOptions(fmt.Sprintf("https://%s/", addr), thrift.THttpClientOptions{Client: client})
 		} else {
-			trans, err = thrift.NewTHttpClient(fmt.Sprintf("http://%s/", hostPort))
+			trans, err = thrift.NewTHttpClient(fmt.Sprintf("http://%s/", addr))
 		}
 	case "framed":
 		trans = thrift.NewTFramedTransportConf(trans, cfg)

--- a/test/go/src/common/context_test.go
+++ b/test/go/src/common/context_test.go
@@ -40,12 +40,17 @@ func (slowHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestHttpContextTimeout(t *testing.T) {
-	unit := test_unit{"127.0.0.1", 9096, "", "http", "binary", false}
+	const (
+		host = "127.0.0.1"
+		port = 9096
+	)
+	addr := fmt.Sprintf("%s:%d", host, port)
+	unit := test_unit{host, port, "", "http", "binary", false}
 
-	server := &http.Server{Addr: unit.host + fmt.Sprintf(":%d", unit.port), Handler: slowHttpHandler{}}
+	server := &http.Server{Addr: addr, Handler: slowHttpHandler{}}
 	go server.ListenAndServe()
 
-	client, trans, err := StartClient(unit.host, unit.port, unit.domain_socket, unit.transport, unit.protocol, unit.ssl)
+	client, trans, err := StartClient(addr, unit.transport, unit.protocol, unit.ssl)
 	if err != nil {
 		t.Errorf("Unable to start client: %v", err)
 		return

--- a/test/go/src/common/server.go
+++ b/test/go/src/common/server.go
@@ -46,10 +46,10 @@ func GetServerParams(
 	ssl bool,
 	certPath string,
 	handler thrifttest.ThriftTest,
-) (thrift.TProcessor, thrift.TServerTransport, thrift.TTransportFactory, thrift.TProtocolFactory, error) {
+) (thrift.TProcessor, thrift.TServerTransport, thrift.TTransportFactory, thrift.TProtocolFactory, string /* addr */, error) {
 
 	var err error
-	hostPort := fmt.Sprintf("%s:%d", host, port)
+	hostPort := fmt.Sprintf("%s:0", host)
 	var cfg *thrift.TConfiguration = nil
 
 	var protocolFactory thrift.TProtocolFactory
@@ -65,30 +65,54 @@ func GetServerParams(
 	case "header":
 		protocolFactory = thrift.NewTHeaderProtocolFactoryConf(nil)
 	default:
-		return nil, nil, nil, nil, fmt.Errorf("invalid protocol specified %s", protocol)
+		return nil, nil, nil, nil, "", fmt.Errorf("invalid protocol specified %s", protocol)
 	}
 	if debugServerProtocol {
 		protocolFactory = thrift.NewTDebugProtocolFactoryWithLogger(protocolFactory, "server:", thrift.StdLogger(nil))
 	}
 
 	var serverTransport thrift.TServerTransport
+	var addr string
 	if ssl {
 		cfg := new(tls.Config)
 		if cert, err := tls.LoadX509KeyPair(certPath+"/server.crt", certPath+"/server.key"); err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, "", err
 		} else {
 			cfg.Certificates = append(cfg.Certificates, cert)
 		}
-		serverTransport, err = thrift.NewTSSLServerSocket(hostPort, cfg)
+		transport, transportErr := thrift.NewTSSLServerSocket(hostPort, cfg)
+		if transportErr == nil {
+			listenErr := transport.Listen()
+			if listenErr == nil {
+				serverTransport = transport
+				addr = transport.Addr().String()
+			} else {
+				err = listenErr
+			}
+		} else {
+			err = transportErr
+		}
 	} else {
 		if domain_socket != "" {
 			serverTransport, err = thrift.NewTServerSocket(domain_socket)
+			addr = domain_socket
 		} else {
-			serverTransport, err = thrift.NewTServerSocket(hostPort)
+			transport, transportErr := thrift.NewTServerSocket(hostPort)
+			if transportErr == nil {
+				listenErr := transport.Listen()
+				if listenErr == nil {
+					serverTransport = transport
+					addr = transport.Addr().String()
+				} else {
+					err = listenErr
+				}
+			} else {
+				err = transportErr
+			}
 		}
 	}
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, "", err
 	}
 
 	var transportFactory thrift.TTransportFactory
@@ -107,9 +131,9 @@ func GetServerParams(
 	case "":
 		transportFactory = thrift.NewTTransportFactory()
 	default:
-		return nil, nil, nil, nil, fmt.Errorf("invalid transport specified %s", transport)
+		return nil, nil, nil, nil, "", fmt.Errorf("invalid transport specified %s", transport)
 	}
 	processor := thrifttest.NewThriftTestProcessor(handler)
 
-	return processor, serverTransport, transportFactory, protocolFactory, nil
+	return processor, serverTransport, transportFactory, protocolFactory, addr, nil
 }


### PR DESCRIPTION
Client: go

With the release of go 1.23, update supported go versions to 1.22+1.23 according to our go support policy.

Also update the code to use the new range loop feature introduced in go 1.22 when appropriate.

Also fix a bug in TSSLServerSocket.Addr that it does not return the listener address.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
