### PR TITLE
THRIFT-1482: Unix domain socket support under PHP

### DIFF
--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -218,7 +218,7 @@ class TSocket extends TTransport
             throw new TTransportException('Cannot open null host', TTransportException::NOT_OPEN);
         }
 
-        if ($this->port_ <= 0) {
+        if ($this->port_ <= 0 && substr($this->host_, 0, strlen('unix://')) !== 'unix://') {
             throw new TTransportException('Cannot open without port', TTransportException::NOT_OPEN);
         }
 

--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -218,7 +218,7 @@ class TSocket extends TTransport
             throw new TTransportException('Cannot open null host', TTransportException::NOT_OPEN);
         }
 
-        if ($this->port_ <= 0 && substr($this->host_, 0, strlen('unix://')) !== 'unix://') {
+        if ($this->port_ <= 0 && strpos($this->host_, 'unix://') !== 0) {
             throw new TTransportException('Cannot open without port', TTransportException::NOT_OPEN);
         }
 

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -246,6 +246,33 @@ class TSocketTest extends TestCase
         $this->assertTrue($transport->isOpen());
     }
 
+    public function testOpenUnixSocket()
+    {
+        $host = 'unix:///tmp/ipc.sock';
+        $port = -1;
+        $persist = false;
+        $debugHandler = null;
+
+        $this->getFunctionMock('Thrift\Transport', 'fsockopen')
+             ->expects($this->once())
+             ->with(
+                 $host,
+                 $port,
+                 $this->anything(), #$errno,
+                 $this->anything(), #$errstr,
+                 $this->anything() #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+             );
+
+        $transport = new TSocket(
+            $host,
+            $port,
+            $persist,
+            $debugHandler
+        );
+
+        $transport->open();
+    }
+
     /**
      * @dataProvider open_THRIFT_5132_DataProvider
      */


### PR DESCRIPTION
Update tests for this pull request https://github.com/apache/thrift/pull/3109


> To open a unix socket, the port number supplied to fsockopen (and pfsockopen) has to be -1.
> 
> We use substr instead of str_starts_with to keep compatibility with php 7.
> 
> Now a UDS can be created like this:
> 
> `new TSocket('unix:///tmp/ipc.sock', -1)`

  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
