### PR TITLE
THRIFT-5952: Optimized Dockerfile for MSVC build

### DIFF
--- a/build/docker/msvc/Dockerfile
+++ b/build/docker/msvc/Dockerfile
@@ -18,41 +18,54 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8.1-windowsservercore-ltsc2025
 # Restore the default Windows shell for correct batch processing below.
 SHELL ["cmd", "/S", "/C"]
 
+RUN IF NOT EXIST C:\TEMP MKDIR C:\TEMP
+
 # Install Build Tools excluding workloads and components with known issues.
-ADD --checksum=sha256:93bf06959261a301aca6406d058ade08f34ae83ca458fe3ed0689aa2105d9ccc https://aka.ms/vs/17/release/vs_BuildTools.exe C:\TEMP\vs_buildtools.exe
-RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+RUN curl.exe -fsSL -o C:\TEMP\vs_buildtools.exe https://download.visualstudio.microsoft.com/download/pr/e8db5368-d542-4208-ab91-ea2ac11f00b8/cfbe96493247c4c4280ea7e765ad427f89a76a1507b1144c7edb319069369387/vs_BuildTools.exe && `
+    powershell -NoProfile -Command "if ((Get-FileHash 'C:\TEMP\vs_buildtools.exe' -Algorithm SHA256).Hash.ToLower() -ne 'cfbe96493247c4c4280ea7e765ad427f89a76a1507b1144c7edb319069369387') { exit 1 }" && `
+    (C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath C:\BuildTools `
     --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 `
- || IF "%ERRORLEVEL%"=="3010" EXIT 0
-RUN DEL C:\TEMP\vs_buildtools.exe
+    || IF "%ERRORLEVEL%"=="3010" EXIT 0) && `
+    DEL /F /Q C:\TEMP\vs_buildtools.exe && `
+    IF EXIST "C:\ProgramData\Package Cache" RMDIR /S /Q "C:\ProgramData\Package Cache" && `
+    IF EXIST C:\Windows\SoftwareDistribution\Download RMDIR /S /Q C:\Windows\SoftwareDistribution\Download
 
 # Install CMake
-ADD --checksum=sha256:a10fc2527ec0727a5913acd310cddafba1e5b4ca765ca23cc6a53c55eebb7c1 https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.msi C:\TEMP\cmake.msi
-RUN msiexec.exe /i C:\TEMP\cmake.msi /qn && `
+RUN curl.exe -fsSL -o C:\TEMP\cmake.msi https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.msi && `
+    powershell -NoProfile -Command "if ((Get-FileHash 'C:\TEMP\cmake.msi' -Algorithm SHA256).Hash.ToLower() -ne 'a10fc2527ec0727a5913acd310cddafdba1e5b4ca765ca23cc6a53c55eebb7c1') { exit 1 }" && `
+    msiexec.exe /i C:\TEMP\cmake.msi /qn && `
     SETX PATH "%PATH%;C:\Program Files\CMake\bin" && `
-    DEL C:\TEMP\cmake.msi
+    DEL /F /Q C:\TEMP\cmake.msi && `
+    FOR %D IN (doc man) DO @IF EXIST "C:\Program Files\CMake\%D" RMDIR /S /Q "C:\Program Files\CMake\%D"
 
 # Install boost (for the thrift runtime library build)
-ADD --checksum=sha256:bff575f21343f602c7b6c3ad3883a28053a1a50cde2153102d30479f85911738 https://boost.teeks99.com/bin/1.88.0/boost_1_88_0-msvc-14.3-64.exe C:\TEMP\boost.exe
 ENV BOOST_ROOT=C:\Libraries\boost_1_88_0
