### PR TITLE
THRIFT-5942: Fix Ruby socket connection timeouts

### DIFF
--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -111,6 +111,30 @@ directly from your application.
 
 ## Breaking Changes
 
+### 0.24.0
+
+Connect timeout handling changed for both `Thrift::Socket` and
+`Thrift::SSLSocket`.
+
+- `timeout == nil` and `timeout == 0` now use blocking connect/open semantics.
+  Older releases already treated `nil` that way, but treated `0` differently
+  across operations: `read` and `write` used the blocking path, plain TCP
+  `open` used a zero-length poll, and TLS `open` could spin in the handshake
+  retry loop.
+- Positive timeouts now bound the whole connect/open operation instead of
+  effectively applying a fresh timeout window at each wait or address attempt.
+  For plain TCP this budget is shared across address fallback. For TLS it is
+  shared across the TCP connect and the SSL handshake.
+- Connect/open timeout expiry now raises
+  `Thrift::TransportException::TIMED_OUT`. Older releases could report the same
+  condition as `NOT_OPEN`, and `Thrift::SSLSocket` could keep retrying the
+  handshake after the wait timed out.
+
+If your application matched `NOT_OPEN` for connect timeout handling, update it
+to handle `TIMED_OUT`. If you relied on `timeout = 0` meaning immediate failure
+or on repeated retries extending the effective timeout during TCP fallback or
+TLS handshake, update those call paths before upgrading.
+
 ### 0.23.0
 
 The documented source-build flow now effectively requires Ruby `2.7+`.
@@ -165,6 +189,12 @@ best-effort, not guaranteed.
 
 ## Migration Notes
 
+- If you upgrade to `0.24.0`, treat `timeout` on `Thrift::Socket` and
+  `Thrift::SSLSocket` as one budget for the whole open path. For
+  `Thrift::SSLSocket`, that includes both the TCP connect and the TLS
+  handshake.
+- If you upgrade to `0.24.0`, handle connect/open timeout expiry as
+  `Thrift::TransportException::TIMED_OUT` instead of `NOT_OPEN`.
 - If you upgrade across the stricter reply-validation changes, regenerate all
   Ruby stubs and deploy them with the matching Ruby runtime. Do not mix old
   generated code, new generated code, and new runtime code on the same client

--- a/lib/rb/lib/thrift/transport/socket.rb
+++ b/lib/rb/lib/thrift/transport/socket.rb
@@ -33,39 +33,19 @@ module Thrift
     attr_accessor :handle, :timeout
 
     def open
-      for addrinfo in ::Socket::getaddrinfo(@host, @port, nil, ::Socket::SOCK_STREAM) do
-        begin
-          socket = ::Socket.new(addrinfo[4], ::Socket::SOCK_STREAM, 0)
-          socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
-          sockaddr = ::Socket.sockaddr_in(addrinfo[1], addrinfo[3])
-          begin
-            socket.connect_nonblock(sockaddr)
-          rescue Errno::EINPROGRESS
-            unless IO.select(nil, [ socket ], nil, @timeout)
-              next
-            end
-            begin
-              socket.connect_nonblock(sockaddr)
-            rescue Errno::EISCONN
-            end
-          end
-          return @handle = socket
-        rescue StandardError => e
-          next
-        end
-      end
-      raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}: #{e}")
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
+      @handle = connect_socket(deadline)
     end
 
     def open?
-      !@handle.nil? and !@handle.closed?
+      !@handle.nil? && !@handle.closed?
     end
 
     def write(str)
       raise TransportException.new(TransportException::NOT_OPEN, "closed stream") unless open?
       str = Bytes.force_binary_encoding(str)
       begin
-        if @timeout.nil? or @timeout == 0
+        if @timeout.nil? || @timeout == 0
           @handle.write(str)
         else
           deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
@@ -87,7 +67,7 @@ module Thrift
         # pass this on
         raise e
       rescue StandardError => e
-        @handle.close
+        close_socket(@handle)
         @handle = nil
         raise TransportException.new(TransportException::NOT_OPEN, e.message)
       end
@@ -97,7 +77,7 @@ module Thrift
       raise TransportException.new(TransportException::NOT_OPEN, "closed stream") unless open?
 
       begin
-        if @timeout.nil? or @timeout == 0
+        if @timeout.nil? || @timeout == 0
           data = @handle.readpartial(sz)
         else
           deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
