### PR TITLE
Ruby: suppress -Wdefault-const-init-field-unsafe for clang 21+

### DIFF
--- a/lib/rb/ext/extconf.rb
+++ b/lib/rb/ext/extconf.rb
@@ -25,6 +25,13 @@ else
 
   append_cflags(["-fsigned-char", "-g", "-O2", "-Wall", "-Werror", "-Werror=old-style-definition"])
 
+  # clang 21+ introduced -Wdefault-const-init-field-unsafe, which fires on
+  # Ruby 3.2's rstring.h (struct RString has a const field via RBasic).
+  # This is a Ruby header issue, not a Thrift bug, so suppress the warning here.
+  # append_cflags silently ignores flags unsupported by the compiler, so this
+  # is safe across all clang versions.
+  append_cflags("-Wno-default-const-init-field-unsafe")
+
   # Makes all symbols private by default to avoid unintended conflict
   # with other gems. To explicitly export symbols you can use RUBY_FUNC_EXPORTED
   # selectively, or entirely remove this flag.


### PR DESCRIPTION
## Problem

clang 21 introduced `-Wdefault-const-init-field-unsafe`, which fires on Ruby 3.2's `rstring.h:465`:

```c
struct RString retval;  // has const field (klass) via RBasic → triggers warning
```

Because `extconf.rb` unconditionally adds `-Werror`, this new warning causes the native extension build to fail with:

```
error: default initialization of an object of type 'struct RString' with const member
       leaves the object uninitialized [-Werror,-Wdefault-const-init-field-unsafe]
```

This affects macOS users on Xcode 26 / Nix with LLVM 21 when building against Ruby 3.2.

## Root cause

The warning is in Ruby's own headers (`rstring.h`), not in Thrift code. Ruby 3.2 did not anticipate this warning being added to clang.

## Fix

Add `append_cflags("-Wno-default-const-init-field-unsafe")` after the existing flags. Since `append_cflags` silently ignores flags that the compiler doesn't recognize, this is safe on all older clang versions.

## Testing

```sh
gem build thrift.gemspec
gem install thrift-*.gem
```