### PR TITLE
Upstream mingw capitalization patch

### DIFF
--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -25,7 +25,7 @@
 #include <thrift/transport/THttpServer.h>
 #include <thrift/transport/TSocket.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
-  #include <Shlwapi.h>
+  #include <shlwapi.h>
 #endif
 
 using std::string;

--- a/lib/cpp/src/thrift/transport/TPipeServer.cpp
+++ b/lib/cpp/src/thrift/transport/TPipeServer.cpp
@@ -27,8 +27,8 @@
 #ifdef _WIN32
 #include <thrift/windows/OverlappedSubmissionThread.h>
 #include <thrift/windows/Sync.h>
-#include <AccCtrl.h>
-#include <Aclapi.h>
+#include <accctrl.h>
+#include <aclapi.h>
 #include <sddl.h>
 #endif //_WIN32
 

--- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
@@ -73,7 +73,7 @@
 // adds problematic macros like min() and max(). Try to work around:
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #undef NOMINMAX
 #undef WIN32_LEAN_AND_MEAN
 #endif

--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -31,7 +31,7 @@
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/THttpServer.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #define THRIFT_strncasecmp(str1, str2, len) _strnicmp(str1, str2, len)
 #define THRIFT_strcasestr(haystack, needle) StrStrIA(haystack, needle)
 #else

--- a/lib/cpp/src/thrift/windows/SocketPair.cpp
+++ b/lib/cpp/src/thrift/windows/SocketPair.cpp
@@ -34,7 +34,7 @@
 #include <string.h>
 
 // Win32
-#include <WS2tcpip.h>
+#include <ws2tcpip.h>
 
 int thrift_socketpair(int d, int type, int protocol, THRIFT_SOCKET sv[2]) {
   THRIFT_UNUSED_VARIABLE(protocol);

--- a/lib/cpp/src/thrift/windows/Sync.h
+++ b/lib/cpp/src/thrift/windows/Sync.h
@@ -37,7 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define _THRIFT_UNDEF_WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 #ifdef _THRIFT_UNDEF_NOMINMAX
 #undef NOMINMAX
 #undef _THRIFT_UNDEF_NOMINMAX


### PR DESCRIPTION
Analogous to https://github.com/apache/thrift/pull/2518, improve case-sensitive mingw capitalization

<!-- Explain the changes in the pull request below: -->
  Upstream mingw capitalization patch [https://github.com/JuliaPackaging…](https://github.com/JuliaPackaging/Yggdrasil/blob/6e82040941e891288e394713ee64562698b7ab0d/T/Thrift/bundled/patches/mingw-capitalization.patch)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
