### PR TITLE
Added missing installation of header `TUuidUtils.hpp`

### DIFF
--- a/lib/cpp/CMakeLists.txt
+++ b/lib/cpp/CMakeLists.txt
@@ -208,7 +208,7 @@ endif()
 
 # Install the headers
 install(DIRECTORY "src/thrift" DESTINATION "${INCLUDE_INSTALL_DIR}"
-    FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc")
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc" PATTERN "*.hpp")
 # Copy config.h file
 install(DIRECTORY "${CMAKE_BINARY_DIR}/thrift" DESTINATION "${INCLUDE_INSTALL_DIR}"
     FILES_MATCHING PATTERN "*.h")

--- a/lib/cpp/Makefile.am
+++ b/lib/cpp/Makefile.am
@@ -178,6 +178,7 @@ include_protocol_HEADERS = \
                          src/thrift/protocol/TProtocolTap.h \
                          src/thrift/protocol/TProtocolTypes.h \
                          src/thrift/protocol/TProtocolException.h \
+                         src/thrift/protocol/TUuidUtils.hpp \
                          src/thrift/protocol/TVirtualProtocol.h \
                          src/thrift/protocol/TProtocol.h
 


### PR DESCRIPTION
I think that current master is missing the installation of a relevant header `src/thrift/protocol/TUuidUtils.hpp`. This PR adds the header to the installation.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
