### PR TITLE
THRIFT-5853: Remove oldstyle casts from TBufferTransports and TCompactProtocol

### DIFF
--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -35,12 +35,12 @@ namespace protocol {
 template <class Transport_>
 class TCompactProtocolT : public TVirtualProtocol<TCompactProtocolT<Transport_> > {
 public:
-  static const int8_t PROTOCOL_ID = (int8_t)0x82u;
+  static const int8_t PROTOCOL_ID = static_cast<int8_t>(0x82u);
   static const int8_t VERSION_N = 1;
   static const int8_t VERSION_MASK = 0x1f;       // 0001 1111
 
 protected:
-  static const int8_t TYPE_MASK = (int8_t)0xE0u; // 1110 0000
+  static const int8_t TYPE_MASK = static_cast<int8_t>(0xE0u); // 1110 0000
   static const int8_t TYPE_BITS = 0x07;          // 0000 0111
   static const int32_t TYPE_SHIFT_AMOUNT = 5;
 

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
@@ -93,7 +93,7 @@ uint32_t TCompactProtocolT<Transport_>::writeMessageBegin(
     const int32_t seqid) {
   uint32_t wsize = 0;
   wsize += writeByte(PROTOCOL_ID);
-  wsize += writeByte((VERSION_N & VERSION_MASK) | (((int32_t)messageType << TYPE_SHIFT_AMOUNT) & TYPE_MASK));
+  wsize += writeByte((VERSION_N & VERSION_MASK) | ((static_cast<int32_t>(messageType) << TYPE_SHIFT_AMOUNT) & TYPE_MASK));
   wsize += writeVarint32(seqid);
   wsize += writeString(name);
   return wsize;
@@ -221,7 +221,7 @@ uint32_t TCompactProtocolT<Transport_>::writeBool(const bool value) {
 
 template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::writeByte(const int8_t byte) {
-  trans_->write((uint8_t*)&byte, 1);
+  trans_->write(reinterpret_cast<const uint8_t*>(&byte), 1);
   return 1;
 }
 
@@ -259,7 +259,7 @@ uint32_t TCompactProtocolT<Transport_>::writeDouble(const double dub) {
 
   auto bits = bitwise_cast<uint64_t>(dub);
   bits = THRIFT_htolell(bits);
-  trans_->write((uint8_t*)&bits, 8);
+  trans_->write(reinterpret_cast<const uint8_t*>(&bits), 8);
   return 8;
 }
 
@@ -282,7 +282,7 @@ uint32_t TCompactProtocolT<Transport_>::writeBinary(const std::string& str) {
   if(ssize > (std::numeric_limits<uint32_t>::max)() - wsize)
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
   wsize += ssize;
-  trans_->write((uint8_t*)str.data(), ssize);
+  trans_->write(reinterpret_cast<const uint8_t*>(str.data()), ssize);
   return wsize;
 }
 
@@ -350,10 +350,10 @@ uint32_t TCompactProtocolT<Transport_>::writeVarint32(uint32_t n) {
 
   while (true) {
     if ((n & ~0x7F) == 0) {
-      buf[wsize++] = (int8_t)n;
+      buf[wsize++] = static_cast<int8_t>(n);
       break;
     } else {
-      buf[wsize++] = (int8_t)((n & 0x7F) | 0x80);
+      buf[wsize++] = static_cast<int8_t>((n & 0x7F) | 0x80);
       n >>= 7;
     }
   }
@@ -371,10 +371,10 @@ uint32_t TCompactProtocolT<Transport_>::writeVarint64(uint64_t n) {
 
   while (true) {
     if ((n & ~0x7FL) == 0) {
-      buf[wsize++] = (int8_t)n;
+      buf[wsize++] = static_cast<int8_t>(n);
       break;
     } else {
-      buf[wsize++] = (int8_t)((n & 0x7F) | 0x80);
+      buf[wsize++] = static_cast<int8_t>((n & 0x7F) | 0x80);
       n >>= 7;
     }
   }
@@ -431,12 +431,12 @@ uint32_t TCompactProtocolT<Transport_>::readMessageBegin(
   }
 
   rsize += readByte(versionAndType);
-  version = (int8_t)(versionAndType & VERSION_MASK);
+  version = static_cast<int8_t>(versionAndType & VERSION_MASK);
   if (version != VERSION_N) {
     throw TProtocolException(TProtocolException::BAD_VERSION, "Bad protocol version");
   }
 
-  messageType = (TMessageType)((versionAndType >> TYPE_SHIFT_AMOUNT) & TYPE_BITS);
+  messageType = static_cast<TMessageType>((versionAndType >> TYPE_SHIFT_AMOUNT) & TYPE_BITS);
   rsize += readVarint32(seqid);
   rsize += readString(name);
 
@@ -489,12 +489,12 @@ uint32_t TCompactProtocolT<Transport_>::readFieldBegin(std::string& name,
   }
 
   // mask off the 4 MSB of the type header. it could contain a field id delta.
-  auto modifier = (int16_t)(((uint8_t)byte & 0xf0) >> 4);
+  auto modifier = static_cast<int16_t>(static_cast<uint8_t>(byte & 0xf0) >> 4);
   if (modifier == 0) {
     // not a delta, look ahead for the zigzag varint field id.
     rsize += readI16(fieldId);
   } else {
-    fieldId = (int16_t)(lastFieldId_ + modifier);
+    fieldId = static_cast<int16_t>(lastFieldId_ + modifier);
   }
   fieldType = getTType(type);
 
@@ -535,9 +535,9 @@ uint32_t TCompactProtocolT<Transport_>::readMapBegin(TType& keyType,
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
   }
 
-  keyType = getTType((int8_t)((uint8_t)kvType >> 4));
-  valType = getTType((int8_t)((uint8_t)kvType & 0xf));
-  size = (uint32_t)msize;
+  keyType = getTType(static_cast<int8_t>(static_cast<uint8_t>(kvType) >> 4));
+  valType = getTType(static_cast<int8_t>(static_cast<uint8_t>(kvType) & 0xf));
+  size = static_cast<uint32_t>(msize);
 
   TMap map(keyType, valType, size);
   checkReadBytesAvailable(map);
@@ -560,7 +560,7 @@ uint32_t TCompactProtocolT<Transport_>::readListBegin(TType& elemType,
 
   rsize += readByte(size_and_type);
 
-  lsize = ((uint8_t)size_and_type >> 4) & 0x0f;
+  lsize = (static_cast<uint8_t>(size_and_type) >> 4) & 0x0f;
   if (lsize == 15) {
     rsize += readVarint32(lsize);
   }
@@ -571,8 +571,8 @@ uint32_t TCompactProtocolT<Transport_>::readListBegin(TType& elemType,
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
   }
 
-  elemType = getTType((int8_t)(size_and_type & 0x0f));
-  size = (uint32_t)lsize;
+  elemType = getTType(static_cast<int8_t>(size_and_type & 0x0f));
+  size = static_cast<uint32_t>(lsize);
 
   TList list(elemType, size);
   checkReadBytesAvailable(list);
@@ -618,7 +618,7 @@ template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::readByte(int8_t& byte) {
   uint8_t b[1];
   trans_->readAll(b, 1);
-  byte = *(int8_t*)b;
+  byte = static_cast<int8_t>(b[0]);
   return 1;
 }
 
@@ -629,7 +629,7 @@ template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::readI16(int16_t& i16) {
   int32_t value;
   uint32_t rsize = readVarint32(value);
-  i16 = (int16_t)zigzagToI32(value);
+  i16 = static_cast<int16_t>(zigzagToI32(value));
   return rsize;
 }
 
@@ -702,21 +702,21 @@ uint32_t TCompactProtocolT<Transport_>::readBinary(std::string& str) {
   }
 
   // Check against MaxMessageSize before alloc
-  trans_->checkReadBytesAvailable((uint32_t)size);
+  trans_->checkReadBytesAvailable(static_cast<uint32_t>(size));
 
   // Use the heap here to prevent stack overflow for v. large strings
   if (size > string_buf_size_ || string_buf_ == nullptr) {
-    void* new_string_buf = std::realloc(string_buf_, (uint32_t)size);
+    void* new_string_buf = std::realloc(string_buf_, static_cast<uint32_t>(size));
     if (new_string_buf == nullptr) {
       throw std::bad_alloc();
     }
-    string_buf_ = (uint8_t*)new_string_buf;
+    string_buf_ = static_cast<uint8_t*>(new_string_buf);
     string_buf_size_ = size;
   }
   trans_->readAll(string_buf_, size);
-  str.assign((char*)string_buf_, size);
+  str.assign(reinterpret_cast<char*>(string_buf_), size);
 
-  return rsize + (uint32_t)size;
+  return rsize + static_cast<uint32_t>(size);
 }
 
 /**
@@ -727,7 +727,7 @@ template <class Transport_>
 uint32_t TCompactProtocolT<Transport_>::readVarint32(int32_t& i32) {
   int64_t val;
   uint32_t rsize = readVarint64(val);
-  i32 = (int32_t)val;
+  i32 = static_cast<int32_t>(val);
   return rsize;
 }
 
@@ -749,7 +749,7 @@ uint32_t TCompactProtocolT<Transport_>::readVarint64(int64_t& i64) {
     while (true) {
       uint8_t byte = borrowed[rsize];
       rsize++;
-      val |= (uint64_t)(byte & 0x7f) << shift;
+      val |= static_cast<uint64_t>(byte & 0x7f) << shift;
       shift += 7;
       if (!(byte & 0x80)) {
         i64 = val;
@@ -768,7 +768,7 @@ uint32_t TCompactProtocolT<Transport_>::readVarint64(int64_t& i64) {
     while (true) {
       uint8_t byte;
       rsize += trans_->readAll(&byte, 1);
-      val |= (uint64_t)(byte & 0x7f) << shift;
+      val |= static_cast<uint64_t>(byte & 0x7f) << shift;
       shift += 7;
       if (!(byte & 0x80)) {
         i64 = val;
@@ -827,7 +827,7 @@ TType TCompactProtocolT<Transport_>::getTType(int8_t type) {
     case detail::compact::CT_STRUCT:
       return T_STRUCT;
     default:
-      throw TException(std::string("don't know what type: ") + (char)type);
+      throw TException(std::string("don't know what type: ") + static_cast<char>(type));
   }
 }
 

--- a/lib/cpp/src/thrift/protocol/TProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TProtocol.h
@@ -170,8 +170,8 @@ static inline To bitwise_cast(From from) {
       | (((n) & 0x0000ff00ul) << 8)  \
       | (((n) & 0x000000fful) << 24) )
 #  define bswap_16(n) \
-      ( (((n) & ((unsigned short)0xff00ul)) >> 8)  \
-      | (((n) & ((unsigned short)0x00fful)) << 8)  )
+      ( (((n) & (static_cast<unsigned short>(0xff00ul)) >> 8)  \
+      | (((n) & (static_cast<unsigned short>(0x00fful)) << 8)  )
 #  define THRIFT_htolell(n) bswap_64(n)
 #  define THRIFT_letohll(n) bswap_64(n)
 #  define THRIFT_htolel(n) bswap_32(n)
@@ -191,11 +191,11 @@ static inline To bitwise_cast(From from) {
 #  define THRIFT_ntohll(n) bswap_64(n)
 #  define THRIFT_htonll(n) bswap_64(n)
 # elif defined(_MSC_VER) /* Microsoft Visual C++ */
-#  define THRIFT_ntohll(n) ( _byteswap_uint64((uint64_t)n) )
-#  define THRIFT_htonll(n) ( _byteswap_uint64((uint64_t)n) )
+#  define THRIFT_ntohll(n) ( _byteswap_uint64(static_cast<uint64_t>(n)) )
+#  define THRIFT_htonll(n) ( _byteswap_uint64(static_cast<uint64_t>(n)) )
 # elif !defined(THRIFT_ntohll) /* Not GNUC/GLIBC or MSVC */
-#  define THRIFT_ntohll(n) ( (((uint64_t)ntohl((uint32_t)n)) << 32) + ntohl((uint32_t)(n >> 32)) )
-#  define THRIFT_htonll(n) ( (((uint64_t)htonl((uint32_t)n)) << 32) + htonl((uint32_t)(n >> 32)) )
+#  define THRIFT_ntohll(n) ( (static_cast<uint64_t>(ntohl(static_cast<uint32_t>(n))) << 32) + ntohl(static_cast<uint32_t>(n >> 32)) )
+#  define THRIFT_htonll(n) ( (static_cast<uint64_t>(htonl(static_cast<uint32_t>(n))) << 32) + htonl(static_cast<uint32_t>(n >> 32)) )
 # endif /* GNUC/GLIBC or MSVC or something else */
 #else /* __THRIFT_BYTE_ORDER */
 # error "Can't define THRIFT_htonll or THRIFT_ntohll!"

--- a/lib/cpp/src/thrift/transport/TBufferTransports.cpp
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.cpp
@@ -256,8 +256,8 @@ void TFramedTransport::flush() {
 
   // Slip the frame size into the start of the buffer.
   sz_hbo = static_cast<uint32_t>(wBase_ - (wBuf_.get() + sizeof(sz_nbo)));
-  sz_nbo = (int32_t)htonl((uint32_t)(sz_hbo));
-  memcpy(wBuf_.get(), (uint8_t*)&sz_nbo, sizeof(sz_nbo));
+  sz_nbo = static_cast<int32_t>(htonl(static_cast<uint32_t>(sz_hbo)));
+  memcpy(wBuf_.get(), reinterpret_cast<uint8_t*>(&sz_nbo), sizeof(sz_nbo));
 
   if (sz_hbo > 0) {
     // Note that we reset wBase_ (with a pad for the frame size)
@@ -347,7 +347,7 @@ uint32_t TMemoryBuffer::readAppendToString(std::string& str, uint32_t len) {
   computeRead(len, &start, &give);
 
   // Append to the provided string.
-  str.append((char*)start, give);
+  str.append(reinterpret_cast<char*>(start), give);
 
   return give;
 }

--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -419,7 +419,7 @@ protected:
 
     // Pad the buffer so we can insert the size later.
     int32_t pad = 0;
-    this->write((uint8_t*)&pad, sizeof(pad));
+    this->write(reinterpret_cast<uint8_t*>(&pad), sizeof(pad));
   }
 
   std::shared_ptr<TTransport> transport_;
@@ -468,7 +468,7 @@ private:
 
     if (buf == nullptr && size != 0) {
       assert(owner);
-      buf = (uint8_t*)std::malloc(size);
+      buf = static_cast<uint8_t*>(std::malloc(size));
       if (buf == nullptr) {
 	throw std::bad_alloc();
       }
@@ -593,7 +593,7 @@ public:
     uint8_t* buf;
     uint32_t sz;
     getBuffer(&buf, &sz);
-    return std::string((char*)buf, (std::string::size_type)sz);
+    return {reinterpret_cast<char*>(buf), static_cast<std::string::size_type>(sz)};
   }
 
   void appendBufferToString(std::string& str) {
@@ -603,7 +603,7 @@ public:
     uint8_t* buf;
     uint32_t sz;
     getBuffer(&buf, &sz);
-    str.append((char*)buf, sz);
+    str.append(reinterpret_cast<char*>(buf), sz);
   }
 
   void resetBuffer() {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Removes all oldstyle casts from the library parts needed to parse with TCompactProtocol in memory, like when using thrift for parquet. Thus, it is now possible to compile it with -Wno-old-style-casts
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
