### PR TITLE
[GO] Fix range check on 32-bit architectures

### DIFF
--- a/lib/go/thrift/framed_transport.go
+++ b/lib/go/thrift/framed_transport.go
@@ -203,8 +203,8 @@ func (p *TFramedTransport) WriteString(s string) (n int, err error) {
 
 func (p *TFramedTransport) Flush(ctx context.Context) error {
 	size := p.writeBuf.Len()
-	if size > math.MaxUint32 {
-		return NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, fmt.Sprintf("frame too large: %d bytes exceeds uint32 max",size))
+	if uint64(size) > uint64(math.MaxUint32) {
+		return NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, fmt.Sprintf("frame too large: %d bytes exceeds uint32 max", size))
 	}
 
 	defer bufPool.put(&p.writeBuf)


### PR DESCRIPTION
PR #3381 introduced range checks for integer values, however, one of the checks fails with 

```
# github.com/apache/thrift/lib/go/thrift
/go/pkg/mod/github.com/apache/thrift@v0.23.0/lib/go/thrift/framed_transport.go:206:12: math.MaxUint32 (untyped int constant 4294967295) overflows int
```

on 32-bit architectures. This is because `math.MaxUint32` is of `untyped int` which is a **signed 32-bit** integer on those architectures and thus cannot hold the maximum 32-bit **unsigned** value.

This PR fixes the issue by comparing the values as `uint64` values avoiding potential overflows.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.