### PR TITLE
THRIFT-5922: made http header lookup case insensitive

### DIFF
--- a/lib/lua/THttpTransport.lua
+++ b/lib/lua/THttpTransport.lua
@@ -42,6 +42,15 @@ function THttpTransport:new(obj)
   return TTransportBase.new(self, obj)
 end
 
+local function THttpHeaders()
+    local data = {}
+    return setmetatable({}, {
+        __index = function(_, key) return data[string.lower(key)] end,
+        __newindex = function(_, key, value) data[string.lower(key)] = value end,
+        __pairs = function() return pairs(data) end
+    })
+end
+
 function THttpTransport:isOpen()
   return self.trans:isOpen()
 end
@@ -112,7 +121,7 @@ function THttpTransport:getLine()
 end
 
 function THttpTransport:_parseHeaders()
-  local headers = {}
+  local headers = THttpHeaders()
 
   repeat
     local line = self:getLine()


### PR DESCRIPTION
Client: lua

<!-- Explain the changes in the pull request below: -->
  
The http transport client breaks when the traffic is routed through a proxy that changes the casing of the header keys. This is not only incorrect but also different from the implementation in all other languages.
This pull request changes this, so http headers are now stored/retrieved in a case insensitive matter.
Since there are no unit tests for lua (that i could find?) I did not add tests that isolate this bug, but it's quite obvious from looking at the source.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