-RUN C:\TEMP\boost.exe /DIR=%BOOST_ROOT% /SILENT && `
-    DEL C:\TEMP\boost.exe && `
+ENV BOOST_LIBRARYDIR=C:\Libraries\boost_1_88_0\lib64-msvc-14.3
+RUN curl.exe -fsSL -o C:\TEMP\boost.exe https://boost.teeks99.com/bin/1.88.0/boost_1_88_0-msvc-14.3-64.exe && `
+    powershell -NoProfile -Command "if ((Get-FileHash 'C:\TEMP\boost.exe' -Algorithm SHA256).Hash.ToLower() -ne 'bff575f21343f602c7b6c3ad3883a28053a1a50cde2153102d30479f85911738') { exit 1 }" && `
+    C:\TEMP\boost.exe /DIR=%BOOST_ROOT% /SILENT && `
+    DEL /F /Q C:\TEMP\boost.exe && `
+    FOR %D IN (doc libs tools status more) DO @IF EXIST "%BOOST_ROOT%\%D" RMDIR /S /Q "%BOOST_ROOT%\%D" && `
     SETX BOOST_LIBRARYDIR "%BOOST_ROOT%\lib64-msvc-14.3" && `
     SETX PATH "%BOOST_LIBRARYDIR%;%PATH%"
 
 # Install chocolatey
+ENV CHOCO_DIR=C:\ProgramData\chocolatey
 RUN @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" `
     -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command `
     "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" `
     && SETX PATH "%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 # Install winflexbison (for the thrift compiler build)
-RUN choco install winflexbison3 -y
+RUN choco install winflexbison3 -y --no-progress && `
+    choco cache remove -y
 
 # Install 7zip and curl (used by the libevent and zlib build scripts)
-RUN choco install 7zip curl -y
+RUN choco install 7zip curl -y --no-progress && `
+    choco cache remove -y
 
 # Install libevent
 COPY appveyor\build-libevent.bat C:\TEMP\build-libevent.bat
@@ -79,21 +92,32 @@ RUN C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=x64 -host_arch=x64 && `
     SETX ZLIB_ROOT "C:\Libraries\zlib-%ZLIB_VERSION%" && `
     SETX PATH "%ZLIB_ROOT%\bin;%PATH%"
 
