### PR TITLE
THRIFT-5857: Remove deprecated Tornado io_loop usage

### DIFF
--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -20,6 +20,7 @@
 import logging
 import socket
 import struct
+import warnings
 
 from .transport.TTransport import TTransportException, TTransportBase, TMemoryBuffer
 
@@ -66,9 +67,19 @@ class _Lock:
 class TTornadoStreamTransport(TTransportBase):
     """a framed, buffered transport over a Tornado stream"""
     def __init__(self, host, port, stream=None, io_loop=None):
+        if io_loop is not None:
+            warnings.warn(
+                "The `io_loop` parameter is deprecated and unused. Passing "
+                "`io_loop` is unnecessary because Tornado now automatically "
+                "provides the current I/O loop via `IOLoop.current()`. "
+                "Remove the `io_loop` parameter to ensure compatibility - it "
+                "will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.host = host
         self.port = port
-        self.io_loop = io_loop or ioloop.IOLoop.current()
+        self.io_loop = ioloop.IOLoop.current()
         self.__wbuf = BytesIO()
         self._read_lock = _Lock()
 
@@ -76,7 +87,7 @@ class TTornadoStreamTransport(TTransportBase):
         self.stream = stream
 
     def with_timeout(self, timeout, future):
-        return gen.with_timeout(timeout, future, self.io_loop)
+        return gen.with_timeout(timeout, future)
 
     @gen.coroutine
     def open(self, timeout=None):
@@ -164,8 +175,7 @@ class TTornadoServer(tcpserver.TCPServer):
     @gen.coroutine
     def handle_stream(self, stream, address):
         host, port = address[:2]
-        trans = TTornadoStreamTransport(host=host, port=port, stream=stream,
-                                        io_loop=self.io_loop)
+        trans = TTornadoStreamTransport(host=host, port=port, stream=stream)
         oprot = self._oprot_factory.getProtocol(trans)
 
         try:


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
As I mentioned in [THRIFT-5024](https://issues.apache.org/jira/browse/THRIFT-5024), there's still another issue that's preventing Thrift from working with newer versions of Tornado. We get this stack trace once the client is started:

```
~/thrift$ cd tutorial/py.tornado/
~/thrift/tutorial/py.tornado$ python3 ./PythonServer.py 
Starting the server...
Exception in callback functools.partial(<function TCPServer._handle_connection.<locals>.<lambda> at 0x7fb547e99360>, <Future finished exception=AttributeError("'TTornadoServer' object has no attribute 'io_loop'")>)
Traceback (most recent call last):
  File "/home/asjad/.local/lib/python3.10/site-packages/tornado/ioloop.py", line 750, in _run_callback
    ret = callback()
  File "/home/asjad/.local/lib/python3.10/site-packages/tornado/tcpserver.py", line 387, in <lambda>
    gen.convert_yielded(future), lambda f: f.result()
  File "/home/asjad/.local/lib/python3.10/site-packages/tornado/gen.py", line 233, in wrapper
    yielded = ctx_run(next, result)
  File "/home/asjad/thrift/tutorial/py.tornado/../../lib/py/build/lib.linux-x86_64-3.10/thrift/TTornado.py", line 168, in handle_stream
    io_loop=self.io_loop)
AttributeError: 'TTornadoServer' object has no attribute 'io_loop'
```
```
~/thrift$ cd tutorial/py.tornado/
~/thrift/tutorial/py.tornado$ python3 ./PythonClient.py
```

This bug appeared because `TTornadoServer` inherits from Tornado's `tcpserver.TCPServer` and is using its `self.io_loop` attribute, which [Tornado removed in v5.0](https://github.com/tornadoweb/tornado/blob/ad9652512ff6a7486ca5290b060e7272d1696a37/tornado/tcpserver.py#L120-L122), [as passing around `io_loop`s is deprecated in favor of using `IOLoop.current()` to retrieve it](https://github.com/tornadoweb/tornado/commit/547e0f98d56bb8f22a89c009b6d2b3cf6b802284). 

I also touched the `gen.with_timeout` call as that signature also changed to remove `io_loop`: ([v4.5](https://www.tornadoweb.org/en/branch4.5/gen.html#tornado.gen.with_timeout) vs [v5.1](https://www.tornadoweb.org/en/branch5.1/gen.html#tornado.gen.with_timeout)). This was mentioned in the [Tornado 5.0 Release Notes](https://www.tornadoweb.org/en/stable/releases/v5.0.0.html).

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [THRIFT-5857](https://issues.apache.org/jira/browse/THRIFT-5857)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- Yes
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- Yes
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- Yes. Originally I wanted to remove `TTornadoStreamTransport`'s `io_loop` parameter, but to avoid making a breaking change, I left a deprecation warning.
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
- Involves a code change

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

