### PR TITLE
Add support for boringssl

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -152,12 +152,16 @@ void cleanupOpenSSL() {
 #if (OPENSSL_VERSION_NUMBER < OPENSSL_ENGINE_CLEANUP_REQUIRED_BEFORE)
   ENGINE_cleanup();             // https://www.openssl.org/docs/man1.1.0/crypto/ENGINE_cleanup.html - cleanup call is needed before 1.1.0
 #endif
+#if !defined(OPENSSL_IS_BORINGSSL)
   CONF_modules_unload(1);
+#endif
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
+#  if !defined(OPENSSL_IS_BORINGSSL)
   // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
   OPENSSL_thread_stop();
+#  endif
 #else
   // ERR_remove_state() was deprecated in OpenSSL 1.0.0 and ERR_remove_thread_state()
   // was deprecated in OpenSSL 1.1.0; these functions and should not be used.
@@ -394,8 +398,10 @@ void TSSLSocket::close() {
     ssl_ = nullptr;
     handshakeCompleted_ = false;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
+#  if !defined(OPENSSL_IS_BORINGSSL)
     // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
     OPENSSL_thread_stop();
+#  endif
 #else
     // ERR_remove_state() was deprecated in OpenSSL 1.0.0 and ERR_remove_thread_state()
     // was deprecated in OpenSSL 1.1.0; these functions and should not be used.


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
This adds support for boringssl where OPENSSL_thread_stop is not implemented/defined and CONF_modules_unload is also missing. Fixed by removing these calls when boringssl is in use.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
