### PR TITLE
Rb gemspec

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib ext]
 
-  s.add_dependency 'logger'
+  s.add_dependency 'logger',                         '~> 1.7'
 
   s.add_development_dependency 'bundler',            '~> 2.2.34'
   s.add_development_dependency 'pry',                '~> 0.11.3'
   s.add_development_dependency 'pry-byebug',         '~> 3.6'
   s.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
-  s.add_development_dependency 'rack',               '>= 2.2.23'
+  s.add_development_dependency 'rack',               '~> 2.2'
   s.add_development_dependency 'rack-test',          '~> 0.8.3'
   s.add_development_dependency 'rake',               '~> 13.3'
   s.add_development_dependency 'rspec',              '~> 3.7'


### PR DESCRIPTION
```
WARNING:  open-ended dependency on logger (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
WARNING:  open-ended dependency on rack (>= 2.2.23, development) is not recommended
  if rack is semantically versioned, use:
    add_development_dependency "rack", "~> 2.2", ">= 2.2.23"
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```
