### PR TITLE
[nit] compile enum test types when building lib/c_glib tests

### DIFF
--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -34,7 +34,8 @@ BUILT_SOURCES = \
         gen-c_glib/t_test_container_service.h \
         gen-c_glib/t_test_srv.h \
         gen-c_glib/t_test_thrift_test.h \
-        gen-c_glib/t_test_thrift_test_types.h
+        gen-c_glib/t_test_thrift_test_types.h \
+        gen-c_glib/t_test_enum_test_types.h
 
 AM_CPPFLAGS = -I../src -I./gen-c_glib -I$(top_builddir)/lib/c_glib/src/thrift
 AM_CFLAGS = -g -Wall -Wextra -pedantic $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) $(OPENSSL_INCLUDES) \


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Tests were failing to build when I ran `make check` otherwise.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)

No ticket, change is trivial