### PR TITLE
Fix build warnings for Erlang/OTP 27

### DIFF
--- a/lib/erl/rebar.config
+++ b/lib/erl/rebar.config
@@ -39,7 +39,7 @@
 ]}.
 
 {plugins, [
-    {erlfmt, "1.1.0"}
+    {erlfmt, "1.5.0"}
 ]}.
 
 {erlfmt, [

--- a/lib/erl/src/thrift.app.src
+++ b/lib/erl/src/thrift.app.src
@@ -21,8 +21,8 @@
     % A quick description of the application.
     {description, "Thrift bindings"},
 
-  % The version of the applicaton
-  {vsn, "0.22.0"},
+    % The version of the applicaton
+    {vsn, "0.22.0"},
 
     % All modules used by the application.
     {modules, []},


### PR DESCRIPTION
Client: Erlang
Since [erlfmt](https://github.com/WhatsApp/erlfmt/releases/tag/v1.5.0) is a build dependency, and the currently used version generates build warnings with latest OTP 27, we lift its version.

Example of warnings that are fixed:
```
===> Compiling erlfmt
    ┌─ _build/default/plugins/erlfmt/src/erlfmt_parse.yrl:
    │
 96 │  node -> standalone_exprs exprs dot : {exprs, (?range_anno('$1', '$3'))#{dot => true}, '$2'}.
    │                                                                        ╰── Warning: expression updates a literal

     ┌─ _build/default/plugins/erlfmt/src/erlfmt_parse.yrl:
     │
 149 │      {record, (?range_anno('$1', '$3'))#{macro_record => true}, '$1', []}.
     │                                        ╰── Warning: expression updates a literal
...
```
Includes a formatting correction (legacy) that is verified to work with the script `build/veralign.sh`.

This change is additionally tested to work with older OTP 23 and 24.