### PR TITLE
Adjust minimum Ruby version in the gemspec to match documentation, CI, and Changelog

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
   s.extensions  = ['ext/extconf.rb']
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.rdoc_options = %w[--line-numbers --inline-source --title Thrift --main README]
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

We have documented the minimum Ruby version as 2.7 everywhere, CI does not test below it. Thrift 0.23.0 will be the last release that can be installed on older Ruby versions, starting with 0.24.0 user will be forced to upgrade Ruby to at least 2.7

Not marking this change as breaking since we already announced that [Ruby 2.7 is effectively required](https://github.com/apache/thrift/blob/master/lib/rb/README.md#0230).

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
