### PR TITLE
Fix UUID handling in Rust Thrift compact protocol

### DIFF
--- a/lib/rs/src/protocol/compact.rs
+++ b/lib/rs/src/protocol/compact.rs
@@ -257,7 +257,11 @@ where
     }
 
     fn read_uuid(&mut self) -> crate::Result<uuid::Uuid> {
-        uuid::Uuid::from_slice(&self.read_bytes()?).map_err(From::from)
+        let mut buf = [0u8; 16];
+        self.transport
+            .read_exact(&mut buf)
+            .map(|_| uuid::Uuid::from_bytes(buf))
+            .map_err(From::from)
     }
 
     fn read_string(&mut self) -> crate::Result<String> {
@@ -547,7 +551,9 @@ where
     }
 
     fn write_uuid(&mut self, uuid: &uuid::Uuid) -> crate::Result<()> {
-        self.write_bytes(uuid.as_bytes())
+        self.transport
+            .write_all(uuid.as_bytes())
+            .map_err(From::from)
     }
 
     fn write_string(&mut self, s: &str) -> crate::Result<()> {

--- a/lib/rs/src/protocol/mod.rs
+++ b/lib/rs/src/protocol/mod.rs
@@ -209,6 +209,7 @@ pub trait TInputProtocol {
             TType::I64 => self.read_i64().map(|_| ()),
             TType::Double => self.read_double().map(|_| ()),
             TType::String => self.read_string().map(|_| ()),
+            TType::Uuid => self.read_uuid().map(|_| ()),
             TType::Struct => {
                 self.read_struct_begin()?;
                 loop {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
This commit fixes two bugs in the Rust Thrift implementation that prevented UUID fields from working correctly with the compact protocol:

1. Missing UUID case in skip_till_depth function
   - The skip function in lib/rs/src/protocol/mod.rs did not handle TType::Uuid
   - This caused "cannot skip field type Uuid" errors when trying to skip UUID fields
   - Fixed by adding: TType::Uuid => self.read_uuid().map(|_| ())

2. Incorrect UUID serialization in compact protocol
   - The compact protocol was using read_bytes()/write_bytes() for UUIDs
   - These methods include a length prefix, but UUIDs should be transmitted as raw 16-byte values per the Thrift specification
   - This caused "don't know what type: 15" errors during cross-language tests
   - Fixed by reading/writing UUID bytes directly without length prefix
   - Implementation now matches the binary protocol's approach for consistency

The bug manifested as failures in cross-language tests between Go and Rust when using compact protocol. The error occurred because Go correctly expected raw 16-byte UUID values while Rust was incorrectly adding a length prefix.

Testing:
- Verified all go-rs and rs-go cross tests now pass with compact protocol
- Tests confirm UUID values are correctly serialized and deserialized
- Both buffered and framed transports work correctly

Test command: python3 test/test.py --server go --client rs -R ".*compact.*"

🤖 Generated with [Claude Code](https://claude.ai/code) -- but I as a human reviewed every line, tested it, and ensured this is code I'm happy to put my name on. I used it to help reproduce the failure, figure out how to run the tests, and diagnose the issue - the diagnosis + fix is correct.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) --> no, trivial changes
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"? --> N/A
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
