### PR TITLE
Fix python build on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,7 @@ jobs:
 
       - name: Python setup
         run: |
-          python -m pip install --upgrade pip setuptools wheel flake8 tornado twisted zope.interface
+          python -m pip install --upgrade pip setuptools wheel flake8 six tornado twisted zope.interface
           python --version
           pip --version
 


### PR DESCRIPTION
There were some recent changes causing six to be installed on the `make
install` step instead of (implicitly) on the `Python setup` step before,
and the six installed on `make install` step was not available to the
next `make check` step and causing errors.

Install six on `Python setup` step explicitly instead.
