### PR TITLE
[rust] Gracefully handle error upon receiving incompatible union

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -1840,9 +1840,19 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
   render_thrift_error("Protocol", "ProtocolError", "ProtocolErrorKind::InvalidData",
                       "\"received multiple fields for union from remote " + union_name + "\"");
   indent_down();
+  f_gen_ << indent() << "} else if let Some(ret) = ret {" << '\n';
+  indent_up();
+  f_gen_ << indent() << "Ok(ret)" << '\n';
+  indent_down();
   f_gen_ << indent() << "} else {" << '\n';
   indent_up();
-  f_gen_ << indent() << "Ok(ret.expect(\"return value should have been constructed\"))" << '\n';
+  f_gen_ << indent() << "Err(" << '\n';
+  indent_up();
+  f_gen_ << indent() << "thrift::Error::Protocol(" << '\n';
+  f_gen_ << indent() << "  ProtocolError::new(ProtocolErrorKind::InvalidData, \"return value should have been constructed\")" << '\n';
+  f_gen_ << indent() << ")" << '\n';
+  indent_down();
+  f_gen_ << indent() << ")" << '\n';
   indent_down();
   f_gen_ << indent() << "}" << '\n';
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 
Improve the code generator so that Rust code, when receiving an union with an invalid field ID, can gracefully return an error.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) --> no, trivial. Note that https://issues.apache.org/jira/browse/THRIFT-5890 is probably the "proper" fix, but this is a step in the right direction while we figure that out.
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.