### PR TITLE
THRIFT-5868: UUID Support for TCompactProtocol

### DIFF
--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
@@ -493,6 +493,7 @@ int TBinaryProtocolT<Transport_, ByteOrder_>::getMinSerializedSize(TType type)
       case T_MAP: return sizeof(int);  // element count
       case T_SET: return sizeof(int);  // element count
       case T_LIST: return sizeof(int);  // element count
+      case T_UUID: return 16; // 16 bytes
       default: throw TProtocolException(TProtocolException::UNKNOWN, "unrecognized type code");
   }
 }

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -140,6 +140,8 @@ public:
 
   uint32_t writeBinary(const std::string& str);
 
+  uint32_t writeUUID(const TUuid& str);
+
   int getMinSerializedSize(TType type) override;
 
   void checkReadBytesAvailable(TSet& set) override
@@ -212,6 +214,8 @@ public:
   uint32_t readString(std::string& str);
 
   uint32_t readBinary(std::string& str);
+
+  uint32_t readUUID(TUuid& str);
 
   /*
    *These methods are here for the struct to call, but don't have any wire

--- a/lib/cpp/test/AllProtocolTests.tcc
+++ b/lib/cpp/test/AllProtocolTests.tcc
@@ -25,6 +25,7 @@
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/Thrift.h>
+#include <thrift/TUuid.h>
 
 #include "GenericHelpers.h"
 
@@ -207,6 +208,9 @@ void testProtocol(const char* protoname) {
     testNaked<TProto, std::string>("borderlinetiny");
     testNaked<TProto, std::string>("a bit longer than the smallest possible");
     testNaked<TProto, std::string>("\x1\x2\x3\x4\x5\x6\x7\x8\x9\xA"); // kinda binary test
+
+    testNaked<TProto, TUuid>(TUuid("5e2ab188-1726-4e75-a04f-1ed9a6a89c4c"));
+    testField<TProto, T_UUID, TUuid>(TUuid("5e2ab188-1726-4e75-a04f-1ed9a6a89c4c"));
 
     testField<TProto, T_STRING, std::string>("");
     testField<TProto, T_STRING, std::string>("short");

--- a/lib/cpp/test/DebugProtoTest.cpp
+++ b/lib/cpp/test/DebugProtoTest.cpp
@@ -78,6 +78,8 @@ BOOST_AUTO_TEST_CASE(test_debug_proto_1) {
     "    [raw] = \"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\",\n"
     "    [enc] = \"00000000-0000-0000-0000-000000000000\"\n"
     "  }\n"
+    "  16: rfc4122_uuid_list (list) = list<uuid>[0] {\n"
+    "  },\n"
     "}");
   const std::string result(apache::thrift::ThriftDebugString(*ooe));
 
@@ -88,6 +90,8 @@ BOOST_AUTO_TEST_CASE(test_debug_proto_1) {
 static ::std::shared_ptr<Nesting> n;
 
 void testCaseSetup_2() {
+  using apache::thrift::TUuid;
+
   testCaseSetup_1();
 
   n.reset(new Nesting);
@@ -102,9 +106,14 @@ void testCaseSetup_2() {
                                "\xb0\xcf\x81\xe2\x84\x8e\x20\xce\x91\x74\x74"
                                "\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80"
                                "\xbc";
-  n->my_ooe.rfc4122_uuid = apache::thrift::TUuid{"{5e2ab188-1726-4e75-a04f-1ed9a6a89c4c}"};
+  n->my_ooe.rfc4122_uuid = TUuid{"{5e2ab188-1726-4e75-a04f-1ed9a6a89c4c}"};
   n->my_bonk.type = 31337;
   n->my_bonk.message = "I am a bonk... xor!";
+
+  std::vector<TUuid> uuiid_list;
+  uuiid_list.push_back(TUuid{"{fa1af5ec-fdc2-4355-844a-9f0dbfd00e50}"});
+  uuiid_list.push_back(TUuid{"{1beece83-34f4-4fa3-b757-1ad1ac157fe3}"});
+  n->my_ooe.rfc4122_uuid_list = uuiid_list;
 }
 
 BOOST_AUTO_TEST_CASE(test_debug_proto_2) {
@@ -150,6 +159,16 @@ BOOST_AUTO_TEST_CASE(test_debug_proto_2) {
     "      [raw] = \"^*\\xb1\\x88\\x17&Nu\\xa0O\\x1e\\xd9\\xa6\\xa8\\x9cL\",\n"
     "      [enc] = \"5e2ab188-1726-4e75-a04f-1ed9a6a89c4c\"\n"
     "    }\n"
+    "    16: rfc4122_uuid_list (list) = list<uuid>[2] {\n"
+    "{\n"
+    "        [raw] =         [0] = \"\\xfa\\x1a\\xf5\\xec\\xfd\\xc2CU\\x84J\\x9f\\r\\xbf\\xd0\\x0eP\",\n"
+    "        [enc] = \"fa1af5ec-fdc2-4355-844a-9f0dbfd00e50\"\n"
+    "      }\n"
+    "{\n"
+    "        [raw] =         [1] = \"\\x1b\\xee\\xce\\x834\\xf4O\\xa3\\xb7W\\x1a\\xd1\\xac\\x15\\x7f\\xe3\",\n"
+    "        [enc] = \"1beece83-34f4-4fa3-b757-1ad1ac157fe3\"\n"
+    "      }\n"
+    "    },\n"
     "  },\n"
     "}");
   const std::string result(apache::thrift::ThriftDebugString(*n));
@@ -241,6 +260,8 @@ BOOST_AUTO_TEST_CASE(test_debug_proto_3) {
     "        [raw] = \"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\",\n"
     "        [enc] = \"00000000-0000-0000-0000-000000000000\"\n"
     "      }\n"
+    "      16: rfc4122_uuid_list (list) = list<uuid>[0] {\n"
+    "      },\n"
     "    },\n"
     "    [1] = OneOfEach {\n"
     "      01: im_true (bool) = true,\n"
@@ -276,6 +297,16 @@ BOOST_AUTO_TEST_CASE(test_debug_proto_3) {
     "        [raw] = \"^*\\xb1\\x88\\x17&Nu\\xa0O\\x1e\\xd9\\xa6\\xa8\\x9cL\",\n"
     "        [enc] = \"5e2ab188-1726-4e75-a04f-1ed9a6a89c4c\"\n"
     "      }\n"
+    "      16: rfc4122_uuid_list (list) = list<uuid>[2] {\n"
+    "{\n"
+    "          [raw] =           [0] = \"\\xfa\\x1a\\xf5\\xec\\xfd\\xc2CU\\x84J\\x9f\\r\\xbf\\xd0\\x0eP\",\n"
+    "          [enc] = \"fa1af5ec-fdc2-4355-844a-9f0dbfd00e50\"\n"
+    "        }\n"
+    "{\n"
+    "          [raw] =           [1] = \"\\x1b\\xee\\xce\\x834\\xf4O\\xa3\\xb7W\\x1a\\xd1\\xac\\x15\\x7f\\xe3\",\n"
+    "          [enc] = \"1beece83-34f4-4fa3-b757-1ad1ac157fe3\"\n"
+    "        }\n"
+    "      },\n"
     "    },\n"
     "  },\n"
     "  02: contain (set) = set<list>[3] {\n"

--- a/lib/cpp/test/GenericHelpers.h
+++ b/lib/cpp/test/GenericHelpers.h
@@ -23,6 +23,7 @@
 #include <thrift/protocol/TProtocol.h>
 #include <memory>
 #include <thrift/Thrift.h>
+#include <thrift/TUuid.h>
 
 /* ClassName Helper for cleaner exceptions */
 class ClassNames {
@@ -57,6 +58,10 @@ template <>
 const char* ClassNames::getName<std::string>() {
   return "string";
 }
+template <>
+const char* ClassNames::getName<apache::thrift::TUuid>() {
+  return "uuid";
+}
 
 /* Generic Protocol I/O function for tests */
 class GenericIO {
@@ -87,6 +92,10 @@ public:
     return proto->writeString(val);
   }
 
+  static uint32_t write(std::shared_ptr<apache::thrift::protocol::TProtocol> proto, const apache::thrift::TUuid& val) {
+    return proto->writeUUID(val);
+  }
+
   /* Read functions */
 
   static uint32_t read(std::shared_ptr<apache::thrift::protocol::TProtocol> proto, int8_t& val) { return proto->readByte(val); }
@@ -101,6 +110,10 @@ public:
 
   static uint32_t read(std::shared_ptr<apache::thrift::protocol::TProtocol> proto, std::string& val) {
     return proto->readString(val);
+  }
+
+  static uint32_t read(std::shared_ptr<apache::thrift::protocol::TProtocol> proto, apache::thrift::TUuid& val) {
+    return proto->readUUID(val);
   }
 };
 

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -60,7 +60,8 @@ BOOST_AUTO_TEST_CASE(test_json_proto_1) {
   "535897931},\"8\":{\"str\":\"JSON THIS! \\\"\\u0001\"},\"9\":{\"str\":\"\xd7\\"
   "n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":\"AQIDrQ\"},\"12\":{\"lst\""
   ":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2,3]},\"14\":{\"lst\":[\"i64"
-  "\",3,1,2,3]},\"15\":{\"uid\":\"00000000-0000-0000-0000-000000000000\"}}");
+  "\",3,1,2,3]},\"15\":{\"uid\":\"00000000-0000-0000-0000-000000000000\"},\"16\""
+  ":{\"lst\":[\"uid\",0]}}");
 
   const std::string result(apache::thrift::ThriftJSONString(*ooe));
 
