### PR TITLE
THRIFT-5818: Add AIX support

### DIFF
--- a/lib/go/thrift/socket_aix_syscall.go
+++ b/lib/go/thrift/socket_aix_syscall.go
@@ -1,0 +1,29 @@
+//go:build aix
+// +build aix
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import "syscall"
+
+func peekNonblocking(fd int, p []byte) (int, syscall.Sockaddr, error) {
+	return syscall.Recvfrom(fd, p, syscall.MSG_PEEK|syscall.MSG_NONBLOCK)
+}

--- a/lib/go/thrift/socket_non_aix_syscall.go
+++ b/lib/go/thrift/socket_non_aix_syscall.go
@@ -1,0 +1,29 @@
+//go:build !aix && !windows && !wasm
+// +build !aix,!windows,!wasm
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import "syscall"
+
+func peekNonblocking(fd int, p []byte) (int, syscall.Sockaddr, error) {
+	return syscall.Recvfrom(fd, p, syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+}

--- a/lib/go/thrift/socket_unix_conn.go
+++ b/lib/go/thrift/socket_unix_conn.go
@@ -58,7 +58,7 @@ func (sc *socketConn) checkConn() error {
 	var n int
 
 	if readErr := rc.Read(func(fd uintptr) bool {
-		n, _, err = syscall.Recvfrom(int(fd), sc.buffer[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+		n, _, err = peekNonblocking(int(fd), sc.buffer[:])
 		return true
 	}); readErr != nil {
 		return readErr


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
This PR adds support for AIX by splitting the `syscall.Recvfrom()` call into AIX and non-AIX variants. This split is necessary because AIX does not have a `MSG_DONTWAIT` flag, but has an equivalent called `MSG_NONBLOCK`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
