### PR TITLE
UUID Cross test debugging and observations

### DIFF
--- a/build/docker/scripts/cross-test.sh
+++ b/build/docker/scripts/cross-test.sh
@@ -2,7 +2,7 @@
 set -ev
 
 ./bootstrap.sh
-./configure --enable-tutorial=no
+./configure --enable-tutorial=no --with-cl=no --with-d=no --with-dart=no
 make -j3 precross
 
 set +e
@@ -10,7 +10,7 @@ make cross$1
 
 RET=$?
 if [ $RET -ne 0 ]; then
-  if [ -f "test/features/log/unexpected_failures.log" ]; then 
+  if [ -f "test/features/log/unexpected_failures.log" ]; then
     cat "test/features/log/unexpected_failures.log"
   fi
   if [ -f "test/log/unexpected_failures.log" ]; then

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/apache/thrift
 
-go 1.23
+go 1.23.0

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.23
+go 1.23.0
 
 require github.com/apache/thrift v0.0.0-00010101000000-000000000000
 

--- a/lib/go/test/go.mod
+++ b/lib/go/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -97,7 +97,7 @@ StressTestNonBlocking_LDADD = \
 #
 # Common thrift code generation rules
 #
-gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_constants.cpp gen-cpp/SecondService.cpp gen-cpp/SecondService.h gen-cpp/SecondService.tcc: $(top_srcdir)/test/v0.16/ThriftTest.thrift $(THRIFT)
+gen-cpp/ThriftTest.cpp gen-cpp/ThriftTest_types.cpp gen-cpp/ThriftTest_constants.cpp gen-cpp/SecondService.cpp gen-cpp/SecondService.h gen-cpp/SecondService.tcc: $(top_srcdir)/test/ThriftTest.thrift $(THRIFT)
 	$(THRIFT) --gen cpp:templates,cob_style -r $<
 
 gen-cpp/Service.cpp: $(top_srcdir)/test/StressTest.thrift $(THRIFT)

