### PR TITLE
Update supported go versions to 1.24+1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,8 +137,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.23'
           - '1.24'
+          - '1.25'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
         run: make -C test/go precross
 
       - name: Upload go precross artifacts
-        if: matrix.go == '1.24'
+        if: matrix.go == '1.25'
         uses: actions/upload-artifact@v4
         with:
           name: go-precross

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -168,7 +168,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/go/README.md">Go</a></td>
 <!-- Since -----------------><td>0.7.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>1.23</td><td>1.24</td>
+<!-- Language Levels -------><td>1.24</td><td>1.25</td>
 <!-- Field types -----------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/apache/thrift
 
-go 1.23
+go 1.24

--- a/lib/go/test/fuzz/go.mod
+++ b/lib/go/test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test/fuzz
 
-go 1.23
+go 1.24
 
 require github.com/apache/thrift v0.0.0-00010101000000-000000000000
 

--- a/lib/go/test/go.mod
+++ b/lib/go/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/lib/go/test
 
-go 1.23
+go 1.24
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/thrift/test/go
 
-go 1.23
+go 1.24
 
 require (
 	github.com/apache/thrift v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
Drop support for go 1.23 as it's no longer supported by upstream.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