@@ -116,18 +96,18 @@ module Thrift
         # don't let this get caught by the StandardError handler
         raise e
       rescue StandardError => e
-        @handle.close unless @handle.closed?
+        close_socket(@handle)
         @handle = nil
         raise TransportException.new(TransportException::NOT_OPEN, e.message)
       end
-      if (data.nil? or data.length == 0)
+      if (data.nil? || data.length == 0)
         raise TransportException.new(TransportException::UNKNOWN, "Socket: Could not read #{sz} bytes from #{@desc}")
       end
       data
     end
 
     def close
-      @handle.close unless @handle.nil? or @handle.closed?
+      close_socket(@handle)
       @handle = nil
     end
 
@@ -140,6 +120,64 @@ module Thrift
     end
 
     private
+
+    def connect_socket(deadline)
+      last_error = nil
+      connected_socket = nil
+
+      Addrinfo.foreach(@host, @port, nil, :STREAM) do |addrinfo|
+        socket = nil
+
+        begin
+          socket = if deadline
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            raise TransportException.new(TransportException::TIMED_OUT, "Socket: Timed out opening connection to #{@desc}") if remaining <= 0
+
+            addrinfo.connect(timeout: remaining)
+          else
+            addrinfo.connect
+          end
+
+          socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+          connected_socket = socket
+          break
+        rescue Errno::ETIMEDOUT => e
+          close_socket(socket)
+          last_error = e
+        rescue TransportException
+          close_socket(socket)
+          raise
+        rescue StandardError => e
+          close_socket(socket)
+          last_error = e
+        end
+      end
+
+      return connected_socket if connected_socket
+
+      if last_error.is_a?(Errno::ETIMEDOUT)
+        raise TransportException.new(TransportException::TIMED_OUT, "Socket: Timed out opening connection to #{@desc}")
+      end
+
+      if deadline && deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC) <= 0
+        raise TransportException.new(TransportException::TIMED_OUT, "Socket: Timed out opening connection to #{@desc}")
+      end
+
+      raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}"), cause: last_error
+    rescue TransportException
+      raise
+    rescue StandardError
+      raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}")
+    end
+
+    def close_socket(socket)
+      return if socket.nil?
+      return if socket.respond_to?(:closed?) && socket.closed?
+
+      socket.close
+    rescue StandardError
+      nil
+    end
 
     def wait_for(operation, deadline, sz)
       rd_ary, wr_ary = case operation

--- a/lib/rb/lib/thrift/transport/ssl_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_socket.rb
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'io/wait'
+
 module Thrift
   class SSLSocket < Socket
     def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil)
@@ -27,20 +29,49 @@ module Thrift
     attr_accessor :ssl_context
 
     def open
-      socket = super
-      @handle = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
+      socket = connect_socket(deadline)
+
       begin
-        @handle.connect_nonblock
+        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+        ssl_socket.sync_close = true
+        @handle = ssl_socket
+
+        if deadline
+          loop do
+            result = @handle.connect_nonblock(exception: false)
+
+            case result
+            when @handle
+              break
+            when :wait_readable
+              remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              if remaining <= 0 || !@handle.to_io.wait_readable(remaining)
+                raise TransportException.new(TransportException::TIMED_OUT, "SSL socket: Timed out establishing session with #{@desc}")
+              end
+            when :wait_writable
+              remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              if remaining <= 0 || !@handle.to_io.wait_writable(remaining)
+                raise TransportException.new(TransportException::TIMED_OUT, "SSL socket: Timed out establishing session with #{@desc}")
+              end
+            else
+              raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}: unexpected SSL connect result #{result.inspect}")
+            end
+          end
+        else
+          @handle.connect
+        end
+
         @handle.post_connection_check(@host)
         @handle
-      rescue IO::WaitReadable
-        IO.select([ @handle ], nil, nil, @timeout)
-        retry
-      rescue IO::WaitWritable
-        IO.select(nil, [ @handle ], nil, @timeout)
-        retry
-      rescue StandardError => e
-        raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}: #{e}")
+      rescue TransportException
+        close_socket(@handle)
+        @handle = nil
+        raise
+      rescue StandardError
+        close_socket(@handle || socket)
+        @handle = nil
+        raise TransportException.new(TransportException::NOT_OPEN, "Could not connect to #{@desc}")
       end
     end
 

