### PR TITLE
THRIFT-5816: lib/cpp/src/thrift/TUuid.h: Fix UUID usage for boost 1.86.0

### DIFF
--- a/lib/cpp/src/thrift/TUuid.h
+++ b/lib/cpp/src/thrift/TUuid.h
@@ -90,7 +90,7 @@ public:
   #endif // THRIFT_TUUID_BOOST_CONSTRUCTOR_EXPLICIT
   TUuid(const boost::uuids::uuid& buuid) noexcept
   {
-    std::copy(std::begin(buuid.data), std::end(buuid.data), std::begin(this->data_));
+    std::copy(std::begin(buuid), std::end(buuid), std::begin(this->data_));
   }
 #endif // THRIFT_TUUID_SUPPORT_BOOST_UUID
 


### PR DESCRIPTION
This is a demo of the change suggested in [https://issues.apache.org/jira/browse/THRIFT-5773](https://issues.apache.org/jira/browse/THRIFT-5773?focusedCommentId=17878870&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17878870)