### PR TITLE
THRIFT-5953: Rust codegen forward-compatible union deserialization in structs

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -1699,10 +1699,41 @@ void t_rs_generator::render_struct_sync_read(const string& struct_name,
 
     for (members_iter = members.begin(); members_iter != members.end(); ++members_iter) {
       t_field* tfield = (*members_iter);
+      t_type* resolved = get_true_type(tfield->get_type());
+      bool is_union_field = resolved->is_struct() && ((t_struct*)resolved)->is_union();
       f_gen_ << indent() << rust_safe_field_id(tfield->get_key()) << " => {" << '\n';
       indent_up();
-      render_type_sync_read("val", tfield->get_type());
-      f_gen_ << indent() << struct_field_read_temp_variable(tfield) << " = Some(val);" << '\n';
+      if (is_union_field) {
+        // Use the resolved (non-Box) type since Box<T>::method() isn't valid syntax.
+        string resolved_type = to_rust_type(resolved);
+        bool is_boxed = false;
+        {
+          t_type* t = tfield->get_type();
+          while (t->is_typedef()) {
+            if (((t_typedef*)t)->is_forward_typedef()) { is_boxed = true; break; }
+            t = ((t_typedef*)t)->get_type();
+          }
+        }
+        string read_call(resolved_type + "::read_from_in_protocol(i_prot)");
+        string val_expr = is_boxed ? "Box::new(val)" : "val";
+        bool suppress_unknown = (struct_type == T_REGULAR || struct_type == T_EXCEPTION) && is_optional(actual_field_req(tfield, struct_type));
+        if (suppress_unknown) {
+          f_gen_ << indent() << "match " << read_call << " {" << '\n';
+          indent_up();
+          f_gen_ << indent() << "Ok(val) => { " << struct_field_read_temp_variable(tfield) << " = Some(" << val_expr << "); }," << '\n';
+          f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => {" << '\n';
+          f_gen_ << indent() << "}," << '\n';
+          f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+          indent_down();
+          f_gen_ << indent() << "}" << '\n';
+        } else {
+          f_gen_ << indent() << "let val = " << read_call << "?;" << '\n';
+          f_gen_ << indent() << struct_field_read_temp_variable(tfield) << " = Some(" << val_expr << ");" << '\n';
+        }
+      } else {
+        render_type_sync_read("val", tfield->get_type());
+        f_gen_ << indent() << struct_field_read_temp_variable(tfield) << " = Some(val);" << '\n';
+      }
       indent_down();
       f_gen_ << indent() << "}," << '\n';
     }
@@ -1778,6 +1809,7 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
   // completed union as well as a count of fields read
   f_gen_ << indent() << "let mut ret: Option<" << union_name << "> = None;" << '\n';
   f_gen_ << indent() << "let mut received_field_count = 0;" << '\n';
+  f_gen_ << indent() << "let mut total_field_count = 0;" << '\n';
 
   // read the struct preamble
   f_gen_ << indent() << "i_prot.read_struct_begin()?;" << '\n';
@@ -1803,16 +1835,40 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
   vector<t_field*>::const_iterator members_iter;
   for (members_iter = members.begin(); members_iter != members.end(); ++members_iter) {
     t_field* member = (*members_iter);
+    t_type* member_resolved = get_true_type(member->get_type());
+    bool member_is_union = member_resolved->is_struct() && ((t_struct*)member_resolved)->is_union();
     f_gen_ << indent() << rust_safe_field_id(member->get_key()) << " => {" << '\n';
     indent_up();
-    render_type_sync_read("val", member->get_type());
-    f_gen_ << indent() << "if ret.is_none() {" << '\n';
-    indent_up();
-    f_gen_ << indent() << "ret = Some(" << union_name << "::" << rust_union_field_name(member)
-           << "(val));" << '\n';
-    indent_down();
-    f_gen_ << indent() << "}" << '\n';
-    f_gen_ << indent() << "received_field_count += 1;" << '\n';
+    if (member_is_union) {
+      string member_type = to_rust_type(member_resolved);
+      string member_read(member_type + "::read_from_in_protocol(i_prot)");
+      f_gen_ << indent() << "match " << member_read << " {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "Ok(val) => {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "if ret.is_none() {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "ret = Some(" << union_name << "::" << rust_union_field_name(member)
+             << "(val));" << '\n';
+      indent_down();
+      f_gen_ << indent() << "}" << '\n';
+      f_gen_ << indent() << "received_field_count += 1;" << '\n';
+      indent_down();
+      f_gen_ << indent() << "}," << '\n';
+      f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => {}," << '\n';
+      f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+      indent_down();
+      f_gen_ << indent() << "}" << '\n';
+    } else {
+      render_type_sync_read("val", member->get_type());
+      f_gen_ << indent() << "if ret.is_none() {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "ret = Some(" << union_name << "::" << rust_union_field_name(member)
+             << "(val));" << '\n';
+      indent_down();
+      f_gen_ << indent() << "}" << '\n';
+      f_gen_ << indent() << "received_field_count += 1;" << '\n';
+    }
     indent_down();
     f_gen_ << indent() << "}," << '\n';
   }
@@ -1826,21 +1882,27 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
 
   indent_down();
   f_gen_ << indent() << "};" << '\n'; // finish match
+  f_gen_ << indent() << "total_field_count += 1;" << '\n';
   f_gen_ << indent() << "i_prot.read_field_end()?;" << '\n';
   indent_down();
   f_gen_ << indent() << "}" << '\n';                          // finish loop
   f_gen_ << indent() << "i_prot.read_struct_end()?;" << '\n'; // finish reading message from wire
 
   // return the value or an error
-  f_gen_ << indent() << "if received_field_count == 0 {" << '\n';
+  f_gen_ << indent() << "if total_field_count == 0 {" << '\n';
   indent_up();
-  render_thrift_error("Protocol", "ProtocolError", "ProtocolErrorKind::InvalidData",
+  render_thrift_error("Protocol", "ProtocolError", "ProtocolErrorKind::EmptyUnion",
                       "\"received empty union from remote " + union_name + "\"");
   indent_down();
   f_gen_ << indent() << "} else if received_field_count > 1 {" << '\n';
   indent_up();
   render_thrift_error("Protocol", "ProtocolError", "ProtocolErrorKind::InvalidData",
                       "\"received multiple fields for union from remote " + union_name + "\"");
+  indent_down();
+  f_gen_ << indent() << "} else if received_field_count == 0 {" << '\n';
+  indent_up();
+  render_thrift_error("Protocol", "ProtocolError", "ProtocolErrorKind::UnknownUnionVariant",
+                      "\"received union with unknown variant from remote " + union_name + "\"");
   indent_down();
   f_gen_ << indent() << "} else if let Some(ret) = ret {" << '\n';
   indent_up();
@@ -1944,8 +2006,22 @@ void t_rs_generator::render_list_sync_read(t_list* tlist, const string& list_var
   indent_up();
 
   string list_elem_var = tmp("list_elem_");
-  render_type_sync_read(list_elem_var, elem_type);
-  f_gen_ << indent() << list_var << ".push(" << list_elem_var << ");" << '\n';
+  t_type* resolved_elem = get_true_type(elem_type);
+  bool elem_is_union = resolved_elem->is_struct() && ((t_struct*)resolved_elem)->is_union();
+  if (elem_is_union) {
+    string resolved_type = to_rust_type(resolved_elem);
+    string read_call(resolved_type + "::read_from_in_protocol(i_prot)");
+    f_gen_ << indent() << "match " << read_call << " {" << '\n';
+    indent_up();
+    f_gen_ << indent() << "Ok(val) => { " << list_var << ".push(val); }," << '\n';
+    f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => { continue; }," << '\n';
+    f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+    indent_down();
+    f_gen_ << indent() << "}" << '\n';
+  } else {
+    render_type_sync_read(list_elem_var, elem_type);
+    f_gen_ << indent() << list_var << ".push(" << list_elem_var << ");" << '\n';
+  }
 
   indent_down();
 
@@ -1965,8 +2041,22 @@ void t_rs_generator::render_set_sync_read(t_set* tset, const string& set_var) {
   indent_up();
 
   string set_elem_var = tmp("set_elem_");
-  render_type_sync_read(set_elem_var, elem_type);
-  f_gen_ << indent() << set_var << ".insert(" << set_elem_var << ");" << '\n';
+  t_type* resolved_elem = get_true_type(elem_type);
+  bool elem_is_union = resolved_elem->is_struct() && ((t_struct*)resolved_elem)->is_union();
+  if (elem_is_union) {
+    string resolved_type = to_rust_type(resolved_elem);
+    string read_call(resolved_type + "::read_from_in_protocol(i_prot)");
+    f_gen_ << indent() << "match " << read_call << " {" << '\n';
+    indent_up();
+    f_gen_ << indent() << "Ok(val) => { " << set_var << ".insert(val); }," << '\n';
+    f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => { continue; }," << '\n';
+    f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+    indent_down();
+    f_gen_ << indent() << "}" << '\n';
+  } else {
+    render_type_sync_read(set_elem_var, elem_type);
+    f_gen_ << indent() << set_var << ".insert(" << set_elem_var << ");" << '\n';
+  }
 
   indent_down();
 
@@ -1986,12 +2076,54 @@ void t_rs_generator::render_map_sync_read(t_map* tmap, const string& map_var) {
 
   indent_up();
 
-  string key_elem_var = tmp("map_key_");
-  render_type_sync_read(key_elem_var, key_type);
-  string val_elem_var = tmp("map_val_");
-  render_type_sync_read(val_elem_var, val_type);
-  f_gen_ << indent() << map_var << ".insert(" << key_elem_var << ", " << val_elem_var << ");"
-         << '\n';
+  t_type* resolved_key = get_true_type(key_type);
+  t_type* resolved_val = get_true_type(val_type);
+  bool key_is_union = resolved_key->is_struct() && ((t_struct*)resolved_key)->is_union();
+  bool val_is_union = resolved_val->is_struct() && ((t_struct*)resolved_val)->is_union();
+  if (key_is_union || val_is_union) {
+    // Read key
+    string key_elem_var = tmp("map_key_");
+    if (key_is_union) {
+      string key_read(to_rust_type(resolved_key) + "::read_from_in_protocol(i_prot)");
+      f_gen_ << indent() << "let " << key_elem_var << " = match " << key_read << " {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "Ok(val) => val," << '\n';
+      f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => {" << '\n';
+      indent_up();
+      // Skip the value and continue to next entry
+      render_type_sync_read(tmp("discard_"), val_type);
+      f_gen_ << indent() << "continue;" << '\n';
+      indent_down();
+      f_gen_ << indent() << "}," << '\n';
+      f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+      indent_down();
+      f_gen_ << indent() << "};" << '\n';
+    } else {
+      render_type_sync_read(key_elem_var, key_type);
+    }
+    // Read value
+    string val_elem_var = tmp("map_val_");
+    if (val_is_union) {
+      string val_read(to_rust_type(resolved_val) + "::read_from_in_protocol(i_prot)");
+      f_gen_ << indent() << "match " << val_read << " {" << '\n';
+      indent_up();
+      f_gen_ << indent() << "Ok(val) => { " << map_var << ".insert(" << key_elem_var << ", val); }," << '\n';
+      f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => { continue; }," << '\n';
+      f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
+      indent_down();
+      f_gen_ << indent() << "}" << '\n';
+    } else {
+      render_type_sync_read(val_elem_var, val_type);
+      f_gen_ << indent() << map_var << ".insert(" << key_elem_var << ", " << val_elem_var << ");" << '\n';
+    }
+  } else {
+    string key_elem_var = tmp("map_key_");
+    render_type_sync_read(key_elem_var, key_type);
+    string val_elem_var = tmp("map_val_");
+    render_type_sync_read(val_elem_var, val_type);
+    f_gen_ << indent() << map_var << ".insert(" << key_elem_var << ", " << val_elem_var << ");"
+           << '\n';
+  }
 
   indent_down();
 

--- a/lib/rs/src/errors.rs
+++ b/lib/rs/src/errors.rs
@@ -509,6 +509,10 @@ pub enum ProtocolErrorKind {
     /// Reached the maximum nested depth to which an encoded Thrift field could
     /// be skipped.
     DepthLimit = 6,
+    /// A Thrift union was deserialized with zero fields on the wire.
+    EmptyUnion = 7,
+    /// A Thrift union contained fields but none matched known variants.
+    UnknownUnionVariant = 8,
 }
 
 impl Display for ProtocolError {
@@ -521,6 +525,8 @@ impl Display for ProtocolError {
             ProtocolErrorKind::BadVersion => "invalid thrift version",
             ProtocolErrorKind::NotImplemented => "not implemented",
             ProtocolErrorKind::DepthLimit => "maximum skip depth reached",
+            ProtocolErrorKind::EmptyUnion => "empty union",
+            ProtocolErrorKind::UnknownUnionVariant => "unknown union variant",
         };
 
         write!(f, "{}", error_text)
@@ -538,6 +544,8 @@ impl TryFrom<i32> for ProtocolErrorKind {
             4 => Ok(ProtocolErrorKind::BadVersion),
             5 => Ok(ProtocolErrorKind::NotImplemented),
             6 => Ok(ProtocolErrorKind::DepthLimit),
+            7 => Ok(ProtocolErrorKind::EmptyUnion),
+            8 => Ok(ProtocolErrorKind::UnknownUnionVariant),
             _ => Err(Error::Protocol(ProtocolError {
                 kind: ProtocolErrorKind::Unknown,
                 message: format!("cannot convert {} to ProtocolErrorKind", from),

--- a/lib/rs/test/src/lib.rs
+++ b/lib/rs/test/src/lib.rs
@@ -106,4 +106,163 @@ mod tests {
             "unknown union variant should result in None field (forward compat)"
         );
     }
+
+    #[test]
+    fn union_with_known_and_unknown_fields_deserializes_to_known_variant() {
+        use std::io::Cursor;
+
+        use thrift::protocol::{
+            TBinaryInputProtocol, TBinaryOutputProtocol, TFieldIdentifier, TOutputProtocol,
+            TSerializable, TStructIdentifier, TType,
+        };
+
+        // Regression test for total_field_count: a newer server may send a union
+        // with a recognised variant (id=2, MeasuringCup) plus an extra unknown
+        // field (id=99).  The deserializer must return the known variant rather
+        // than failing with "received multiple fields for union".
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut prot = TBinaryOutputProtocol::new(Cursor::new(&mut buf), false);
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "MeasuringAids".to_owned(),
+            })
+            .unwrap();
+            // Known variant: MeasuringCup (field id=2)
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::Struct,
+                id: Some(2),
+            })
+            .unwrap();
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "MeasuringCup".to_owned(),
+            })
+            .unwrap();
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::Double,
+                id: Some(1),
+            })
+            .unwrap();
+            prot.write_double(250.0).unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+            prot.write_field_end().unwrap();
+            // Unknown field from a newer schema (field id=99)
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::I32,
+                id: Some(99),
+            })
+            .unwrap();
+            prot.write_i32(0).unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+        }
+
+        let aids = base_one::MeasuringAids::read_from_in_protocol(&mut TBinaryInputProtocol::new(
+            Cursor::new(buf),
+            false,
+        ))
+        .expect("union with a known variant plus an unknown field must deserialize successfully");
+
+        assert!(
+            matches!(aids, base_one::MeasuringAids::Cup(_)),
+            "known variant (Cup) must be returned when an unknown field is also present"
+        );
+    }
+
+    #[test]
+    fn nested_union_unknown_variant_does_not_corrupt_stream() {
+        use std::io::Cursor;
+
+        use thrift::protocol::{
+            TBinaryInputProtocol, TBinaryOutputProtocol, TFieldIdentifier, TOutputProtocol,
+            TSerializable, TStructIdentifier, TType,
+        };
+
+        // Regression test for stream corruption: when suppress_unknown catches
+        // an UnknownUnionVariant error from a union field whose variant value is
+        // itself a union, the outer union's Stop byte must have been consumed
+        // before the error propagates.  If it hasn't, the enclosing struct loop
+        // reads that orphaned 0x00 as its own Stop and silently drops every
+        // subsequent field.
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut prot = TBinaryOutputProtocol::new(Cursor::new(&mut buf), false);
+            // InstrumentBox
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "InstrumentBox".to_owned(),
+            })
+            .unwrap();
+            // field 1: InstrumentUnion
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::Struct,
+                id: Some(1),
+            })
+            .unwrap();
+            // InstrumentUnion: known variant 1 whose value (MeasuringAids) carries
+            // only an unknown sub-variant, so MeasuringAids::read returns
+            // UnknownUnionVariant, which propagates via ? before InstrumentUnion
+            // has consumed its own Stop byte.
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "InstrumentUnion".to_owned(),
+            })
+            .unwrap();
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::Struct,
+                id: Some(1),
+            })
+            .unwrap();
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "MeasuringAids".to_owned(),
+            })
+            .unwrap();
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::I32,
+                id: Some(99),
+            })
+            .unwrap();
+            prot.write_i32(0).unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap(); // InstrumentUnion's Stop
+            prot.write_struct_end().unwrap();
+            prot.write_field_end().unwrap();
+            // field 2: tag=42 — must survive even if field 1 triggers suppress_unknown
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::I32,
+                id: Some(2),
+            })
+            .unwrap();
+            prot.write_i32(42).unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+        }
+
+        let ibox = base_one::InstrumentBox::read_from_in_protocol(&mut TBinaryInputProtocol::new(
+            Cursor::new(buf),
+            false,
+        ))
+        .expect("struct with a nested unknown union variant must deserialize without error");
+
+        assert!(
+            ibox.instrument.is_none(),
+            "outer union with nested unknown variant must become None"
+        );
+        assert_eq!(
+            ibox.tag,
+            Some(42),
+            "field following a suppressed union must not be silently dropped due to stream corruption"
+        );
+    }
 }

