### PR TITLE
THRIFT-5861: Add isOpen method to TTornadoStreamTransport

### DIFF
--- a/lib/py/src/TTornado.py
+++ b/lib/py/src/TTornado.py
@@ -89,6 +89,11 @@ class TTornadoStreamTransport(TTransportBase):
     def with_timeout(self, timeout, future):
         return gen.with_timeout(timeout, future)
 
+    def isOpen(self):
+       if self.stream is None:
+           return False
+       return not self.stream.closed()
+
     @gen.coroutine
     def open(self, timeout=None):
         logger.debug('socket connecting')


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Normally I include a check like this before closing Thrift connections:

```
if transport and transport.isOpen():
    transport.close()
```

However, for Tornado, `TTornadoStreamTransport.isOpen()` is not implemented, so the call falls back to `TTransportBase`'s empty implementation which just returns `None`. As a result, the above condition to close the connection never gets satisfied, and my application accumulates open connections until eventually it crashes with error message `OSError: [Errno 24] Too many open files`.

To fix this, this patch implements `TTornadoStreamTransport.isOpen()`, using Tornado's [`BaseIOStream.closed()`](https://www.tornadoweb.org/en/stable/iostream.html#tornado.iostream.BaseIOStream.closed
), which returns `True` if the stream has been closed. Before checking if the stream is open, we need to verify that the stream exists.

To test the patch, we can add these print statements into [`thrift/tutorial/py.tornado/PythonClient.py`](https://github.com/apache/thrift/blob/2e00c9998f1aa316c8d0168488887fb957845230/tutorial/py.tornado/PythonClient.py#L46) in the appropriate places:
```
print(f"transport.isOpen() before transport.open(): {transport.isOpen()}")
print(f"transport.isOpen() after transport.open(): {transport.isOpen()}")
print(f"transport.isOpen() after TTransportException: {transport.isOpen()}")
print(f"transport.isOpen() before transport.close(): {transport.isOpen()}")
print(f"transport.isOpen() after transport.close(): {transport.isOpen()}")
```

Without the patch applied, `isOpen()` always returns `None`, regardless of whether the transport is opened or closed:

```
transport.isOpen() before transport.open(): None
transport.isOpen() after transport.open(): None
transport.isOpen() before transport.close(): None
transport.isOpen() after transport.close(): None
```
```
transport.isOpen() before transport.open(): None
ERROR:root:could not connect to 127.0.0.1:9090 (Stream is closed)
transport.isOpen() after TTransportException: None
```

With the patch applied, `isOpen()` accurately reflects the transport state:

```
transport.isOpen() before transport.open(): False
transport.isOpen() after transport.open(): True
transport.isOpen() before transport.close(): True
transport.isOpen() after transport.close(): False
```
```
transport.isOpen() before transport.open(): False
ERROR:root:could not connect to localhost:9090 (Stream is closed)
transport.isOpen() after TTransportException: False
```

It also worked neatly with reopening the transport but I didn't include that as it didn't fit in neatly with the tutorial's outline.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [THRIFT-5861](https://issues.apache.org/jira/browse/THRIFT-5861)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- Yes
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- Yes
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- Yes
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
- Involves a code change

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
