### PR TITLE
Build & Publish Thrift Maven Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,12 @@ if(BUILD_PYTHON)
     endif()
 endif()
 
+if(BUILD_CONTRIB)
+    if(BUILD_MAVEN_PLUGIN)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/contrib/thrift-maven-plugin)
+    endif()
+endif()
+
 # Create the uninstall target
 add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/build/cmake/uninstall.cmake")
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,10 @@ if WITH_TUTORIAL
 SUBDIRS += tutorial
 endif
 
+if WITH_CONTRIB
+SUBDIRS += contrib
+endif
+
 clean-local:
 	$(RM) -r vendor/
 

--- a/aclocal/ax_prog_maven.m4
+++ b/aclocal/ax_prog_maven.m4
@@ -1,0 +1,54 @@
+# SYNOPSIS
+#
+#   AX_PROG_MAVEN_VERSION([VERSION],[ACTION-IF-TRUE],[ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   Makes sure that maven supports the version indicated. If true the shell
+#   commands in ACTION-IF-TRUE are executed. If not the shell commands in
+#   ACTION-IF-FALSE are run. The $MAVEN_VERSION variable will be filled with
+#   the detected version.
+#
+#   This macro uses the $MAVEN variable to perform the check. If $MAVEN is not
+#   set prior to calling this macro, the macro will fail.
+#
+#   Example:
+#
+#     AC_PATH_PROG([MAVEN],[mvn])
+#     AC_PROG_MAVEN_VERSION([3.0.0],[ ... ],[ ... ])
+#
+#   Searches for Maven, then checks if at least version 3.0.0 is present.
+#
+# LICENSE
+#
+#   Copyright (c) 2026 Joshua M. Keyes <joshua.michael.keyes@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_PROG_MAVEN_VERSION],[
+    AS_IF([test -n "$MAVEN"],[
+        ax_maven_version="$1"
+
+        AC_MSG_CHECKING([for maven version])
+        maven_version=`$MAVEN --quiet --version`
+        AC_MSG_RESULT($maven_version)
+
+           AC_SUBST([MAVEN_VERSION],[$maven_version])
+
+        AX_COMPARE_VERSION([$ax_maven_version],[le],[$maven_version],[
+           :
+            $2
+        ],[
+           :
+            $3
+        ])
+    ],[
+        AC_MSG_WARN([could not find maven])
+        $3
+    ])
+])

--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -31,6 +31,7 @@ endif()
 CMAKE_DEPENDENT_OPTION(BUILD_TESTING "Build with unit tests" ON "HAVE_COMPILER" OFF)
 CMAKE_DEPENDENT_OPTION(BUILD_TUTORIALS "Build Thrift tutorials" ON "HAVE_COMPILER" OFF)
 option(BUILD_LIBRARIES "Build Thrift libraries" ON)
+option(BUILD_CONTRIB "Build Thrift contrib" ON)
 
 # Libraries to build
 
