### PR TITLE
THRIFT-5849: Expose createClient in browser version of nodejs package

### DIFF
--- a/lib/nodejs/lib/thrift/browser.js
+++ b/lib/nodejs/lib/thrift/browser.js
@@ -33,6 +33,8 @@ exports.OhosConnection = ohosConnection.OhosConnection;
 exports.createOhosConnection = ohosConnection.createOhosConnection;
 exports.createOhosClient = ohosConnection.createOhosClient;
 
+exports.createClient = require('./create_client');
+
 exports.Int64 = require('node-int64');
 exports.Q = require('q');
 


### PR DESCRIPTION
`createClient` is exposed in a nodejs context, but not for browsers. Even though this is the same function as `createWsClient`, `createHttpClient`, etc, it would be better to be able to use the generic name with custom connection types. There is no reason I know of that prevents this from being exposed in a browser context - it appears to be more of an oversight.  

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
