### PR TITLE
Fix parent class resolution in c_glib generated dispatch_call

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -2594,8 +2594,8 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
   f_service_ << indent() << parent_class_name << "Class "
                                                  "*parent_class =" << '\n';
   indent_up();
-  f_service_ << indent() << "g_type_class_peek_parent (" << class_name_uc << "_GET_CLASS (self));"
-             << '\n';
+  f_service_ << indent() << "g_type_class_peek_parent (g_type_class_peek ("
+             << class_name_lc << "_get_type ()));" << '\n';
   indent_down();
   f_service_ << '\n'
              << indent() << "process_function_def = "


### PR DESCRIPTION
Client: c_glib

Use g_type_class_peek() with the processor type ID instead of GET_CLASS(self) when looking up the parent class in generated dispatch_call. GET_CLASS(self) returns the runtime class of the instance, which may differ from the class defining the method when service inheritance is used, leading to incorrect dispatch.
