### PR TITLE
THRIFT-5948: Reduce Ruby binary extension write-path overhead in native force_binary_encoding helper

### DIFF
--- a/lib/rb/ext/bytes.c
+++ b/lib/rb/ext/bytes.c
@@ -24,6 +24,20 @@
 #include <constants.h>
 
 VALUE force_binary_encoding(VALUE buffer) {
+  if (RB_TYPE_P(buffer, T_STRING)) {
+    if (rb_enc_get_index(buffer) == rb_ascii8bit_encindex()) {
+      return buffer;
+    }
+
+    if (RB_OBJ_FROZEN(buffer)) {
+      buffer = rb_obj_dup(buffer);
+    }
+
+    rb_enc_associate_index(buffer, rb_ascii8bit_encindex());
+
+    return buffer;
+  }
+
   return rb_funcall(thrift_bytes_module, force_binary_encoding_id, 1, buffer);
 }
 

--- a/lib/rb/lib/thrift/bytes.rb
+++ b/lib/rb/lib/thrift/bytes.rb
@@ -36,13 +36,15 @@ module Thrift
     end
 
     # Forces the encoding of the buffer to BINARY. If the buffer
-    # passed is frozen, then it will be duplicated.
+    # passed is frozen and not already BINARY, then it will be duplicated.
     #
     # buffer - The String to force the encoding of.
     #
     # Returns the String passed with an encoding of BINARY; returned
     # String may be a duplicate.
     def self.force_binary_encoding(buffer)
+      return buffer if buffer.encoding == Encoding::BINARY
+
       buffer = buffer.dup if buffer.frozen?
       buffer.force_encoding(Encoding::BINARY)
     end

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -338,6 +338,21 @@ describe 'BaseTransport' do
       expect(@buffer.read(@buffer.available)).to eq("foo bar")
     end
 
+    it "should force mutable write buffers into binary in place" do
+      s = "abc \u20AC".encode("UTF-8")
+      @buffer.write(s)
+      expect(s.encoding).to eq(Encoding::BINARY)
+      expect(@buffer.read(@buffer.available)).to eq("abc \u20AC".encode("UTF-8").b)
+    end
+
+    it "should not mutate frozen write buffers while forcing binary encoding" do
+      s = "abc \u20AC".encode("UTF-8").freeze
+      @buffer.write(s)
+      expect(s.encoding).to eq(Encoding::UTF_8)
+      expect(s).to be_frozen
+      expect(@buffer.read(@buffer.available)).to eq("abc \u20AC".encode("UTF-8").b)
+    end
+
     it "should throw an EOFError when there isn't enough data in the buffer" do
       @buffer.reset_buffer("")
       expect{ @buffer.read(1) }.to raise_error(EOFError)

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -229,6 +229,16 @@ shared_examples_for 'a binary protocol' do
     expect(a.unpack('C*')).to eq([0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x02, 0x03])
   end
 
+  it 'should write a frozen non-binary string without mutating the input' do
+    buffer = "abc \u20AC".encode('UTF-8').freeze
+    @prot.write_binary(buffer)
+    a = @trans.read(@trans.available)
+    expect(buffer.encoding).to eq(Encoding::UTF_8)
+    expect(buffer).to be_frozen
+    expect(a.encoding).to eq(Encoding::BINARY)
+    expect(a.unpack('C*')).to eq([0x00, 0x00, 0x00, 0x07, 0x61, 0x62, 0x63, 0x20, 0xE2, 0x82, 0xAC])
+  end
+
   it "should error gracefully when trying to write a nil string" do
     expect { @prot.write_string(nil) }.to raise_error(StandardError, 'nil argument not allowed!')
   end

--- a/lib/rb/spec/bytes_spec.rb
+++ b/lib/rb/spec/bytes_spec.rb
@@ -44,6 +44,23 @@ describe Thrift::Bytes do
       a = Thrift::Bytes.force_binary_encoding e
       expect(a.encoding).to eq(Encoding::BINARY)
     end
