### PR TITLE
THRIFT-5813: Close the socket in TSocket.isOpen() when peek() fails

### DIFF
--- a/lib/py/test/test_socket.py
+++ b/lib/py/test/test_socket.py
@@ -67,9 +67,11 @@ class TSocketTest(unittest.TestCase):
             # once the server side closes, it no longer shows open
             acc.client.close()  # this also blocks until the other thread is done
             acc.close()
-            self.assertFalse(sock.isOpen())
 
-            sock.close()
+            self.assertIsNotNone(sock.handle)
+            self.assertFalse(sock.isOpen())
+            # after isOpen() returned False the socket should be closed (THRIFT-5813)
+            self.assertIsNone(sock.handle)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Client: py

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
