### PR TITLE
Expose thriftnb cmake target

### DIFF
--- a/build/cmake/ThriftConfig.cmake.in
+++ b/build/cmake/ThriftConfig.cmake.in
@@ -51,6 +51,13 @@ if(@Qt5_FOUND@ AND @WITH_QT5@)
     set(THRIFT_LIBRARIES thriftqt5::thriftqt5)
 endif()
 
+if(@Libevent_FOUND@ AND @WITH_LIBEVENT@)
+    if (NOT TARGET thriftnb::thriftnb)
+        include("${THRIFT_CMAKE_DIR}/thriftnbTargets.cmake")
+    endif()
+    set(THRIFT_LIBRARIES thriftnb::thriftnb)
+endif()
+
 if ("${THRIFT_LIBRARIES}" STREQUAL "")
     message(FATAL_ERROR "thrift libraries were not found")
 endif()


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Auto generated `ThriftConfig.cmake` does not export `thriftnb` library, so it is impossible to use `TNonblockingServer` with CMake build system. Note that, library's export file (`thriftnbTargets.cmake`) is generated and correctly installed by CMake.

This commit adds conditional include of `thriftnb`'s export file.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) - trivial change
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