-# Install OpenSSL 3.6.1
-ADD --checksum=sha256:c395482a1af33b2cdd4b801b227c864ed049e0f6aff79413d31b4fa916a67b1a https://slproweb.com/download/Win64OpenSSL-3_6_2.exe C:\TEMP\openssl.exe
-RUN C:\TEMP\openssl.exe /silent && `
-    DEL C:\TEMP\openssl.exe && `
-    SETX OPENSSL_ROOT "C:\OpenSSL-Win64" && `
+# Install OpenSSL
+RUN curl.exe -fsSL -o C:\TEMP\openssl.exe https://slproweb.com/download/Win64OpenSSL-3_6_2.exe && `
+    powershell -NoProfile -Command "if ((Get-FileHash 'C:\TEMP\openssl.exe' -Algorithm SHA256).Hash.ToLower() -ne 'c395482a1af33b2cdd4b801b227c864ed049e0f6aff79413d31b4fa916a67b1a') { exit 1 }" && `
+    C:\TEMP\openssl.exe /silent && `
+    DEL /F /Q C:\TEMP\openssl.exe && `
+    IF EXIST "C:\Program Files\OpenSSL-Win64\tests" RMDIR /S /Q "C:\Program Files\OpenSSL-Win64\tests" && `
+    SETX OPENSSL_ROOT "C:\Program Files\OpenSSL-Win64" && `
     SETX PATH "%OPENSSL_ROOT%\bin;%PATH%"
 
 # Install java
-RUN choco install jdk8 -y
+RUN choco install jdk8 -y --no-progress -params "source=false" && `
+    choco cache remove -y && `
+    IF EXIST "%CHOCO_DIR%\lib\jdk8" RMDIR /S /Q "%CHOCO_DIR%\lib\jdk8"
 
 # Install python3
-RUN choco install python3 -y
-RUN pip install setuptools
+RUN choco install python314 -y --no-progress --install-arguments "'Include_doc=0 Include_launcher=0 Include_tcltk=0 Include_test=0'" && `
+    choco cache remove -y && `
+    C:\Python314\python.exe -m pip install --disable-pip-version-check --no-cache-dir setuptools && `
+    IF EXIST "C:\ProgramData\Package Cache" RMDIR /S /Q "C:\ProgramData\Package Cache" && `
+    IF EXIST "%CHOCO_DIR%\lib\python314" RMDIR /S /Q "%CHOCO_DIR%\lib\python314"
 
-RUN choco install nodejs -y
+RUN choco install nodejs -y --no-progress && `
+    choco cache remove -y && `
+    IF EXIST "C:\ProgramData\Package Cache" RMDIR /S /Q "C:\ProgramData\Package Cache" && `
+    IF EXIST "%CHOCO_DIR%\lib\nodejs" RMDIR /S /Q "%CHOCO_DIR%\lib\nodejs" && `
+    IF EXIST "%CHOCO_DIR%\lib\nodejs.install" RMDIR /S /Q "%CHOCO_DIR%\lib\nodejs.install"
 
 # Start developer command prompt with any other commands specified.
 ENTRYPOINT C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=x64 -host_arch=x64 &&


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

MSVC Docker image is 8.8GiB and takes 20-30 minutes to pull from registry. Some of the layers include software installation packages, some documentation, extracted MSIs, chocolatey caches. There seem to be a lot of opportunity to reduce the size.

* before: `ghcr.io/apache/thrift-build:msvc-d5d97583f97d`
   9,511,251,810 bytes
   8.86 GiB
* after: `ghcr.io/kpumuk/thrift-build:msvc-f2db224329b8`
   6,986,460,516 bytes
   6.51 GiB
* Delta:
   -2,524,791,294 bytes
   -2.35 GiB
   -26.5%

Base/custom split:

* First 9 layers are identical in both images: 4,224,296,837 bytes (3.93 GiB)
* Custom build layers:
   * before: **5,286,954,973 bytes (4.92 GiB)**
   * after: **2,762,163,679 bytes (2.57 GiB)**
   * delta: **-2.35 GiB (-47.8%)**

Example job on the cached image: https://github.com/kpumuk/thrift/actions/runs/24630106512/job/72015848598
The image pull time decreased to 12 minutes.

### Comparison per layer(s)

| Step                  | Before layers | Before MiB | After layers | After MiB | Delta MiB |
|-----------------------|---------------:|------------:|--------------:|-----------:|---:|
| Shell/init            | 10            | 0.0        | 10-11        | 0.4       | +0.4 |
| VS Build Tools        | 11-13         | 2248.9     | 12           | 1466.8    | -782.1 |
| CMake                 | 14-15         | 104.8      | 13           | 63.5      | -41.3 |
| Boost                 | 16-18         | 653.1      | 14-16        | 293.2     | -360.0 |
| Chocolatey bootstrap  | 19            | 22.4       | 17-18        | 22.4      | -0.0 |
| winflexbison3         | 20            | 3.1        | 19           | 3.1       | -0.0 |
| 7zip + curl           | 21            | 33.8       | 20           | 33.8      | -0.0 |
| libevent              | 22-25         | 2.1        | 21-24        | 2.0       | -0.1 |
| zlib                  | 26-29         | 1.4        | 25-28        | 1.4       | -0.0 |
| OpenSSL               | 30-31         | 559.2      | 29           | 105.1     | -454.1 |
| Java (jdk8)           | 32            | 609.2      | 30           | 376.7     | -232.4 |
| Python + setuptools   | 33-34         | 671.7      | 31           | 133.5     | -538.1 |
| Node.js               | 35            | 132.3      | 32           | 132.3     | -0.0 |
| Entrypoint/Cmd        | 36-37         | 0.0        | 33-34        | 0.0       | +0.0 |

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5952](https://issues.apache.org/jira/browse/THRIFT-5952)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
