### PR TITLE
go: Add a zlib reader pool

### DIFF
--- a/lib/go/thrift/compact_protocol_test.go
+++ b/lib/go/thrift/compact_protocol_test.go
@@ -33,9 +33,18 @@ func TestReadWriteCompactProtocol(t *testing.T) {
 		NewTFramedTransport(NewTMemoryBuffer()),
 	}
 
-	zlib0, _ := NewTZlibTransport(NewTMemoryBuffer(), 0)
-	zlib6, _ := NewTZlibTransport(NewTMemoryBuffer(), 6)
-	zlib9, _ := NewTZlibTransport(NewTFramedTransport(NewTMemoryBuffer()), 9)
+	newTZlibTransport := func(trans TTransport, level int) *TZlibTransport {
+		t.Helper()
+		zlibTrans, err := NewTZlibTransport(trans, level)
+		if err != nil {
+			t.Fatalf("NewTZlibTransport returned error: %v", err)
+		}
+		return zlibTrans
+	}
+
+	zlib0 := newTZlibTransport(NewTMemoryBuffer(), 0)
+	zlib6 := newTZlibTransport(NewTMemoryBuffer(), 6)
+	zlib9 := newTZlibTransport(NewTFramedTransport(NewTMemoryBuffer()), 9)
 	transports = append(transports, zlib0, zlib6, zlib9)
 
 	for _, trans := range transports {

--- a/lib/go/thrift/pool.go
+++ b/lib/go/thrift/pool.go
@@ -43,7 +43,7 @@ func newPool[T any](generate func() *T, reset func(*T)) *pool[T] {
 	}
 	return &pool[T]{
 		pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return generate()
 			},
 		},

--- a/lib/go/thrift/zlib_pool.go
+++ b/lib/go/thrift/zlib_pool.go
@@ -1,0 +1,109 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package thrift
+
+import (
+	"compress/zlib"
+	"io"
+	"sync"
+)
+
+type zlibReader interface {
+	io.ReadCloser
+	zlib.Resetter
+}
+
+var zlibReaderPool sync.Pool
+
+func newZlibReader(r io.Reader) (io.ReadCloser, error) {
+	if reader, _ := zlibReaderPool.Get().(*wrappedZlibReader); reader != nil {
+		if err := reader.Reset(r, nil); err == nil {
+			return reader, nil
+		}
+	}
+	reader, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedZlibReader{reader.(zlibReader)}, nil
+}
+
+type wrappedZlibReader struct {
+	zlibReader
+}
+
+func (wr *wrappedZlibReader) Close() error {
+	defer func() {
+		zlibReaderPool.Put(wr)
+	}()
+	return wr.zlibReader.Close()
+}
+
+func newZlibWriterLevelMust(level int) *zlib.Writer {
+	w, err := zlib.NewWriterLevel(nil, level)
+	if err != nil {
+		panic(err)
+	}
+	return w
+}
+
+// level -> pool
+var zlibWriterPools map[int]*pool[zlib.Writer] = func() map[int]*pool[zlib.Writer] {
+	m := make(map[int]*pool[zlib.Writer])
+	for level := zlib.HuffmanOnly; level <= zlib.BestCompression; level++ {
+		// force a panic at init if we have an invalid level here
+		newZlibWriterLevelMust(level)
+		m[level] = newPool(
+			func() *zlib.Writer {
+				return newZlibWriterLevelMust(level)
+			},
+			nil,
+		)
+	}
+	return m
+}()
+
+type zlibWriterPoolCloser struct {
+	writer *zlib.Writer
+	pool   *pool[zlib.Writer]
+}
+
+func (z *zlibWriterPoolCloser) Close() error {
+	defer func() {
+		z.writer.Reset(nil)
+		z.pool.put(&z.writer)
+	}()
+	return z.writer.Close()
+}
+
+func newZlibWriterCloserLevel(w io.Writer, level int) (*zlib.Writer, io.Closer, error) {
+	pool, ok := zlibWriterPools[level]
+	if !ok {
+		// not pooled
+		writer, err := zlib.NewWriterLevel(w, level)
+		if err != nil {
+			return nil, nil, err
+		}
+		return writer, writer, nil
+	}
+	writer := pool.get()
+	writer.Reset(w)
+	return writer, &zlibWriterPoolCloser{writer: writer, pool: pool}, nil
+}

--- a/lib/go/thrift/zlib_pool_test.go
+++ b/lib/go/thrift/zlib_pool_test.go
@@ -1,0 +1,51 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package thrift
+
+import (
+	"compress/zlib"
+	"fmt"
+	"maps"
+	"slices"
+	"testing"
+)
+
+func TestZlibWriterPools(t *testing.T) {
+	// make sure we have the writer pools created at the given levels
+	for _, level := range []int{
+		zlib.HuffmanOnly,
+		zlib.DefaultCompression,
+		zlib.NoCompression,
+		zlib.BestSpeed,
+		zlib.BestCompression,
+	} {
+		t.Run(fmt.Sprintf("%d", level), func(t *testing.T) {
+			_, ok := zlibWriterPools[level]
+			if !ok {
+				t.Errorf("level %d does not exist in the writer pools", level)
+			}
+		})
+	}
+	if t.Failed() {
+		levels := slices.Collect(maps.Keys(zlibWriterPools))
+		slices.Sort(levels)
+		t.Log("zlib writer pools:", levels)
+	}
+}


### PR DESCRIPTION
We implemented a zlib writer pool for default level when implementing THeader, this change also add a zlib reader pool to help speed up things when zlib is used.

Also make TZlibTransport to use the zlib writer pool when it's using the default compression level.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