--- a/test/cpp/src/TestClient.cpp
+++ b/test/cpp/src/TestClient.cpp
@@ -661,6 +661,7 @@ int main(int argc, char** argv) {
     UUID_TEST(testUuid, TUuid{"5e2ab18817264e75a04f1ed9a6a89c4c"}, expected_uuid);
     UUID_TEST(testUuid, TUuid{"{5e2ab18817264e75a04f1ed9a6a89c4c}"}, expected_uuid);
     UUID_TEST(testUuid, TUuid{}, TUuid{"00000000-0000-0000-0000-000000000000"});
+    UUID_TEST(testUuid, TUuid{"00112233-4455-6677-8899-aabbccddeeff"}, TUuid{"00112233-4455-6677-8899-aabbccddeeff"});
 
     /**
      * STRUCT TEST

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/test/go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/go/src/bin/testclient/main.go
+++ b/test/go/src/bin/testclient/main.go
@@ -152,6 +152,7 @@ func callEverything(client *thrifttest.ThriftTestClient) {
 		0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
 	}
 	u, err := client.TestUuid(defaultCtx, uout)
+	t.Printf("TestUuid(%v)", uout)
 	if err != nil {
 		t.Fatalf("TestUuid failed with %v", err)
 	}

--- a/test/swift/CrossTests/Sources/TestClient/main.swift
+++ b/test/swift/CrossTests/Sources/TestClient/main.swift
@@ -384,7 +384,8 @@ Bân-lâm-gú, 粵語
    }*/
   
   func testUuid() throws {
-    let uuid = UUID()
+    let uuid = UUID(uuidString: "00112233-4455-6677-8899-aabbccddeeff")!
+    print("testUuid(\(uuid))")
     guard try client.testUuid(thing: uuid) == uuid else {
       resultCode |= Error.baseTypes.rawValue
       return

--- a/test/test.py
+++ b/test/test.py
@@ -36,7 +36,6 @@ import os
 import sys
 
 import crossrunner
-from crossrunner.compat import path_join
 
 # 3.3 introduced subprocess timeouts on waiting for child
 req_version = (3, 3)
@@ -46,15 +45,15 @@ assert (cur_version >= req_version), "Python 3.3 or later is required for proper
 
 ROOT_DIR = os.path.dirname(os.path.realpath(os.path.dirname(__file__)))
 TEST_DIR_RELATIVE = 'test'
-TEST_DIR = path_join(ROOT_DIR, TEST_DIR_RELATIVE)
-FEATURE_DIR_RELATIVE = path_join(TEST_DIR_RELATIVE, 'features')
+TEST_DIR = os.path.join(ROOT_DIR, TEST_DIR_RELATIVE)
+FEATURE_DIR_RELATIVE = os.path.join(TEST_DIR_RELATIVE, 'features')
 CONFIG_FILE = 'tests.json'
 
 
 def run_cross_tests(server_match, client_match, jobs, skip_known_failures, only_known_failures, retry_count, regex):
     logger = multiprocessing.get_logger()
     logger.debug('Collecting tests')
-    with open(path_join(TEST_DIR, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(TEST_DIR, CONFIG_FILE), 'r') as fp:
         j = json.load(fp)
     tests = crossrunner.collect_cross_tests(j, server_match, client_match, regex)
     if not tests:
@@ -85,12 +84,12 @@ def run_cross_tests(server_match, client_match, jobs, skip_known_failures, only_
 
 
 def run_feature_tests(server_match, feature_match, jobs, skip_known_failures, only_known_failures, retry_count, regex):
-    basedir = path_join(ROOT_DIR, FEATURE_DIR_RELATIVE)
+    basedir = os.path.join(ROOT_DIR, FEATURE_DIR_RELATIVE)
     logger = multiprocessing.get_logger()
     logger.debug('Collecting tests')
-    with open(path_join(TEST_DIR, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(TEST_DIR, CONFIG_FILE), 'r') as fp:
         j = json.load(fp)
-    with open(path_join(basedir, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(basedir, CONFIG_FILE), 'r') as fp:
         j2 = json.load(fp)
     tests = crossrunner.collect_feature_tests(j, j2, server_match, feature_match, regex)
     if not tests:
@@ -171,7 +170,7 @@ def main(argv):
     client_match = list(chain(*[x.split(',') for x in options.client]))
 
     if options.update_failures or options.print_failures:
-        dire = path_join(ROOT_DIR, FEATURE_DIR_RELATIVE) if options.features is not None else TEST_DIR
+        dire = os.path.join(ROOT_DIR, FEATURE_DIR_RELATIVE) if options.features is not None else TEST_DIR
         res = crossrunner.generate_known_failures(
             dire, options.update_failures == 'overwrite',
             options.update_failures, options.print_failures)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  Trying to get cross tests to work:

@Jens-G I am trying to investigate a possible issue with the UUID type between implementations.
These are some changes I had to make to get me going. If you perhaps have some time to look through and maybe comment or consider why the CI build does not need these changes.

I am following the steps as per [Raw Commands for Building with Docker](https://github.com/apache/thrift/tree/master/build/docker#raw-commands-for-building-with-docker)

```
docker build --build-arg uid=$(id -u) --build-arg gid=$(id -g) -t thrift-jammy build/docker/ubuntu-jammy
docker run -v $(pwd):/thrift/src -it thrift-jammy /bin/bash
build/docker/scripts/cross-test.sh
```

My current observation is that the Java and Swift implementation of UUID is not correct as per the spec: [Universal unique identifier encoding](https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md#universal-unique-identifier-encoding)

My current test includes running one server and running another client. 
What I observe: I check the UUID being sent by the client and the UUID as reported by the server. In all cases the expectation is that what is sent is received and then returned. This however is not the case. 

For all of these I am running the C++ server: `/thrift/src/test/cpp/TestServer --port=37471`
| Language | Client Sent | Server Received | cmd | 
| --- | --- | --- | --- |
| C++ | `00112233-4455-6677-8899-aabbccddeeff` | `00112233-4455-6677-8899-aabbccddeeff`  | `/thrift/src/test/cpp/TestClient --port=37471` | 
| Java | `00112233-4455-6677-8899-aabbccddeeff` | **`8899aabb-ccdd-eeff-0011-223344556677`** | `/thrift/src/lib/java/build/runclient --port=37471` |
| go | `00112233-4455-6677-8899-aabbccddeeff` | `00112233-4455-6677-8899-aabbccddeeff` | `/thrift/src/test/go/bin/testclient --port=37471` |
| swift | `00112233-4455-6677-8899-aabbccddeeff` | **`8899aabb-ccdd-eeff-0011-223344556677`** | `thrift/src/test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug/TestClient --port=37471`
| .NET | `00112233-4455-6677-8899-aabbccddeeff` | `00112233-4455-6677-8899-aabbccddeeff` | `/thrift/src/test/netstd/Client/bin/Release/net9.0/Client` | 

- 'Client Sent' is the string that is hard coded in the client, and printed on the console when the client is run
- 'Server Received' is what the server interpreted and printed to the console
 
That about covers the php support except for Haxe and Delphi as per the [LANGUAGES.md](https://github.com/apache/thrift/blob/master/LANGUAGES.md) (I am having trouble building Delphi as seen in the cross-test.sh script.

From the above at least the C++, go and .NET implementations are compatible (and I would argue correct)

NB: This is not about what the client sends and receives: The client that sends the UUID receives the same UUID which means the server re-transmits as-is. The issue is about what one langauge sends (encode) and what another language receives (decode).

**Where to from here?** 

1. First I would like someone else to look into this and confirm or deny my hypothesis
2. If there is a mismatch, irrespective of which implementation is correct, this is a problem and should be addressed.
    - I don't know if this can be changed, it probably depends on the how strict is the spec and how wide is adoption
    - I know of projects using the C++ and go side already (with interop) 
 3. I need UUIDs to work for C++, Java, JS (no support yet), python (no support yet)


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
    - No, I first want engagement on this before making a ticket
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
