### PR TITLE
THRIFT-5024: Replace removed @gen.engine with @gen.coroutine

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1460,7 +1460,7 @@ void t_py_generator::generate_service_client(t_service* tservice) {
 
   if (gen_tornado_ && extends.empty()) {
     f_service_ << '\n' <<
-      indent() << "@gen.engine" << '\n' <<
+      indent() << "@gen.coroutine" << '\n' <<
       indent() << "def _start_receiving(self):" << '\n';
     indent_up();
     indent(f_service_) << "while True:" << '\n';


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
When using Thrift with Tornado 6+, we get an error `builtins.AttributeError: module 'tornado.gen' has no attribute 'engine'`

This is because Tornado deprecated `@gen.engine` by Tornado 5.1 and removed it by Tornado 6, telling users to replace it with `@gen.coroutine` or `async def`. Between those choices, using `@gen.coroutine` is simpler to migrate to.

This PR replaces `@gen.engine` with `@gen.coroutine` in the py:tornado code generation. This is also the only match for "gen.engine" in the repo.

I also left a lengthier comment on the [THRIFT-5024](https://issues.apache.org/jira/browse/THRIFT-5024) ticket.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- Someone else did
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- Yes
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- Yes
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- There shouldn't be any breakage; this is the highlighted migration path in the docs. Even for users on older versions of Tornado, the docs always say the two methods are similar.
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
- N/A

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
