### PR TITLE
THRIFT-5564: Add nodets tests to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,7 +530,7 @@ jobs:
 
       - name: Run configure
         run: |
-          ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-nodejs/with-nodejs/')
+          ./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed -E 's/without-node([tj])s/with-node\1s/g')
 
       - uses: actions/download-artifact@v4
         with:
@@ -542,8 +542,11 @@ jobs:
           chmod a+x compiler/cpp/thrift
           compiler/cpp/thrift -version
 
-      - name: Run tests
+      - name: Run js tests
         run: make -C lib/nodejs check
+
+      - name: Run ts tests
+        run: make -C lib/nodets check
 
   cross-test:
     needs:


### PR DESCRIPTION
Client: nodets

This adds the tests for the "nodets" library. This isn't an actual library, and are just another set of tests for the nodejs library, but using typescript. Therefore I have added them in the existing "nodejs" job.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
