### PR TITLE
THRIFT-5860: Update minimum required CMake version for CMake 4.0 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.16)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)  # package version behavior added in cmake 3.0

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.16)
 project("thrift-compiler" VERSION ${PACKAGE_VERSION})
 
 # version.h now handled via veralign.sh

--- a/compiler/cpp/tests/CMakeLists.txt
+++ b/compiler/cpp/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(thrift_compiler_tests)
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This PR updates the minimum required version of CMake. This change is necessary because the CMake 4.0 release [removed policies that allowed supporting such old versions of CMake](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features), so having such a low required minimum version of CMake prohibits using the latest versions. CMake 3.16 is already quite old (the release was [back in 2019](https://www.kitware.com/cmake-3-16-0-available-for-download/)) and it is a reasonable choice based on Linux distro support (for example, [it is the supported version for Ubuntu's 20.04 LTS release](https://packages.ubuntu.com/search?suite=focal&searchon=names&keywords=cmake)).

I can mark this PR as breaking if desired, but I assume that in general breaking changes are reserved to indicate API/ABI/specification breaks, not changes to the build requirements.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
