### PR TITLE
THRIFT-5880: ipv6 only linux systems cannot resolve 127.0.0.1

### DIFF
--- a/lib/cpp/src/thrift/transport/TSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSocket.cpp
@@ -461,7 +461,9 @@ void TSocket::local_open() {
 #ifdef _WIN32
       error == WSANO_DATA
 #else
-      error == EAI_NODATA
+      // to support systems with no ipv4 addresses but using "127.0.0.1" as a hostname
+      // getaddrinfo() fails when AI_ADDRCONFIG is present in this situation...
+      error == EAI_NODATA || error == EAI_ADDRFAMILY
 #endif
     ) {
     hints.ai_flags &= ~AI_ADDRCONFIG;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
getaddrinfo() resolving 127.0.0.1 as a hostname on a linux system with ipv6 only defined on eth0 results in EAI_ADDRFAMILY.  This means AI_ADDRCONFIG needs to be removed to properly resolve it.  This is similar to the fix for EAI_NODATA for ipv6.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
