### PR TITLE
THRIFT-5854: Move the checkReadBytesAvailable check before allocation

### DIFF
--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
@@ -701,6 +701,9 @@ uint32_t TCompactProtocolT<Transport_>::readBinary(std::string& str) {
     throw TProtocolException(TProtocolException::SIZE_LIMIT);
   }
 
+  // Check against MaxMessageSize before alloc
+  trans_->checkReadBytesAvailable((uint32_t)size);
+
   // Use the heap here to prevent stack overflow for v. large strings
   if (size > string_buf_size_ || string_buf_ == nullptr) {
     void* new_string_buf = std::realloc(string_buf_, (uint32_t)size);
@@ -712,8 +715,6 @@ uint32_t TCompactProtocolT<Transport_>::readBinary(std::string& str) {
   }
   trans_->readAll(string_buf_, size);
   str.assign((char*)string_buf_, size);
-
-  trans_->checkReadBytesAvailable(rsize + (uint32_t)size);
 
   return rsize + (uint32_t)size;
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Affects: TCompactProtocol::readBinary

We allocated the string first and only checked afterward whether this allocation would be larger than MaxMessageSize allows. Since it throws, we throw away the buffer and the read, so we should check it earlier.

Furthermore, we check for varint_size + strlen instead of only strlen. However, since we can read varint using borrow and consume, this already decreases the remainingMessageSize by varint_size. Thus it can falsely trigger MaxMessageSize.

The tests for TCompactProtocol now use values closer to the egde case ana also test for successfull reads instead of only checking for exceptions.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
