### PR TITLE
THRIFT-5816: Fix UUID for boost 1.86.0 (change in {{data}} member usage)

### DIFF
--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -112,8 +112,8 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  std::string testUuid(const std::string thing) override {
-    cout << "[C -> C++] testUuid(\"" << std::hex << thing << "\")" << '\n';
+  apache::thrift::TUuid testUuid(const apache::thrift::TUuid thing) override {
+    cout << "[C -> C++] testUuid(\"" << thing << "\")" << '\n';
     return thing;
   }
 

--- a/lib/c_glib/test/testthrifttestzlibclient.cpp
+++ b/lib/c_glib/test/testthrifttestzlibclient.cpp
@@ -107,8 +107,8 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  std::string testUuid(const std::string thing) override {
-    cout << "[C -> C++] testUuid(\"" << std::hex << thing << "\")" << '\n';
+  apache::thrift::TUuid testUuid(const apache::thrift::TUuid thing) override {
+    cout << "[C -> C++] testUuid(\"" << thing << "\")" << '\n';
     return thing;
   }
 

--- a/lib/cpp/src/thrift/TUuid.cpp
+++ b/lib/cpp/src/thrift/TUuid.cpp
@@ -37,7 +37,7 @@ TUuid::TUuid(const std::string& str) noexcept {
   }
 
   try {
-    const boost::uuids::uuid uuid{gen(str)};
+    const boost::uuids::uuid uuid = gen(str);
     std::copy(uuid.begin(), uuid.end(), this->begin());
   } catch (const std::runtime_error&) {
     // Invalid string most probably

--- a/lib/cpp/src/thrift/TUuid.h
+++ b/lib/cpp/src/thrift/TUuid.h
@@ -90,7 +90,7 @@ public:
   #endif // THRIFT_TUUID_BOOST_CONSTRUCTOR_EXPLICIT
   TUuid(const boost::uuids::uuid& buuid) noexcept
   {
-    std::copy(std::begin(buuid.data), std::end(buuid.data), std::begin(this->data_));
+    std::copy(buuid.begin(), buuid.end(), std::begin(this->data_));
   }
 #endif // THRIFT_TUUID_SUPPORT_BOOST_UUID
 

--- a/lib/cpp/test/TUuidTest.cpp
+++ b/lib/cpp/test/TUuidTest.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(into_boost_uuid) {
 
 BOOST_AUTO_TEST_CASE(from_boost_uuid) {
   static boost::uuids::string_generator gen;
-  boost::uuids::uuid boost_uuid{gen("1f610073-db33-4d21-adf2-75460d4955cc")};
+  boost::uuids::uuid boost_uuid = gen("1f610073-db33-4d21-adf2-75460d4955cc");
   BOOST_TEST(!boost_uuid.is_nil());
   TUuid uuid;
   BOOST_TEST(uuid.is_nil());
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(test_character_buffer) {
 BOOST_AUTO_TEST_CASE(test_boost_buffer) {
 
   static boost::uuids::string_generator gen;
-  boost::uuids::uuid boost_uuid{gen("1f610073-db33-4d21-adf2-75460d4955cc")};
+  boost::uuids::uuid boost_uuid = gen("1f610073-db33-4d21-adf2-75460d4955cc");
   BOOST_TEST(!boost_uuid.is_nil());
 
   const TUuid uuid{boost_uuid.data};


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Tries to fix compiler issues with latest boost (1.86)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
 [THRIFT-5816](https://issues.apache.org/jira/browse/THRIFT-5816)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
