### PR TITLE
THRIFT-5785: fix boost include

### DIFF
--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
@@ -23,6 +23,8 @@
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/protocol/TCompactProtocol.h>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <limits>
 #include <utility>
 #include <string>
@@ -39,6 +41,20 @@ namespace thrift {
 using std::shared_ptr;
 
 namespace transport {
+
+/**
+ * Legacy code in transport implementations have overflow issues
+ * that need to be enforced.
+ */
+template <typename To, typename From> To safe_numeric_cast(From i) {
+  try {
+    return boost::numeric_cast<To>(i);
+  }
+  catch (const std::bad_cast& bc) {
+    throw TTransportException(TTransportException::CORRUPTED_DATA,
+                              bc.what());
+  }
+}
 
 using namespace apache::thrift::protocol;
 using apache::thrift::protocol::TBinaryProtocol;
@@ -607,6 +623,11 @@ uint32_t THeaderTransport::writeVarint32(int32_t n, uint8_t* pkt) {
 uint32_t THeaderTransport::writeVarint16(int16_t n, uint8_t* pkt) {
   return writeVarint32(n, pkt);
 }
+
+uint16_t THeaderTransport::getNumTransforms() const {
+  return safe_numeric_cast<uint16_t>(writeTrans_.size());
+}
+
 }
 }
 } // apache::thrift::transport

--- a/lib/cpp/src/thrift/transport/THeaderTransport.h
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.h
@@ -72,7 +72,7 @@ public:
   static const int THRIFT_MAX_VARINT32_BYTES = 5;
 
   /// Use default buffer sizes.
-  explicit THeaderTransport(const std::shared_ptr<TTransport>& transport, 
+  explicit THeaderTransport(const std::shared_ptr<TTransport>& transport,
                             std::shared_ptr<TConfiguration> config = nullptr)
     : TVirtualTransport(transport, config),
       outTransport_(transport),
@@ -140,9 +140,7 @@ public:
    */
   void transform(uint8_t* ptr, uint32_t sz);
 
-  uint16_t getNumTransforms() const {
-    return safe_numeric_cast<uint16_t>(writeTrans_.size());
-  }
+  uint16_t getNumTransforms() const;
 
   void setTransform(uint16_t transId) { writeTrans_.push_back(transId); }
 

--- a/lib/cpp/src/thrift/transport/TTransportException.h
+++ b/lib/cpp/src/thrift/transport/TTransportException.h
@@ -20,7 +20,6 @@
 #ifndef _THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_
 #define _THRIFT_TRANSPORT_TTRANSPORTEXCEPTION_H_ 1
 
-#include <boost/numeric/conversion/cast.hpp>
 #include <string>
 #include <thrift/Thrift.h>
 
@@ -85,20 +84,6 @@ protected:
   /** Error code */
   TTransportExceptionType type_;
 };
-
-/**
- * Legacy code in transport implementations have overflow issues
- * that need to be enforced.
- */
-template <typename To, typename From> To safe_numeric_cast(From i) {
-  try {
-    return boost::numeric_cast<To>(i);
-  }
-  catch (const std::bad_cast& bc) {
-    throw TTransportException(TTransportException::CORRUPTED_DATA,
-                              bc.what());
-  }
-}
 
 }
 }

--- a/test/cpp/src/TestServer.cpp
+++ b/test/cpp/src/TestServer.cpp
@@ -136,7 +136,7 @@ public:
   void testBinary(std::string& _return, const std::string& thing) override {
     std::ostringstream hexstr;
     hexstr << std::hex << thing;
-    printf("testBinary(%lu: %s)\n", safe_numeric_cast<unsigned long>(thing.size()), hexstr.str().c_str());
+    printf("testBinary(%lu: %s)\n", static_cast<unsigned long>(thing.size()), hexstr.str().c_str());
     _return = thing;
   }
 


### PR DESCRIPTION
Remove another boost header include from the public API
- It is only used in THeaderTransport.cpp so move it there without complicating it
- It throws a TTransportException so it should not be used in other code
- People that depends on this can use `boost::numeric_cast` or `std::in_range` (C++20) instead
- The usage in the unit test was not needed since `std::string::size()` returns an `unsigned long` on 64-bit compilers
 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  [THRIFT-5785](https://issues.apache.org/jira/browse/THRIFT-5785)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

The following tickets are releated
- [THRIFT-5660](https://issues.apache.org/jira/browse/THRIFT-5660)
- [THRIFT-5785](https://issues.apache.org/jira/browse/THRIFT-5785)

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
