### PR TITLE
THRIFT-5855: Add netstd fuzzers

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -24,10 +24,7 @@ We currently maintain fuzzers for the following languages:
 - Ruby
 - Rust
 - Swift
-
-We are working on adding fuzzers for the following languages:
-
-- netstd
+- netstd (only supported locally, and not on oss-fuzz)
 
 ## Fuzzer Types
 

--- a/lib/netstd/Makefile.am
+++ b/lib/netstd/Makefile.am
@@ -29,6 +29,23 @@ check-local:
 	$(DOTNETCORE) test Tests/Thrift.Tests/Thrift.Tests.csproj
 	$(DOTNETCORE) test Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
 
+# Opt-in. Not wired into check-local because it requires the
+# SharpFuzz.CommandLine global tool and libfuzzer-dotnet binary,
+# which are dev-only dependencies. Run manually: `make build-fuzzers`.
+build-fuzzers:
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Binary -p:FuzzerType=Parse -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Binary -p:FuzzerType=Parse -p:Engine=Libfuzzer
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Binary -p:FuzzerType=Roundtrip -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Binary -p:FuzzerType=Roundtrip -p:Engine=Libfuzzer
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Compact -p:FuzzerType=Parse -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Compact -p:FuzzerType=Parse -p:Engine=Libfuzzer
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Compact -p:FuzzerType=Roundtrip -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Compact -p:FuzzerType=Roundtrip -p:Engine=Libfuzzer
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Json -p:FuzzerType=Parse -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Json -p:FuzzerType=Parse -p:Engine=Libfuzzer
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Json -p:FuzzerType=Roundtrip -p:Engine=AFL
+	$(DOTNETCORE) build Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj -p:Protocol=Json -p:FuzzerType=Roundtrip -p:Engine=Libfuzzer
+
 clean-local:
 	$(RM) -r Thrift/bin
 	$(RM) -r Thrift/obj
@@ -44,6 +61,8 @@ clean-local:
 	$(RM) -r Tests/Thrift.Compile.Tests/Thrift.Compile.net9/obj
 	$(RM) -r Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/bin
 	$(RM) -r Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/obj
+	$(RM) -r Tests/Thrift.FuzzTests/bin
+	$(RM) -r Tests/Thrift.FuzzTests/obj
 
 distdir:
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am
@@ -60,6 +79,7 @@ EXTRA_DIST = \
 	Tests/Thrift.Compile.Tests/Thrift.Compile.net8/Thrift.Compile.net8.csproj \
 	Tests/Thrift.Compile.Tests/Thrift.Compile.net9/Thrift.Compile.net9.csproj \
 	Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/Thrift.Compile.netstd2.csproj \
+	Tests/Thrift.FuzzTests \
 	Tests/Thrift.Tests/Collections \
 	Tests/Thrift.Tests/DataModel \
 	Tests/Thrift.Tests/Protocols \

--- a/lib/netstd/README.md
+++ b/lib/netstd/README.md
@@ -53,3 +53,64 @@ Because of the different environment requirements, migration from C# takes sligh
 - In case you are using Thrift server event handlers: the `SetEventHandler` method now starts with an uppercase letter
 - and you will also have to revise the method names of all `TServerEventHandler` descendants you have in your code
 
