### PR TITLE
Add recursion depth limit to TProtocol.skip() in Python

### DIFF
--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -186,7 +186,10 @@ class TProtocolBase(object):
     def readUuid(self):
         pass
 
-    def skip(self, ttype):
+    def skip(self, ttype, max_depth=64):
+        if max_depth <= 0:
+            raise TProtocolException(TProtocolException.DEPTH_LIMIT,
+                                     "Maximum skip depth exceeded")
         if ttype == TType.BOOL:
             self.readBool()
         elif ttype == TType.BYTE:
@@ -207,24 +210,24 @@ class TProtocolBase(object):
                 (name, ttype, id) = self.readFieldBegin()
                 if ttype == TType.STOP:
                     break
-                self.skip(ttype)
+                self.skip(ttype, max_depth - 1)
                 self.readFieldEnd()
             self.readStructEnd()
         elif ttype == TType.MAP:
             (ktype, vtype, size) = self.readMapBegin()
             for i in range(size):
-                self.skip(ktype)
-                self.skip(vtype)
+                self.skip(ktype, max_depth - 1)
+                self.skip(vtype, max_depth - 1)
             self.readMapEnd()
         elif ttype == TType.SET:
             (etype, size) = self.readSetBegin()
             for i in range(size):
-                self.skip(etype)
+                self.skip(etype, max_depth - 1)
             self.readSetEnd()
         elif ttype == TType.LIST:
             (etype, size) = self.readListBegin()
             for i in range(size):
-                self.skip(etype)
+                self.skip(etype, max_depth - 1)
             self.readListEnd()
         elif ttype == TType.UUID:
             self.readUuid()

--- a/lib/py/test/thrift_TBinaryProtocol.py
+++ b/lib/py/test/thrift_TBinaryProtocol.py
@@ -17,11 +17,13 @@
 # under the License.
 #
 
+import struct
 import unittest
 import uuid
 
 import _import_local_thrift  # noqa
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TProtocol import TProtocolException
 from thrift.transport import TTransport
 
 
@@ -295,6 +297,37 @@ class TestTBinaryProtocol(unittest.TestCase):
         except Exception as e:
             print("Assertion fail")
             raise e
+
+
+def _craft_nested_structs(depth):
+    buf = bytearray()
+    for _ in range(depth):
+        buf += bytes([0x0c])           # TType.STRUCT = 12
+        buf += struct.pack('>h', 1)    # field ID 1
+    for _ in range(depth + 1):
+        buf += bytes([0x00])           # STOP per level + innermost
+    return bytes(buf)
+
+
+class TestSkipDepthLimit(unittest.TestCase):
+
+    def _make_proto(self, payload):
+        trans = TTransport.TMemoryBuffer(payload)
+        return TBinaryProtocol(trans)
+
+    def test_skip_rejects_deeply_nested_struct(self):
+        from thrift.Thrift import TType
+        payload = _craft_nested_structs(64)
+        proto = self._make_proto(payload)
+        with self.assertRaises(TProtocolException) as ctx:
+            proto.skip(TType.STRUCT)
+        self.assertEqual(ctx.exception.type, TProtocolException.DEPTH_LIMIT)
+
+    def test_skip_accepts_struct_within_depth_limit(self):
+        from thrift.Thrift import TType
+        payload = _craft_nested_structs(63)
+        proto = self._make_proto(payload)
+        proto.skip(TType.STRUCT)  # must not raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

`TProtocolBase.skip()` in Python had no recursion depth limit. When deserializing an unknown field, generated code calls `skip()`, which recursively calls itself for each nested container or struct element. C++, Go, and Node.js all cap this recursion at 64 levels and raise a protocol exception when the limit is exceeded.

This change brings Python into parity:

- **`lib/py/src/protocol/TProtocol.py`**: `skip()` gains an optional `max_depth` parameter (default 64). At the start of each call, if `max_depth <= 0` a `TProtocolException(DEPTH_LIMIT)` is raised. All recursive calls pass `max_depth - 1`.

Tests added in `lib/py/test/thrift_TBinaryProtocol.py`:
- `test_skip_rejects_deeply_nested_struct`: a payload with 64 levels of nesting raises `DEPTH_LIMIT`.
- `test_skip_accepts_struct_within_depth_limit`: a payload with 63 levels succeeds.

## Test plan

- [ ] `python3 lib/py/test/thrift_TBinaryProtocol.py -v` — two new skip depth tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)