### PR TITLE
THRIFT-5847: http.client.HTTPSConnection: drop key_file, cert_file

### DIFF
--- a/lib/py/src/transport/THttpClient.py
+++ b/lib/py/src/transport/THttpClient.py
@@ -111,8 +111,6 @@ class THttpClient(TTransportBase):
                                                      timeout=self.__timeout)
         elif self.scheme == 'https':
             self.__http = http.client.HTTPSConnection(self.host, self.port,
-                                                      key_file=self.keyfile,
-                                                      cert_file=self.certfile,
                                                       timeout=self.__timeout,
                                                       context=self.context)
         if self.using_proxy():


### PR DESCRIPTION
Because removed in Python 3.12 https://docs.python.org/3/whatsnew/3.12.html#others

Solves to [THRIFT-5847](https://issues.apache.org/jira/browse/THRIFT-5847)