@@ -86,6 +87,10 @@ void testCaseSetup_2() {
                                "\xce\xb1\xe2\x85\xbd\xce\xba\xc7\x83\xe2\x80"
                                "\xbc";
   n->my_ooe.rfc4122_uuid = apache::thrift::TUuid{"5e2ab188-1726-4e75-a04f-1ed9a6a89c4c"};
+  std::vector<apache::thrift::TUuid> uuiid_list;
+  uuiid_list.push_back(apache::thrift::TUuid{"{fa1af5ec-fdc2-4355-844a-9f0dbfd00e50}"});
+  uuiid_list.push_back(apache::thrift::TUuid{"{1beece83-34f4-4fa3-b757-1ad1ac157fe3}"});
+  n->my_ooe.rfc4122_uuid_list = uuiid_list;
   n->my_bonk.type = 31337;
   n->my_bonk.message = "I am a bonk... xor!";
 }
@@ -101,7 +106,8 @@ BOOST_AUTO_TEST_CASE(test_json_proto_2) {
     "\"str\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκǃ‼\"},\"10\":{\"tf\":0},\"11\":{\"str\":\""
     "AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2"
     ",3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]},\"15\":{\"uid\":\"5e2ab188-1726-"
-    "4e75-a04f-1ed9a6a89c4c\"}}}}"
+    "4e75-a04f-1ed9a6a89c4c\"},\"16\":{\"lst\":[\"uid\",2,\"fa1af5ec-fdc2-4355-"
+    "844a-9f0dbfd00e50\",\"1beece83-34f4-4fa3-b757-1ad1ac157fe3\"]}}}}"
   );
 
   const std::string result(apache::thrift::ThriftJSONString(*n));