+
+    it 'should return the same frozen binary string unchanged' do
+      e = 'STRING'.b.freeze
+      a = Thrift::Bytes.force_binary_encoding(e)
+      expect(a).to equal(e)
+      expect(a.encoding).to eq(Encoding::BINARY)
+      expect(a).to be_frozen
+    end
+
+    it 'should duplicate a frozen non-binary string before changing encoding' do
+      e = 'STRING'.encode('UTF-8').freeze
+      a = Thrift::Bytes.force_binary_encoding(e)
+      expect(a).not_to equal(e)
+      expect(a.encoding).to eq(Encoding::BINARY)
+      expect(e.encoding).to eq(Encoding::UTF_8)
+      expect(e).to be_frozen
+    end
   end
 
   describe '.get_string_byte' do

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -170,6 +170,18 @@ describe Thrift::CompactProtocol do
     expect(Thrift::CompactProtocol.new(trans).to_s).to eq("compact(memory)")
   end
 
+  it "should write a frozen non-binary string without mutating the input" do
+    trans = Thrift::MemoryBufferTransport.new
+    prot = Thrift::CompactProtocol.new(trans)
+    buffer = "abc \u20AC".encode("UTF-8").freeze
+
+    prot.write_binary(buffer)
+
+    expect(buffer.encoding).to eq(Encoding::UTF_8)
+    expect(buffer).to be_frozen
+    expect(trans.read(trans.available).unpack("C*")).to eq([0x07, 0x61, 0x62, 0x63, 0x20, 0xE2, 0x82, 0xAC])
+  end
+
   class JankyHandler
     def Janky(i32arg)
       i32arg * 2


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

While working on serialization depth limits improvement, noticed a quick performance win in a hot path when writing binary strings to memory buffer or socket. For strings that are already have `ASCII-8BIT` encoding, C extension will call into Ruby, which will return the original string. Even more, Ruby code would always duplicate the string if it is frozen, even when the encoding is already binary, which is unnecessary.

Instead, this PR re-implements Ruby land's `Thrift::Bytes.force_binary_encoding` in C, and corrects Ruby logic to not duplicate strings unneceserily.

## Benchmark

Benchmarked using 
```bash
test/rb/benchmarks/protocol_benchmark.rb --large-runs 5 --small-runs 50000
```

### Accelerated binary scenarios only

| Scenario | Before | After | Delta |
| --- | ---: | ---: | ---: |
| c binary write large (1MB) structure 5 times | 0.758s | 0.473s | -37.6% |
| c binary read large (1MB) structure 5 times | 0.546s | 0.544s | -0.2% |
| c binary write 50000 small structures | 0.372s | 0.236s | -36.4% |
| c binary read 50000 small structures | 0.228s | 0.224s | -1.4% |
| **c-only suite total** | **1.901s** | **1.484s** | **-21.9%** |
| **c-only write total** | **1.130s** | **0.709s** | **-37.2%** |
| **c-only read total** | **0.773s** | **0.769s** | **-0.5%** |

### Full suite summary

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Full suite total | 35.912s | 33.222s | -7.5% |
| Write scenarios total | 16.282s | 13.473s | -17.3% |
| Read scenarios total | 19.635s | 19.579s | -0.3% |

### Selected write-path highlights

| Scenario | Before | After | Delta |
| --- | ---: | ---: | ---: |
| ruby binary write large (1MB) structure 5 times | 1.286s | 0.999s | -22.3% |
| c binary write large (1MB) structure 5 times | 0.741s | 0.473s | -36.2% |
| ruby compact write large (1MB) structure 5 times | 0.760s | 0.505s | -33.7% |
| ruby json write large (1MB) structure 5 times | 6.387s | 5.366s | -16.0% |
| ruby binary write 50000 small structures | 0.611s | 0.486s | -20.5% |
| c binary write 50000 small structures | 0.365s | 0.237s | -35.0% |
| ruby compact write 50000 small structures | 0.377s | 0.258s | -31.5% |
| ruby json write 50000 small structures | 2.973s | 2.439s | -18.0% |

Read-side scenarios stayed essentially flat overall, while write-side allocation counts remained unchanged, which is consistent with reducing write-path overhead rather than reducing allocation volume.

### Serializer / Deserializer benchmark

This also brings a huge win for `Thrift::Serializer` on accelerated protocols (compact and binary accelerated):

| Operation | Before | After | Delta | Allocations Before | Allocations After |
| --- | ---: | ---: | ---: | ---: | ---: |
| `Thrift::Serializer` with `CompactProtocolFactory` (`50000` serializations) | 0.407s | 0.259s | -36.3% | 1,800,031 | 1,800,031 |
| `Thrift::Deserializer` with `CompactProtocolFactory` (`50000` deserializations) | 0.251s | 0.252s | +0.8% | 850,007 | 850,007 |

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5948](https://issues.apache.org/jira/browse/THRIFT-5948)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
