### PR TITLE
Update supported go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.22'
           - '1.23'
+          - '1.24'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
         run: make -C test/go precross
 
       - name: Upload go precross artifacts
-        if: matrix.go == '1.23'
+        if: matrix.go == '1.24'
         uses: actions/upload-artifact@v4
         with:
           name: go-precross

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -163,7 +163,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.22</td><td>1.23</td>
+<!-- Language Levels -------><td>1.23</td><td>1.24</td>
 <!-- Field types -----------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/apache/thrift
 
-go 1.22.0
+go 1.23

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.22.0
+go 1.23
 
 require github.com/apache/thrift v0.0.0-00010101000000-000000000000
 

--- a/lib/go/test/go.mod
+++ b/lib/go/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/test/go
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
With the release of go 1.24.0, go 1.22.x is no longer supported. Update supported go versions to go 1.23 and go 1.24.