@@ -166,13 +172,14 @@ BOOST_AUTO_TEST_CASE(test_json_proto_3) {
   "\"},\"9\":{\"str\":\"\xd7\\n\\u0007\\t\"},\"10\":{\"tf\":0},\"11\":{\"str\":"
   "\"AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16\",3,1,2"
   ",3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]},\"15\":{\"uid\":\"00000000-0000-0000"
-  "-0000-000000000000\"}},{\"1\":{\"tf\":1},\"2\":{\"tf\":0},"
+  "-0000-000000000000\"},\"16\":{\"lst\":[\"uid\",0]}},{\"1\":{\"tf\":1},\"2\":{\"tf\":0},"
   "\"3\":{\"i8\":51},\"4\":{\"i16\":16},\"5\":{\"i32\":32},\"6\":{\"i64\":64},"
   "\"7\":{\"dbl\":1.6180339887498949},\"8\":{\"str\":\":R (me going \\\"rrrr\\\""
   ")\"},\"9\":{\"str\":\"ӀⅮΝ Нοⅿоɡгаρℎ Αttαⅽκǃ‼\"},\"10\":{\"tf\":0},\"11\":{"
   "\"str\":\"AQIDrQ\"},\"12\":{\"lst\":[\"i8\",3,1,2,3]},\"13\":{\"lst\":[\"i16"
   "\",3,1,2,3]},\"14\":{\"lst\":[\"i64\",3,1,2,3]},\"15\":{\"uid\":\"5e2ab188-"
-  "1726-4e75-a04f-1ed9a6a89c4c\"}}]},\"2\":{\"set\":[\"lst\",3"
+  "1726-4e75-a04f-1ed9a6a89c4c\"},\"16\":{\"lst\":[\"uid\",2,\"fa1af5ec-fdc2-4355-"
+  "844a-9f0dbfd00e50\",\"1beece83-34f4-4fa3-b757-1ad1ac157fe3\"]}}]},\"2\":{\"set\":[\"lst\",3"
   ",[\"str\",0],[\"str\",2,\"and a one\",\"and a two\"],[\"str\",3,\"then a one"
   ", two\",\"three!\",\"FOUR!!\"]]},\"3\":{\"map\":[\"str\",\"lst\",3,{\"nothin"
   "g\":[\"rec\",0],\"poe\":[\"rec\",3,{\"1\":{\"i32\":3},\"2\":{\"str\":\"quoth"

--- a/test/DebugProtoTest.thrift
+++ b/test/DebugProtoTest.thrift
@@ -47,8 +47,9 @@ struct OneOfEach {
   11: binary base64,
   12: list<i8> byte_list = [1, 2, 3],
   13: list<i16> i16_list = [1,2,3],
-  14: list<i64> i64_list = [1,2,3]
-  15: uuid rfc4122_uuid
+  14: list<i64> i64_list = [1,2,3],
+  15: uuid rfc4122_uuid,
+  16: list<uuid> rfc4122_uuid_list,
 }
 
 struct Bonk {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Add UUID support to the TCompactProtocol

Not only was this missing but also enables UUID tests in the AllProtocolTests

PS: This PR is from the same branch as #3136 thus the changes there are included in this PR and should dispensary if/when #3136 is merged

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  [THRIFT-5868](https://issues.apache.org/jira/browse/THRIFT-5868)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
