### PR TITLE
Fix cross-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -619,13 +619,12 @@ jobs:
 
       - name: Set back executable flags
         run: |
-          chmod a+x \
-            lib/java/build/run* \
-            lib/kotlin/cross-test-client/build/install/TestClient/bin/* \
-            lib/kotlin/cross-test-server/build/install/TestServer/bin/* \
-            # THRIFT-5864  test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug/* \
-            test/rs/bin/* \
-            test/go/bin/*
+          chmod a+x lib/java/build/run*
+          chmod a+x lib/kotlin/cross-test-client/build/install/TestClient/bin/*
+          chmod a+x lib/kotlin/cross-test-server/build/install/TestServer/bin/*
+          # THRIFT-5864  chmod a+x test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug/*
+          chmod a+x test/rs/bin/*
+          chmod a+x test/go/bin/*
 
       - name: Create tmp domain socket folder
         run: mkdir /tmp/v0.16

--- a/test/test.py
+++ b/test/test.py
@@ -36,7 +36,6 @@ import os
 import sys
 
 import crossrunner
-from crossrunner.compat import path_join
 
 # 3.3 introduced subprocess timeouts on waiting for child
 req_version = (3, 3)
@@ -46,15 +45,15 @@ assert (cur_version >= req_version), "Python 3.3 or later is required for proper
 
 ROOT_DIR = os.path.dirname(os.path.realpath(os.path.dirname(__file__)))
 TEST_DIR_RELATIVE = 'test'
-TEST_DIR = path_join(ROOT_DIR, TEST_DIR_RELATIVE)
-FEATURE_DIR_RELATIVE = path_join(TEST_DIR_RELATIVE, 'features')
+TEST_DIR = os.path.join(ROOT_DIR, TEST_DIR_RELATIVE)
+FEATURE_DIR_RELATIVE = os.path.join(TEST_DIR_RELATIVE, 'features')
 CONFIG_FILE = 'tests.json'
 
 
 def run_cross_tests(server_match, client_match, jobs, skip_known_failures, only_known_failures, retry_count, regex):
     logger = multiprocessing.get_logger()
     logger.debug('Collecting tests')
-    with open(path_join(TEST_DIR, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(TEST_DIR, CONFIG_FILE), 'r') as fp:
         j = json.load(fp)
     tests = crossrunner.collect_cross_tests(j, server_match, client_match, regex)
     if not tests:
@@ -85,12 +84,12 @@ def run_cross_tests(server_match, client_match, jobs, skip_known_failures, only_
 
 
 def run_feature_tests(server_match, feature_match, jobs, skip_known_failures, only_known_failures, retry_count, regex):
-    basedir = path_join(ROOT_DIR, FEATURE_DIR_RELATIVE)
+    basedir = os.path.join(ROOT_DIR, FEATURE_DIR_RELATIVE)
     logger = multiprocessing.get_logger()
     logger.debug('Collecting tests')
-    with open(path_join(TEST_DIR, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(TEST_DIR, CONFIG_FILE), 'r') as fp:
         j = json.load(fp)
-    with open(path_join(basedir, CONFIG_FILE), 'r') as fp:
+    with open(os.path.join(basedir, CONFIG_FILE), 'r') as fp:
         j2 = json.load(fp)
     tests = crossrunner.collect_feature_tests(j, j2, server_match, feature_match, regex)
     if not tests:
@@ -171,7 +170,7 @@ def main(argv):
     client_match = list(chain(*[x.split(',') for x in options.client]))
 
     if options.update_failures or options.print_failures:
-        dire = path_join(ROOT_DIR, FEATURE_DIR_RELATIVE) if options.features is not None else TEST_DIR
+        dire = os.path.join(ROOT_DIR, FEATURE_DIR_RELATIVE) if options.features is not None else TEST_DIR
         res = crossrunner.generate_known_failures(
             dire, options.update_failures == 'overwrite',
             options.update_failures, options.print_failures)


### PR DESCRIPTION
1. Comment in the middle of multi-line shell command joined by \ does not work, change to multiple individual commands instead.
2. Fix a py 2vs3 compat issue missed in 24df0a5 used in cross runner.