### PR TITLE
Support socket activation by  fd passing

### DIFF
--- a/lib/cpp/src/thrift/transport/TServerSocket.h
+++ b/lib/cpp/src/thrift/transport/TServerSocket.h
@@ -40,6 +40,13 @@ namespace transport {
 
 class TSocket;
 
+enum class SocketType {
+    NONE,
+    INET,
+    INET6,
+    UNIX
+};
+
 /**
  * Server socket implementation of TServerTransport. Wrapper around a unix
  * socket listen and accept calls.
@@ -81,6 +88,14 @@ public:
    * @param path Pathname for unix socket.
    */
   TServerSocket(const std::string& path);
+
+  /**
+   * Constructor used for to initialize from an already bound unix socket.
+   * Useful for socket activation on systemd.
+   *
+   * @param fd
+   */
+  TServerSocket(THRIFT_SOCKET sock,SocketType socketType);
 
   ~TServerSocket() override;
 
@@ -172,6 +187,7 @@ private:
 
   socket_func_t listenCallback_;
   socket_func_t acceptCallback_;
+  SocketType boundSocketType_;
 };
 }
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 
This change adds another constructor to the TServerSocket class to support passing a socket that's already bound with the goal to support socket-activation by systemd. If a service is configured to use socket-activation systemd will bind the socket and pass an FD that's already bound as an environment variable when the service is started with the goal to parallelize boot startup and remove ordering dependencies between server ( bind ) and client ( connect).

The new enum type introduced is used mostly to disambiguate constructors.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