--- a/lib/rs/test/src/lib.rs
+++ b/lib/rs/test/src/lib.rs
@@ -50,4 +50,60 @@ mod tests {
             ..Default::default()
         };
     }
+
+    #[test]
+    fn unknown_union_variant_in_struct_field_is_treated_as_none() {
+        use std::io::Cursor;
+
+        use thrift::protocol::{
+            TBinaryInputProtocol, TBinaryOutputProtocol, TFieldIdentifier, TOutputProtocol,
+            TSerializable, TStructIdentifier, TType,
+        };
+
+        // Serialize AidKit with an unknown union variant (id=99), verify it deserializes as None.
+
+        let mut write_buf: Vec<u8> = Vec::new();
+        {
+            let cursor = Cursor::new(&mut write_buf);
+            let mut prot = TBinaryOutputProtocol::new(cursor, false);
+
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "AidKit".to_owned(),
+            })
+            .unwrap();
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::Struct,
+                id: Some(1),
+            })
+            .unwrap();
+            prot.write_struct_begin(&TStructIdentifier {
+                name: "MeasuringAids".to_owned(),
+            })
+            .unwrap();
+            prot.write_field_begin(&TFieldIdentifier {
+                name: None,
+                field_type: TType::I32,
+                id: Some(99),
+            })
+            .unwrap();
+            prot.write_i32(42).unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+            prot.write_field_end().unwrap();
+            prot.write_field_stop().unwrap();
+            prot.write_struct_end().unwrap();
+        }
+
+        let read_cursor = Cursor::new(write_buf);
+        let mut rprot = TBinaryInputProtocol::new(read_cursor, false);
+        let kit = base_one::AidKit::read_from_in_protocol(&mut rprot)
+            .expect("forward-compat deserialization should succeed");
+
+        assert!(
+            kit.aid.is_none(),
+            "unknown union variant should result in None field (forward compat)"
+        );
+    }
 }

