### PR TITLE
[THRIFT-5871] Improve MAX_MESSAGE_SIZE_CHECK and friends

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.h
@@ -52,6 +52,10 @@ typedef struct _ThriftBinaryProtocol ThriftBinaryProtocol;
 struct _ThriftBinaryProtocol
 {
   ThriftProtocol parent;
+
+  /* protected */
+  gint32 string_limit;
+  gint32 container_limit;
 };
 
 typedef struct _ThriftBinaryProtocolClass ThriftBinaryProtocolClass;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.c
@@ -164,7 +164,7 @@ thrift_transport_checkReadBytesAvailable(ThriftTransport *transport, glong numBy
 {
   gboolean boolean = TRUE;
   ThriftTransport *tt = THRIFT_TRANSPORT (transport);
-  if(tt->remainingMessageSize_ < numBytes)
+  if(tt->remainingMessageSize_ < numBytes || numBytes < 0)
   {
     g_set_error(error,
                 THRIFT_TRANSPORT_ERROR,

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.tcc
@@ -469,6 +469,9 @@ uint32_t TBinaryProtocolT<Transport_, ByteOrder_>::readStringBody(StrType& str, 
     return size;
   }
 
+  // Check against MaxMessageSize before alloc
+  trans_->checkReadBytesAvailable(size);
+
   str.resize(size);
   this->trans_->readAll(reinterpret_cast<uint8_t*>(&str[0]), size);
   return (uint32_t)size;
@@ -480,8 +483,8 @@ int TBinaryProtocolT<Transport_, ByteOrder_>::getMinSerializedSize(TType type)
 {
   switch (type)
   {
-      case T_STOP: return 0;
-      case T_VOID: return 0;
+      case T_STOP: return 1;  // T_STOP needs to count itself
+      case T_VOID: return 1;  // T_VOID needs to count itself
       case T_BOOL: return sizeof(int8_t);
       case T_BYTE: return sizeof(int8_t);
       case T_DOUBLE: return sizeof(double);
@@ -489,7 +492,7 @@ int TBinaryProtocolT<Transport_, ByteOrder_>::getMinSerializedSize(TType type)
       case T_I32: return sizeof(int);
       case T_I64: return sizeof(long);
       case T_STRING: return sizeof(int);  // string length
-      case T_STRUCT: return 0;  // empty struct
+      case T_STRUCT: return 1;  // empty struct needs at least 1 byte for the T_STOP
       case T_MAP: return sizeof(int);  // element count
       case T_SET: return sizeof(int);  // element count
       case T_LIST: return sizeof(int);  // element count

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.tcc
@@ -859,8 +859,8 @@ int TCompactProtocolT<Transport_>::getMinSerializedSize(TType type)
 {
   switch (type)
   {
-    case T_STOP:    return 0;
-    case T_VOID:    return 0;
+    case T_STOP:    return 1;  // T_STOP needs to count itself
+    case T_VOID:    return 1;  // T_VOID needs to count itself
     case T_BOOL:   return sizeof(int8_t);
     case T_DOUBLE: return 8;  // uses fixedLongToBytes() which always writes 8 bytes
     case T_BYTE: return sizeof(int8_t);
@@ -868,7 +868,7 @@ int TCompactProtocolT<Transport_>::getMinSerializedSize(TType type)
     case T_I32:     return sizeof(int8_t);  // zigzag
     case T_I64:     return sizeof(int8_t);  // zigzag
     case T_STRING: return sizeof(int8_t);  // string length
-    case T_STRUCT:  return 0;             // empty struct
+    case T_STRUCT:  return 1;  // empty struct needs at least 1 byte for the T_STOP
     case T_MAP:     return sizeof(int8_t);  // element count
     case T_SET:    return sizeof(int8_t);  // element count
     case T_LIST:    return sizeof(int8_t);  // element count

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -1131,8 +1131,8 @@ int TJSONProtocol::getMinSerializedSize(TType type)
 {
   switch (type)
   {
-    case T_STOP: return 0;
-    case T_VOID: return 0;
+    case T_STOP: return 1;  // T_STOP needs to count itself
+    case T_VOID: return 1;  // T_VOID needs to count itself
     case T_BOOL: return 1;  // written as int
     case T_BYTE: return 1;
     case T_DOUBLE: return 1;

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -274,7 +274,7 @@ public:
    */
   void checkReadBytesAvailable(long int numBytes)
   {
-    if (remainingMessageSize_ < numBytes)
+    if (remainingMessageSize_ < numBytes || numBytes < 0)
       throw TTransportException(TTransportException::END_OF_FILE, "MaxMessageSize reached");
   }
 

--- a/lib/delphi/src/Thrift.Protocol.Compact.pas
+++ b/lib/delphi/src/Thrift.Protocol.Compact.pas
@@ -1011,8 +1011,8 @@ function TCompactProtocolImpl.GetMinSerializedSize( const aType : TType) : Integ
 // Return the minimum number of bytes a type will consume on the wire
 begin
   case aType of
-    TType.Stop:    result := 0;
-    TType.Void:    result := 0;
+    TType.Stop:    result := 1;  // T_STOP needs to count itself
+    TType.Void:    result := 1;  // T_VOID needs to count itself
     TType.Bool_:   result := SizeOf(Byte);
     TType.Byte_:   result := SizeOf(Byte);
     TType.Double_: result := 8;  // uses fixedLongToBytes() which always writes 8 bytes
@@ -1020,7 +1020,7 @@ begin
     TType.I32:     result := SizeOf(Byte);
     TType.I64:     result := SizeOf(Byte);
     TType.String_: result := SizeOf(Byte);  // string length
-    TType.Struct:  result := 0;             // empty struct
+    TType.Struct:  result := 1;  // empty struct needs at least 1 byte for the T_STOP
     TType.Map:     result := SizeOf(Byte);  // element count
     TType.Set_:    result := SizeOf(Byte);  // element count
     TType.List:    result := SizeOf(Byte);  // element count

--- a/lib/delphi/src/Thrift.Protocol.JSON.pas
+++ b/lib/delphi/src/Thrift.Protocol.JSON.pas
@@ -1257,8 +1257,8 @@ function TJSONProtocolImpl.GetMinSerializedSize( const aType : TType) : Integer;
 // Return the minimum number of bytes a type will consume on the wire
 begin
   case aType of
-    TType.Stop:    result := 0;
-    TType.Void:    result := 0;
+    TType.Stop:    result := 1;  // T_STOP needs to count itself
+    TType.Void:    result := 1;  // T_VOID needs to count itself
     TType.Bool_:   result := 1;
     TType.Byte_:   result := 1;
     TType.Double_: result := 1;

--- a/lib/delphi/src/Thrift.Protocol.pas
+++ b/lib/delphi/src/Thrift.Protocol.pas
@@ -1237,8 +1237,8 @@ function TBinaryProtocolImpl.GetMinSerializedSize( const aType : TType) : Intege
 // Return the minimum number of bytes a type will consume on the wire
 begin
   case aType of
-    TType.Stop:    result := 0;
-    TType.Void:    result := 0;
+    TType.Stop:    result := 1;  // T_STOP needs to count itself
+    TType.Void:    result := 1;  // T_VOID needs to count itself
     TType.Bool_:   result := SizeOf(Byte);
     TType.Byte_:   result := SizeOf(Byte);
     TType.Double_: result := SizeOf(Double);
@@ -1246,7 +1246,7 @@ begin
     TType.I32:     result := SizeOf(Int32);
     TType.I64:     result := SizeOf(Int64);
     TType.String_: result := SizeOf(Int32);  // string length
-    TType.Struct:  result := 0;  // empty struct
+    TType.Struct:  result := 1;  // empty struct needs at least 1 byte for the T_STOP
     TType.Map:     result := SizeOf(Int32);  // element count
     TType.Set_:    result := SizeOf(Int32);  // element count
     TType.List:    result := SizeOf(Int32);  // element count

--- a/lib/haxe/src/org/apache/thrift/protocol/TBinaryProtocol.hx
+++ b/lib/haxe/src/org/apache/thrift/protocol/TBinaryProtocol.hx
@@ -321,8 +321,8 @@ class TBinaryProtocol extends TProtocolImplBase implements TProtocol {
 	{
 		switch (type)
 		{
-			case TType.STOP: return 0;
-			case TType.VOID_: return 0;
+			case TType.STOP: return 1;  // T_STOP needs to count itself
+			case TType.VOID_: return 1;  // T_VOID needs to count itself
 			case TType.BOOL: return 1;
 			case TType.BYTE: return 1;
 			case TType.DOUBLE: return 8;
@@ -330,7 +330,7 @@ class TBinaryProtocol extends TProtocolImplBase implements TProtocol {
 			case TType.I32: return 4;
 			case TType.I64: return 8;
 			case TType.STRING: return 4;  // string length
-			case TType.STRUCT: return 0;  // empty struct
+			case TType.STRUCT: return 1;  // empty struct needs at least 1 byte for the T_STOP
 			case TType.MAP: return 4;  // element count
 			case TType.SET: return 4;  // element count
 			case TType.LIST: return 4;  // element count

--- a/lib/haxe/src/org/apache/thrift/protocol/TCompactProtocol.hx
+++ b/lib/haxe/src/org/apache/thrift/protocol/TCompactProtocol.hx
@@ -725,8 +725,8 @@ class TCompactProtocol extends TProtocolImplBase implements TProtocol {
 	{
 		switch (type)
 		{
-			case TType.STOP:    return 0;
-			case TType.VOID_:    return 0;
+			case TType.STOP:    return 1;  // T_STOP needs to count itself
+			case TType.VOID_:    return 1;  // T_VOID needs to count itself
 			case TType.BOOL:   return 1;
 			case TType.DOUBLE: return 8;  // uses fixedLongToBytes() which always writes 8 bytes
 			case TType.BYTE: return 1;
@@ -734,7 +734,7 @@ class TCompactProtocol extends TProtocolImplBase implements TProtocol {
 			case TType.I32:     return 1;  // zigzag
 			case TType.I64:     return 1;  // zigzag
 			case TType.STRING: return 1;  // string length
-			case TType.STRUCT:  return 0;             // empty struct
+			case TType.STRUCT:  return 1;  // empty struct needs at least 1 byte for the T_STOP
 			case TType.MAP:     return 1;  // element count
 			case TType.SET:    return 1;  // element count
 			case TType.LIST:    return 1;  // element count

--- a/lib/haxe/src/org/apache/thrift/protocol/TJSONProtocol.hx
+++ b/lib/haxe/src/org/apache/thrift/protocol/TJSONProtocol.hx
@@ -792,8 +792,8 @@ class TJSONProtocol extends TProtocolImplBase implements TProtocol {
 	{
 		switch (type)
 		{
-			case TType.STOP: return 0;
-			case TType.VOID_: return 0;
+			case TType.STOP: return 1;  // T_STOP needs to count itself
+			case TType.VOID_: return 1;  // T_VOID needs to count itself
 			case TType.BOOL: return 1;  // written as int  
 			case TType.BYTE: return 1;
 			case TType.DOUBLE: return 1;

--- a/lib/haxe/src/org/apache/thrift/transport/TEndpointTransport.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TEndpointTransport.hx
@@ -78,7 +78,7 @@ class TEndpointTransport extends TTransport
 	// Throws if there are not enough bytes in the input stream to satisfy a read of numBytes bytes of data
 	public override function CheckReadBytesAvailable(numBytes : Int64) : Void
 	{
-		if (RemainingMessageSize < numBytes)
+		if (RemainingMessageSize < numBytes || numBytes < 0)
 			throw new TTransportException(TTransportException.END_OF_FILE, 'CheckReadBytesAvailable(${numBytes}): MaxMessageSize reached, only ${RemainingMessageSize} bytes available');
 	}
 

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -524,9 +524,9 @@ public class TBinaryProtocol extends TProtocol {
   public int getMinSerializedSize(byte type) throws TTransportException {
     switch (type) {
       case 0:
-        return 0; // Stop
+        return 1; // Stop - T_STOP needs to count itself
       case 1:
-        return 0; // Void
+        return 1; // Void - T_VOID needs to count itself
       case 2:
         return 1; // Bool sizeof(byte)
       case 3:
@@ -542,7 +542,7 @@ public class TBinaryProtocol extends TProtocol {
       case 11:
         return 4; // string length sizeof(int)
       case 12:
-        return 0; // empty struct
+        return 1; // empty struct needs at least 1 byte for the T_STOP
       case 13:
         return 4; // element count Map sizeof(int)
       case 14:

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
@@ -911,9 +911,9 @@ public class TCompactProtocol extends TProtocol {
   public int getMinSerializedSize(byte type) throws TTransportException {
     switch (type) {
       case 0:
-        return 0; // Stop
+        return 1; // Stop - T_STOP needs to count itself
       case 1:
-        return 0; // Void
+        return 1; // Void - T_VOID needs to count itself
       case 2:
         return 1; // Bool sizeof(byte)
       case 3:
@@ -929,7 +929,7 @@ public class TCompactProtocol extends TProtocol {
       case 11:
         return 1; // string length sizeof(byte)
       case 12:
-        return 0; // empty struct
+        return 1; // empty struct needs at least 1 byte for the T_STOP
       case 13:
         return 1; // element count Map sizeof(byte)
       case 14:

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TJSONProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TJSONProtocol.java
@@ -972,9 +972,9 @@ public class TJSONProtocol extends TProtocol {
   public int getMinSerializedSize(byte type) throws TTransportException {
     switch (type) {
       case 0:
-        return 0; // Stop
+        return 1; // Stop - T_STOP needs to count itself
       case 1:
-        return 0; // Void
+        return 1; // Void - T_VOID needs to count itself
       case 2:
         return 1; // Bool
       case 3:

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TSimpleJSONProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TSimpleJSONProtocol.java
@@ -477,9 +477,9 @@ public class TSimpleJSONProtocol extends TProtocol {
   public int getMinSerializedSize(byte type) throws TException {
     switch (type) {
       case 0:
-        return 0; // Stop
+        return 1; // Stop - T_STOP needs to count itself
       case 1:
-        return 0; // Void
+        return 1; // Void - T_VOID needs to count itself
       case 2:
         return 1; // Bool
       case 3:

--- a/lib/java/src/main/java/org/apache/thrift/transport/TEndpointTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TEndpointTransport.java
@@ -92,7 +92,7 @@ public abstract class TEndpointTransport extends TTransport {
    * @param numBytes
    */
   public void checkReadBytesAvailable(long numBytes) throws TTransportException {
-    if (remainingMessageSize < numBytes)
+    if (remainingMessageSize < numBytes || numBytes < 0)
       throw new TTransportException(
           TTransportException.MESSAGE_SIZE_LIMIT,
           "Message size exceeds limit: " + getMaxMessageSize());

--- a/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TBinaryProtocol.cs
@@ -452,8 +452,8 @@ namespace Thrift.Protocol
         {
             switch (type)
             {
-                case TType.Stop: return 0;
-                case TType.Void: return 0;
+                case TType.Stop: return 1;  // T_STOP needs to count itself
+                case TType.Void: return 1;  // T_VOID needs to count itself
                 case TType.Bool: return sizeof(byte);
                 case TType.Byte: return sizeof(byte);
                 case TType.Double: return sizeof(double);
@@ -461,7 +461,7 @@ namespace Thrift.Protocol
                 case TType.I32: return sizeof(int);
                 case TType.I64: return sizeof(long);
                 case TType.String: return sizeof(int);  // string length
-                case TType.Struct: return 0;  // empty struct
+                case TType.Struct: return 1;  // empty struct needs at least 1 byte for the T_STOP
                 case TType.Map: return sizeof(int);  // element count
                 case TType.Set: return sizeof(int);  // element count
                 case TType.List: return sizeof(int);  // element count

--- a/lib/netstd/Thrift/Protocol/TCompactProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TCompactProtocol.cs
@@ -816,8 +816,8 @@ namespace Thrift.Protocol
         {
             switch (type)
             {
-                case TType.Stop: return 0;
-                case TType.Void: return 0;
+                case TType.Stop: return 1;  // T_STOP needs to count itself
+                case TType.Void: return 1;  // T_VOID needs to count itself
                 case TType.Bool: return sizeof(byte);
                 case TType.Double: return 8;  // uses fixedLongToBytes() which always writes 8 bytes
                 case TType.Byte: return sizeof(byte);
@@ -825,7 +825,7 @@ namespace Thrift.Protocol
                 case TType.I32: return sizeof(byte);  // zigzag
                 case TType.I64: return sizeof(byte);  // zigzag
                 case TType.String: return sizeof(byte);  // string length
-                case TType.Struct: return 0;             // empty struct
+                case TType.Struct: return 1;             // empty struct needs at least 1 byte for the T_STOP
                 case TType.Map: return sizeof(byte);  // element count
                 case TType.Set: return sizeof(byte);  // element count
                 case TType.List: return sizeof(byte);  // element count

--- a/lib/netstd/Thrift/Protocol/TJSONProtocol.cs
+++ b/lib/netstd/Thrift/Protocol/TJSONProtocol.cs
@@ -837,8 +837,8 @@ namespace Thrift.Protocol
         {
             switch (type)
             {
-                case TType.Stop: return 0;
-                case TType.Void: return 0;
+                case TType.Stop: return 1;  // T_STOP needs to count itself
+                case TType.Void: return 1;  // T_VOID needs to count itself
                 case TType.Bool: return 1;  // written as int  
                 case TType.Byte: return 1;
                 case TType.Double: return 1;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This makes a number of changes, following the spec laid out in the ticket. The high level goal is to ensure that these checks are consistent throughout the various implementations.

Concretely:

* Some implementations checked for numBytes < 0 in the checkReadBytesAvailable() call. Do this everywhere  
* Always ensure we call checkReadBytesAvailable() with the number of bytes to read, not just container size
* The C glib binary protocol was missing some checks the compact protocol had (I just wholesale copied them, replacing 'compact' with 'binary')
* Some string length checks weren't consistently applied
* getMinSerializedSize() should generally return a minimum of 1, if my understanding of the spec and the context in which it's called in is correct.

I made one PR touching all languages, I can split into separate PRs if desired but I figured this gives a more holistic picture of the changes.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

