### PR TITLE
Put field name in error message for set duplication check on write

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -3747,8 +3747,8 @@ void t_go_generator::generate_serialize_container(ostream& out,
     out << indent() << "}(" << wrapped_prefix << "[i], " << wrapped_prefix << "[j]) {" << '\n';
     indent_up();
     out << indent() << "return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, "
-                    << "fmt.Errorf(\"%T error writing set field: slice is not " "unique\", "
-                    << wrapped_prefix << "))" << '\n';
+                    << "fmt.Errorf(\"%T error writing set field %q: slice is not unique\", "
+                    << wrapped_prefix << ", \"" << escape_string(prefix) << "\"))" << '\n';
     indent_down();
     out << indent() << "}" << '\n';
     indent_down();


### PR DESCRIPTION
Client: go

Before:

    thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("%T error writing set field: slice is not unique", p.Foo))

After:

    thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("%T error writing set field %q: slice is not unique", p.Foo, "p.Foo"))

Currently when there are more than one field inside a struct being sets and this error happens, it's impossible to tell which field contains duplications to cause this error.
