### PR TITLE
Erlang generator improvements for enum and type

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -811,7 +811,7 @@ string t_erl_generator::render_member_type(t_field* field) {
     return type_name(type) + "()";
   } else if (type->is_map()) {
     if (maps_) {
-      return "map()";
+      return "maps:map()";
     } else {
       return "dict:dict()";
     }

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -886,10 +886,12 @@ void t_erl_generator::generate_erl_struct_definition(ostream& out, t_struct* tst
   indent(out) << "%% ";
   if (tstruct->is_union()) {
     out << "union ";
+  } else if (tstruct->is_xception()) {
+    out << "exception ";
   } else {
     out << "struct ";
   }
-  out << type_name(tstruct) << '\n' << '\n';
+  out << tstruct->get_name() << '\n' << '\n';
 
   std::stringstream buf;
   buf << indent() << "-record(" << type_name(tstruct) << ", {";

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -132,6 +132,8 @@ public:
   std::string render_member_type(t_field* field);
   std::string render_member_value(t_field* field);
   std::string render_member_requiredness(t_field* field);
+
+  std::string render_base_type(t_type* type);
   std::string render_typedef_type(t_type* ttype);
   std::string render_string_type();
 
@@ -807,27 +809,12 @@ string t_erl_generator::render_default_sets_value() {
 }
 
 string t_erl_generator::render_member_type(t_field* field) {
-  t_type* type = get_true_type(field->get_type());
+  t_type* type = field->get_type();
   if (type->is_base_type()) {
-    t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
-    switch (tbase) {
-    case t_base_type::TYPE_STRING:
-      return render_string_type();
-    case t_base_type::TYPE_BOOL:
-      return "boolean()";
-    case t_base_type::TYPE_I8:
-    case t_base_type::TYPE_I16:
-    case t_base_type::TYPE_I32:
-    case t_base_type::TYPE_I64:
-      return "integer()";
-    case t_base_type::TYPE_DOUBLE:
-      return "float()";
-    default:
-      throw "compiler error: unsupported base type " + t_base_type::t_base_name(tbase);
-    }
+    return render_base_type(type);
   } else if (type->is_enum()) {
-    return "integer()";
-  } else if (type->is_struct() || type->is_xception()) {
+    return type_name(type) + "()";
+  } else if (type->is_struct() || type->is_typedef()) {
     return type_name(type) + "()";
   } else if (type->is_map()) {
     if (maps_) {
@@ -841,6 +828,25 @@ string t_erl_generator::render_member_type(t_field* field) {
     return "list()";
   } else {
     throw "compiler error: unsupported type " + type->get_name();
+  }
+}
+
+string t_erl_generator::render_base_type(t_type* type) {
+  t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
+  switch (tbase) {
+  case t_base_type::TYPE_STRING:
+    return render_string_type();
+  case t_base_type::TYPE_BOOL:
+    return "boolean()";
+  case t_base_type::TYPE_I8:
+  case t_base_type::TYPE_I16:
+  case t_base_type::TYPE_I32:
+  case t_base_type::TYPE_I64:
+    return "integer()";
+  case t_base_type::TYPE_DOUBLE:
+    return "float()";
+  default:
+    throw "compiler error: unsupported base type " + t_base_type::t_base_name(tbase);
   }
 }
 
@@ -870,24 +876,8 @@ string t_erl_generator::render_member_requiredness(t_field* field) {
 
 string t_erl_generator::render_typedef_type(t_type* ttype) {
   if (ttype->is_base_type()) {
-    t_base_type::t_base tbase = ((t_base_type*)ttype)->get_base();
-    switch (tbase) {
-    case t_base_type::TYPE_STRING:
-      return render_string_type();
-    case t_base_type::TYPE_BOOL:
-      return "boolean()";
-    case t_base_type::TYPE_I8:
-    case t_base_type::TYPE_I16:
-    case t_base_type::TYPE_I32:
-    case t_base_type::TYPE_I64:
-      return "integer()";
-    case t_base_type::TYPE_DOUBLE:
-      return "float()";
-    default:
-      throw "compiler error: unsupported base type " + t_base_type::t_base_name(tbase);
-    }
-  }
-   else if (ttype->is_enum()) {
+    return render_base_type(ttype);
+  } else if (ttype->is_enum()) {
     return type_name(ttype) + "()";
   } else if (ttype->is_struct() || ttype->is_xception() || ttype->is_typedef()) {
     return type_name(ttype) + "()";

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -138,6 +138,7 @@ public:
   std::string render_type(t_type* type);
   std::string render_base_type(t_type* type);
   std::string render_string_type();
+  std::string render_const_name(std::string name);
   std::string render_const_name(std::string sname, std::string name);
 
   //  std::string render_default_value(t_type* type);
@@ -601,8 +602,12 @@ void t_erl_generator::generate_enum(t_enum* tenum) {
   f_types_hrl_file_ << ".\n" << "\n";
 }
 
+string t_erl_generator::render_const_name(std::string name) {
+  return constify(make_safe_for_module_name(program_name_)) + "_" + constify(name);
+}
+
 string t_erl_generator::render_const_name(std::string sname, std::string name) {
-  return constify(make_safe_for_module_name(program_name_)) + "_" + constify(sname) + "_" + constify(name);
+  return render_const_name(sname) + "_" + constify(name);
 }
 
 void t_erl_generator::generate_enum_info(t_enum* tenum){
@@ -650,8 +655,8 @@ void t_erl_generator::generate_const(t_const* tconst) {
   // Save the tconst so that function can be emitted in generate_const_functions().
   v_consts_.push_back(tconst);
 
-  f_consts_hrl_file_ << "-define(" << constify(make_safe_for_module_name(program_name_)) << "_"
-                     << constify(name) << ", " << render_const_value(type, value) << ")." << '\n' << '\n';
+  f_consts_hrl_file_ << "-define(" << render_const_name(name) << ", "
+                     << render_const_value(type, value) << ")." << '\n' << '\n';
 }
 
 /**

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -133,8 +133,10 @@ public:
   std::string render_member_value(t_field* field);
   std::string render_member_requiredness(t_field* field);
 
+  std::string render_typedef_type(t_typedef* ttypedef);
+
+  std::string render_type(t_type* type);
   std::string render_base_type(t_type* type);
-  std::string render_typedef_type(t_type* ttype);
   std::string render_string_type();
 
   //  std::string render_default_value(t_type* type);
@@ -486,8 +488,7 @@ void t_erl_generator::generate_type_metadata(std::string function_name, vector<s
  * @param ttypedef The type definition
  */
 void t_erl_generator::generate_typedef(t_typedef* ttypedef) {
-  t_type* type = ttypedef->get_type();
-  f_types_hrl_file_ << "-type " << type_name(ttypedef) << "() :: " << render_typedef_type(type) << ".\n" << "\n";
+  f_types_hrl_file_ << "-type " << type_name(ttypedef) << "() :: " << render_typedef_type(ttypedef) << ".\n" << "\n";
 }
 
 
@@ -810,11 +811,15 @@ string t_erl_generator::render_default_sets_value() {
 
 string t_erl_generator::render_member_type(t_field* field) {
   t_type* type = field->get_type();
+  return render_type(type);
+}
+
+string t_erl_generator::render_type(t_type* type) {
   if (type->is_base_type()) {
     return render_base_type(type);
   } else if (type->is_enum()) {
     return type_name(type) + "()";
-  } else if (type->is_struct() || type->is_typedef()) {
+  } else if (type->is_struct() || type->is_xception() || type->is_typedef()) {
     return type_name(type) + "()";
   } else if (type->is_map()) {
     if (maps_) {
@@ -874,26 +879,9 @@ string t_erl_generator::render_member_requiredness(t_field* field) {
   }
 }
 
-string t_erl_generator::render_typedef_type(t_type* ttype) {
-  if (ttype->is_base_type()) {
-    return render_base_type(ttype);
-  } else if (ttype->is_enum()) {
-    return type_name(ttype) + "()";
-  } else if (ttype->is_struct() || ttype->is_xception() || ttype->is_typedef()) {
-    return type_name(ttype) + "()";
-  } else if (ttype->is_map()) {
-    if (maps_) {
-      return "map()";
-    } else {
-      return "dict:dict()";
-    }
-  } else if (ttype->is_set()) {
-    return "sets:set()";
-  } else if (ttype->is_list()) {
-    return "list()";
-  } else {
-    throw "compiler error: unsupported type " + ttype->get_name();
-  }
+string t_erl_generator::render_typedef_type(t_typedef* ttypedef) {
+  t_type* type = ttypedef->get_type();
+  return render_type(type);
 }
 
 /**


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Another bunch of Erlang generator improvements. This time changes in type and enum generation with some minor typos. 

Changes:
- [x] Mark exception declaration with 'exception' in commentary
- [x] Mark enum declaration with 'enum' in commentary
- [x] Generate type for typedef declaration, use generated type instead of base type in declaration
- [x] Generate type for enum values, type consist of declared values. Use constant names in type declaration
- [x] Avoid integer type as enum value type, use generated type instead
- [x] Avoid magic numbers for enum as default values, use enum's constant name instead
- [x] Introduce nominal types (Erlang 28+)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
