### PR TITLE
THRIFT-5817: [C++] Avoid copy of TUuid

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -274,9 +274,12 @@ public:
   bool is_complex_type(t_type* ttype) {
     ttype = get_true_type(ttype);
 
-    return ttype->is_container() || ttype->is_struct() || ttype->is_xception()
+    return ttype->is_container() //
+           || ttype->is_struct() //
+           || ttype->is_xception()
            || (ttype->is_base_type()
-               && (((t_base_type*)ttype)->get_base() == t_base_type::TYPE_STRING));
+               && ((((t_base_type*)ttype)->get_base() == t_base_type::TYPE_STRING)
+                   || (((t_base_type*)ttype)->get_base() == t_base_type::TYPE_UUID)));
   }
 
   void set_use_include_prefix(bool use_include_prefix) { use_include_prefix_ = use_include_prefix; }
@@ -4498,7 +4501,7 @@ string t_cpp_generator::type_name(t_type* ttype, bool in_typedef, bool arg) {
       return bname;
     }
 
-    if (((t_base_type*)ttype)->get_base() == t_base_type::TYPE_STRING) {
+    if ((((t_base_type*)ttype)->get_base() == t_base_type::TYPE_STRING) || ((((t_base_type*)ttype)->get_base() == t_base_type::TYPE_UUID))) {
       return "const " + bname + "&";
     } else {
       return "const " + bname;

--- a/lib/c_glib/test/testthrifttestclient.cpp
+++ b/lib/c_glib/test/testthrifttestclient.cpp
@@ -112,9 +112,9 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  apache::thrift::TUuid testUuid(const apache::thrift::TUuid thing) override {
+  void testUuid(apache::thrift::TUuid& out, const apache::thrift::TUuid& thing) override {
     cout << "[C -> C++] testUuid(\"" << thing << "\")" << '\n';
-    return thing;
+    out = thing;
   }
 
   void testStruct(Xtruct& out, const Xtruct &thing) override {

--- a/lib/c_glib/test/testthrifttestzlibclient.cpp
+++ b/lib/c_glib/test/testthrifttestzlibclient.cpp
@@ -107,9 +107,9 @@ class TestHandler : public ThriftTestIf {
     out = thing;
   }
 
-  apache::thrift::TUuid testUuid(const apache::thrift::TUuid thing) override {
+  void testUuid(apache::thrift::TUuid& out, const apache::thrift::TUuid& thing) override {
     cout << "[C -> C++] testUuid(\"" << thing << "\")" << '\n';
-    return thing;
+    out = thing;
   }
 
   void testStruct(Xtruct& out, const Xtruct &thing) override {
@@ -297,7 +297,7 @@ class TestHandler : public ThriftTestIf {
   }
 
   void testException(const std::string &arg)
-    throw(Xception, apache::thrift::TException) override
+    noexcept(false) override
   {
     cout << "[C -> C++] testException(" << arg << ")" << '\n';
     if (arg.compare("Xception") == 0) {
@@ -315,7 +315,7 @@ class TestHandler : public ThriftTestIf {
     }
   }
 
-  void testMultiException(Xtruct &result, const std::string &arg0, const std::string &arg1) throw(Xception, Xception2) override {
+  void testMultiException(Xtruct &result, const std::string &arg0, const std::string &arg1) noexcept(false) override {
 
     cout << "[C -> C++] testMultiException(" << arg0 << ", " << arg1 << ")" << '\n';
 

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -181,7 +181,9 @@ bool print_eq(T expected, T actual) {
 #define UUID_TEST(func, value, expected)                                                           \
   cout << #func "(" << value << ") = ";                                                            \
   try {                                                                                            \
-    if (!print_eq(expected, testClient.func(value)))                                               \
+    TUuid ret;                                                                                     \
+    testClient.func(ret, value);                                                                   \
+    if (!print_eq(expected, ret))                                                                  \
       return_code |= ERR_BASETYPES;                                                                \
   } catch (TTransportException&) {                                                                 \
     throw;                                                                                         \

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -132,9 +132,9 @@ public:
     _return = thing;
   }
 
-  TUuid testUuid(const TUuid thing) override {
+  void testUuid(apache::thrift::TUuid& _return, const apache::thrift::TUuid& thing) override {
     printf("testUuid(\"{%s}\")\n", to_string(thing).c_str());
-    return thing;
+    _return = thing;
   }
 
   void testStruct(Xtruct& out, const Xtruct& thing) override {
@@ -447,8 +447,9 @@ public:
     cob(res);
   }
 
-  void testUuid(::std::function<void(TUuid const& _return)> cob, const TUuid thing) override {
-    TUuid res = _delegate->testUuid(thing);
+  void testUuid(::std::function<void(apache::thrift::TUuid const& _return)> cob, const apache::thrift::TUuid& thing) override {
+    TUuid res;
+    _delegate->testUuid(res, thing);
     cob(res);
   }
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
[THRIFT-5817: [C++] Avoid copy of TUuid](https://issues.apache.org/jira/browse/THRIFT-5817)
Make TYPE_UUID as complex for C and C++ generator
- Generate code that does not make a copy for TUuid for C and C++

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) 
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"? 
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
    **This can be breaking, but not sure if it applies since I don't think UUID support has been released for C++**
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
