### PR TITLE
go: Fix cross test server

### DIFF
--- a/test/go/src/bin/testserver/main.go
+++ b/test/go/src/bin/testserver/main.go
@@ -59,7 +59,10 @@ func main() {
 				return
 			}
 		} else {
-			http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
+			if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {
+				fmt.Println(err)
+				return
+			}
 		}
 	} else {
 		server := thrift.NewTSimpleServer4(processor, serverTransport, transportFactory, protocolFactory)


### PR DESCRIPTION
Client: go

This was a bug introduced by 91565d490e98306ac6797dd6ed4f72c0e8222e78 that broke go's cross-test server, but because other CI issues we didn't run cross-test so we didn't notice the issue.