--- a/lib/rb/spec/socket_spec.rb
+++ b/lib/rb/spec/socket_spec.rb
@@ -24,44 +24,150 @@ describe 'Socket' do
   describe Thrift::Socket do
     before(:each) do
       @socket = Thrift::Socket.new
+      @addrinfo = double("Addrinfo")
       @handle = double("Handle", :closed? => false)
       allow(@handle).to receive(:close)
-      allow(@handle).to receive(:connect_nonblock)
       allow(@handle).to receive(:setsockopt)
-      allow(::Socket).to receive(:new).and_return(@handle)
+      allow(@addrinfo).to receive(:connect).and_return(@handle)
+      allow(Addrinfo).to receive(:foreach).and_yield(@addrinfo)
     end
 
     it_should_behave_like "a socket"
 
     it "should raise a TransportException when it cannot open a socket" do
-      expect(::Socket).to receive(:getaddrinfo).with("localhost", 9090, nil, ::Socket::SOCK_STREAM).and_return([[]])
-      expect { @socket.open }.to raise_error(Thrift::TransportException) { |e| expect(e.type).to eq(Thrift::TransportException::NOT_OPEN) }
+      allow(Addrinfo).to receive(:foreach).and_raise(SocketError.new("lookup failed"))
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+        expect(e.cause).to be_a(SocketError)
+      end
     end
 
     it "should open a ::Socket with default args" do
-      expect(::Socket).to receive(:new).and_return(double("Handle", :connect_nonblock => true, :setsockopt => nil))
-      expect(::Socket).to receive(:getaddrinfo).with("localhost", 9090, nil, ::Socket::SOCK_STREAM).and_return([[]])
-      expect(::Socket).to receive(:sockaddr_in)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo)
+      expect(@addrinfo).to receive(:connect).with(no_args).and_return(@handle)
+      expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       @socket.to_s == "socket(localhost:9090)"
       @socket.open
     end
 
     it "should accept host/port options" do
-      expect(::Socket).to receive(:new).and_return(double("Handle", :connect_nonblock => true, :setsockopt => nil))
-      expect(::Socket).to receive(:getaddrinfo).with("my.domain", 1234, nil, ::Socket::SOCK_STREAM).and_return([[]])
-      expect(::Socket).to receive(:sockaddr_in)
+      handle = double("Handle", :closed? => false)
+      allow(handle).to receive(:close)
+      expect(handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(Addrinfo).to receive(:foreach).with("my.domain", 1234, nil, :STREAM).and_yield(@addrinfo)
+      expect(@addrinfo).to receive(:connect).with(no_args).and_return(handle)
       @socket = Thrift::Socket.new('my.domain', 1234).open
       @socket.to_s == "socket(my.domain:1234)"
     end
 
     it "should accept an optional timeout" do
-      allow(::Socket).to receive(:new)
       expect(Thrift::Socket.new('localhost', 8080, 5).timeout).to eq(5)
     end
 
     it "should provide a reasonable to_s" do
-      allow(::Socket).to receive(:new)
       expect(Thrift::Socket.new('myhost', 8090).to_s).to eq("socket(myhost:8090)")
+    end
+
+    it "should pass the remaining timeout to each address attempt" do
+      @socket.timeout = 5
+      second_addrinfo = double("Addrinfo")
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 103.0)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ECONNREFUSED)
+      expect(second_addrinfo).to receive(:connect).with(timeout: 2.0).and_return(@handle)
+      expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should continue to the next address after a connect timeout while time remains" do
+      @socket.timeout = 5
+      second_addrinfo = double("Addrinfo")
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 103.0)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ETIMEDOUT)
+      expect(second_addrinfo).to receive(:connect).with(timeout: 2.0).and_return(@handle)
+      expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should raise TIMED_OUT when an address attempt times out" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ETIMEDOUT)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::TIMED_OUT)
+        expect(e.message).to eq("Socket: Timed out opening connection to localhost:9090")
+      end
+    end
+
+    it "should raise TIMED_OUT when the deadline expires before the next address attempt" do
+      @socket.timeout = 5
+      second_addrinfo = double("Addrinfo")
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 105.0)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ECONNREFUSED)
+      expect(second_addrinfo).not_to receive(:connect)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::TIMED_OUT)
+        expect(e.message).to eq("Socket: Timed out opening connection to localhost:9090")
+      end
+    end
+
+    it "should treat zero timeout as blocking for open" do
+      @socket.timeout = 0
+
+      expect(@addrinfo).to receive(:connect).with(no_args).and_return(@handle)
+      expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should report the last connection error when all addresses fail" do
+      second_addrinfo = double("Addrinfo")
+
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).and_raise(Errno::ECONNREFUSED)
+      expect(second_addrinfo).to receive(:connect).and_raise(Errno::EHOSTUNREACH)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+        expect(e.cause).to be_a(Errno::EHOSTUNREACH)
+      end
+    end
+
+    it "should close a connected candidate before falling back when socket setup fails" do
+      first_addrinfo = @addrinfo
+      second_addrinfo = double("Addrinfo")
+      first_handle = double("Handle", :closed? => false)
+      allow(first_handle).to receive(:close)
+
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(first_addrinfo).and_yield(second_addrinfo)
+      expect(first_addrinfo).to receive(:connect).with(no_args).and_return(first_handle)
+      expect(first_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1).and_raise(StandardError.new("setsockopt failed"))
+      expect(first_handle).to receive(:close)
+      expect(second_addrinfo).to receive(:connect).with(no_args).and_return(@handle)
+      expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should avoid a blank error when no addresses are returned" do
+      allow(Addrinfo).to receive(:foreach)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+      end
     end
   end
 end

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -25,40 +25,56 @@ describe 'SSLSocket' do
     before(:each) do
       @context = OpenSSL::SSL::SSLContext.new
       @socket = Thrift::SSLSocket.new
