### PR TITLE
Avoid dispatching to parent when not needed in c_glib implementation

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -2759,9 +2759,14 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
              << "gobject_class->finalize = " << class_name_lc << "_finalize;" << '\n' << indent()
              << "gobject_class->set_property = " << class_name_lc << "_set_property;" << '\n'
              << indent() << "gobject_class->get_property = " << class_name_lc << "_get_property;"
-             << '\n' << '\n' << indent()
-             << "dispatch_processor_class->dispatch_call = " << class_name_lc << "_dispatch_call;"
-             << '\n' << indent() << "cls->dispatch_call = " << class_name_lc << "_dispatch_call;"
+             << '\n' << '\n';
+
+  if (extends_service) {
+    f_service_ << indent() << "dispatch_processor_class->dispatch_call = " << class_name_lc
+               << "_dispatch_call;" << '\n';
+  }
+
+  f_service_ << indent() << "cls->dispatch_call = " << class_name_lc << "_dispatch_call;"
              << '\n' << '\n' << indent() << "param_spec = g_param_spec_object (\"handler\","
              << '\n';
   args_indent = indent() + string(34, ' ');


### PR DESCRIPTION
As titled. This avoids dispatching calls up to the parent implementation if there isn't one, saving a hop.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

I tested this by:

* Building the compiler
* Building the c_glib tutorial server and client
* Verifying that the client/server interaction works as previously expected
* Inspecting the generated code and noticing shared_service.c does not have the code to dispatch to its parent anymore, while the calculator.c implementation does. 