### PR TITLE
Cleanup Adobe Flex SDK installation following AS3 library removal

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -99,7 +99,7 @@ jobs:
           if ($LASTEXITCODE -eq 0) {
             Write-Host "Successfully pulled cached image with hash tag"
             $needBuild = $false
-          } elseif ($output -match 'not found|does not exist|404') {
+          } elseif ($output -match 'not found|does not exist|404|manifest unknown') {
             Write-Host "Image not found in registry, will build from scratch."
             $needBuild = $true
           } else {

--- a/build/appveyor/MSVC-appveyor-full.bat
+++ b/build/appveyor/MSVC-appveyor-full.bat
@@ -152,13 +152,6 @@ IF "%WITH_PYTHON%" == "ON" (
               zope.interface>=6.1 || EXIT /B
 )
 
-:: Adobe Flex SDK 4.6 for ActionScript
-MKDIR "C:\Adobe\Flex\SDK\4.6" || EXIT /B
-appveyor DownloadFile https://fpdownload.adobe.com/pub/flex/sdk/builds/flex4.6/flex_sdk_4.6.0.23201B.zip -FileName C:\Adobe\Flex\SDK\4.6\SDK.zip || EXIT /B
-CD "C:\Adobe\Flex\SDK\4.6" || EXIT /B
-7z x SDK.zip || EXIT /B
-SETX FLEX_HOME "C:\Adobe\Flex\SDK\4.6"
-
 
 ::
 :: Configure and build our software with cmake

--- a/build/cmake/DefineOptions.cmake
+++ b/build/cmake/DefineOptions.cmake
@@ -44,15 +44,6 @@ if (NOT Boost_USE_STATIC_LIBS)
     add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 
-# as3
-option(WITH_AS3 "Build ActionScript 3 Thrift Library" ON)
-if (WITH_AS3)
-    set(POSSIBLE_PATHS "${FLEX_HOME}/bin" "$ENV{FLEX_HOME}/bin")
-    find_program(HAVE_COMPC NAMES compc HINTS ${POSSIBLE_PATHS})
-endif ()
-CMAKE_DEPENDENT_OPTION(BUILD_AS3 "Build as3 library" ON
-                       "BUILD_LIBRARIES;WITH_AS3;HAVE_COMPC" OFF)
-
 # C++
 option(WITH_CPP "Build C++ Thrift library" ON)
 if(WITH_CPP)
@@ -170,10 +161,6 @@ MESSAGE_DEP(HAVE_COMPILER "Disabled because BUILD_COMPILER=OFF and no valid THRI
 message(STATUS "  Build type:                                 ${CMAKE_BUILD_TYPE}")
 message(STATUS)
 message(STATUS "Language libraries:")
-message(STATUS)
-message(STATUS "  Build as3 library:                          ${BUILD_AS3}")
-MESSAGE_DEP(WITH_AS3 "Disabled by WITH_AS3=OFF")
-MESSAGE_DEP(HAVE_COMPC "Adobe Flex compc was not found - did you set env var FLEX_HOME?")
 message(STATUS)
 message(STATUS "  Build with OpenSSL:                         ${WITH_OPENSSL}")
 if(WITH_OPENSSL)

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -175,7 +175,6 @@ Last updated: March 5, 2024
 | Tool      | ubuntu-focal  | ubuntu-jammy  | ubuntu-noble  | Notes |
 | :-------- | :------------ | :------------ | :------------ | :---- |
 | as of     | Mar 06, 2018  | Jul 1, 2019   |               |       |
-| as3       | 4.6.0         | 4.6.0         |               |       |
 | C++ gcc   | 9.4.0         | 11.4.0        |               |       |
 | C++ clang | 13.0.0        | 13.0.0        |               |       |
 | c\_glib   | 3.2.12        | 3.2.12        |               |       |

--- a/build/docker/msvc/Dockerfile
+++ b/build/docker/msvc/Dockerfile
@@ -80,7 +80,7 @@ RUN C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=x64 -host_arch=x64 && `
     SETX PATH "%ZLIB_ROOT%\bin;%PATH%"
 
 # Install OpenSSL 3.6.1
-ADD --checksum=sha256:8ce11c409adbd177ca627115bc697c3b66c414bb36175ebb375341eb426894a8 https://slproweb.com/download/Win64OpenSSL-3_6_1.exe C:\TEMP\openssl.exe
+ADD --checksum=sha256:c395482a1af33b2cdd4b801b227c864ed049e0f6aff79413d31b4fa916a67b1a https://slproweb.com/download/Win64OpenSSL-3_6_2.exe C:\TEMP\openssl.exe
 RUN C:\TEMP\openssl.exe /silent && `
     DEL C:\TEMP\openssl.exe && `
     SETX OPENSSL_ROOT "C:\OpenSSL-Win64" && `
@@ -92,13 +92,6 @@ RUN choco install jdk8 -y
 # Install python3
 RUN choco install python3 -y
 RUN pip install setuptools
-
-# Install Adobe Flex 4.6 SDK and set FLEX_HOME so it can be found
-ADD --checksum=sha256:622b63f29de44600ff8d4231174a70fcb3085812c0e146a42e91877ca8b46798 http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip C:\Adobe\Flex\SDK\4.6\SDK.zip
-RUN CD C:\Adobe\Flex\SDK\4.6 && `
-    7z x SDK.zip && `
-    DEL SDK.zip && `
-    SETX FLEX_HOME "C:\Adobe\Flex\SDK\4.6"
 
 RUN choco install nodejs -y
 

--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -85,13 +85,6 @@ RUN apt-get update -yq && \
       vim
 ENV PATH=/usr/lib/llvm-6.0/bin:$PATH
 
-# lib/as3 (ActionScript)
-RUN mkdir -p /usr/local/adobe/flex/4.6 && \
-      cd /usr/local/adobe/flex/4.6 && \
-      wget -q "http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip" && \
-      unzip flex_sdk_4.6.zip
-ENV FLEX_HOME=/usr/local/adobe/flex/4.6
-
 # TODO: "apt-get install" without "apt-get update" in the same "RUN" step can cause cache issues if modified later.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -79,13 +79,6 @@ RUN apt-get update -yq && \
   vim
 ENV PATH=/usr/lib/llvm-6.0/bin:$PATH
 
-# lib/as3 (ActionScript)
-RUN mkdir -p /usr/local/adobe/flex/4.6 && \
-  cd /usr/local/adobe/flex/4.6 && \
-  wget -q "http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip" && \
-  unzip flex_sdk_4.6.zip
-ENV FLEX_HOME=/usr/local/adobe/flex/4.6
-
 # TODO: "apt-get install" without "apt-get update" in the same "RUN" step can cause cache issues if modified later.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 RUN apt-get install -y --no-install-recommends \

--- a/build/docker/ubuntu-noble/Dockerfile
+++ b/build/docker/ubuntu-noble/Dockerfile
@@ -78,13 +78,6 @@ RUN apt-get update -yq && \
   vim
 ENV PATH=/usr/lib/llvm-6.0/bin:$PATH
 
-# lib/as3 (ActionScript)
-RUN mkdir -p /usr/local/adobe/flex/4.6 && \
-  cd /usr/local/adobe/flex/4.6 && \
-  wget -q "http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip" && \
-  unzip flex_sdk_4.6.zip
-ENV FLEX_HOME=/usr/local/adobe/flex/4.6
-
 # TODO: "apt-get install" without "apt-get update" in the same "RUN" step can cause cache issues if modified later.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

AS3 support was dropped in https://github.com/apache/thrift/pull/2329, but we still install Adobe Flex SDK in a few places. For example, it takes 654.4 MiB in 2 layers in MSVC docker (325.0 MiB downloaded archive + 329.4 MiB uncompressed).

I am investigating the insane MSVC build times, a Docker image download step dominates the build with 27 minutes clock time.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
