### PR TITLE
THRIFT-1916: Avoid Ruby generated FIELDS constant collisions

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -206,6 +206,7 @@ public:
   std::string argument_list(t_struct* tstruct);
   std::string type_to_enum(t_type* ttype);
   std::string rb_namespace_to_path_prefix(std::string rb_namespace);
+  std::string field_id_constant_name(const std::string& field_name);
 
   std::vector<std::string> ruby_modules(const t_program* p) {
     std::string ns = p->get_namespace("rb");
@@ -701,9 +702,8 @@ void t_rb_generator::generate_field_constants(t_rb_ofstream& out, t_struct* tstr
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     std::string field_name = (*f_iter)->get_name();
-    std::string cap_field_name = upcase_string(field_name);
 
-    out.indent() << cap_field_name << " = " << (*f_iter)->get_key() << '\n';
+    out.indent() << field_id_constant_name(field_name) << " = " << (*f_iter)->get_key() << '\n';
   }
   out << '\n';
 }
@@ -722,7 +722,7 @@ void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct)
     // generate the field docstrings within the FIELDS constant. no real better place...
     generate_rdoc(out, *f_iter);
 
-    out.indent() << upcase_string((*f_iter)->get_name()) << " => ";
+    out.indent() << field_id_constant_name((*f_iter)->get_name()) << " => ";
 
     generate_field_data(out,
                         (*f_iter)->get_type(),
@@ -735,6 +735,10 @@ void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct)
   out.indent() << "}" << '\n' << '\n';
 
   out.indent() << "def struct_fields; FIELDS; end" << '\n' << '\n';
+}
+
+std::string t_rb_generator::field_id_constant_name(const std::string& field_name) {
+  return upcase_string(field_name) + "_FIELD_ID";
 }
 
 void t_rb_generator::generate_field_data(t_rb_ofstream& out,

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -63,3 +63,38 @@ TEST_CASE("t_rb_generator emits bare marker for CRLF blank RDoc lines", "[functi
 
     std::remove(thrift_path.c_str());
 }
+
+TEST_CASE("t_rb_generator uses suffixed field id constants to avoid FIELDS collisions", "[functional]")
+{
+    const string thrift_path = "test_field_id_conflict.thrift";
+    const string thrift_source =
+        "struct Example {\n"
+        "  1: string fields\n"
+        "}\n";
+
+    {
+        std::ofstream thrift_file(thrift_path, std::ios::binary);
+        REQUIRE(thrift_file.is_open());
+        thrift_file << thrift_source;
+    }
+
+    map<string, string> parsed_options;
+    std::unique_ptr<t_program> program(new t_program(thrift_path, "test_field_id_conflict"));
+    parse_thrift_for_test(program.get());
+
+    std::unique_ptr<t_generator> gen(
+        t_generator_registry::get_generator(program.get(), "rb", parsed_options, ""));
+    REQUIRE(gen != nullptr);
+    REQUIRE_NOTHROW(gen->generate_program());
+
+    const string generated_content = read_file("gen-rb/test_field_id_conflict_types.rb");
+    REQUIRE(!generated_content.empty());
+    REQUIRE(generated_content.find("FIELDS_FIELD_ID = 1") != string::npos);
+    REQUIRE(generated_content.find("FIELDS_FIELD_ID => {:type => ::Thrift::Types::STRING, :name => 'fields'}")
+            != string::npos);
+    REQUIRE(generated_content.find("FIELDS = 1") == string::npos);
+    REQUIRE(generated_content.find("FIELDS => {:type => ::Thrift::Types::STRING, :name => 'fields'}")
+            == string::npos);
+
+    std::remove(thrift_path.c_str());
+}

--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -135,6 +135,13 @@ to handle `TIMED_OUT`. If you relied on `timeout = 0` meaning immediate failure
 or on repeated retries extending the effective timeout during TCP fallback or
 TLS handshake, update those call paths before upgrading.
 
+Generated Ruby structs and unions now suffix field ID constants as
+`*_FIELD_ID` instead of exposing bare uppercased field names. For example,
+`MyStruct::FOO` becomes `MyStruct::FOO_FIELD_ID`. This avoids collisions with
+the generated `FIELDS` metadata hash for field names such as `fields`, but it
+is a source-compatible break if your application referenced the old constants
+directly. Regenerate Ruby code and update those constant references atomically.
+
 ### 0.23.0
 
 The documented source-build flow now effectively requires Ruby `2.7+`.


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Suffix generated Ruby field ID constants with `_FIELD_ID` so field names like `fields` no longer collide with the `FIELDS` metadata hash.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-1916](https://issues.apache.org/jira/browse/THRIFT-1916)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