+      @addrinfo = double("Addrinfo")
       @simple_socket_handle = double("Handle", :closed? => false)
       allow(@simple_socket_handle).to receive(:close)
-      allow(@simple_socket_handle).to receive(:connect_nonblock)
       allow(@simple_socket_handle).to receive(:setsockopt)
+      allow(@simple_socket_handle).to receive(:wait_readable)
+      allow(@simple_socket_handle).to receive(:wait_writable)
 
-      @handle = double(double("SSLHandle", :connect_nonblock => true, :post_connection_check => true), :closed? => false)
-      allow(@handle).to receive(:connect_nonblock)
+      @handle = double("SSLHandle", :closed? => false)
+      allow(@handle).to receive(:connect).and_return(true)
+      allow(@handle).to receive(:connect_nonblock).and_return(@handle)
       allow(@handle).to receive(:close)
       allow(@handle).to receive(:post_connection_check)
+      allow(@handle).to receive(:sync_close=)
       allow(@handle).to receive(:to_io).and_return(@simple_socket_handle)
 
-      allow(::Socket).to receive(:new).and_return(@simple_socket_handle)
+      allow(@addrinfo).to receive(:connect).and_return(@simple_socket_handle)
+      allow(Addrinfo).to receive(:foreach).and_yield(@addrinfo)
       allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(@handle)
     end
 
     it_should_behave_like "a socket"
 
     it "should raise a TransportException when it cannot open a ssl socket" do
-      expect(::Socket).to receive(:getaddrinfo).with("localhost", 9090, nil, ::Socket::SOCK_STREAM).and_return([[]])
-      expect { @socket.open }.to raise_error(Thrift::TransportException) { |e| expect(e.type).to eq(Thrift::TransportException::NOT_OPEN) }
+      allow(Addrinfo).to receive(:foreach).and_raise(SocketError.new("lookup failed"))
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+        expect(e.cause).to be_a(SocketError)
+      end
     end
 
     it "should open a ::Socket with default args" do
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_return(@handle)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect).and_return(true)
       expect(@handle).to receive(:post_connection_check).with('localhost')
       @socket.open
     end
 
     it "should accept host/port options" do
