### PR TITLE
THRIFT-5836 No rule to make target 'Thrift5272.thrift', needed by 'gen-cpp/Thrift5272_types.h'

### DIFF
--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -471,4 +471,6 @@ EXTRA_DIST = \
 	CMakeLists.txt \
 	DebugProtoTest_extras.cpp \
 	ThriftTest_extras.cpp \
-	OneWayTest.thrift
+	OneWayTest.thrift \
+	Thrift5272.thrift
+


### PR DESCRIPTION
Patch: Jens Geyer