### PR TITLE
THRIFT-5888: Do not dynamically enable the GIL under free-threaded Python

### DIFF
--- a/lib/py/src/ext/module.cpp
+++ b/lib/py/src/ext/module.cpp
@@ -196,6 +196,10 @@ void initfastbinary() {
   if (module == nullptr)
     INITERROR;
 
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
 #if PY_MAJOR_VERSION >= 3
   return module;
 #endif


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

I've completed an auditing of the C extension modules and it does not appear to have any global state. Thus, we can signify that the extension does not rely on the GIL for thread safety, so that it's not dynamically reenabled when `thrift.protocal.fastbinary` is imported.  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
