### PR TITLE
Various build fixes for clang and rust builds

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.h
@@ -288,7 +288,7 @@ public:
 
   static bool is_pointer_field(t_field* tfield, bool in_container = false);
 
-  std::string indent_str() const {
+  std::string indent_str() const override {
     return "\t";
   }
 

--- a/compiler/cpp/src/thrift/parse/t_function.h
+++ b/compiler/cpp/src/thrift/parse/t_function.h
@@ -83,7 +83,7 @@ public:
 
   std::map<std::string, std::vector<std::string>> annotations_;
 
-  void validate() const {
+  void validate() const override {
     get_returntype()->validate();
 
 #ifndef ALLOW_EXCEPTIONS_AS_TYPE

--- a/compiler/cpp/src/thrift/parse/t_list.h
+++ b/compiler/cpp/src/thrift/parse/t_list.h
@@ -34,7 +34,7 @@ public:
 
   bool is_list() const override { return true; }
 
-  void validate() const {
+  void validate() const override {
 #ifndef ALLOW_EXCEPTIONS_AS_TYPE
     if( get_elem_type()->get_true_type()->is_xception()) {
       failure("exception type \"%s\" cannot be used inside a list", get_elem_type()->get_name().c_str());

--- a/compiler/cpp/src/thrift/parse/t_map.h
+++ b/compiler/cpp/src/thrift/parse/t_map.h
@@ -37,7 +37,7 @@ public:
 
   bool is_map() const override { return true; }
 
-  void validate() const {
+  void validate() const override {
 #ifndef ALLOW_EXCEPTIONS_AS_TYPE
     if( get_key_type()->get_true_type()->is_xception()) {
       failure("exception type \"%s\" cannot be used inside a map", get_key_type()->get_name().c_str());

--- a/compiler/cpp/src/thrift/parse/t_set.h
+++ b/compiler/cpp/src/thrift/parse/t_set.h
@@ -36,7 +36,7 @@ public:
 
   bool is_set() const override { return true; }
 
-  void validate() const {
+  void validate() const override {
 #ifndef ALLOW_EXCEPTIONS_AS_TYPE
     if( get_elem_type()->get_true_type()->is_xception()) {
       failure("exception type \"%s\" cannot be used inside a set", get_elem_type()->get_name().c_str());

--- a/compiler/cpp/src/thrift/parse/t_struct.h
+++ b/compiler/cpp/src/thrift/parse/t_struct.h
@@ -130,7 +130,7 @@ public:
     return nullptr;
   }
 
-  void validate() const {
+  void validate() const override {
     std::string what = "struct";
     if( is_union()) {
       what = "union";

--- a/tutorial/rs/src/bin/tutorial_client.rs
+++ b/tutorial/rs/src/bin/tutorial_client.rs
@@ -107,7 +107,7 @@ fn new_client(
 
     // open the underlying TCP stream
     println!("connecting to tutorial server on {}:{}", host, port);
-    c.open(&format!("{}:{}", host, port))?;
+    c.open(format!("{}:{}", host, port))?;
 
     // clone the TCP channel into two halves, one which
     // we'll use for reading, the other for writing


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 
This PR fixes the clang build (for the thrift compiler) and makes the Rust tutorial build pass as well.

The C++ changes fix `inconsistent override` compiler warnings, and the Rust change fixes a clippy warning about an unnecessary dereference.

I tested this with the below, which now passes (previously failed):

```
./configure --disable-dependency-tracking --without-python --without-ruby --without-perl  --without-py3 --without-swift --without-nodejs
make -j16
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), **not required for trivial changes**)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
