### PR TITLE
[nit] Return early if no bytes left to return in thrift_memory_buffer_read

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_memory_buffer.c
@@ -91,6 +91,10 @@ thrift_memory_buffer_read (ThriftTransport *transport, gpointer buf,
     give = t->buf->len;
   }
 
+  if (give == 0) {
+    return -1;
+  }
+
   memcpy (buf, t->buf->data, give);
   g_byte_array_remove_range (t->buf, 0, give);
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

As title. Return early with an error if there's nothing left to read, which the caller can use to know the buffer has been fully consumed.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)

Did not create a ticket as the change is pretty trivial.