### PR TITLE
build python wheels for pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,10 +21,56 @@ name: "PyPI publishing"
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
+  build_wheels:
+    name: Build wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { os: macos-12, arch: x86_64, build: "*" }
+          - { os: macos-12, arch: arm64, build: "*" }
+          - { os: windows-latest, arch: AMD64, build: "*" }
+          - { os: ubuntu-latest, arch: x86_64, build: "*" }
+
+          # arm is slow on github actions
+          # split built to multiple jobs to make whole job finish faster
+          - { os: ubuntu-latest, arch: aarch64, build: "*[05]-manylinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[16]-manylinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[27]-manylinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[38]-manylinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[49]-manylinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[05]-musllinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[16]-musllinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[27]-musllinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[38]-musllinux*" }
+          - { os: ubuntu-latest, arch: aarch64, build: "*[49]-musllinux*" }
+    steps:
+      - uses: docker/setup-qemu-action@v3
+        if: matrix.os == 'ubuntu-latest'
+
+      - uses: actions/checkout@v4
+
+      - uses: pypa/cibuildwheel@v2.21.1
+        with:
+          package-dir: lib/py
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.build }}
+          CIBW_SKIP: 'pp*'
+
+      - run: ls ./wheelhouse/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: 'wheels-${{ runner.os }}-${{ matrix.arch }}-${{ strategy.job-index }}'
+          path: ./wheelhouse/*.whl
+
   pypi-publish:
+    needs: [ 'build_wheels' ]
     name: Publish release to PyPI
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
@@ -41,9 +87,18 @@ jobs:
           python-version: "3.8"
 
       - name: Build
-        run: |
-          cd lib/py
-          python setup.py sdist
+        working-directory: lib/py
+        env:
+          THRIFT_BUILD_PURE_PYTHON: '1'
+        run: pipx run build
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: lib/py/dist/
+          merge-multiple: true
+
+      - run: ls -ahl lib/py/dist/
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -96,11 +96,10 @@ def run_setup(with_binary):
     else:
         extensions = dict()
 
-    ssl_deps = []
-    if sys.version_info[0] == 2:
-        ssl_deps.append('ipaddress')
-    if sys.hexversion < 0x03050000:
-        ssl_deps.append('backports.ssl_match_hostname>=3.5')
+    ssl_deps = [
+        'ipaddress; python_version < "3.0"',
+        'backports.ssl_match_hostname>=3.5; python_version < "3.5"',
+    ]
     tornado_deps = ['tornado>=4.0']
     twisted_deps = ['twisted']
 
@@ -142,15 +141,5 @@ def run_setup(with_binary):
           )
 
 
-try:
-    with_binary = True
-    run_setup(with_binary)
-except BuildFailed:
-    print()
-    print('*' * 80)
-    print("An error occurred while trying to compile with the C extension enabled")
-    print("Attempting to build without the extension now")
-    print('*' * 80)
-    print()
-
-    run_setup(False)
+with_binary = os.environ.get('THRIFT_BUILD_PURE_PYTHON') != '1'
+run_setup(with_binary)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->


current we only publish sdist on pypi and it require users to have a complete build environment setup to use c extension.

This PR add jobs to ci, compile binary extension and build package as wheels, so a py downstream user could use fastbinary without any compiler.

ci files have been test in my personal repo (it fails at uploading as expected, please checkout ls step to see wheels):

https://github.com/trim21/thrift/actions/runs/10965757082/job/30452465665

