### PR TITLE
Fix python tests

### DIFF
--- a/lib/py/test/thrift_TSerializer.py
+++ b/lib/py/test/thrift_TSerializer.py
@@ -56,15 +56,11 @@ class TestSerializer(unittest.TestCase):
         self.assertRaises(EOFError, deserialize, Message(), b'', factory)
 
     def test_TBinaryProtocol(self):
-        buf = TTransport.TMemoryBuffer()
-        transport = TTransport.TBufferedTransportFactory().getTransport(buf)
-        factory = TBinaryProtocolFactory(transport)
+        factory = TBinaryProtocolFactory()
         self.verify(self.binary_serialized, factory)
 
     def test_TBinaryProtocolAccelerated(self):
-        buf = TTransport.TMemoryBuffer()
-        transport = TTransport.TBufferedTransportFactory().getTransport(buf)
-        factory = TBinaryProtocolAcceleratedFactory(transport)
+        factory = TBinaryProtocolAcceleratedFactory()
         self.verify(self.binary_serialized, factory)
 
     def test_TCompactProtocol(self):


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Fix a CI test issue exposed by OSS-fuzz integration in https://github.com/google/oss-fuzz/pull/13874

I can reproduce this with the oss-fuzz build (by setting UBSan flags locally). I do not know why the issue only shows up then, but this fix is correct - the method signatures are the same as the Compact protocol factory. The factory is supposed to not be passed any argument, or the arguments that are passed should be the limits. This manifested as the below failure:

```
2025-08-26T18:20:18.9632418Z /usr/local/bin/python test/thrift_TSerializer.py
2025-08-26T18:20:19.0144330Z .E..
2025-08-26T18:20:19.0145197Z ======================================================================
2025-08-26T18:20:19.0146549Z ERROR: test_TBinaryProtocolAccelerated (__main__.TestSerializer.test_TBinaryProtocolAccelerated)
2025-08-26T18:20:19.0148344Z ----------------------------------------------------------------------
2025-08-26T18:20:19.0149187Z Traceback (most recent call last):
2025-08-26T18:20:19.0158543Z   File "/src/thrift/lib/py/test/thrift_TSerializer.py", line 68, in test_TBinaryProtocolAccelerated
2025-08-26T18:20:19.0159474Z     self.verify(self.binary_serialized, factory)
2025-08-26T18:20:19.0160254Z   File "/src/thrift/lib/py/test/thrift_TSerializer.py", line 50, in verify
2025-08-26T18:20:19.0160914Z     deserialize(Message(), serialized, factory).body,
2025-08-26T18:20:19.0161739Z     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-08-26T18:20:19.0162428Z   File "/src/thrift/lib/py/build/lib.linux-x86_64-cpython-311/thrift/TSerialization.py", line 37, in deserialize
2025-08-26T18:20:19.0163082Z     base.read(protocol)
2025-08-26T18:20:19.0163513Z   File "/src/thrift/lib/py/gen-py/TestServer/ttypes.py", line 45, in read
2025-08-26T18:20:19.0164259Z     self.body = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
2025-08-26T18:20:19.0164897Z                                                                                                       ^^^^^^^^^^^^^^^^^^
2025-08-26T18:20:19.0165620Z   File "/src/thrift/lib/py/build/lib.linux-x86_64-cpython-311/thrift/protocol/TProtocol.py", line 179, in readString
2025-08-26T18:20:19.0166301Z     return self.readBinary().decode('utf-8')
2025-08-26T18:20:19.0166624Z            ^^^^^^^^^^^^^^^^^
2025-08-26T18:20:19.0167302Z   File "/src/thrift/lib/py/build/lib.linux-x86_64-cpython-311/thrift/protocol/TBinaryProtocol.py", line 234, in readBinary
2025-08-26T18:20:19.0167990Z     self._check_string_length(size)
2025-08-26T18:20:19.0168745Z   File "/src/thrift/lib/py/build/lib.linux-x86_64-cpython-311/thrift/protocol/TBinaryProtocol.py", line 48, in _check_string_length
2025-08-26T18:20:19.0169531Z     self._check_length(self.string_length_limit, length)
2025-08-26T18:20:19.0170268Z   File "/src/thrift/lib/py/build/lib.linux-x86_64-cpython-311/thrift/protocol/TProtocol.py", line 57, in _check_length
2025-08-26T18:20:19.0170906Z     if limit is not None and length > limit:
2025-08-26T18:20:19.0171360Z                              ^^^^^^^^^^^^^^
2025-08-26T18:20:19.0171764Z TypeError: '>' not supported between instances of 'int' and 'TBufferedTransport'
2025-08-26T18:20:19.0172088Z 
2025-08-26T18:20:19.0172231Z ----------------------------------------------------------------------
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
