### PR TITLE
Change SSL_get_verify_result() return value from int to long

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -705,7 +705,7 @@ void TSSLSocket::initializeHandshake() {
 }
 
 void TSSLSocket::authorize() {
-  int rc = SSL_get_verify_result(ssl_);
+  long rc = SSL_get_verify_result(ssl_);
   if (rc != X509_V_OK) { // verify authentication result
     throw TSSLException(string("SSL_get_verify_result(), ") + X509_verify_cert_error_string(rc));
   }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
`SSL_get_verify_result()` is [documented to return `long`](https://docs.openssl.org/master/man3/SSL_get_verify_result/).   This change updates the calling code to store the result in `long` instead of `int`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
