### PR TITLE
THRIFT-5564: Add nodejs tests to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,6 +519,32 @@ jobs:
       - name: Run make check for python
         run: make -C lib/py check
 
+  lib-nodejs:
+    needs: compiler
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Run configure
+        run: |
+          ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-nodejs/with-nodejs/')
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Run thrift-compiler
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+
+      - name: Run tests
+        run: make -C lib/nodejs check
+
   cross-test:
     needs:
       - lib-java-kotlin

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -86,7 +86,7 @@ function TApplicationException(type, message) {
 };
 util.inherits(TApplicationException, TException);
 
-TApplicationException.prototype.read = function(input) {
+TApplicationException.prototype[Symbol.for("read")] = TApplicationException.prototype.read = function(input) {
   var ftype;
   var ret = input.readStructBegin('TApplicationException');
 
@@ -121,7 +121,7 @@ TApplicationException.prototype.read = function(input) {
   input.readStructEnd();
 };
 
-TApplicationException.prototype.write = function(output){
+TApplicationException.prototype[Symbol.for("write")] = TApplicationException.prototype.write = function(output){
   output.writeStructBegin('TApplicationException');
 
   if (this.message) {

--- a/lib/nodejs/test/deep-constructor.test.js
+++ b/lib/nodejs/test/deep-constructor.test.js
@@ -28,7 +28,7 @@ function serializeBinary(data) {
     buff = msg;
   });
   const prot = new thrift.TBinaryProtocol(transport);
-  data.write(prot);
+  data[Symbol.for("write")](prot);
   prot.flush();
   return buff;
 }
@@ -37,7 +37,7 @@ function deserializeBinary(serialized, type) {
   const t = new thrift.TFramedTransport(serialized);
   const p = new thrift.TBinaryProtocol(t);
   const data = new type();
-  data.read(p);
+  data[Symbol.for("read")](p);
   return data;
 }
 
@@ -48,7 +48,7 @@ function serializeJSON(data) {
   });
   const protocol = new thrift.TJSONProtocol(transport);
   protocol.writeMessageBegin("", 0, 0);
-  data.write(protocol);
+  data[Symbol.for("write")](protocol);
   protocol.writeMessageEnd();
   protocol.flush();
   return buff;
@@ -59,7 +59,7 @@ function deserializeJSON(serialized, type) {
   const protocol = new thrift.TJSONProtocol(transport);
   protocol.readMessageBegin();
   const data = new type();
-  data.read(protocol);
+  data[Symbol.for("read")](protocol);
   protocol.readMessageEnd();
   return data;
 }


### PR DESCRIPTION
These tests exist, but don't currently run on github actions. This adds a new job to run these.

This also fixes the regression in the tests caused by https://github.com/apache/thrift/pull/3014.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
