### PR TITLE
Fix field stop read in duplicate_protocol.go

### DIFF
--- a/lib/go/thrift/duplicate_protocol.go
+++ b/lib/go/thrift/duplicate_protocol.go
@@ -198,6 +198,10 @@ func (tdtp *TDuplicateToProtocol) ReadStructEnd(ctx context.Context) (err error)
 
 func (tdtp *TDuplicateToProtocol) ReadFieldBegin(ctx context.Context) (name string, typeId TType, id int16, err error) {
 	name, typeId, id, err = tdtp.Delegate.ReadFieldBegin(ctx)
+	if typeID == STOP {
+		tpdp.DuplicateTo.WriteFieldStop(ctx)
+		return
+	}
 	tdtp.DuplicateTo.WriteFieldBegin(ctx, name, typeId, id)
 	return
 }

--- a/lib/go/thrift/duplicate_protocol.go
+++ b/lib/go/thrift/duplicate_protocol.go
@@ -198,8 +198,8 @@ func (tdtp *TDuplicateToProtocol) ReadStructEnd(ctx context.Context) (err error)
 
 func (tdtp *TDuplicateToProtocol) ReadFieldBegin(ctx context.Context) (name string, typeId TType, id int16, err error) {
 	name, typeId, id, err = tdtp.Delegate.ReadFieldBegin(ctx)
-	if typeID == STOP {
-		tpdp.DuplicateTo.WriteFieldStop(ctx)
+	if typeId == STOP {
+		tdtp.DuplicateTo.WriteFieldStop(ctx)
 		return
 	}
 	tdtp.DuplicateTo.WriteFieldBegin(ctx, name, typeId, id)

--- a/lib/go/thrift/duplicate_protocol_test.go
+++ b/lib/go/thrift/duplicate_protocol_test.go
@@ -1,0 +1,52 @@
+package thrift
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestDuplicateToJSONReadMakesEqualJSON(t *testing.T) {
+	delegateBuf := NewTMemoryBuffer()
+	iprot := NewTJSONProtocolFactory().GetProtocol(delegateBuf)
+
+	s := NewMyTestStruct()
+	ctx := context.Background()
+	s.Write(ctx, iprot)
+
+	iprot.Flush(ctx)
+	jsonBytesWritten := delegateBuf.Bytes()
+
+	if err := json.Unmarshal(jsonBytesWritten, NewMyTestStruct()); err != nil {
+		t.Errorf("error unmarshaling written bytes: %s", err)
+	}
+
+	duplicateBuf := NewTMemoryBuffer()
+	dupProto := NewTJSONProtocolFactory().GetProtocol(duplicateBuf)
+	proto := &TDuplicateToProtocol{
+		Delegate:    NewTJSONProtocolFactory().GetProtocol(delegateBuf),
+		DuplicateTo: dupProto,
+	}
+
+	if err := s.Read(ctx, proto); err != nil {
+		t.Errorf("error reading struct from DuplicateTo: %s", err)
+	}
+	dupProto.Flush(ctx)
+
+	jsonBytesRead := duplicateBuf.Bytes()
+
+	if !bytes.Equal(jsonBytesWritten, jsonBytesRead) {
+		t.Errorf(`bytes read into duplicate do not equal bytes written
+		read:
+		%+v
+		written:
+		%+v
+		`, jsonBytesRead, jsonBytesWritten)
+	}
+
+	dup := NewMyTestStruct()
+	if err := dup.Read(ctx, dupProto); err != nil {
+		t.Errorf("error reading struct from duplicated protocol: %s", err)
+	}
+}

--- a/lib/go/thrift/duplicate_protocol_test.go
+++ b/lib/go/thrift/duplicate_protocol_test.go
@@ -39,9 +39,9 @@ func TestDuplicateToJSONReadMakesEqualJSON(t *testing.T) {
 	if !bytes.Equal(jsonBytesWritten, jsonBytesRead) {
 		t.Errorf(`bytes read into duplicate do not equal bytes written
 		read:
-		%+v
+		%s
 		written:
-		%+v
+		%s
 		`, jsonBytesRead, jsonBytesWritten)
 	}
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
When generated code reads a struct, it runs a `for` loop calling `ReadFieldBegin` at the top, but breaks if the field type ID is `thrift.STOP`.

With TDuplicateToProtocol naively performing an equivalent write for every read, this results in extra bytes, which breaks just about any protocol in the `DuplicateTo` struct field.

The proposed fix is to simply add special handling for `thrift.STOP` to `ReadFieldBegin`.

I'm no thrift expert, so I have no idea how other libraries handle this concern.  Ideally, it seems like each protocol should understand and enforce the invariant that an attempt to call `WriteFieldBegin` with type ID 0 either isn't valid or is a misguided attempt to call `WriteFieldStop`, which could be performed instead, perhaps with the additional guardrail that a sequence of stops (with length > 1) never makes any sense.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ x ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ x ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ x ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ x ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

^^ hopefully we can agree this change is trivial, I very badly do not want to look at anyone's Jira, especially if it doesn't belong to my employer.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
