### PR TITLE
Add various/minor changes to some TProtocols for consistency and convenience

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/protocol/TProtocolDecorator.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TProtocolDecorator.java
@@ -262,6 +262,46 @@ public abstract class TProtocolDecorator extends TProtocol {
     return concreteProtocol.readBinary();
   }
 
+  @Override
+  public int readFieldBeginData() throws TException {
+    return concreteProtocol.readFieldBeginData();
+  }
+
+  @Override
+  protected void skipBool() throws TException {
+    concreteProtocol.skipBool();
+  }
+
+  @Override
+  protected void skipByte() throws TException {
+    concreteProtocol.skipByte();
+  }
+
+  @Override
+  protected void skipI16() throws TException {
+    concreteProtocol.skipI16();
+  }
+
+  @Override
+  protected void skipI32() throws TException {
+    concreteProtocol.skipI32();
+  }
+
+  @Override
+  protected void skipI64() throws TException {
+    concreteProtocol.skipI64();
+  }
+
+  @Override
+  protected void skipDouble() throws TException {
+    concreteProtocol.skipDouble();
+  }
+
+  @Override
+  protected void skipBinary() throws TException {
+    concreteProtocol.skipBinary();
+  }
+
   /**
    * @param type Returns the minimum amount of bytes needed to store the smallest possible instance
    *     of TType.
@@ -271,5 +311,10 @@ public abstract class TProtocolDecorator extends TProtocol {
   @Override
   public int getMinSerializedSize(byte type) throws TException {
     return concreteProtocol.getMinSerializedSize(type);
+  }
+
+  @Override
+  public void reset() {
+    concreteProtocol.reset();
   }
 }


### PR DESCRIPTION
I noticed that when partial deserialization was added a new method `readFieldBeginData()` was added to elide the TField object creation. However, only the **TBinaryProtocol** takes advantage of this. This PR updates **TCompactProtocol** to do the same.

Also, while using the **TProtocol** helper method `readMap()` that takes a **ReadMapEntryCallback** I found myself wishing I could passing a separate keyCallback and valueCallback so my calling code can use method references/lambdas.

Another minor tweak in this area was the default `mapCreator` for maps and sets. In later versions of Java they added the `HashMap.newHashMap()` factory method which will size the table to prevent resizing when given an initial capacity that won't be exceeded. I don't know of an equivalent for HashSet, though the HashSet constructor that takes in a Collection also performs this optimization. I have added them here for convenience. I have noticed in the past that the Java thrift compiler initially sizes maps to 2x their size likely for this reason, so this is like an analogue to that. Perhaps the compiler should also be doing this, but I suspect it's of minor consequence either way.

While trying to utilize the **TProtocolDecorator** I was sad that none of the `skip*()` methods were delegated to. I mostly wanted `skipBinary()`, but added them all for completeness. Again, looks like these were added for partial deserialization so I assume it was just missed. I added a few more overrides to it as well to really treat it as a delegating wrapper.