+# Fuzzing
+
+We use [SharpFuzz](https://github.com/Metalnem/sharpfuzz) (and its libfuzzer variant) to fuzz the Thrift protocol parsers. This is **not** integrated with oss-fuzz, so all fuzzing must be run locally. **Supported platform: Linux only.** The fuzzers are opt-in and are **not** built by `make check`; run `make build-fuzzers` (or `./buildfuzzers.sh`) explicitly.
+
+## Prerequisites
+
+1. A .NET 10 SDK (same one used for the rest of `lib/netstd`).
+
+2. The SharpFuzz IL-rewriter CLI, installed as a .NET global tool:
+
+   ```bash
+   dotnet tool install --global SharpFuzz.CommandLine
+   export PATH="$PATH:$HOME/.dotnet/tools"
+   ```
+
+   Add the `PATH` export to your shell rc if you want it to persist.
+
+3. The native `libfuzzer-dotnet` driver binary. Grab a prebuilt release from the
+   [Metalnem/libfuzzer-dotnet releases page](https://github.com/Metalnem/libfuzzer-dotnet/releases)
+   (or build it from source). Place it in a directory of your choice and point
+   `SHARPFUZZ_DIR` at that directory:
+
+   ```bash
+   export SHARPFUZZ_DIR=/path/to/libfuzzer-dotnet-dir
+   ```
+
+   `buildfuzzers.sh` and `runfuzzer.sh` expect to find `$SHARPFUZZ_DIR/libfuzzer-dotnet`.
+
+## A temporary note on `DOTNET_ROLL_FORWARD`
+
+As of SharpFuzz.CommandLine 2.2.0, the global tool's `runtimeconfig.json` pins the
+tool to .NET 9, which prevents it from running under a .NET 10-only host. Both
+`buildfuzzers.sh` and `runfuzzer.sh` therefore export `DOTNET_ROLL_FORWARD=Major`
+at the top of the script as a workaround. Upstream fix:
+[SharpFuzz PR #72](https://github.com/Metalnem/sharpfuzz/pull/72) (merged, pending
+release as SharpFuzz 2.3.0). Once that release ships, remove the `DOTNET_ROLL_FORWARD`
+exports from both shell drivers and update the SharpFuzz package pin in
+`Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj`.
+
+## Running the fuzzers
+
+Build all twelve fuzzer assemblies (3 protocols x 2 fuzzer types x 2 engines) and
+instrument them with SharpFuzz:
+
+```bash
+./buildfuzzers.sh
+```
+
+Run one fuzzer:
+
+```bash
+./runfuzzer.sh <fuzzer-name> <engine> [extra-fuzzer-args...]
+```
+
+Where `<fuzzer-name>` is one of `binary`, `compact`, `json`, `binary-roundtrip`,
+`compact-roundtrip`, `json-roundtrip`, and `<engine>` is `libfuzzer` or `afl`.
+Any additional arguments are passed through to the underlying fuzzer engine, e.g.:
+
+```bash
+./runfuzzer.sh binary libfuzzer -runs=10000
+```

--- a/lib/netstd/Tests/Thrift.FuzzTests/ProtocolFuzzerBase.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/ProtocolFuzzerBase.cs
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    /// <summary>
+    /// Base class for protocol fuzzers that handles the common fuzzing logic.
+    /// </summary>
+    /// <typeparam name="FuzzProtocol">The type of protocol to use for deserialization.</typeparam>
+    public abstract class ProtocolFuzzerBase<FuzzProtocol> where FuzzProtocol : TProtocol
+    {
+        /// <summary>
+        /// Environment variable that controls whether to use in-process fuzzing for AFL.
+        /// When set to "1", uses Fuzzer.Run instead of Fuzzer.OutOfProcess.Run.
+        /// </summary>
+        protected const string UseInProcessFuzzingEnvVar = "THRIFT_AFL_IN_PROCESS";
+
+        /// <summary>
+        /// 10MB message size limit to prevent over-allocation during fuzzing
+        /// </summary>
+        protected const int FUZZ_MAX_MESSAGE_SIZE = 10 * 1024 * 1024;
+
+        /// <summary>
+        /// Creates a new instance of the protocol for the given transport.
+        /// </summary>
+        protected abstract FuzzProtocol CreateProtocol(TTransport transport);
+
+        /// <summary>
+        /// Helper method that contains the core fuzzing logic.
+        /// </summary>
+        private void ProcessFuzzStream(Stream stream)
+        {
+            try
+            {
+                var config = new TConfiguration();
+                config.MaxMessageSize = FUZZ_MAX_MESSAGE_SIZE;
+                var transport = new TStreamTransport(stream, null, config);
+                var protocol = CreateProtocol(transport);
+
+                var obj = new FuzzTest();
+                obj.ReadAsync(protocol, default).GetAwaiter().GetResult();
+            }
+            // Narrow catch list: these are the exception families we expect from the
+            // protocol/transport layer on malformed fuzzer input. Do NOT widen to
+            // catch (Exception) — a broad catch would swallow legitimate bugs and
+            // defeat the purpose of fuzzing.
+            catch (TProtocolException) { /* Expected for malformed fuzzer input */ }
+            catch (TTransportException) { /* Expected for malformed fuzzer input */ }
+            catch (TException) { /* Expected for malformed fuzzer input */ }
+            catch (EndOfStreamException) { /* Expected for malformed fuzzer input */ }
+            catch (IOException) { /* Expected for malformed fuzzer input */ }
+        }
+
+        /// <summary>
+        /// The core fuzzing logic that processes a single input.
+        /// </summary>
+        protected void ProcessFuzzInput(ReadOnlySpan<byte> span)
+        {
+            using var stream = new MemoryStream(span.ToArray());
+            ProcessFuzzStream(stream);
+        }
+
+        /// <summary>
+        /// Runs the fuzzer with LibFuzzer.
+        /// </summary>
+        protected void RunLibFuzzer()
+        {
+            Fuzzer.LibFuzzer.Run(ProcessFuzzInput);
+        }
+
+        /// <summary>
+        /// Runs the fuzzer with AFL.
+        /// </summary>
+        protected void RunAFL()
+        {
+            var useInProcess = Environment.GetEnvironmentVariable(UseInProcessFuzzingEnvVar) == "1";
+            if (useInProcess)
+            {
+                Fuzzer.Run(ProcessFuzzStream);
+            }
+            else
+            {
+                Fuzzer.OutOfProcess.Run(ProcessFuzzStream);
+            }
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/ProtocolRoundtripFuzzerBase.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/ProtocolRoundtripFuzzerBase.cs
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    /// <summary>
+    /// Base class for protocol round-trip fuzzers that handles the common fuzzing logic.
+    /// </summary>
+    /// <typeparam name="FuzzProtocol">The type of protocol to use for serialization/deserialization.</typeparam>
+    public abstract class ProtocolRoundtripFuzzerBase<FuzzProtocol> where FuzzProtocol : TProtocol
+    {
+        /// <summary>
+        /// Environment variable that controls whether to use in-process fuzzing for AFL.
+        /// When set to "1", uses Fuzzer.Run instead of Fuzzer.OutOfProcess.Run.
+        /// </summary>
+        protected const string UseInProcessFuzzingEnvVar = "THRIFT_AFL_IN_PROCESS";
+
+        /// <summary>
+        /// 10MB message size limit to prevent over-allocation during fuzzing
+        /// </summary>
+        protected const int FUZZ_MAX_MESSAGE_SIZE = 10 * 1024 * 1024;
+
+        /// <summary>
+        /// Creates a new instance of the protocol for the given transport.
+        /// </summary>
+        protected abstract FuzzProtocol CreateProtocol(TTransport transport);
+
+        /// <summary>
+        /// Helper method that contains the core fuzzing logic.
+        /// </summary>
+        private void ProcessFuzzStream(Stream stream)
+        {
+            try
+            {
+                // First deserialize the input
+                var config = new TConfiguration();
+                config.MaxMessageSize = FUZZ_MAX_MESSAGE_SIZE;
+                var inputTransport = new TStreamTransport(stream, null, config);
+                var inputProtocol = CreateProtocol(inputTransport);
+
+                var inputObj = new FuzzTest();
+                inputObj.ReadAsync(inputProtocol, default).GetAwaiter().GetResult();
+
+                // Now serialize it back
+                using var outputStream = new MemoryStream();
+                var outputTransport = new TStreamTransport(null, outputStream, config);
+                var outputProtocol = CreateProtocol(outputTransport);
+                inputObj.WriteAsync(outputProtocol, default).GetAwaiter().GetResult();
+                outputTransport.FlushAsync(default).GetAwaiter().GetResult();
+
+                // Get the serialized bytes and deserialize again
+                var serialized = outputStream.ToArray();
+                using var reStream = new MemoryStream(serialized);
+                var reTransport = new TStreamTransport(reStream, null, config);
+                var reProtocol = CreateProtocol(reTransport);
+
+                var outputObj = new FuzzTest();
+                outputObj.ReadAsync(reProtocol, default).GetAwaiter().GetResult();
+
+                // Compare the objects
+                if (!inputObj.Equals(outputObj))
+                {
+                    throw new Exception("Round-trip objects are not equal");
+                }
+            }
+            // Narrow catch list: these are the exception families we expect from the
+            // protocol/transport layer on malformed fuzzer input. Do NOT widen to
+            // catch (Exception) — a broad catch would swallow the
+            // "Round-trip objects are not equal" System.Exception thrown above,
+            // which is exactly the round-trip divergence the fuzzer is supposed to
+            // surface as a finding.
+            catch (TProtocolException) { /* Expected for malformed fuzzer input */ }
+            catch (TTransportException) { /* Expected for malformed fuzzer input */ }
+            catch (TException) { /* Expected for malformed fuzzer input */ }
+            catch (EndOfStreamException) { /* Expected for malformed fuzzer input */ }
+            catch (IOException) { /* Expected for malformed fuzzer input */ }
+        }
+
+        /// <summary>
+        /// The core fuzzing logic that processes a single input.
+        /// </summary>
+        protected void ProcessFuzzInput(ReadOnlySpan<byte> span)
+        {
+            using var stream = new MemoryStream(span.ToArray());
+            ProcessFuzzStream(stream);
+        }
+
+        /// <summary>
+        /// Runs the fuzzer with LibFuzzer.
+        /// </summary>
+        protected void RunLibFuzzer()
+        {
+            Fuzzer.LibFuzzer.Run(ProcessFuzzInput);
+        }
+
+        /// <summary>
+        /// Runs the fuzzer with AFL.
+        /// </summary>
+        protected void RunAFL()
+        {
+            var useInProcess = Environment.GetEnvironmentVariable(UseInProcessFuzzingEnvVar) == "1";
+            if (useInProcess)
+            {
+                Fuzzer.Run(ProcessFuzzStream);
+            }
+            else
+            {
+                Fuzzer.OutOfProcess.Run(ProcessFuzzStream);
+            }
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TBinaryProtocolFuzzer : ProtocolFuzzerBase<TBinaryProtocol>
+    {
+        protected override TBinaryProtocol CreateProtocol(TTransport transport)
+        {
+            return new TBinaryProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TBinaryProtocolFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolLibfuzzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TBinaryProtocolFuzzer : ProtocolFuzzerBase<TBinaryProtocol>
+    {
+        protected override TBinaryProtocol CreateProtocol(TTransport transport)
+        {
+            return new TBinaryProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TBinaryProtocolFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolRoundtripAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolRoundtripAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TBinaryProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TBinaryProtocol>
+    {
+        protected override TBinaryProtocol CreateProtocol(TTransport transport)
+        {
+            return new TBinaryProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TBinaryProtocolRoundtripFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolRoundtripLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TBinaryProtocolRoundtripLibfuzzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TBinaryProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TBinaryProtocol>
+    {
+        protected override TBinaryProtocol CreateProtocol(TTransport transport)
+        {
+            return new TBinaryProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TBinaryProtocolRoundtripFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TCompactProtocolFuzzer : ProtocolFuzzerBase<TCompactProtocol>
+    {
+        protected override TCompactProtocol CreateProtocol(TTransport transport)
+        {
+            return new TCompactProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TCompactProtocolFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolLibfuzzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TCompactProtocolFuzzer : ProtocolFuzzerBase<TCompactProtocol>
+    {
+        protected override TCompactProtocol CreateProtocol(TTransport transport)
+        {
+            return new TCompactProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TCompactProtocolFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolRoundtripAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolRoundtripAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TCompactProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TCompactProtocol>
+    {
+        protected override TCompactProtocol CreateProtocol(TTransport transport)
+        {
+            return new TCompactProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TCompactProtocolRoundtripFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolRoundtripLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TCompactProtocolRoundtripLibfuzzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TCompactProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TCompactProtocol>
+    {
+        protected override TCompactProtocol CreateProtocol(TTransport transport)
+        {
+            return new TCompactProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TCompactProtocolRoundtripFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TJsonProtocolFuzzer : ProtocolFuzzerBase<TJsonProtocol>
+    {
+        protected override TJsonProtocol CreateProtocol(TTransport transport)
+        {
+            return new TJsonProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TJsonProtocolFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolLibfuzzer.cs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Boilerplate fuzzer for TJSONProtocol using SharpFuzz
+// Attempts to deserialize a FuzzTest struct from the input stream using TJSONProtocol
+// Expected exceptions (e.g., TProtocolException) are caught and ignored
+// Unexpected exceptions are reported as crashes
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TJsonProtocolFuzzer : ProtocolFuzzerBase<TJsonProtocol>
+    {
+        protected override TJsonProtocol CreateProtocol(TTransport transport)
+        {
+            return new TJsonProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TJsonProtocolFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolRoundtripAFL.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolRoundtripAFL.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TJsonProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TJsonProtocol>
+    {
+        protected override TJsonProtocol CreateProtocol(TTransport transport)
+        {
+            return new TJsonProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TJsonProtocolRoundtripFuzzer().RunAFL();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolRoundtripLibfuzzer.cs
+++ b/lib/netstd/Tests/Thrift.FuzzTests/TJsonProtocolRoundtripLibfuzzer.cs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using SharpFuzz;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
+
+namespace Thrift.Tests.Protocols.Fuzzers
+{
+    public class TJsonProtocolRoundtripFuzzer : ProtocolRoundtripFuzzerBase<TJsonProtocol>
+    {
+        protected override TJsonProtocol CreateProtocol(TTransport transport)
+        {
+            return new TJsonProtocol(transport);
+        }
+
+        public static void Main(string[] args)
+        {
+            new TJsonProtocolRoundtripFuzzer().RunLibFuzzer();
+        }
+    }
+} 

--- a/lib/netstd/Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj
+++ b/lib/netstd/Tests/Thrift.FuzzTests/Thrift.FuzzTests.csproj
@@ -1,0 +1,70 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Licensed to the Apache Software Foundation(ASF) under one
+    or more contributor license agreements.See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+    
+  	  http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latestMajor</LangVersion>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    
+    <!-- Configuration properties with defaults -->
+    <Protocol Condition="'$(Protocol)' == ''">Binary</Protocol>
+    <FuzzerType Condition="'$(FuzzerType)' == ''">Parse</FuzzerType>
+    <Engine Condition="'$(Engine)' == ''">AFL</Engine>
+    
+    <!-- Dynamic assembly name based on configuration -->
+    <AssemblyName>Thrift.FuzzTests.$(Protocol)$(FuzzerType)$(Engine)</AssemblyName>
+    
+    <!-- Unique intermediate output path to prevent overwrites -->
+    <IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\$(Protocol)$(FuzzerType)$(Engine)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <!-- Common dependencies -->
+  <ItemGroup>
+    <ProjectReference Include="../../Thrift/Thrift.csproj" />
+    <PackageReference Include="SharpFuzz" Version="2.2.0" />
+  </ItemGroup>
+
+  <!-- Generated code -->
+  <ItemGroup>
+    <Compile Include="gen-netstd/**/*.cs" />
+  </ItemGroup>
+
+  <!-- Base classes based on fuzzer type -->
+  <ItemGroup Condition="'$(FuzzerType)' == 'Parse'">
+    <Compile Include="ProtocolFuzzerBase.cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(FuzzerType)' == 'Roundtrip'">
+    <Compile Include="ProtocolRoundtripFuzzerBase.cs" />
+  </ItemGroup>
+
+  <!-- Protocol and engine specific implementation files -->
+  <!-- The pattern is T{Protocol}Protocol{FuzzerType}{Engine}.cs -->
+  <!-- But for Parse fuzzers, the files don't have "Parse" in the name -->
+  <ItemGroup Condition="'$(FuzzerType)' == 'Parse'">
+    <Compile Include="T$(Protocol)Protocol$(Engine).cs" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(FuzzerType)' == 'Roundtrip'">
+    <Compile Include="T$(Protocol)ProtocolRoundtrip$(Engine).cs" />
+  </ItemGroup>
+</Project>

--- a/lib/netstd/buildfuzzers.sh
+++ b/lib/netstd/buildfuzzers.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+# Ensure the SharpFuzz.CommandLine global tool (runtimeconfig-pinned to
+# net9.0 in package 2.2.0) can roll forward onto the net10 runtime used
+# by this repo. Remove once SharpFuzz 2.3.0 (upstream PR #72) ships with
+# an updated runtimeconfig.
+export DOTNET_ROLL_FORWARD=Major
+
+# Check for SHARPFUZZ_DIR environment variable
+if [ -z "$SHARPFUZZ_DIR" ]; then
+    echo "Error: SHARPFUZZ_DIR environment variable is not set."
+    echo "Please set SHARPFUZZ_DIR to the location of your SharpFuzz installation."
+    echo "See README for installation instructions."
+    exit 1
+fi
+
+# Verify libfuzzer-dotnet exists
+LIBFUZZER="$SHARPFUZZ_DIR/libfuzzer-dotnet"
+if [ ! -f "$LIBFUZZER" ]; then
+    echo "Error: libfuzzer-dotnet not found at $LIBFUZZER"
+    echo "Please ensure SharpFuzz is properly installed in $SHARPFUZZ_DIR"
+    echo "See README for installation instructions."
+    exit 1
+fi
+
+# Verify the sharpfuzz instrumentation CLI is on PATH before we spend
+# time building 12 assemblies that would otherwise fail to be instrumented.
+if ! command -v sharpfuzz >/dev/null 2>&1; then
+    echo "Error: 'sharpfuzz' CLI not found on PATH."
+    echo "Install it with:"
+    echo "  dotnet tool install --global SharpFuzz.CommandLine"
+    echo "  export PATH=\"\$PATH:\$HOME/.dotnet/tools\""
+    echo "See README for full installation instructions."
+    exit 1
+fi
+
+# Find the local Thrift compiler
+THRIFT="$(dirname "$0")/../../compiler/cpp/thrift"
+THRIFT=$(realpath "$THRIFT")
+
+# Paths — resolved to absolute so they survive the cd below
+THRIFT_FILE=$(realpath "$(dirname "$0")/../../test/FuzzTest.thrift")
+GEN_DIR=$(realpath -m "$(dirname "$0")/Tests/Thrift.FuzzTests/gen-netstd")
+FUZZERS_DIR=$(realpath "$(dirname "$0")/Tests/Thrift.FuzzTests")
+OUTPUT_DIR="$FUZZERS_DIR/bin/Debug/net10.0"
+
+# Step 1: Generate C# code from FuzzTest.thrift
+if [ ! -x "$THRIFT" ]; then
+  echo "Error: Thrift compiler not found at $THRIFT"
+  exit 1
+fi
+
+# Clean and create the generated directory
+rm -rf "$GEN_DIR"
+mkdir -p "$GEN_DIR"
+
+echo "[1/13] Generating C# code from $THRIFT_FILE ..."
+"$THRIFT" --gen netstd:net10 -out "$GEN_DIR" "$THRIFT_FILE"
+echo "C# code generated in $GEN_DIR."
+
+# Step 2: Build all fuzzer projects
+cd "$(dirname "$0")"
+
+# Build all fuzzer combinations using the consolidated project
+BUILD_COUNT=2
+for protocol in Binary Compact Json; do
+  for fuzzer_type_raw in Parse Roundtrip; do
+    for engine in AFL Libfuzzer; do
+      # Construct display name
+      if [ "$fuzzer_type_raw" = "Parse" ]; then
+        display_name="$protocol Protocol $engine"
+        fuzzer_type=""
+      else
+        display_name="$protocol Protocol round-trip $engine"
+        fuzzer_type="Roundtrip"
+      fi
+      
+      echo "[$BUILD_COUNT/13] Building $display_name ..."
+      dotnet build "$FUZZERS_DIR/Thrift.FuzzTests.csproj" \
+        -p:Protocol=$protocol \
+        -p:FuzzerType=$fuzzer_type_raw \
+        -p:Engine=$engine
+      
+      BUILD_COUNT=$((BUILD_COUNT + 1))
+    done
+  done
+done
+
+# Step 3: Instrument the assemblies
+echo "Instrumenting assemblies for fuzzing ..."
+
+# Exclusions for instrumentation
+EXCLUSIONS=("dnlib.dll" "SharpFuzz.dll" "SharpFuzz.Common.dll")
+
+# Find and instrument fuzzing targets
+while IFS= read -r -d '' dll; do
+    dll_name=$(basename "$dll")
+    skip=false
+    for excl in "${EXCLUSIONS[@]}"; do
+        if [[ "$dll_name" == "$excl" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if [[ "$dll_name" == System.*.dll ]]; then
+        skip=true
+    fi
+    if [[ "$dll_name" == Thrift.FuzzTests.*.dll ]]; then
+        skip=true  # Skip the fuzzer assemblies themselves
+    fi
+    if [ "$skip" = true ]; then
+        echo "Skipping $dll_name"
+        continue
+    fi
+    if [ "$skip" = false ]; then
+        echo "Instrumenting $dll_name"
+        sharpfuzz "$dll"
+        if [ $? -ne 0 ]; then
+            echo "An error occurred while instrumenting $dll"
+            exit 1
+        fi
+    fi
+done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name "*.dll" -print0)
+
+echo "Build and instrumentation complete." 

--- a/lib/netstd/runfuzzer.sh
+++ b/lib/netstd/runfuzzer.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+# Ensure the SharpFuzz.CommandLine global tool (runtimeconfig-pinned to
+# net9.0 in package 2.2.0) can roll forward onto the net10 runtime used
+# by this repo. Remove once SharpFuzz 2.3.0 (upstream PR #72) ships with
+# an updated runtimeconfig.
+export DOTNET_ROLL_FORWARD=Major
+
+# Check if a fuzzer name and type were provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <fuzzer_name> <fuzzer_type> [additional fuzzer arguments...]"
+    echo "Available fuzzer names: json, compact, binary, json-roundtrip, compact-roundtrip, binary-roundtrip"
+    echo "Available fuzzer types: libfuzzer, afl"
+    exit 1
+fi
+
+FUZZER_NAME="$1"
+FUZZER_TYPE="$2"
+shift 2  # Remove the first two arguments, leaving only additional arguments
+
+VALID_FUZZERS=("json" "compact" "binary" "json-roundtrip" "compact-roundtrip" "binary-roundtrip")
+VALID_TYPES=("libfuzzer" "afl")
+
+# Validate fuzzer name
+VALID=0
+for f in "${VALID_FUZZERS[@]}"; do
+    if [ "$f" = "$FUZZER_NAME" ]; then
+        VALID=1
+        break
+    fi
+done
+
+if [ $VALID -eq 0 ]; then
+    echo "Invalid fuzzer name: $FUZZER_NAME"
+    echo "Available fuzzers: json, compact, binary, json-roundtrip, compact-roundtrip, binary-roundtrip"
+    exit 1
+fi
+
+# Validate fuzzer type
+VALID=0
+for t in "${VALID_TYPES[@]}"; do
+    if [ "$t" = "$FUZZER_TYPE" ]; then
+        VALID=1
+        break
+    fi
+done
+
+if [ $VALID -eq 0 ]; then
+    echo "Invalid fuzzer type: $FUZZER_TYPE"
+    echo "Available types: libfuzzer, afl"
+    exit 1
+fi
+
+# Map fuzzer name and type to assembly name
+# With the consolidated project, names follow the pattern:
+# Thrift.FuzzTests.{Protocol}{FuzzerType}{Engine}
+# where FuzzerType is "Parse" or "Roundtrip"
+case "$FUZZER_NAME" in
+    "json")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.JsonParseLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.JsonParseAFL"
+        fi
+        ;;
+    "compact")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.CompactParseLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.CompactParseAFL"
+        fi
+        ;;
+    "binary")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.BinaryParseLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.BinaryParseAFL"
+        fi
+        ;;
+    "json-roundtrip")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.JsonRoundtripLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.JsonRoundtripAFL"
+        fi
+        ;;
+    "compact-roundtrip")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.CompactRoundtripLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.CompactRoundtripAFL"
+        fi
+        ;;
+    "binary-roundtrip")
+        if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+            ASSEMBLY_NAME="Thrift.FuzzTests.BinaryRoundtripLibfuzzer"
+        else
+            ASSEMBLY_NAME="Thrift.FuzzTests.BinaryRoundtripAFL"
+        fi
+        ;;
+esac
+
+# Check for SHARPFUZZ_DIR environment variable
+if [ -z "$SHARPFUZZ_DIR" ]; then
+    echo "Error: SHARPFUZZ_DIR environment variable is not set."
+    echo "Please set SHARPFUZZ_DIR to the location of your SharpFuzz installation."
+    echo "See README for installation instructions."
+    exit 1
+fi
+
+# Verify libfuzzer-dotnet exists
+LIBFUZZER="$SHARPFUZZ_DIR/libfuzzer-dotnet"
+if [ ! -f "$LIBFUZZER" ]; then
+    echo "Error: libfuzzer-dotnet not found at $LIBFUZZER"
+    echo "Please ensure SharpFuzz is properly installed in $SHARPFUZZ_DIR"
+    echo "See README for installation instructions."
+    exit 1
+fi
+OUTPUT_DIR="$(dirname "$0")/Tests/Thrift.FuzzTests/bin/Debug/net10.0"
+CORPUS_DIR="$(dirname "$0")/corpus/$FUZZER_NAME"
+
+# Create corpus directory if it doesn't exist
+mkdir -p "$CORPUS_DIR"
+
+# Get project path
+PROJECT_PATH="$OUTPUT_DIR/$ASSEMBLY_NAME.dll"
+
+# Run the appropriate fuzzer
+echo "Running $ASSEMBLY_NAME fuzzer..."
+if [ "$FUZZER_TYPE" = "libfuzzer" ]; then
+    "$LIBFUZZER" --target_path=dotnet --target_arg="$PROJECT_PATH" "$CORPUS_DIR" "$@"
+else
+    # For AFL, we need separate input and findings directories
+    AFL_INPUT_DIR="$CORPUS_DIR/input"
+    AFL_FINDINGS_DIR="$CORPUS_DIR/findings"
+    mkdir -p "$AFL_INPUT_DIR"
+    mkdir -p "$AFL_FINDINGS_DIR"
+
+    # If input directory is empty, create a minimal test case
+    if [ ! "$(ls -A $AFL_INPUT_DIR)" ]; then
+        echo -n "test" > "$AFL_INPUT_DIR/test.txt"
+    fi
+    export AFL_SKIP_BIN_CHECK=1
+    afl-fuzz -i "$AFL_INPUT_DIR" -o "$AFL_FINDINGS_DIR" -m none dotnet "$PROJECT_PATH" "$@"
+fi


### PR DESCRIPTION
## Summary

Revive and update the netstd fuzzer infrastructure originally submitted in PR #3203 by @mhlakhani. This adds SharpFuzz-based protocol fuzzing for the Thrift netstd library, covering all three protocols (Binary, Compact, JSON) with both parse and roundtrip fuzzer types, for both AFL and libfuzzer engines.

Key changes on top of the original PR:

- **net10 bump**: Target framework updated from `net9.0` to `net10.0`, matching the current Thrift build matrix. The `--gen netstd:net10` flag is used for code generation (verified via `t_netstd_generator.cc` — using `net9` would actively break the build on net10 targets due to `#if NET10_0_OR_GREATER` guards).
- **SharpFuzz version pin**: `<PackageReference Include="SharpFuzz" Version="2.2.0" />` — pinned to a known-good release instead of wildcard `*`.
- **`DOTNET_ROLL_FORWARD=Major`**: Temporary workaround in both `buildfuzzers.sh` and `runfuzzer.sh`. SharpFuzz.CommandLine 2.2.0 pins its runtimeconfig to net9.0; this env var allows it to run on a net10-only host. Tracked for removal: upstream fix merged as [SharpFuzz PR #72](https://github.com/Metalnem/sharpfuzz/pull/72), pending release as SharpFuzz 2.3.0.
- **Opt-in build**: `build-fuzzers` target removed from `check-local` in `Makefile.am`. It requires the SharpFuzz.CommandLine global tool and libfuzzer-dotnet binary, which are dev-only dependencies not present in CI. Run manually with `make build-fuzzers` or `./buildfuzzers.sh`.
- **`sharpfuzz` CLI preflight**: `buildfuzzers.sh` now checks for the `sharpfuzz` command before building 12 assemblies, with actionable install instructions on failure.
- **Exception narrowing**: Catch blocks in `ProtocolFuzzerBase` and `ProtocolRoundtripFuzzerBase` narrowed from `catch (Exception)` to specific types (`TProtocolException`, `TTransportException`, `TException`, `EndOfStreamException`, `IOException`) for improved fuzzer effectiveness.
- **Path fix**: `FUZZERS_DIR` and related paths in `buildfuzzers.sh` resolved via `realpath` so the script works when invoked from the repo root, not just from `lib/netstd/`.
- **Documentation**: README fuzzing section rewritten with exact install commands, PATH setup, rollforward workaround explanation, and usage examples.

oss-fuzz integration is out of scope for this PR.

## Verification

Tested end-to-end inside the `thrift:jammy` docker image:
- All 12 fuzzer assemblies build successfully (0 warnings, 0 errors)
- `Thrift.dll` instrumented by SharpFuzz
- Parse fuzzer (`binary libfuzzer -runs=1000`): 1000 iterations, exit 0
- `make check` passes without SharpFuzz on PATH (89 tests, 0 failures)

## JIRA

[THRIFT-5855](https://issues.apache.org/jira/browse/THRIFT-5855)

---

Co-Authored-By: Hasnain Lakhani <m.hasnain.lakhani@gmail.com>
Generated-by: Claude Opus 4.6