### PR TITLE
Connect skip() to TConfiguration recursion limit

### DIFF
--- a/lib/java/README.md
+++ b/lib/java/README.md
@@ -82,10 +82,10 @@ The default build will run the unit tests which expect a usable
 Thrift compiler to exist on the system. You have two choices for
 that.
 
-* Build the Thrift executable from source at the default
+- Build the Thrift executable from source at the default
   location in the source tree. The project is configured
   to look for it there.
-* Install the published binary distribution to have Thrift
+- Install the published binary distribution to have Thrift
   executable in a known location and add the path to the
   ~/.gradle/gradle.properties file using the property name
   "thrift.compiler". For example this would set the path in
@@ -217,12 +217,18 @@ http://gradle.org/
 
 # Breaking Changes
 
+## 0.24.0
+
+- `TProtocolUtil.setMaxSkipDepth(int depth)` has been deprecated and 
+made a no-op. Use TConfiguration.setRecursionLimit() instead.
+
+
 ## 0.13.0
 
-* The signature of the 'process' method in TAsyncProcessor and TProcessor has
-changed to remove the boolean return type and instead rely on Exceptions.
+- The signature of the 'process' method in TAsyncProcessor and TProcessor 
+has changed to remove the boolean return type and instead rely on Exceptions.
 