-      handle = double("Handle", :connect_nonblock => true, :setsockopt => nil)
-      allow(::Socket).to receive(:new).and_return(handle)
-      expect(::Socket).to receive(:getaddrinfo).with("my.domain", 1234, nil, ::Socket::SOCK_STREAM).and_return([[]])
-      expect(::Socket).to receive(:sockaddr_in)
+      handle = double("Handle", :closed? => false)
+      allow(handle).to receive(:close)
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.0)
+      expect(handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(Addrinfo).to receive(:foreach).with("my.domain", 1234, nil, :STREAM).and_yield(@addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 6000).and_return(handle)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(handle, nil).and_return(@handle)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(@handle)
       expect(@handle).to receive(:post_connection_check).with('my.domain')
       Thrift::SSLSocket.new('my.domain', 1234, 6000, nil).open
     end
@@ -69,6 +85,150 @@ describe 'SSLSocket' do
 
     it "should accept an optional context" do
       expect(Thrift::SSLSocket.new('localhost', 8080, 5, @context).ssl_context).to eq(@context)
+    end
+
+    it "should treat zero timeout as blocking for open and handshake" do
+      @socket.timeout = 0
+
+      expect(@addrinfo).to receive(:connect).with(no_args).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).not_to receive(:connect_nonblock)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should use the remaining timeout across ssl wait states" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 102.0, 104.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).ordered.and_return(:wait_readable)
+      expect(@simple_socket_handle).to receive(:wait_readable).with(3.0).ordered.and_return(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).ordered.and_return(:wait_writable)
+      expect(@simple_socket_handle).to receive(:wait_writable).with(1.0).ordered.and_return(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).ordered.and_return(@handle)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should share one timeout budget across tcp fallback and the ssl handshake" do
+      @socket.timeout = 5
+      second_addrinfo = double("Addrinfo")
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 102.0, 103.0)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ECONNREFUSED)
+      expect(second_addrinfo).to receive(:connect).with(timeout: 3.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).ordered.and_return(:wait_readable)
+      expect(@simple_socket_handle).to receive(:wait_readable).with(2.0).ordered.and_return(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).ordered.and_return(@handle)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should continue to the next address after a tcp connect timeout during ssl open" do
+      @socket.timeout = 5
+      second_addrinfo = double("Addrinfo")
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 103.0)
+      expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo).and_yield(second_addrinfo)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ETIMEDOUT)
+      expect(second_addrinfo).to receive(:connect).with(timeout: 2.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(@handle)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+
+      expect(@socket.open).to eq(@handle)
+    end
+
+    it "should raise TIMED_OUT when ssl handshake wait times out" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0, 102.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(:wait_readable)
+      expect(@simple_socket_handle).to receive(:wait_readable).with(3.0).and_return(nil)
+      expect(@handle).to receive(:close)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::TIMED_OUT)
+        expect(e.message).to eq("SSL socket: Timed out establishing session with localhost:9090")
+      end
+    end
+
+    it "should surface tcp open timeout before starting ssl" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_raise(Errno::ETIMEDOUT)
+      expect(OpenSSL::SSL::SSLSocket).not_to receive(:new)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::TIMED_OUT)
+        expect(e.message).to eq("Socket: Timed out opening connection to localhost:9090")
+      end
+    end
+
+    it "should close the raw socket if ssl wrapper creation fails" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_raise(StandardError.new("ssl init failed"))
+      expect(@simple_socket_handle).to receive(:close)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+        expect(e.cause.message).to eq("ssl init failed")
+      end
+    end
+
+    it "should close the ssl socket when post connection check fails" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(@handle)
+      expect(@handle).to receive(:post_connection_check).with('localhost').and_raise(StandardError.new("hostname mismatch"))
+      expect(@handle).to receive(:close)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to eq("Could not connect to localhost:9090")
+        expect(e.cause.message).to eq("hostname mismatch")
+      end
+    end
+
+    it "should close the ssl socket on an unexpected nonblocking handshake result" do
+      @socket.timeout = 5
+
+      expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
+      expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(:unexpected)
+      expect(@handle).to receive(:close)
+
+      expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
+        expect(e.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(e.message).to include("unexpected SSL connect result")
+      end
     end
 
     it "should delegate to_io to the underlying SSL socket handle" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The Ruby transport has inconsistent and partially broken timeout behavior during connection establishment. Plain TCP open does not appear to hang forever, but it handles timeout and cleanup poorly. SSL open is worse: the handshake loop can retry indefinitely when the readiness wait times out, so a caller-provided timeout is not reliably enforced.

In this change connection logic changes to bind the timeout to the whole connect operation, including TCP connect and TLS handshake.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5942](https://issues.apache.org/jira/browse/THRIFT-5942)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
