### PR TITLE
Enable TLS hostname verification in TNonblockingSSLSocket

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/transport/TNonblockingSSLSocket.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TNonblockingSSLSocket.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,9 @@ public class TNonblockingSSLSocket extends TNonblockingSocket implements SocketA
     super(host, port, timeout);
     sslEngine_ = sslContext.createSSLEngine(host, port);
     sslEngine_.setUseClientMode(true);
+    SSLParameters sslParams = sslEngine_.getSSLParameters();
+    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    sslEngine_.setSSLParameters(sslParams);
 
     int appBufferSize = sslEngine_.getSession().getApplicationBufferSize();
     int netBufferSize = sslEngine_.getSession().getPacketBufferSize();


### PR DESCRIPTION
## Summary

- Sets `EndpointIdentificationAlgorithm` to `HTTPS` on the `SSLEngine` parameters in the `TNonblockingSSLSocket` constructor, so the server certificate CN/SAN is validated against the target hostname during the TLS handshake.
- Follow-up to #3390, which added the same behavior to the sync client in `TSSLTransportFactory.createClient()`. Before this change, the async SSL client path (via `SSLEngine`) did not set the endpoint identification algorithm, leaving the two client paths inconsistent. This was pointed out in [#3390 (comment)](https://github.com/apache/thrift/pull/3390#issuecomment-4233338180).

Client: java

## Test plan

- [ ] Existing Java SSL/nonblocking tests pass
- [ ] Manual smoke test: async SSL client connects to a server whose certificate matches the target hostname
- [ ] Manual smoke test: async SSL client rejects a server whose certificate CN/SAN does not match the target hostname

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>