### PR TITLE
Use sslcompat hostname matcher in TSSLSocket

### DIFF
--- a/lib/py/src/transport/TSSLSocket.py
+++ b/lib/py/src/transport/TSSLSocket.py
@@ -24,13 +24,9 @@ import ssl
 import sys
 import warnings
 
-from .sslcompat import _match_has_ipaddress
+from .sslcompat import _match_has_ipaddress, _match_hostname
 from thrift.transport import TSocket
 from thrift.transport.TTransport import TTransportException
-
-
-def _match_hostname(cert, hostname):
-    return True
 
 
 logger = logging.getLogger(__name__)

--- a/lib/py/test/test_sslsocket.py
+++ b/lib/py/test/test_sslsocket.py
@@ -351,6 +351,22 @@ class TSSLSocketTest(unittest.TestCase):
         self._assert_connection_success(server, ssl_context=client_context)
 
 
+class TestMatchHostname(unittest.TestCase):
+    def test_match_hostname_is_from_sslcompat(self):
+        from thrift.transport.TSSLSocket import _match_hostname as ssl_match
+        from thrift.transport.sslcompat import _match_hostname as compat_match
+        self.assertIs(ssl_match, compat_match,
+                      "_match_hostname in TSSLSocket must be the sslcompat version, not an inline no-op")
+
+    @unittest.skipIf(sys.version_info >= (3, 12),
+                     "ssl.match_hostname removed in Python 3.12; OpenSSL handles hostname verification")
+    def test_match_hostname_rejects_mismatch(self):
+        from thrift.transport.TSSLSocket import _match_hostname
+        fake_cert = {"subject": ((("commonName", "evil.attacker.com"),),)}
+        with self.assertRaises(Exception):
+            _match_hostname(fake_cert, "real-server.com")
+
+
 # Add a dummy test because starting from python 3.12, if all tests in a test
 # file are skipped that's considered an error.
 class DummyTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

`TSSLSocket.py` defined `_match_hostname` as a module-level no-op lambda, shadowing the more complete implementation already exported by the companion `sslcompat` module. The `sslcompat` module exists specifically to abstract over Python version differences in `ssl.match_hostname`: it provides the real implementation on Python < 3.12 and a no-op on Python 3.12+ (where `ssl.match_hostname` was removed and hostname verification is handled entirely by OpenSSL via `check_hostname=True`).

This change:

- **`lib/py/src/transport/TSSLSocket.py`**: imports `_match_hostname` from `sslcompat` alongside the existing `_match_has_ipaddress` import; removes the inline no-op lambda definition.

Tests added in `lib/py/test/test_sslsocket.py` (`TestMatchHostname` class):
- `test_match_hostname_is_from_sslcompat`: asserts `TSSLSocket._match_hostname is sslcompat._match_hostname`.
- `test_match_hostname_rejects_mismatch`: on Python < 3.12, verifies a hostname mismatch raises an exception (skipped on 3.12+ where `ssl.match_hostname` no longer exists).

## Test plan

- [ ] `python3 lib/py/test/test_sslsocket.py -v` — two new matcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)