### PR TITLE
Add type annotations for java

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -2997,7 +2997,7 @@ std::string t_java_generator::get_java_type_string(t_type* type) {
 }
 
 void t_java_generator::generate_metadata_for_field_annotations(std::ostream& out, t_field* field) {
-  if (field->annotations_.size() == 0) {
+  if (field->annotations_.size() == 0 && field->get_type()->annotations_.size() == 0) {
     return;
   }
   out << ", " << '\n';
@@ -3010,6 +3010,15 @@ void t_java_generator::generate_metadata_for_field_annotations(std::ostream& out
   indent_up();
   indent_up();
   for (auto& annotation : field->annotations_) {
+    indent(out) << ".add(new java.util.AbstractMap.SimpleImmutableEntry<>(\"" + annotation.first
+                       + "\", \"" + annotation.second.back() + "\"))"
+                << '\n';
+  }
+  for (auto& annotation : field->get_type()->annotations_) {
+    // field annotations have higher priority than type annotations
+    if (field->annotations_.find(annotation.first) != field->annotations_.end()) {
+      continue;
+    }
     indent(out) << ".add(new java.util.AbstractMap.SimpleImmutableEntry<>(\"" + annotation.first
                        + "\", \"" + annotation.second.back() + "\"))"
                 << '\n';

--- a/lib/java/src/test/java/org/apache/thrift/TestAnnotationMetadata.java
+++ b/lib/java/src/test/java/org/apache/thrift/TestAnnotationMetadata.java
@@ -65,5 +65,13 @@ public class TestAnnotationMetadata {
       expected.put("compression", "false");
       assertEquals(expected, metadata);
     }
+    {
+      Map<String, String> metadata =
+              structMetaDataMap.get(OneOfEachBeansWithAnnotations._Fields.TYPEDEF_META).getFieldAnnotations();
+      Map<String, String> expected = new HashMap<>();
+      expected.put("a", "b");
+      expected.put("c", "d");
+      assertEquals(expected, metadata);
+    }
   }
 }

--- a/lib/java/src/test/resources/JavaAnnotationTest.thrift
+++ b/lib/java/src/test/resources/JavaAnnotationTest.thrift
@@ -19,6 +19,8 @@
 
 namespace java thrift.test.annotations
 
+typedef string my_typedef (a = "a", c = "d")
+
 struct OneOfEachBeansWithAnnotations {
   1: bool boolean_field,
   2: byte a_bite (compression = "false"),
@@ -30,5 +32,7 @@ struct OneOfEachBeansWithAnnotations {
   8: binary base64,
   9: list<byte> byte_list (non_empty = "true"),
   10: list<i16> i16_list,
-  11: list<i64> i64_list
+  11: list<i64> i64_list,
+  // a is overridden to b
+  12: my_typedef typedef_meta (a = "b");
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
https://github.com/apache/thrift/pull/2553 had added the ability to access field annotations in java.

In our use-case, we would like to annotate arbitrary types and re-use it without explicitly re-annotating each field.

e.g.
```
struct should_mask {
} (a = "b")

struct struct_1 {
  1: should_mask field;
}

struct struct_2 {
  1: should_mask field;
}
```

instead of 

```
struct should_mask {
}

struct struct_1 {
  1: should_mask field (a = "b")
}

struct struct_2 {
  1: should_mask field (a = "b")
}
```

I would like to propose that `FieldMetaData#getFieldAnnotations` returns annotations on types as well to achieve this.

Misc1) If it feels safer to hide this change behind an option (i.e. type_annotations_as_metadata_), then I can also make this change
Misc2) If it is preferred that type annotations are exposed via a different method, I can make this change as well. Overall, I'm happy if there is a way to access annotations added to types from Java.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
