### PR TITLE
[nit] Throw exception instead of asserting in TJSONProtocol::readByte

### DIFF
--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -1087,7 +1087,10 @@ uint32_t TJSONProtocol::readBool(bool& value) {
 uint32_t TJSONProtocol::readByte(int8_t& byte) {
   auto tmp = (int16_t)byte;
   uint32_t result = readJSONInteger(tmp);
-  assert(tmp < 256);
+  if (tmp > 255 || tmp < -128) {
+    throw TProtocolException(TProtocolException::INVALID_DATA,
+                            "Expected byte value; got " + to_string(tmp));
+  }
   byte = (int8_t)tmp;
   return result;
 }

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -1087,7 +1087,7 @@ uint32_t TJSONProtocol::readBool(bool& value) {
 uint32_t TJSONProtocol::readByte(int8_t& byte) {
   auto tmp = (int16_t)byte;
   uint32_t result = readJSONInteger(tmp);
-  if (tmp > 255 || tmp < -128) {
+  if (tmp > 127 || tmp < -128) {
     throw TProtocolException(TProtocolException::INVALID_DATA,
                             "Expected byte value; got " + to_string(tmp));
   }

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -366,3 +366,16 @@ BOOST_AUTO_TEST_CASE(test_json_unicode_escaped_missing_hi_surrogate) {
   BOOST_CHECK_THROW(ooe2.read(proto.get()),
     apache::thrift::protocol::TProtocolException);
 }
+
+BOOST_AUTO_TEST_CASE(test_json_invalid_byte_range) {
+  // Test case for byte values outside valid range
+  const char json_string[] = "\"3\":{\"i8\":849}";
+
+  std::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(
+    (uint8_t*)(json_string), sizeof(json_string)));
+  std::shared_ptr<TJSONProtocol> proto(new TJSONProtocol(buffer));
+
+  OneOfEach ooe2;
+  BOOST_CHECK_THROW(ooe2.read(proto.get()),
+    apache::thrift::protocol::TProtocolException);
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Code structure wise, I think this is a bit nicer as it lets a caller catch this and return their own specific error messages.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)

Change is trivial, so I didn't file a ticket

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
