### PR TITLE
Adds trace logging for java non blocking server memory limit

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -312,9 +312,10 @@ public abstract class AbstractNonblockingServer extends TServer {
     }
 
     /**
-     * @return the amount of memory currently used to read data from clients. This information can be useful for debugging, metrics, and configuring the maximum memory limit.
+     * @return the amount of memory currently used to read data from clients. This information can
+     *     be useful for debugging, metrics, and configuring the maximum memory limit.
      */
-    public long getReadBufferBytesAllocated(){
+    public long getReadBufferBytesAllocated() {
       return readBufferBytesAllocated.get();
     }
 
@@ -358,9 +359,13 @@ public abstract class AbstractNonblockingServer extends TServer {
 
           // if this frame will push us over the memory limit, then return.
           // with luck, more memory will free up the next time around.
-	  long currentAllocated = readBufferBytesAllocated.get();
+          long currentAllocated = readBufferBytesAllocated.get();
           if (currentAllocated + frameSize > MAX_READ_BUFFER_BYTES) {
-            LOGGER.trace("Deferring reading frame of size {} because {} is already buffered and {} is the limit.", frameSize, currentAllocated, MAX_READ_BUFFER_BYTES); 
+            LOGGER.trace(
+                "Deferring reading frame of size {} because {} is already buffered and {} is the limit.",
+                frameSize,
+                currentAllocated,
+                MAX_READ_BUFFER_BYTES);
             return true;
           }
 

--- a/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -359,7 +359,7 @@ public abstract class AbstractNonblockingServer extends TServer {
 
           // if this frame will push us over the memory limit, then return.
           // with luck, more memory will free up the next time around.
-          long currentAllocated = readBufferBytesAllocated.get();
+          long currentAllocated = getReadBufferBytesAllocated();
           if (currentAllocated + frameSize > MAX_READ_BUFFER_BYTES) {
             LOGGER.trace(
                 "Deferring reading frame of size {} because {} is already buffered and {} is the limit.",

--- a/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -312,6 +312,13 @@ public abstract class AbstractNonblockingServer extends TServer {
     }
 
     /**
+     * @return the amount of memory currently used to read data from clients. This information can be useful for debugging, metrics, and configuring the maximum memory limit.
+     */
+    public long getReadBufferBytesAllocated(){
+      return readBufferBytesAllocated.get();
+    }
+
+    /**
      * Give this FrameBuffer a chance to read. The selector loop should have received a read event
      * for this FrameBuffer.
      *
@@ -351,7 +358,9 @@ public abstract class AbstractNonblockingServer extends TServer {
 
           // if this frame will push us over the memory limit, then return.
           // with luck, more memory will free up the next time around.
-          if (readBufferBytesAllocated.get() + frameSize > MAX_READ_BUFFER_BYTES) {
+	  long currentAllocated = readBufferBytesAllocated.get();
+          if (currentAllocated + frameSize > MAX_READ_BUFFER_BYTES) {
+            LOGGER.trace("Deferring reading frame of size {} because {} is already buffered and {} is the limit.", frameSize, currentAllocated, MAX_READ_BUFFER_BYTES); 
             return true;
           }
 

--- a/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
+++ b/lib/java/src/main/java/org/apache/thrift/server/AbstractNonblockingServer.java
@@ -315,7 +315,7 @@ public abstract class AbstractNonblockingServer extends TServer {
      * @return the amount of memory currently used to read data from clients. This information can
      *     be useful for debugging, metrics, and configuring the maximum memory limit.
      */
-    public long getReadBufferBytesAllocated() {
+    public final long getReadBufferBytesAllocated() {
       return readBufferBytesAllocated.get();
     }
 


### PR DESCRIPTION
Added a trace log and a method to help get information about the java AbstractNonblockingServer memory limit for reading data from clients.  This memory limit is configurable, but there is no mechanism to help someone understand how that limits impacts a thrift server at runtime.  These two simple changes attempt to provide some runtime insight in the memory usage and when the limit is hit.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
