### PR TITLE
Remove unused Ruby client reply helpers

### DIFF
--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -61,11 +61,6 @@ module Thrift
       [fname, mtype, rseqid]
     end
 
-    def reply_seqid(rseqid)
-      expected_seqid = dequeue_pending_seqid
-      !expected_seqid.nil? && rseqid == expected_seqid
-    end
-
     def validate_message_begin(fname, mtype, rseqid, expected_name)
       expected_seqid = dequeue_pending_seqid
 
@@ -100,13 +95,6 @@ module Thrift
       result.read(@iprot)
       @iprot.read_message_end
       result
-    end
-
-    def handle_exception(mtype)
-      if mtype == MessageTypes::EXCEPTION
-        dequeue_pending_seqid
-        raise_application_exception
-      end
     end
 
     private


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This is a follow-up to https://github.com/apache/thrift/pull/3345. I left the old helpers around, so that code generated with the compiler pre- and post- seqid change would work (although pre- would not generate correct sequence IDs nor validate them).

With this cleanup we force people to re-generate, as per Ruby documentation on version upgrade. This will also go into the next release (0.24.0), so I feel like it should not affect anybody.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
