### PR TITLE
THRIFT-5887: ensure using our CMake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ project("thrift" VERSION ${PACKAGE_VERSION})
 message(STATUS "Configuring ${CMAKE_PROJECT_NAME} ${thrift_VERSION}")
 
 
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/build/cmake")
 
 # Some default settings
 include(DefineCMakeDefaults)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Client: cpp

If we append our CMake module path to `CMAKE_MODULE_PATH` and Apache Thrift is built with FetchContent, our CMake modules in `build/cmake/` may not be used. Because other paths in `CMAKE_MODULE_PATH` may be used. For example, both of Apache Arrow and Apache Thrift has `DefineOptions.cmake`. If Apache Arrow builds Apache Thrift with FetchContent, Apache Arrow's `DefineOptions.cmake` is used unexpectedly.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
