### PR TITLE
THRIFT-5914: Disable lingering for the Ruby server and configure client

### DIFF
--- a/lib/rb/lib/thrift/transport/server_socket.rb
+++ b/lib/rb/lib/thrift/transport/server_socket.rb
@@ -38,6 +38,14 @@ module Thrift
 
     def listen
       @handle = TCPServer.new(@host, @port)
+
+      # Turn linger off, don't want to block on calls to close
+      begin
+        @handle.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, [0, 0].pack('ii'))
+      rescue IOError => e
+        close
+        raise TransportException.new(TransportException::NOT_OPEN, "Could not set SO_LINGER: #{e.message}")
+      end
     end
 
     def accept

--- a/lib/rb/lib/thrift/transport/ssl_server_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_server_socket.rb
@@ -30,8 +30,8 @@ module Thrift
     attr_accessor :ssl_context
 
     def listen
-      socket = TCPServer.new(@host, @port)
-      @handle = OpenSSL::SSL::SSLServer.new(socket, @ssl_context)
+      super
+      @handle = OpenSSL::SSL::SSLServer.new(@handle, @ssl_context)
     end
     
     def to_s

--- a/lib/rb/spec/server_socket_spec.rb
+++ b/lib/rb/spec/server_socket_spec.rb
@@ -28,19 +28,22 @@ describe 'Thrift::ServerSocket' do
     end
 
     it "should create a handle when calling listen" do
-      expect(TCPServer).to receive(:new).with(nil, 1234)
+      handle = double("TCPServer", :setsockopt => nil)
+      expect(TCPServer).to receive(:new).with(nil, 1234).and_return(handle)
       @socket.listen
     end
 
     it "should accept an optional host argument" do
       @socket = Thrift::ServerSocket.new('localhost', 1234)
-      expect(TCPServer).to receive(:new).with('localhost', 1234)
+      handle = double("TCPServer", :setsockopt => nil)
+      expect(TCPServer).to receive(:new).with('localhost', 1234).and_return(handle)
       @socket.to_s == "server(localhost:1234)"
       @socket.listen
     end
 
     it "should create a Thrift::Socket to wrap accepted sockets" do
       handle = double("TCPServer")
+      expect(handle).to receive(:setsockopt).with(Socket::SOL_SOCKET, Socket::SO_LINGER, [0, 0].pack('ii'))
       expect(TCPServer).to receive(:new).with(nil, 1234).and_return(handle)
       @socket.listen
       sock = double("sock")
@@ -53,7 +56,7 @@ describe 'Thrift::ServerSocket' do
     end
 
     it "should close the handle when closed" do
-      handle = double("TCPServer", :closed? => false)
+      handle = double("TCPServer", :closed? => false, :setsockopt => nil)
       expect(TCPServer).to receive(:new).with(nil, 1234).and_return(handle)
       @socket.listen
       expect(handle).to receive(:close)
@@ -65,7 +68,7 @@ describe 'Thrift::ServerSocket' do
     end
 
     it "should return true for closed? when appropriate" do
-      handle = double("TCPServer", :closed? => false)
+      handle = double("TCPServer", :closed? => false, :setsockopt => nil)
       allow(TCPServer).to receive(:new).and_return(handle)
       @socket.listen
       expect(@socket).not_to be_closed

--- a/lib/rb/spec/ssl_server_socket_spec.rb
+++ b/lib/rb/spec/ssl_server_socket_spec.rb
@@ -27,6 +27,14 @@ describe 'SSLServerSocket' do
       @socket = Thrift::SSLServerSocket.new(1234)
     end
 
+    it "should set linger on the underlying server socket" do
+      tcp = double("TCPServer")
+      expect(TCPServer).to receive(:new).with(nil, 1234).and_return(tcp)
+      expect(tcp).to receive(:setsockopt).with(Socket::SOL_SOCKET, Socket::SO_LINGER, [0, 0].pack('ii'))
+      expect(OpenSSL::SSL::SSLServer).to receive(:new).with(tcp, nil)
+      @socket.listen
+    end
+
     it "should provide a reasonable to_s" do
       expect(@socket.to_s).to eq("ssl(socket(:1234))")
     end

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -53,8 +53,18 @@ describe 'SSLSocket' do
       @socket.open
     end
 
