### PR TITLE
Fix Java Spotless formatting

### DIFF
--- a/lib/java/src/test/java/org/apache/thrift/test/fuzz/TestRecursionLimit.java
+++ b/lib/java/src/test/java/org/apache/thrift/test/fuzz/TestRecursionLimit.java
@@ -184,7 +184,8 @@ public class TestRecursionLimit {
     TProtocol inputProtocol = new TBinaryProtocol(inputTransport);
 
     TProtocolException exception =
-        assertThrows(TProtocolException.class, () -> TProtocolUtil.skip(inputProtocol, TType.STRUCT));
+        assertThrows(
+            TProtocolException.class, () -> TProtocolUtil.skip(inputProtocol, TType.STRUCT));
     assertTrue(
         exception.getType() == TProtocolException.DEPTH_LIMIT,
         "Expected DEPTH_LIMIT, got: " + exception.getType());


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Addresses a formatting issue caused by https://github.com/apache/thrift/pull/3415.

Before:

```
> The following files had format violations:
      src/test/java/org/apache/thrift/test/fuzz/TestRecursionLimit.java
          @@ -184,7 +184,8 @@
           ····TProtocol·inputProtocol·=·new·TBinaryProtocol(inputTransport);
           
           ····TProtocolException·exception·=
          -········assertThrows(TProtocolException.class,·()·->·TProtocolUtil.skip(inputProtocol,·TType.STRUCT));
          +········assertThrows(
          +············TProtocolException.class,·()·->·TProtocolUtil.skip(inputProtocol,·TType.STRUCT));
           ····assertTrue(
           ········exception.getType()·==·TProtocolException.DEPTH_LIMIT,
           ········"Expected·DEPTH_LIMIT,·got:·"·+·exception.getType());
  Run './gradlew spotlessApply' to fix all violations.
```

After:

```
> Task :spotlessJava
> Task :spotlessJavaCheck
> Task :spotlessCheck

BUILD SUCCESSFUL in 15s
```  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
