### PR TITLE
THRIFT-5896: Fix race condition in TServerSocket.Addr()

### DIFF
--- a/lib/go/thrift/server_socket.go
+++ b/lib/go/thrift/server_socket.go
@@ -26,12 +26,12 @@ import (
 )
 
 type TServerSocket struct {
-	listener      net.Listener
 	addr          net.Addr
 	clientTimeout time.Duration
 
-	// Protects the interrupted value to make it thread safe.
+	// Protects the listener and interrupted fields to make them thread safe.
 	mu          sync.RWMutex
+	listener    net.Listener
 	interrupted bool
 }
 
@@ -110,7 +110,9 @@ func (p *TServerSocket) Open() error {
 }
 
 func (p *TServerSocket) Addr() net.Addr {
-	if p.listener != nil {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.IsListening() {
 		return p.listener.Addr()
 	}
 	return p.addr


### PR DESCRIPTION
Client: go

<!-- Explain the changes in the pull request below: -->
  ## Problem
The `Addr()` method in `server_socket.go` was accessing the `p.listener` field without mutex protection, which could cause data races when multiple goroutines access it concurrently (e.g., one goroutine calling `Addr()` while another calls `Close()`, `Open()`, or `Listen()`).

## Solution
- Added `RLock()`/`RUnlock()` protection around listener access for thread-safety
- Changed direct nil check to use `IsListening()` method for consistency with the codebase
- Follows the same locking pattern used in other methods (`Accept()`, `Close()`, `Listen()`, `Open()`)

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