--- a/lib/rs/test/thrifts/Base_One.thrift
+++ b/lib/rs/test/thrifts/Base_One.thrift
@@ -64,6 +64,10 @@ union MeasuringAids {
   2: MeasuringCup cup
 }
 
+struct AidKit {
+  1: optional MeasuringAids aid
+}
+
 struct CookingTemperatures {
   1: set<double> commonTemperatures
   2: list<double> usedTemperatures

--- a/lib/rs/test/thrifts/Base_One.thrift
+++ b/lib/rs/test/thrifts/Base_One.thrift
@@ -68,6 +68,15 @@ struct AidKit {
   1: optional MeasuringAids aid
 }
 
+union InstrumentUnion {
+  1: MeasuringAids measuring_aids
+}
+
+struct InstrumentBox {
+  1: optional InstrumentUnion instrument
+  2: optional i32 tag
+}
+
 struct CookingTemperatures {
   1: set<double> commonTemperatures
   2: list<double> usedTemperatures


### PR DESCRIPTION
## Problem

When a struct contains a union-typed field and the wire data has a union variant (field ID) not present in the local IDL, the generated Rust code fails to deserialize the **entire struct** — not just the unknown union field.

The root cause: the union's `read_from_in_protocol` correctly returns `Err("received empty union")` for unknown variants (fixed in PR #3336). But the parent struct's generated deserializer propagates this error via `?`, causing the whole struct to fail.

This breaks Thrift's forward-compatibility guarantee. When a server adds a new union variant, all clients running an older IDL version fail to parse any message containing that variant — even though the client doesn't need to understand the new variant to process the rest of the struct.

Java, Go, Python, and C++ Thrift all handle this gracefully: unknown union variants are silently skipped, and the struct field is left unset.

## Fix

In `render_struct_sync_read`, detect struct fields whose type is a union. For those fields, wrap the `read_from_in_protocol` call in a `match` that catches the `"received empty union"` error and treats it as `None` (field absent):

```rust
// Before (all fields):
let val = FooUnion::read_from_in_protocol(i_prot)?;
f_N = Some(val);

// After (union fields only):
match FooUnion::read_from_in_protocol(i_prot) {
    Ok(val) => { f_N = Some(val); },
    Err(thrift::Error::Protocol(ref e))
        if e.message.contains("received empty union") => {
        // forward compatibility: unknown union variant skipped
    },
    Err(e) => return Err(e),
}
```

Non-union fields are unchanged. The union's own `TSerializable` impl is unchanged — it still returns `Err` for unknown variants, preserving the contract for callers that read unions directly.

## Impact

- Fixes forward compatibility for all Rust Thrift users with evolving union schemas
- No changes to the `TSerializable` trait or the thrift runtime library
- No changes to the union`s own serialization/deserialization
- Struct fields with union types that receive unknown variants get `None` instead of causing parse failure
- All other errors (malformed data, I/O, multiple union fields) still propagate normally