-* Per THRIFT-4805, TSaslTransportException has been removed. The same condition
+- Per THRIFT-4805, TSaslTransportException has been removed. The same condition 
 is now covered by TTansportException, where `TTransportException.getType() == END_OF_FILE`.
 
 ## 0.12.0

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TProtocol.java
@@ -441,12 +441,12 @@ public abstract class TProtocol implements TWriteProtocol, TReadProtocol {
   }
 
   public void skip(byte fieldType) throws TException {
-    this.skip(fieldType, Integer.MAX_VALUE);
+    this.skip(fieldType, this.getTransport().getConfiguration().getRecursionLimit());
   }
 
   public void skip(byte fieldType, int maxDepth) throws TException {
     if (maxDepth <= 0) {
-      throw new TException("Maximum skip depth exceeded");
+      throw new TProtocolException(TProtocolException.DEPTH_LIMIT, "Maximum skip depth exceeded");
     }
 
     switch (fieldType) {

--- a/lib/java/src/main/java/org/apache/thrift/protocol/TProtocolUtil.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TProtocolUtil.java
@@ -28,23 +28,12 @@ public class TProtocolUtil {
   private TProtocolUtil() {}
 
   /**
-   * The maximum recursive depth the skip() function will traverse before throwing a TException.
-   * Matches the DEFAULT_RECURSION_DEPTH used by C++, Go, and Node.js (64). Override with
-   * setMaxSkipDepth() when your application requires deeper nesting.
+   * @deprecated Use {@link org.apache.thrift.TConfiguration#setRecursionLimit(int)} instead. The
+   *     skip recursion depth is now controlled per-transport via {@code TConfiguration}.
    */
-  private static int maxSkipDepth = 64;
-
-  /**
-   * Specifies the maximum recursive depth that the skip function will traverse before throwing a
-   * TException. This is a global setting, so any call to skip in this JVM will enforce this value.
-   *
-   * @param depth the maximum recursive depth. A value of 2 would allow the skip function to skip a
-   *     structure or collection with basic children, but it would not permit skipping a struct that
-   *     had a field containing a child struct. A value of 1 would only allow skipping of simple
-   *     types and empty structs/collections.
-   */
+  @Deprecated
   public static void setMaxSkipDepth(int depth) {
-    maxSkipDepth = depth;
+    // no-op: use TConfiguration.setRecursionLimit() instead
   }
 
   /**
@@ -54,7 +43,7 @@ public class TProtocolUtil {
    * @param type the next value will be interpreted as this TType value.
    */
   public static void skip(TProtocol prot, byte type) throws TException {
-    skip(prot, type, maxSkipDepth);
+    skip(prot, type, prot.getTransport().getConfiguration().getRecursionLimit());
   }
 
   /**
@@ -67,7 +56,7 @@ public class TProtocolUtil {
    */
   public static void skip(TProtocol prot, byte type, int maxDepth) throws TException {
     if (maxDepth <= 0) {
-      throw new TException("Maximum skip depth exceeded");
+      throw new TProtocolException(TProtocolException.DEPTH_LIMIT, "Maximum skip depth exceeded");
     }
     switch (type) {
       case TType.BOOL:

--- a/lib/java/src/test/java/org/apache/thrift/test/fuzz/TestRecursionLimit.java
+++ b/lib/java/src/test/java/org/apache/thrift/test/fuzz/TestRecursionLimit.java
@@ -31,6 +31,8 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TJSONProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.protocol.TProtocolUtil;
+import org.apache.thrift.protocol.TType;
 import org.apache.thrift.transport.TIOStreamTransport;
 import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TTransport;
@@ -140,6 +142,74 @@ public class TestRecursionLimit {
     assertTrue(
         exception.getType() == TProtocolException.DEPTH_LIMIT,
         "Expected DEPTH_LIMIT exception type, got: " + exception.getType());
+  }
+
+  /** Tests that TProtocol.skip() throws DEPTH_LIMIT when nesting exceeds recursionLimit. */
+  @Test
+  public void testTProtocolSkipExceedsRecursionLimit() throws Exception {
+    final int limit = 5;
+    RecursiveStruct deepStruct = createNestedStruct(limit + 1);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    TConfiguration config = TConfiguration.custom().setRecursionLimit(limit).build();
+    TTransport transport = new TIOStreamTransport(config, baos);
+    TProtocol protocol = new TBinaryProtocol(transport);
+    deepStruct.write(protocol);
+    byte[] serialized = baos.toByteArray();
+
+    TTransport inputTransport = new TMemoryInputTransport(config, serialized);
+    TProtocol inputProtocol = new TBinaryProtocol(inputTransport);
+
+    TProtocolException exception =
+        assertThrows(TProtocolException.class, () -> inputProtocol.skip(TType.STRUCT));
+    assertTrue(
+        exception.getType() == TProtocolException.DEPTH_LIMIT,
+        "Expected DEPTH_LIMIT, got: " + exception.getType());
+  }
+
+  /** Tests that TProtocolUtil.skip() throws DEPTH_LIMIT when nesting exceeds recursionLimit. */
+  @Test
+  public void testTProtocolUtilSkipExceedsRecursionLimit() throws Exception {
+    final int limit = 5;
+    RecursiveStruct deepStruct = createNestedStruct(limit + 1);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    TConfiguration config = TConfiguration.custom().setRecursionLimit(limit).build();
+    TTransport transport = new TIOStreamTransport(config, baos);
+    TProtocol protocol = new TBinaryProtocol(transport);
+    deepStruct.write(protocol);
+    byte[] serialized = baos.toByteArray();
+
+    TTransport inputTransport = new TMemoryInputTransport(config, serialized);
+    TProtocol inputProtocol = new TBinaryProtocol(inputTransport);
+
+    TProtocolException exception =
+        assertThrows(TProtocolException.class, () -> TProtocolUtil.skip(inputProtocol, TType.STRUCT));
+    assertTrue(
+        exception.getType() == TProtocolException.DEPTH_LIMIT,
+        "Expected DEPTH_LIMIT, got: " + exception.getType());
+  }
+
+  /** Tests that skip() succeeds when nesting is within recursionLimit. */
+  @Test
+  public void testSkipWithinRecursionLimit() throws Exception {
+    final int limit = 5;
+    RecursiveStruct struct = createNestedStruct(limit - 1);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    TConfiguration config = TConfiguration.custom().setRecursionLimit(limit).build();
+    TTransport transport = new TIOStreamTransport(config, baos);
+    TProtocol protocol = new TBinaryProtocol(transport);
+    struct.write(protocol);
+    byte[] serialized = baos.toByteArray();
+
+    TTransport inputTransport1 = new TMemoryInputTransport(config, serialized);
+    TProtocol inputProtocol1 = new TBinaryProtocol(inputTransport1);
+    assertDoesNotThrow(() -> inputProtocol1.skip(TType.STRUCT));
+
+    TTransport inputTransport2 = new TMemoryInputTransport(config, serialized);
+    TProtocol inputProtocol2 = new TBinaryProtocol(inputTransport2);
+    assertDoesNotThrow(() -> TProtocolUtil.skip(inputProtocol2, TType.STRUCT));
   }
 
   /** Tests that structures within the recursion limit deserialize successfully. */


### PR DESCRIPTION
Client: java

Make sure to connect all `skip()` implementations propertly and consistently to `TConfiguration`. Also, this drops `maxSkipDepth` and deprecates `TProtocolUtil.setMaxSkipDepth()` in favour of TConfiguration.