### PR TITLE
THRIFT-5892: Always define PY_SSIZE_T_CLEAN before including Python.h

### DIFF
--- a/lib/py/src/ext/module.cpp
+++ b/lib/py/src/ext/module.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "types.h"
 #include "binary.h"

--- a/lib/py/src/ext/types.cpp
+++ b/lib/py/src/ext/types.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "ext/types.h"
 #include "ext/protocol.h"
 


### PR DESCRIPTION
The error THRIFT-5488 tried to solve resurfaced in a spefic environment: Python3.11.13, chainguard based docker image, GCC 15

Defining PY_SSIZE_T_CLEAN in module.cpp fixed the issue in that environment. Also defined it in types.cpp to consistently define it before including Python.h, which seems to be the recommended way: https://docs.python.org/3.11/c-api/intro.html#include-files

It is not clear to me why this was a problem in some environments and not in others. My guess is that including Python.h with different defines leads to different behavior based on GCC version and options.
