### PR TITLE
THRIFT-5838: ensure original exception added to new exceptions

### DIFF
--- a/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
+++ b/lib/netstd/Thrift/Transport/Client/THttpTransport.cs
@@ -167,7 +167,7 @@ namespace Thrift.Transport.Client
             }
             catch (IOException iox)
             {
-                throw new TTransportException(TTransportException.ExceptionType.Unknown, iox.ToString());
+                throw new TTransportException(TTransportException.ExceptionType.Unknown, iox.ToString(), iox);
             }
         }
 
@@ -260,16 +260,20 @@ namespace Thrift.Transport.Client
             }
             catch (IOException iox)
             {
-                throw new TTransportException(TTransportException.ExceptionType.Unknown, iox.ToString());
+                throw new TTransportException(TTransportException.ExceptionType.Unknown, iox.ToString(), iox);
             }
             catch (HttpRequestException wx)
             {
                 throw new TTransportException(TTransportException.ExceptionType.Unknown,
-                    "Couldn't connect to server: " + wx);
+                    "Couldn't connect to server: " + wx, wx);
+            }
+            catch (OperationCanceledException ocx)
+            {
+                throw new TTransportException(TTransportException.ExceptionType.Interrupted, ocx.Message, ocx);
             }
             catch (Exception ex)
             {
-                throw new TTransportException(TTransportException.ExceptionType.Unknown, ex.Message);
+                throw new TTransportException(TTransportException.ExceptionType.Unknown, ex.Message, ex);
             }
             finally
             {

--- a/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TNamedPipeServerTransport.cs
@@ -347,7 +347,7 @@ namespace Thrift.Transport.Server
             catch (Exception e)
             {
                 Close();
-                throw new TTransportException(TTransportException.ExceptionType.NotOpen, e.Message);
+                throw new TTransportException(TTransportException.ExceptionType.NotOpen, e.Message, e);
             }
         }
 

--- a/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TServerSocketTransport.cs
@@ -51,10 +51,10 @@ namespace Thrift.Transport.Server
                 _server.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
                 _server.Server.NoDelay = true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 _server = null;
-                throw new TTransportException("Could not create ServerSocket on port " + port + ".");
+                throw new TTransportException("Could not create ServerSocket on port " + port + ".", ex);
             }
         }
 
@@ -95,7 +95,7 @@ namespace Thrift.Transport.Server
                 }
                 catch (SocketException sx)
                 {
-                    throw new TTransportException("Could not accept on listening socket: " + sx.Message);
+                    throw new TTransportException("Could not accept on listening socket: " + sx.Message, sx);
                 }
             }
         }
@@ -147,7 +147,7 @@ namespace Thrift.Transport.Server
             }
             catch (Exception ex)
             {
-                throw new TTransportException(ex.ToString());
+                throw new TTransportException(ex.ToString(), ex);
             }
         }
 
@@ -161,7 +161,7 @@ namespace Thrift.Transport.Server
                 }
                 catch (Exception ex)
                 {
-                    throw new TTransportException("WARNING: Could not close server socket: " + ex);
+                    throw new TTransportException("WARNING: Could not close server socket: " + ex, ex);
                 }
                 _server = null;
             }

--- a/lib/netstd/Thrift/Transport/Server/TTlsServerSocketTransport.cs
+++ b/lib/netstd/Thrift/Transport/Server/TTlsServerSocketTransport.cs
@@ -74,10 +74,10 @@ namespace Thrift.Transport.Server
                 _server = new TcpListener(IPAddress.Any, port);
                 _server.Server.NoDelay = true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 _server = null;
-                throw new TTransportException($"Could not create ServerSocket on port {port}.");
+                throw new TTransportException($"Could not create ServerSocket on port {port}.", ex);
             }
         }
 
@@ -118,7 +118,7 @@ namespace Thrift.Transport.Server
                 }
                 catch (SocketException sx)
                 {
-                    throw new TTransportException($"Could not accept on listening socket: {sx.Message}");
+                    throw new TTransportException($"Could not accept on listening socket: {sx.Message}", sx);
                 }
             }
         }
@@ -158,7 +158,7 @@ namespace Thrift.Transport.Server
             }
             catch (Exception ex)
             {
-                throw new TTransportException(ex.ToString());
+                throw new TTransportException(ex.ToString(), ex);
             }
         }
 
@@ -172,7 +172,7 @@ namespace Thrift.Transport.Server
                 }
                 catch (Exception ex)
                 {
-                    throw new TTransportException($"WARNING: Could not close server socket: {ex}");
+                    throw new TTransportException($"WARNING: Could not close server socket: {ex}", ex);
                 }
 
                 _server = null;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
1. Adds the original exception to any rethrown exception. This ensures callers can find the original underlying exception. For example, `TaskCanceledException`.
2. Adds an explicit exception handler for `OperationCanceledException`.
 
Resolves issue : https://issues.apache.org/jira/browse/THRIFT-5838

