### PR TITLE
remove unused writeUtf8 and readUtf8 from TProtocol.py

### DIFF
--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -121,9 +121,6 @@ class TProtocolBase(object):
     def writeBinary(self, str_val):
         pass
 
-    def writeUtf8(self, str_val):
-        self.writeString(str_val.encode('utf-8'))
-
     def readMessageBegin(self):
         pass
 
@@ -183,9 +180,6 @@ class TProtocolBase(object):
 
     def readBinary(self):
         pass
-
-    def readUtf8(self):
-        return self.readString().decode('utf-8')
 
     def skip(self, ttype):
         if ttype == TType.BOOL:


### PR DESCRIPTION
cleanup after https://github.com/apache/thrift/pull/3105

<!-- Explain the changes in the pull request below: -->

writeUtf8 and readUtf8 are not referenced anywhere in the code any more

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