@@ -125,6 +126,13 @@ find_package(Python3
 CMAKE_DEPENDENT_OPTION(BUILD_PYTHON "Build Python library" ON
                        "BUILD_LIBRARIES;WITH_PYTHON;Python3_Interpreter_FOUND;Python3_Development_FOUND" OFF)
 
+## Maven Plugin
+option(WITH_MAVEN_PLUGIN "Build Maven plugin" ON)
+find_package(Java QUIET)
+find_package(Maven QUIET)
+CMAKE_DEPENDENT_OPTION(BUILD_MAVEN_PLUGIN "Build Maven plugin" ON
+                       "BUILD_CONTRIB;WITH_JAVA;JAVA_FOUND;MAVEN_FOUND" OFF)
+
 # Common library options
 # https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html
 # Default on Windows is static, shared mode library support needs work...
@@ -167,6 +175,8 @@ message(STATUS "  Build compiler:                             ${BUILD_COMPILER}"
 message(STATUS "  Build libraries:                            ${BUILD_LIBRARIES}")
 message(STATUS "  Build tests:                                ${BUILD_TESTING}")
 MESSAGE_DEP(HAVE_COMPILER "Disabled because BUILD_COMPILER=OFF and no valid THRIFT_COMPILER is given")
+message(STATUS "  Build contrib:                              ${BUILD_CONTRIB}")
+MESSAGE_DEP(BUILD_CONTRIB "Disabled because BUILD_CONTRIB=OFF")
 message(STATUS "  Build type:                                 ${CMAKE_BUILD_TYPE}")
 message(STATUS)
 message(STATUS "Language libraries:")
@@ -218,6 +228,12 @@ if(MSVC)
     message(STATUS "  Using static runtime library:               ${WITH_MT}")
 endif(MSVC)
 message(STATUS)
+message(STATUS "Contributed:")
+message(STATUS)
+message(STATUS "  Build Maven plugin:                         ${BUILD_MAVEN_PLUGIN}")
+MESSAGE_DEP(WITH_MAVEN_PLUGIN "Disabled by WITH_MAVEN_PLUGIN=OFF")
+MESSAGE_DEP(JAVA_FOUND "Java Runtime missing")
+MESSAGE_DEP(MAVEN_FOUND "Maven missing")
 message(STATUS)
 message(STATUS "----------------------------------------------------------")
 endmacro(PRINT_CONFIG_SUMMARY)

--- a/build/cmake/FindMaven.cmake
+++ b/build/cmake/FindMaven.cmake
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+#  MAVEN_FOUND - system has Maven
+#  MAVEN_EXECUTABLE - the Maven executable
+#
+# It will search the environment variable MAVEN_HOME if it is set
+
+include(FindPackageHandleStandardArgs)
+
+find_program(MAVEN_EXECUTABLE NAMES mvn PATHS $ENV{MAVEN_HOME}/bin NO_CMAKE_FIND_ROOT_PATH)
+find_package_handle_standard_args(Maven DEFAULT_MSG MAVEN_EXECUTABLE)
+mark_as_advanced(MAVEN_EXECUTABLE)

--- a/configure.ac
+++ b/configure.ac
@@ -593,6 +593,28 @@ if test "$enable_tutorial" = "no"; then
 fi
 AM_CONDITIONAL(WITH_TUTORIAL, [test "$have_tutorial" = "yes"])
 
+AC_ARG_ENABLE([contrib],
+  AS_HELP_STRING([--enable-contrib], [build contrib [default=yes]]),
+  [], enable_contrib=yes
+)
+have_contrib=yes
+if test "$enable_contrib" = "no"; then
+  have_contrib="no"
+fi
+AM_CONDITIONAL(WITH_CONTRIB, [test "$have_contrib" = "yes"])
+
+AC_ARG_WITH([maven-plugin],
+  [AS_HELP_STRING([--with-maven-plugin], [build the Maven plugin [default=yes]])],
+  [with_maven_plugin="$withval"], [with_maven_plugin="yes"])
+have_maven_plugin="no"
+if test "$enable_contrib" = "yes" -a "$with_maven_plugin" = "yes";  then
+  AC_PATH_PROG([MAVEN], [mvn])
+  if [[ -x "$MAVEN" ]] ; then
+    AX_PROG_MAVEN_VERSION([3.0.0], have_maven_plugin="yes", have_maven_plugin="no")
+  fi
+fi
+AM_CONDITIONAL(WITH_MAVEN_PLUGIN, [test "$have_maven_plugin" = "yes"])
+
 AM_CONDITIONAL(MINGW, false)
 case "${host_os}" in
 *mingw*)
@@ -769,6 +791,8 @@ AC_CONFIG_FILES([
   compiler/cpp/Makefile
   compiler/cpp/src/Makefile
   compiler/cpp/test/Makefile
+  contrib/Makefile
+  contrib/thrift-maven-plugin/Makefile
   lib/Makefile
   lib/cl/Makefile
   lib/cpp/Makefile
@@ -929,6 +953,7 @@ echo "Building Py3 Library ......... : $have_py3"
 echo "Building Ruby Library ........ : $have_ruby"
 echo "Building Rust Library ........ : $have_rs"
 echo "Building Swift Library ....... : $have_swift"
+echo "Building Maven Plugin ........ : $have_maven_plugin"
 
 if test "$have_c_glib" = "yes" ; then
   echo
@@ -1063,6 +1088,12 @@ if test "$have_swift" = "yes" ; then
   echo "Swift Library:"
   echo "   Using Swift ............... : $SWIFT"
   echo "   Using Swift version ....... : $($SWIFT --version | head -1)"
+fi
+if test "$have_maven_plugin" = "yes" ; then
+  echo
+  echo "Maven Plugin:"
+  echo "   Using Maven ............... : $MAVEN"
+  echo "   Using Maven version ....... : $($MAVEN --version --quiet)"
 fi
 echo
 echo "If something is missing that you think should be present,"

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+SUBDIRS =
+
+if MINGW
+# do nothing, just build the compiler
+else
+
+if WITH_MAVEN_PLUGIN
+SUBDIRS += thrift-maven-plugin
+endif
+
+endif
+
+distdir:
+	$(MAKE) $(AM_MAKEFLAGS) distdir-am
+
+# Any folders or files not listed above being added to SUBDIR need to be placed here in
+# EXTRA_DIST to be included in the release
+EXTRA_DIST = \
+	README.md

--- a/contrib/thrift-maven-plugin/CMakeLists.txt
+++ b/contrib/thrift-maven-plugin/CMakeLists.txt
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if(NOT THRIFTMAVENPLUGIN_INSTALL_DIR)
+    if(IS_ABSOLUTE "${CONTRIB_INSTALL_DIR}")
+        set(THRIFTMAVENPLUGIN_INSTALL_DIR "${CONTRIB_INSTALL_DIR}/thrift-maven-plugin")
+    else()
+        set(THRIFTMAVENPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${CONTRIB_INSTALL_DIR}/thrift-maven-plugin")
+    endif()
+endif()
+
+set(PRELEASE "true")
+if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+    set(PRELEASE "false")
+endif ()
+
+set(MAVEN_OUTPUT_JAR "${CMAKE_CURRENT_SOURCE_DIR}/target/thrift-maven-plugin-${thrift_VERSION}.jar")
+
+file(GLOB_RECURSE THRIFTMAVENPLUGIN_SOURCES LIST_DIRECTORIES false
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*"
+    "${CMAKE_CURRENT_SOURCE_DIR}/pom.xml")
+
+add_custom_command(OUTPUT "${MAVEN_OUTPUT_JAR}"
+    COMMENT "Building Maven plugin using Maven"
+    COMMAND ${MAVEN_EXECUTABLE} clean package
+        -B -DskipTests
+        -Drelease=${PRELEASE}
+        -Dthrift.version=${thrift_VERSION}
+    DEPENDS ${THRIFTMAVENPLUGIN_SOURCES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(ThriftMavenPlugin ALL DEPENDS "${MAVEN_OUTPUT_JAR}")
+
+# Enable publishing from CMake if the publishing information is provided
+add_custom_target(ThriftMavenPluginMavenPublish
+    COMMENT "Publishing Maven plugin to Apache Maven staging"
+    DEPENDS ThriftMavenPlugin
+    COMMAND ${MAVEN_EXECUTABLE} deploy
+        -B -DskipTests
+        -Drelease=${PRELEASE}
+        -Dthrift.version=${thrift_VERSION}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Hook the CMake install process to the results from make ALL.
+# This works best when 'make all && sudo make install/fast' is used.
+install(FILES "${MAVEN_OUTPUT_JAR}" DESTINATION ${THRIFTMAVENPLUGIN_INSTALL_DIR})
+
+if(BUILD_TESTING)
+    add_test(NAME ThriftMavenPluginTest
+        COMMAND ${MAVEN_EXECUTABLE} test
+            -B
+            -Drelease=${PRELEASE}
+            -Dthrift.version=${thrift_VERSION}
+            -Dthrift.compiler=${THRIFT_COMPILER}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/contrib/thrift-maven-plugin/Makefile.am
+++ b/contrib/thrift-maven-plugin/Makefile.am
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+export CLASSPATH
+
+all-local:
+	$(MAVEN) $(MAVEN_OPTS) package
+
+clean-local:
+	$(MAVEN) $(MAVEN_OPTS) clean
+
+check-local: $(THRIFT)
+	$(MAVEN) $(MAVEN_OPTS) verify
+
+maven-publish:
+	$(MAVEN) $(MAVEN_OPTS) deploy
+
+distdir:
+	$(MAKE) $(AM_MAKEFLAGS) distdir-am
+
+EXTRA_DIST = \
+	src \
+	pom.xml


### PR DESCRIPTION
This change builds the `thrift-maven-plugin` in the `contrib` folder with Maven by default.

The intention is to keep [`org.apache.thrift:thrift-maven-plugin`](https://mvnrepository.com/artifact/org.apache.thrift/thrift-maven-plugin) updated as Thrift evolves.