### PR TITLE
THRIFT-5848: Expose InputBufferUnderrunError in nodejs client

### DIFF
--- a/lib/nodejs/lib/thrift/browser.js
+++ b/lib/nodejs/lib/thrift/browser.js
@@ -51,3 +51,5 @@ exports.Protocol = require('./json_protocol');
 exports.TJSONProtocol = require('./json_protocol');
 exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
+
+exports.InputBufferUnderrunError = require('./input_buffer_underrun_error');

--- a/lib/nodejs/lib/thrift/index.js
+++ b/lib/nodejs/lib/thrift/index.js
@@ -74,3 +74,5 @@ exports.TJSONProtocol = require('./json_protocol');
 exports.TBinaryProtocol = require('./binary_protocol');
 exports.TCompactProtocol = require('./compact_protocol');
 exports.THeaderProtocol = require('./header_protocol');
+
+exports.InputBufferUnderrunError = require('./input_buffer_underrun_error');

--- a/lib/nodejs/test/exceptions.js
+++ b/lib/nodejs/test/exceptions.js
@@ -20,7 +20,7 @@
 "use strict";
 const test = require("tape");
 const thrift = require("../lib/thrift/thrift.js");
-const InputBufferUnderrunError = require("../lib/thrift/input_buffer_underrun_error");
+const { InputBufferUnderrunError } = require("../lib/thrift");
 
 test("TApplicationException", function t(assert) {
   const e = new thrift.TApplicationException(1, "foo");


### PR DESCRIPTION
Client: nodejs

When implementing a custom `Connection`, it is very useful to be able to respond to `InputBufferUnderrunError` to roll back the position of the transport. This is now exposed through the root module, so that custom connections can use this.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