+    it "should set linger on the underlying socket" do
+      expect(::Socket).to receive(:getaddrinfo).with("localhost", 9090, nil, ::Socket::SOCK_STREAM).and_return([[]])
+      expect(::Socket).to receive(:sockaddr_in)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(Socket::SOL_SOCKET, Socket::SO_LINGER, [1, 0].pack('ii'))
+      expect(@simple_socket_handle).to receive(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_return(@handle)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+      @socket.open
+    end
+
     it "should accept host/port options" do
-      handle = double("Handle", :connect_nonblock => true, :setsockopt => nil)
+      handle = double("Handle", :connect_nonblock => true, :setsockopt => nil, :closed? => false)
       allow(::Socket).to receive(:new).and_return(handle)
       expect(::Socket).to receive(:getaddrinfo).with("my.domain", 1234, nil, ::Socket::SOCK_STREAM).and_return([[]])
       expect(::Socket).to receive(:sockaddr_in)


### PR DESCRIPTION
> [!CAUTION]
> This pull request introduces lingering settings aligned with C++ library, but upon further investigation does not seem to be safe. For example, [THRIFT-3888](https://issues.apache.org/jira/browse/THRIFT-3888) talks about abnormal connection termination from the client side.

<!-- Explain the changes in the pull request below: -->

Implemented lingering the same way C++ library handles it:

* completely disabled for the server https://github.com/apache/thrift/blob/master/lib/cpp/src/thrift/transport/TServerSocket.cpp#L335-L342
* enabled for the client but with timeout of 0 seconds https://github.com/apache/thrift/blob/master/lib/cpp/src/thrift/transport/TSocket.cpp#L101-L102

Lingering for the client can be configured:

```ruby
socket = Thrift::Socket.new('localhost', port)
# Disable lingering
socket.linger(false, 0)
# Enable lingering with timeout 10 seconds
socket.linger(true, 10)
```

## Benchmark

Before:

```
THRIFT_NUM_CALLS=1 THRIFT_NUM_CLIENTS=1000 THRIFT_SERVER=Thrift::ThreadPoolServer ruby benchmark/benchmark.rb; netstat -n | wc -l
Starting server...
Spawning benchmark processes...
Collecting output...
Translating output...
Analyzing output...

Server class:        Thrift::ThreadPoolServer
Server interpreter:  ruby
Client interpreter:  ruby
Socket class:        Thrift::Socket
Number of processes: 40
Clients per process: 1000
Calls per client:    1
Using fastthread:    no

Connection failures:               0
Connection errors:                 0
Average time per call:             0.0080 seconds
Average time per client (1 calls): 0.0082 seconds
Total time for all calls:          319.6949 seconds
Real time for benchmarking:        9.1044 seconds
Shortest call time:                0.0001 seconds
Longest call time:                 0.0229 seconds
Shortest client time (1 calls):    0.0003 seconds
Longest client time (1 calls):     0.2283 seconds

====> 13714 open sockets afterwards in TIME_WAIT status
```

After:

```
$ THRIFT_NUM_CALLS=1 THRIFT_NUM_CLIENTS=1000 THRIFT_SERVER=Thrift::ThreadPoolServer ruby benchmark/benchmark.rb; netstat -n | wc -l
Starting server...
Spawning benchmark processes...
Collecting output...
Translating output...
Analyzing output...

Server class:        Thrift::ThreadPoolServer
Server interpreter:  ruby
Client interpreter:  ruby
Socket class:        Thrift::Socket
Number of processes: 40
Clients per process: 1000
Calls per client:    1
Using fastthread:    no

Connection failures:               0
Connection errors:                 0
Average time per call:             0.0083 seconds
Average time per client (1 calls): 0.0084 seconds
Total time for all calls:          330.7904 seconds
Real time for benchmarking:        9.2939 seconds
Shortest call time:                0.0001 seconds
Longest call time:                 0.0245 seconds
Shortest client time (1 calls):    0.0003 seconds
Longest client time (1 calls):     0.2390 seconds

====> 4 open sockets afterwards, ~85 in the process
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5914](https://issues.apache.org/jira/browse/THRIFT-5914)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
