### PR TITLE
THRIFT-5961: Migrate PHPUnit tests to attributes and upgrade to PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0",
         "squizlabs/php_codesniffer": "^3.10",
         "php-mock/php-mock-phpunit": "^2.10",
         "phpstan/phpstan": "^1.12",

--- a/lib/php/lib/Server/TForkingServer.php
+++ b/lib/php/lib/Server/TForkingServer.php
@@ -101,6 +101,7 @@ class TForkingServer extends TServer
      */
     private function collectChildren()
     {
+        $status = null;
         foreach ($this->children_ as $pid => $transport) {
             if (pcntl_waitpid($pid, $status, WNOHANG) > 0) {
                 unset($this->children_[$pid]);

--- a/lib/php/phpunit.xml
+++ b/lib/php/phpunit.xml
@@ -21,18 +21,15 @@
          bootstrap="test/bootstrap.php"
          cacheResult="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          stopOnWarning="true"
          stopOnFailure="true"
          processIsolation="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <source>
+        <include>
             <directory suffix=".php">./lib</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
     <testsuites>
         <testsuite name="Thrift PHP Unit Test Suite">
             <directory>./test/Unit</directory>

--- a/lib/php/test/Integration/AbstractValidatorTestCase.php
+++ b/lib/php/test/Integration/AbstractValidatorTestCase.php
@@ -26,7 +26,7 @@ use Thrift\Exception\TProtocolException;
 use Thrift\Protocol\TBinaryProtocol;
 use Thrift\Transport\TMemoryBuffer;
 
-abstract class BaseValidatorTest extends TestCase
+abstract class AbstractValidatorTestCase extends TestCase
 {
     abstract public function getNsGlobal();
 

--- a/lib/php/test/Integration/Lib/ClassLoader/ThriftClassLoaderTest.php
+++ b/lib/php/test/Integration/Lib/ClassLoader/ThriftClassLoaderTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Integration\Lib\ClassLoader;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\ClassLoader\ThriftClassLoader;
 
 /***
@@ -33,9 +34,7 @@ class ThriftClassLoaderTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @dataProvider registerDefinitionDataProvider
-     */
+    #[DataProvider('registerDefinitionDataProvider')]
     public function testRegisterDefinition(
         $definitions,
         $class,
@@ -67,7 +66,7 @@ class ThriftClassLoaderTest extends TestCase
         }
     }
 
-    public function registerDefinitionDataProvider()
+    public static function registerDefinitionDataProvider()
     {
         yield 'loadType' => [
             'definitions' => [

--- a/lib/php/test/Integration/Lib/Protocol/TJSONProtocolTest.php
+++ b/lib/php/test/Integration/Lib/Protocol/TJSONProtocolTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Integration\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
 use Basic\ThriftTest\Insanity;
@@ -64,9 +65,7 @@ class TJSONProtocolTest extends TestCase
         $this->assertSame('successResponse', $result);
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $argsClassName,
         $argsValues,
@@ -80,7 +79,7 @@ class TJSONProtocolTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         if (!is_dir(__DIR__ . '/../../../Resources/packages/php')) {
             throw new \RuntimeException(
@@ -316,9 +315,7 @@ class TJSONProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $buffer,
         $argsClassName,
@@ -343,7 +340,7 @@ class TJSONProtocolTest extends TestCase
         }
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'void' => [
             'buffer' => '{}',

--- a/lib/php/test/Integration/Lib/Protocol/TSimpleJSONProtocolTest.php
+++ b/lib/php/test/Integration/Lib/Protocol/TSimpleJSONProtocolTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Integration\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TJSONProtocol;
 use Thrift\Protocol\TSimpleJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
@@ -64,9 +65,7 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->assertSame('["testString",1,0,{"thing":"test"}]', $this->protocol->getTransport()->getBuffer());
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $argsClassName,
         $argsValues,
@@ -80,7 +79,7 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         if (!is_dir(__DIR__ . '/../../../Resources/packages/php')) {
             throw new \RuntimeException(

--- a/lib/php/test/Integration/ValidatorOopTest.php
+++ b/lib/php/test/Integration/ValidatorOopTest.php
@@ -25,7 +25,7 @@ namespace Test\Thrift\Integration;
  * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
  * lib/php/test$ ../../../compiler/cpp/thrift --gen php:validate,oop,nsglobal="ValidateOop" -r --out ./Resources/packages/phpvo ./Resources/ThriftTest.thrift
  */
-class ValidatorOopTest extends BaseValidatorTest
+class ValidatorOopTest extends AbstractValidatorTestCase
 {
     public function getNsGlobal()
     {

--- a/lib/php/test/Integration/ValidatorTest.php
+++ b/lib/php/test/Integration/ValidatorTest.php
@@ -25,7 +25,7 @@ namespace Test\Thrift\Integration;
  * This test suite depends on running the compiler against the ./Resources/ThriftTest.thrift file:
  * lib/php/test$ ../../../compiler/cpp/thrift --gen php:validate,nsglobal="Validate" -r  --out ./Resources/packages/phpv ./Resources/ThriftTest.thrift
  */
-class ValidatorTest extends BaseValidatorTest
+class ValidatorTest extends AbstractValidatorTestCase
 {
     public function getNsGlobal()
     {

--- a/lib/php/test/Unit/Lib/ClassLoader/ThriftClassLoaderTest.php
+++ b/lib/php/test/Unit/Lib/ClassLoader/ThriftClassLoaderTest.php
@@ -23,15 +23,14 @@ namespace Test\Thrift\Unit\Lib\ClassLoader;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\ClassLoader\ThriftClassLoader;
 
 class ThriftClassLoaderTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @dataProvider registerNamespaceDataProvider
-     */
+    #[DataProvider('registerNamespaceDataProvider')]
     public function testRegisterNamespace(
         $namespaces,
         $class,
@@ -62,7 +61,7 @@ class ThriftClassLoaderTest extends TestCase
         }
     }
 
-    public function registerNamespaceDataProvider()
+    public static function registerNamespaceDataProvider()
     {
         yield 'default' => [
             'namespaces' => [

--- a/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
+++ b/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Unit\Lib\Exception;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\Fixture\TestRichException;
 use Thrift\Exception\TException;
 use Thrift\Protocol\TBinaryProtocol;
@@ -81,9 +82,7 @@ class TExceptionTest extends TestCase
         $this->assertEquals('set', $exception->field1);
     }
 
-    /**
-     * @dataProvider writeAndReadFieldDataProvider
-     */
+    #[DataProvider('writeAndReadFieldDataProvider')]
     public function testWriteAndReadField($field, $value)
     {
         $exception = new TestRichException();
@@ -94,7 +93,7 @@ class TExceptionTest extends TestCase
         $this->assertEquals($value, $result->$field);
     }
 
-    public function writeAndReadFieldDataProvider()
+    public static function writeAndReadFieldDataProvider()
     {
         // scalars
         yield 'string' => ['field' => 'stringField', 'value' => 'hello world'];

--- a/lib/php/test/Unit/Lib/Factory/TBinaryProtocolFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TBinaryProtocolFactoryTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Unit\Lib\Factory;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Factory\TBinaryProtocolFactory;
 use Thrift\Protocol\TBinaryProtocol;
@@ -32,16 +33,16 @@ class TBinaryProtocolFactoryTest extends TestCase
     use ReflectionHelper;
 
     /**
-     * @dataProvider getProtocolDataProvider
      * @param bool $strictRead
      * @param bool $strictWrite
      * @return void
      */
+    #[DataProvider('getProtocolDataProvider')]
     public function testGetProtocol(
         $strictRead,
         $strictWrite
     ) {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TBinaryProtocolFactory($strictRead, $strictWrite);
         $protocol = $factory->getProtocol($transport);
 
@@ -52,7 +53,7 @@ class TBinaryProtocolFactoryTest extends TestCase
         $this->assertSame($transport, $this->getPropertyValue($protocol, 'trans_'));
     }
 
-    public function getProtocolDataProvider()
+    public static function getProtocolDataProvider()
     {
         yield 'allTrue' => [
             'strictRead' => true,
@@ -77,7 +78,7 @@ class TBinaryProtocolFactoryTest extends TestCase
      */
     public function testGetTransport()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TBinaryProtocolFactory();
         $protocol = $factory->getProtocol($transport);
 
@@ -89,7 +90,7 @@ class TBinaryProtocolFactoryTest extends TestCase
      */
     public function testGetProtocolCreatesNewInstancePerCall()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TBinaryProtocolFactory();
 
         $protocol1 = $factory->getProtocol($transport);

--- a/lib/php/test/Unit/Lib/Factory/TCompactProtocolFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TCompactProtocolFactoryTest.php
@@ -36,7 +36,7 @@ class TCompactProtocolFactoryTest extends TestCase
      */
     public function testGetProtocol()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TCompactProtocolFactory();
         $protocol = $factory->getProtocol($transport);
 
@@ -50,7 +50,7 @@ class TCompactProtocolFactoryTest extends TestCase
      */
     public function testGetTransport()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TCompactProtocolFactory();
         $protocol = $factory->getProtocol($transport);
 
@@ -62,7 +62,7 @@ class TCompactProtocolFactoryTest extends TestCase
      */
     public function testGetProtocolCreatesNewInstancePerCall()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TCompactProtocolFactory();
 
         $protocol1 = $factory->getProtocol($transport);

--- a/lib/php/test/Unit/Lib/Factory/TFramedTransportFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TFramedTransportFactoryTest.php
@@ -36,7 +36,7 @@ class TFramedTransportFactoryTest extends TestCase
      */
     public function testGetTransport()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TFramedTransportFactory();
         $framedTransport = $factory->getTransport($transport);
 
@@ -52,7 +52,7 @@ class TFramedTransportFactoryTest extends TestCase
      */
     public function testGetTransportWrapsInnerTransport()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TFramedTransportFactory();
         $framedTransport = $factory->getTransport($transport);
 
@@ -65,7 +65,7 @@ class TFramedTransportFactoryTest extends TestCase
      */
     public function testGetTransportCreatesNewInstancePerCall()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TFramedTransportFactory();
 
         $result1 = $factory->getTransport($transport);

--- a/lib/php/test/Unit/Lib/Factory/TJSONProtocolFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TJSONProtocolFactoryTest.php
@@ -36,7 +36,7 @@ class TJSONProtocolFactoryTest extends TestCase
      */
     public function testGetProtocol()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TJSONProtocolFactory();
         $protocol = $factory->getProtocol($transport);
 

--- a/lib/php/test/Unit/Lib/Factory/TStringFuncFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TStringFuncFactoryTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Unit\Lib\Factory;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Factory\TStringFuncFactory;
 use Thrift\StringFunc\Core;
@@ -34,9 +35,7 @@ class TStringFuncFactoryTest extends TestCase
     use PHPMock;
     use ReflectionHelper;
 
-    /**
-     * @dataProvider createDataProvider
-     */
+    #[DataProvider('createDataProvider')]
     public function testCreate(
         $mbstringFuncOverload,
         $expectedClass
@@ -58,16 +57,16 @@ class TStringFuncFactoryTest extends TestCase
         $this->assertInstanceOf($expectedClass, $stringFunc);
     }
 
-    public function createDataProvider()
+    public static function createDataProvider()
     {
         yield 'mbstring' => [
-            'mbstring.func_overload' => 2,
-            'expected' => Mbstring::class
+            'mbstringFuncOverload' => 2,
+            'expectedClass' => Mbstring::class,
         ];
 
         yield 'string' => [
-            'mbstring.func_overload' => 0,
-            'expected' => Core::class
+            'mbstringFuncOverload' => 0,
+            'expectedClass' => Core::class,
         ];
     }
 }

--- a/lib/php/test/Unit/Lib/Factory/TTransportFactoryTest.php
+++ b/lib/php/test/Unit/Lib/Factory/TTransportFactoryTest.php
@@ -32,7 +32,7 @@ class TTransportFactoryTest extends TestCase
      */
     public function testGetTransport()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $factory = new TTransportFactory();
         $result = $factory->getTransport($transport);
 
@@ -46,8 +46,8 @@ class TTransportFactoryTest extends TestCase
     {
         $factory = new TTransportFactory();
 
-        $transport1 = $this->createMock(TTransport::class);
-        $transport2 = $this->createMock(TTransport::class);
+        $transport1 = $this->createStub(TTransport::class);
+        $transport2 = $this->createStub(TTransport::class);
 
         $this->assertSame($transport1, $factory->getTransport($transport1));
         $this->assertSame($transport2, $factory->getTransport($transport2));

--- a/lib/php/test/Unit/Lib/Protocol/BoundaryValuesTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/BoundaryValuesTest.php
@@ -23,6 +23,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TBinaryProtocol;
 use Thrift\Protocol\TCompactProtocol;
 use Thrift\Protocol\TJSONProtocol;
@@ -41,9 +42,7 @@ class BoundaryValuesTest extends TestCase
         'writeBool' => TType::BOOL,
     ];
 
-    /**
-     * @dataProvider boundaryProvider
-     */
+    #[DataProvider('boundaryProvider')]
     public function testBoundaryValues($protocolClass, $writeMethod, $readMethod, $value)
     {
         $this->assertRoundtrip($protocolClass, $writeMethod, $readMethod, $value);

--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolAcceleratedTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolAcceleratedTest.php
@@ -23,6 +23,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TBinaryProtocolAccelerated;
 use Thrift\Transport\TBufferedTransport;
 use Thrift\Transport\TMemoryBuffer;
@@ -30,9 +31,7 @@ use Thrift\Transport\TSocket;
 
 class TBinaryProtocolAcceleratedTest extends TestCase
 {
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[DataProvider('constructDataProvider')]
     public function testConstruct(
         $transport,
         $expectedTransport
@@ -41,7 +40,7 @@ class TBinaryProtocolAcceleratedTest extends TestCase
         $this->assertInstanceOf($expectedTransport, $protocol->getTransport());
     }
 
-    public function constructDataProvider()
+    public static function constructDataProvider()
     {
         yield 'not buffered transport' => [
             'transport' => new TMemoryBuffer(),
@@ -53,9 +52,7 @@ class TBinaryProtocolAcceleratedTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider strictParamsDataProvider
-     */
+    #[DataProvider('strictParamsDataProvider')]
     public function testStrictParams($strictRead, $strictWrite)
     {
         $protocol = new TBinaryProtocolAccelerated(new TMemoryBuffer(), $strictRead, $strictWrite);
@@ -63,7 +60,7 @@ class TBinaryProtocolAcceleratedTest extends TestCase
         $this->assertEquals($strictWrite, $protocol->isStrictWrite());
     }
 
-    public function strictParamsDataProvider()
+    public static function strictParamsDataProvider()
     {
         yield 'strict read and write' => [true, true];
         yield 'not strict read and write' => [false, false];

--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
@@ -23,6 +23,8 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TProtocolException;
 use Thrift\Protocol\TBinaryProtocol;
 use Thrift\Transport\TTransport;
@@ -33,9 +35,7 @@ class TBinaryProtocolTest extends TestCase
     private const VERSION_MASK = 0xffff0000;
     private const VERSION_1 = 0x80010000;
 
-    /**
-     * @dataProvider writeMessageBeginDataProvider
-     */
+    #[DataProvider('writeMessageBeginDataProvider')]
     public function testWriteMessageBegin(
         $strictWrite,
         $name,
@@ -50,14 +50,25 @@ class TBinaryProtocolTest extends TestCase
 
         $transport->expects($this->exactly(count($writeCallsParams)))
                   ->method('write')
-                  ->withConsecutive(...$writeCallsParams)
-                  ->willReturnOnConsecutiveCalls(...$writeCallsResults);
+                  ->willReturnCallback(function (...$callArgs) use ($writeCallsParams, $writeCallsResults) {
+                      static $iteration = 0;
+                      $expected = $writeCallsParams[$iteration];
+                    foreach ($expected as $i => $exp) {
+                        if ($exp instanceof Constraint) {
+                            $this->assertThat($callArgs[$i], $exp);
+                        } else {
+                            $this->assertSame($exp, $callArgs[$i]);
+                        }
+                    }
+
+                      return $writeCallsResults[$iteration++];
+                  });
 
         $result = $protocol->writeMessageBegin($name, $type, $seqid);
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function writeMessageBeginDataProvider()
+    public static function writeMessageBeginDataProvider()
     {
         $type = TType::STRING;
         $seqid = 555;
@@ -105,7 +116,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testWriteMessageEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeMessageEnd());
@@ -113,7 +124,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testWriteStructBegin()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeStructBegin('testName'));
@@ -121,7 +132,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testWriteStructEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeStructEnd());
@@ -136,22 +147,34 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedWriteArgs = [
+            [pack('c', $fieldType), 1], #writeByte
+            [pack('n', $fieldId), 2], #writeI16
+        ];
+        $writeReturns = [1, 2];
         $transport
             ->expects($this->exactly(2))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('c', $fieldType), 1], #writeByte
-                       [pack('n', $fieldId), 2], #writeI16
-                   ]
-            )->willReturnOnConsecutiveCalls([1, 2]);
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $this->assertEquals(3, $protocol->writeFieldBegin($fieldName, $fieldType, $fieldId));
     }
 
     public function testWriteFieldEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeFieldEnd());
@@ -180,23 +203,35 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedWriteArgs = [
+            [pack('c', $keyType), 1], #writeByte
+            [pack('c', $valType), 1], #writeByte
+            [pack('N', $size), 4], #writeI32
+        ];
+        $writeReturns = [1, 1, 4];
         $transport
             ->expects($this->exactly(3))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('c', $keyType), 1], #writeByte
-                       [pack('c', $valType), 1], #writeByte
-                       [pack('N', $size), 4], #writeI32
-                   ]
-            )->willReturnOnConsecutiveCalls([1, 1, 4]);
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $this->assertEquals(6, $protocol->writeMapBegin($keyType, $valType, $size));
     }
 
     public function testWriteMapEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeMapEnd());
@@ -210,22 +245,34 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedWriteArgs = [
+            [pack('c', $elemType), 1], #writeByte
+            [pack('N', $size), 4], #writeI32
+        ];
+        $writeReturns = [1, 4];
         $transport
             ->expects($this->exactly(2))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('c', $elemType), 1], #writeByte
-                       [pack('N', $size), 4], #writeI32
-                   ]
-            )->willReturnOnConsecutiveCalls([1, 4]);
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $this->assertEquals(5, $protocol->writeListBegin($elemType, $size));
     }
 
     public function testWriteListEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeListEnd());
@@ -239,22 +286,34 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedWriteArgs = [
+            [pack('c', $elemType), 1], #writeByte
+            [pack('N', $size), 4], #writeI32
+        ];
+        $writeReturns = [1, 4];
         $transport
             ->expects($this->exactly(2))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('c', $elemType), 1], #writeByte
-                       [pack('N', $size), 4], #writeI32
-                   ]
-            )->willReturnOnConsecutiveCalls([1, 4]);
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $this->assertEquals(5, $protocol->writeSetBegin($elemType, $size));
     }
 
     public function testWriteSetEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->writeSetEnd());
@@ -400,15 +459,27 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedWriteArgs = [
+            [pack('N', strlen($value))], #writeI32,
+            [$value, strlen($value)], #write,
+        ];
+        $writeReturns = [4, 6];
         $transport
             ->expects($this->exactly(2))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('N', strlen($value))], #writeI32,
-                       [$value, strlen($value)], #write,
-                   ]
-            )->willReturnOnConsecutiveCalls([4, 6]);
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $this->assertEquals(10, $protocol->writeString($value));
     }
@@ -443,9 +514,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals('01234567-89ab-cdef-0123-456789abcdef', $value);
     }
 
-    /**
-     * @dataProvider readMessageBeginDataProvider
-     */
+    #[DataProvider('readMessageBeginDataProvider')]
     public function testReadMessageBegin(
         $strictRead,
         $readCallsParams,
@@ -469,8 +538,19 @@ class TBinaryProtocolTest extends TestCase
 
         $transport->expects($this->exactly(count($readCallsParams)))
                   ->method('readAll')
-                  ->withConsecutive(...$readCallsParams)
-                  ->willReturnOnConsecutiveCalls(...$readCallsResults);
+                  ->willReturnCallback(function (...$callArgs) use ($readCallsParams, $readCallsResults) {
+                      static $iteration = 0;
+                      $expected = $readCallsParams[$iteration];
+                    foreach ($expected as $i => $exp) {
+                        if ($exp instanceof Constraint) {
+                            $this->assertThat($callArgs[$i], $exp);
+                        } else {
+                            $this->assertSame($exp, $callArgs[$i]);
+                        }
+                    }
+
+                      return $readCallsResults[$iteration++];
+                  });
 
         $result = $protocol->readMessageBegin($name, $type, $seqid);
         $this->assertEquals($expectedReadLengthResult, $result);
@@ -479,7 +559,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals($expectedSeqid, $seqid);
     }
 
-    public function readMessageBeginDataProvider()
+    public static function readMessageBeginDataProvider()
     {
         yield 'strictRead=true' => [
             'strictRead' => true,
@@ -558,7 +638,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadMessageEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readMessageEnd());
@@ -566,7 +646,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadStructBegin()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readStructBegin($name));
@@ -575,15 +655,13 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadStructEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readStructEnd());
     }
 
-    /**
-     * @dataProvider readFieldBeginDataProvider
-     */
+    #[DataProvider('readFieldBeginDataProvider')]
     public function testReadFieldBegin(
         $storedFieldType,
         $readCallsParams,
@@ -599,8 +677,19 @@ class TBinaryProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($readCallsParams)))
             ->method('readAll')
-            ->withConsecutive(...$readCallsParams)
-            ->willReturnOnConsecutiveCalls(...$readCallsResults);
+            ->willReturnCallback(function (...$callArgs) use ($readCallsParams, $readCallsResults) {
+                static $iteration = 0;
+                $expected = $readCallsParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $readCallsResults[$iteration++];
+            });
 
         $this->assertEquals($expectedResult, $protocol->readFieldBegin($name, $fieldType, $fieldId));
         $this->assertEquals($expectedName, $name);
@@ -608,7 +697,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals($expectedFieldId, $fieldId);
     }
 
-    public function readFieldBeginDataProvider()
+    public static function readFieldBeginDataProvider()
     {
         yield 'default' => [
             'storedFieldType' => TType::STRING,
@@ -621,7 +710,7 @@ class TBinaryProtocolTest extends TestCase
                 pack('n', 555),
             ],
             'expectedResult' => 3,
-            'exprectedName' => '',
+            'expectedName' => '',
             'expectedFieldType' => TType::STRING,
             'expectedFieldId' => 555,
         ];
@@ -635,7 +724,7 @@ class TBinaryProtocolTest extends TestCase
                 pack('c', TType::STOP),
             ],
             'expectedResult' => 1,
-            'exprectedName' => '',
+            'expectedName' => '',
             'expectedFieldType' => 0,
             'expectedFieldId' => 0,
         ];
@@ -643,7 +732,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadFieldEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readFieldEnd());
@@ -654,20 +743,32 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedReadAllArgs = [
+            [1], #readByte
+            [1], #readByte
+            [4], #readI32
+        ];
+        $readAllReturns = [
+            pack('c', TType::I32),
+            pack('c', TType::STRING),
+            pack('N', 555),
+        ];
         $transport
             ->expects($this->exactly(3))
             ->method('readAll')
-            ->withConsecutive(
-                ...[
-                       [1], #readByte
-                       [1], #readByte
-                       [4], #readI32
-                   ]
-            )->willReturnOnConsecutiveCalls(
-                pack('c', TType::I32),
-                pack('c', TType::STRING),
-                pack('N', 555)
-            );
+            ->willReturnCallback(function (...$callArgs) use ($expectedReadAllArgs, $readAllReturns) {
+                static $iteration = 0;
+                $expected = $expectedReadAllArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $readAllReturns[$iteration++];
+            });
 
         $this->assertEquals(6, $protocol->readMapBegin($keyType, $valType, $size));
         $this->assertEquals(TType::I32, $keyType);
@@ -677,7 +778,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadMapEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readMapEnd());
@@ -688,18 +789,30 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedReadAllArgs = [
+            [1], #readByte
+            [4], #readI32
+        ];
+        $readAllReturns = [
+            pack('c', TType::I32),
+            pack('N', 555),
+        ];
         $transport
             ->expects($this->exactly(2))
             ->method('readAll')
-            ->withConsecutive(
-                ...[
-                       [1], #readByte
-                       [4], #readI32
-                   ]
-            )->willReturnOnConsecutiveCalls(
-                pack('c', TType::I32),
-                pack('N', 555)
-            );
+            ->willReturnCallback(function (...$callArgs) use ($expectedReadAllArgs, $readAllReturns) {
+                static $iteration = 0;
+                $expected = $expectedReadAllArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $readAllReturns[$iteration++];
+            });
 
         $this->assertEquals(5, $protocol->readListBegin($elemType, $size));
         $this->assertEquals(TType::I32, $elemType);
@@ -708,7 +821,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadListEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readListEnd());
@@ -719,18 +832,30 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
+        $expectedReadAllArgs = [
+            [1], #readByte
+            [4], #readI32
+        ];
+        $readAllReturns = [
+            pack('c', TType::I32),
+            pack('N', 555),
+        ];
         $transport
             ->expects($this->exactly(2))
             ->method('readAll')
-            ->withConsecutive(
-                ...[
-                       [1], #readByte
-                       [4], #readI32
-                   ]
-            )->willReturnOnConsecutiveCalls(
-                pack('c', TType::I32),
-                pack('N', 555)
-            );
+            ->willReturnCallback(function (...$callArgs) use ($expectedReadAllArgs, $readAllReturns) {
+                static $iteration = 0;
+                $expected = $expectedReadAllArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $readAllReturns[$iteration++];
+            });
 
         $this->assertEquals(5, $protocol->readSetBegin($elemType, $size));
         $this->assertEquals(TType::I32, $elemType);
@@ -739,7 +864,7 @@ class TBinaryProtocolTest extends TestCase
 
     public function testReadSetEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
         $this->assertEquals(0, $protocol->readSetEnd());
@@ -775,9 +900,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals(1, $value);
     }
 
-    /**
-     * @dataProvider readI16DataProvider
-     */
+    #[DataProvider('readI16DataProvider')]
     public function testReadI16(
         $storedValue,
         $expectedValue
@@ -795,15 +918,13 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals($expectedValue, $value);
     }
 
-    public function readI16DataProvider()
+    public static function readI16DataProvider()
     {
         yield 'positive' => [1, 1];
         yield 'negative' => [-1, -1];
     }
 
-    /**
-     * @dataProvider readI16DataProvider
-     */
+    #[DataProvider('readI16DataProvider')]
     public function testReadI32(
         $storedValue,
         $expectedValue
@@ -827,9 +948,7 @@ class TBinaryProtocolTest extends TestCase
         yield 'negative' => [-1, -1];
     }
 
-    /**
-     * @dataProvider readI64For32BitArchitectureDataProvider
-     */
+    #[DataProvider('readI64For32BitArchitectureDataProvider')]
     public function testReadI64For32BitArchitecture(
         $storedValue,
         $expectedValue
@@ -871,7 +990,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals($expectedValue, $value);
     }
 
-    public function readI64For32BitArchitectureDataProvider()
+    public static function readI64For32BitArchitectureDataProvider()
     {
         $storedValueRepresent = function ($value) {
             // PHP_INT_MIN (-2^63) cannot be safely negated:
@@ -924,9 +1043,7 @@ class TBinaryProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider readI64For64BitArchitectureDataProvider
-     */
+    #[DataProvider('readI64For64BitArchitectureDataProvider')]
     public function testReadI64For64BitArchitecture(
         $storedValue,
         $expectedValue
@@ -947,7 +1064,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals($expectedValue, $value);
     }
 
-    public function readI64For64BitArchitectureDataProvider()
+    public static function readI64For64BitArchitectureDataProvider()
     {
         $storedValueRepresent = function ($value) {
             $hi = $value >> 32;
@@ -992,9 +1109,7 @@ class TBinaryProtocolTest extends TestCase
         $this->assertEquals(789, $value);
     }
 
-    /**
-     * @dataProvider readStringDataProvider
-     */
+    #[DataProvider('readStringDataProvider')]
     public function testReadString(
         $readCallsParams,
         $readCallsResults,
@@ -1007,14 +1122,25 @@ class TBinaryProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($readCallsParams)))
             ->method('readAll')
-            ->withConsecutive(...$readCallsParams)
-            ->willReturnOnConsecutiveCalls(...$readCallsResults);
+            ->willReturnCallback(function (...$callArgs) use ($readCallsParams, $readCallsResults) {
+                static $iteration = 0;
+                $expected = $readCallsParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $readCallsResults[$iteration++];
+            });
 
         $this->assertEquals($expectedLength, $protocol->readString($value));
         $this->assertEquals($expectedValue, $value);
     }
 
-    public function readStringDataProvider()
+    public static function readStringDataProvider()
     {
         $storedValue = '';
         yield 'empty' => [

--- a/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
@@ -23,6 +23,8 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TProtocolException;
 use Thrift\Protocol\TCompactProtocol;
@@ -64,19 +66,17 @@ class TCompactProtocolTest extends TestCase
     private const TYPE_BITS = 0x07;
     private const TYPE_SHIFT_AMOUNT = 5;
 
-    /**
-     * @dataProvider toZigZagDataProvider
-     */
+    #[DataProvider('toZigZagDataProvider')]
     public function testToZigZag(
         $n,
         $bits,
         $expected
     ) {
-        $protocol = new TCompactProtocol($this->createMock(TTransport::class));
+        $protocol = new TCompactProtocol($this->createStub(TTransport::class));
         $this->assertSame($expected, $protocol->toZigZag($n, $bits));
     }
 
-    public function toZigZagDataProvider()
+    public static function toZigZagDataProvider()
     {
         yield ['n' => 0, 'bits' => 16, 'expected' => 0];
         yield ['n' => -1, 'bits' => 16, 'expected' => 1];
@@ -91,18 +91,16 @@ class TCompactProtocolTest extends TestCase
         yield ['n' => 0x7fffffff, 'bits' => 64, 'expected' => 4294967294];
     }
 
-    /**
-     * @dataProvider fromZigZagDataProvider
-     */
+    #[DataProvider('fromZigZagDataProvider')]
     public function testFromZigZag(
         $n,
         $expected
     ) {
-        $protocol = new TCompactProtocol($this->createMock(TTransport::class));
+        $protocol = new TCompactProtocol($this->createStub(TTransport::class));
         $this->assertSame($expected, $protocol->fromZigZag($n));
     }
 
-    public function fromZigZagDataProvider()
+    public static function fromZigZagDataProvider()
     {
         yield ['n' => 0, 'expected' => 0];
         yield ['n' => 1, 'expected' => -1];
@@ -113,18 +111,16 @@ class TCompactProtocolTest extends TestCase
         yield ['n' => 4294967294, 'expected' => 0x7fffffff];
     }
 
-    /**
-     * @dataProvider getVarintDataProvider
-     */
+    #[DataProvider('getVarintDataProvider')]
     public function testGetVarint(
         $data,
         $expected
     ) {
-        $protocol = new TCompactProtocol($this->createMock(TTransport::class));
+        $protocol = new TCompactProtocol($this->createStub(TTransport::class));
         $this->assertSame($expected, $protocol->getVarint($data));
     }
 
-    public function getVarintDataProvider()
+    public static function getVarintDataProvider()
     {
         yield ['data' => 0, 'expected' => "\x00"];
         yield ['data' => 1, 'expected' => "\x01"];
@@ -205,24 +201,30 @@ class TCompactProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TCompactProtocol($transport);
 
+        $expectedWriteArgs = [
+            [pack('C', self::PROTOCOL_ID), 1], #protocal id
+            [pack('C', self::VERSION | ($type << TCompactProtocol::TYPE_SHIFT_AMOUNT)), 1], #version
+            ["\x01", 1], #seqid
+            ["\x08", 1], #field name length
+            ["testName", 8], #field name
+        ];
+        $writeReturns = [1, 1, 1, 1, 8];
         $transport
             ->expects($this->exactly(5))
             ->method('write')
-            ->withConsecutive(
-                ...[
-                       [pack('C', self::PROTOCOL_ID), 1], #protocal id
-                       [pack('C', self::VERSION | ($type << TCompactProtocol::TYPE_SHIFT_AMOUNT)), 1], #version
-                       ["\x01", 1], #seqid
-                       ["\x08", 1], #field name length
-                       ["testName", 8], #field name
-                   ]
-            )->willReturnOnConsecutiveCalls(
-                1,
-                1,
-                1,
-                1,
-                8
-            );
+            ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs, $writeReturns) {
+                static $iteration = 0;
+                $expected = $expectedWriteArgs[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeReturns[$iteration++];
+            });
 
         $result = $protocol->writeMessageBegin($name, $type, $seqid);
         $this->assertSame(12, $result);
@@ -232,7 +234,7 @@ class TCompactProtocolTest extends TestCase
 
     public function testWriteMessageEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TCompactProtocol($transport);
 
         $this->assertSame(0, $protocol->writeMessageEnd());
@@ -243,7 +245,7 @@ class TCompactProtocolTest extends TestCase
     {
         $name = 'testName';
 
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TCompactProtocol($transport);
         $this->assertSame(0, $protocol->writeStructBegin($name));
         $this->assertSame([[self::STATE_CLEAR, 0]], $this->getPropertyValue($protocol, 'structs'));
@@ -278,9 +280,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(1, $protocol->writeFieldStop());
     }
 
-    /**
-     * @dataProvider writeFieldHeaderDataProvider
-     */
+    #[DataProvider('writeFieldHeaderDataProvider')]
     public function testWriteFieldHeader(
         $type,
         $fid,
@@ -294,13 +294,24 @@ class TCompactProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($writeCallParams)))
             ->method('write')
-            ->withConsecutive(...$writeCallParams)
-            ->willReturnOnConsecutiveCalls(...$writeCallResult);
+            ->willReturnCallback(function (...$callArgs) use ($writeCallParams, $writeCallResult) {
+                static $iteration = 0;
+                $expected = $writeCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeCallResult[$iteration++];
+            });
 
         $this->assertSame($expectedResult, $protocol->writeFieldHeader($type, $fid));
     }
 
-    public function writeFieldHeaderDataProvider()
+    public static function writeFieldHeaderDataProvider()
     {
         yield 'bool' => [
             'type' => TType::BOOL,
@@ -322,14 +333,13 @@ class TCompactProtocolTest extends TestCase
             ],
             'writeCallResult' => [
                 1,
+                1,
             ],
             'expectedResult' => 2,
         ];
     }
 
-    /**
-     * @dataProvider writeFieldBeginDataProvider
-     */
+    #[DataProvider('writeFieldBeginDataProvider')]
     public function testWriteFieldBegin(
         $fieldName,
         $fieldType,
@@ -347,8 +357,19 @@ class TCompactProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($writeCallParams)))
             ->method('write')
-            ->withConsecutive(...$writeCallParams)
-            ->willReturnOnConsecutiveCalls(...$writeCallResult);
+            ->willReturnCallback(function (...$callArgs) use ($writeCallParams, $writeCallResult) {
+                static $iteration = 0;
+                $expected = $writeCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeCallResult[$iteration++];
+            });
 
         $this->assertSame($expectedResult, $protocol->writeFieldBegin($fieldName, $fieldType, $fieldId));
 
@@ -357,7 +378,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame($expectedLastFid, $this->getPropertyValue($protocol, 'lastFid'));
     }
 
-    public function writeFieldBeginDataProvider()
+    public static function writeFieldBeginDataProvider()
     {
         yield 'bool' => [
             'fieldName' => 'testName',
@@ -389,7 +410,7 @@ class TCompactProtocolTest extends TestCase
 
     public function testWriteFieldEnd()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TCompactProtocol($transport);
 
         $this->assertSame(0, $protocol->writeFieldEnd());
@@ -397,9 +418,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(self::STATE_FIELD_WRITE, $this->getPropertyValue($protocol, 'state'));
     }
 
-    /**
-     * @dataProvider writeCollectionDataProvider
-     */
+    #[DataProvider('writeCollectionDataProvider')]
     public function testWriteCollection(
         $etype,
         $size,
@@ -415,8 +434,19 @@ class TCompactProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($writeCallParams)))
             ->method('write')
-            ->withConsecutive(...$writeCallParams)
-            ->willReturnOnConsecutiveCalls(...$writeCallResult);
+            ->willReturnCallback(function (...$callArgs) use ($writeCallParams, $writeCallResult) {
+                static $iteration = 0;
+                $expected = $writeCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeCallResult[$iteration++];
+            });
 
         $this->assertSame($expectedResult, $protocol->writeCollectionBegin($etype, $size));
 
@@ -427,7 +457,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(TCompactProtocol::STATE_CLEAR, $this->getPropertyValue($protocol, 'state'));
     }
 
-    public function writeCollectionDataProvider()
+    public static function writeCollectionDataProvider()
     {
         yield 'size < 14' => [
             'etype' => TType::STRING,
@@ -463,9 +493,7 @@ class TCompactProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeMapDataProvider
-     */
+    #[DataProvider('writeMapDataProvider')]
     public function testWriteMap(
         $keyType,
         $valType,
@@ -481,8 +509,19 @@ class TCompactProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($writeCallParams)))
             ->method('write')
-            ->withConsecutive(...$writeCallParams)
-            ->willReturnOnConsecutiveCalls(...$writeCallResult);
+            ->willReturnCallback(function (...$callArgs) use ($writeCallParams, $writeCallResult) {
+                static $iteration = 0;
+                $expected = $writeCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeCallResult[$iteration++];
+            });
 
         $this->assertSame($expectedResult, $protocol->writeMapBegin($keyType, $valType, $size));
 
@@ -494,7 +533,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame([], $this->getPropertyValue($protocol, 'containers'));
     }
 
-    public function writeMapDataProvider()
+    public static function writeMapDataProvider()
     {
         yield 'size zero' => [
             'keyType' => TType::STRING,
@@ -576,9 +615,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(1, $protocol->writeSetEnd());
     }
 
-    /**
-     * @dataProvider writeBinaryDataProvider
-     */
+    #[DataProvider('writeBinaryDataProvider')]
     public function testWriteBool(
         $value,
         $startState,
@@ -602,13 +639,24 @@ class TCompactProtocolTest extends TestCase
         $transport
             ->expects($this->exactly(count($writeCallParams)))
             ->method('write')
-            ->withConsecutive(...$writeCallParams)
-            ->willReturnOnConsecutiveCalls(...$writeCallResult);
+            ->willReturnCallback(function (...$callArgs) use ($writeCallParams, $writeCallResult) {
+                static $iteration = 0;
+                $expected = $writeCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                return $writeCallResult[$iteration++];
+            });
 
         $this->assertSame($expectedResult, $protocol->writeBool($value));
     }
 
-    public function writeBinaryDataProvider()
+    public static function writeBinaryDataProvider()
     {
         yield 'invalid state' => [
             'value' => true,
@@ -667,9 +715,7 @@ class TCompactProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeByteDataProvider
-     */
+    #[DataProvider('writeByteDataProvider')]
     public function testWriteByte(
         $value,
         $expectedWriteCallParam
@@ -684,7 +730,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(1, $protocol->writeByte($value));
     }
 
-    public function writeByteDataProvider()
+    public static function writeByteDataProvider()
     {
         yield 'signed' => [
             'value' => -1,
@@ -704,9 +750,7 @@ class TCompactProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeUByteDataProvider
-     */
+    #[DataProvider('writeUByteDataProvider')]
     public function testWriteUByte(
         $value,
         $expectedWriteCallParam
@@ -721,7 +765,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame(1, $protocol->writeUByte($value));
     }
 
-    public function writeUByteDataProvider()
+    public static function writeUByteDataProvider()
     {
         yield 'signed' => [
             'value' => -1,
@@ -782,12 +826,25 @@ class TCompactProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TCompactProtocol($transport);
 
+        $expectedWriteArgs = [
+            ["\x04", 1],
+            ["test", 4],
+        ];
         $transport->expects($this->exactly(2))
                   ->method('write')
-                  ->withConsecutive(
-                      ["\x04", 1],
-                      ["test", 4]
-                  );
+                  ->willReturnCallback(function (...$callArgs) use ($expectedWriteArgs) {
+                      static $iteration = 0;
+                      $expected = $expectedWriteArgs[$iteration++];
+                    foreach ($expected as $i => $exp) {
+                        if ($exp instanceof Constraint) {
+                            $this->assertThat($callArgs[$i], $exp);
+                        } else {
+                            $this->assertSame($exp, $callArgs[$i]);
+                        }
+                    }
+
+                      return null;
+                  });
 
         $this->assertSame(5, $protocol->writeString('test'));
     }
@@ -822,9 +879,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', $value);
     }
 
-    /**
-     * @dataProvider writeI64DataProvider
-     */
+    #[DataProvider('writeI64DataProvider')]
     public function testWriteI64(
         $value,
         $expectedWriteCallParam,
@@ -840,7 +895,7 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame($expectedResult, $protocol->writeI64($value));
     }
 
-    public function writeI64DataProvider()
+    public static function writeI64DataProvider()
     {
         yield 'simple' => [
             'value' => 0,

--- a/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
@@ -23,6 +23,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TProtocolException;
 use Thrift\Protocol\TJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
@@ -31,9 +32,7 @@ use Thrift\Type\TType;
 
 class TJSONProtocolTest extends TestCase
 {
-    /**
-     * @dataProvider writeAndReadMessageBeginDataProvider
-     */
+    #[DataProvider('writeAndReadMessageBeginDataProvider')]
     public function testWriteAndReadMessageBegin(string $name, int $type, int $seqid)
     {
         $transport = new TMemoryBuffer();
@@ -57,7 +56,7 @@ class TJSONProtocolTest extends TestCase
         $this->assertSame($seqid, $readSeqid);
     }
 
-    public function writeAndReadMessageBeginDataProvider()
+    public static function writeAndReadMessageBeginDataProvider()
     {
         yield 'call message' => [
             'name' => 'testMethod',
@@ -97,9 +96,7 @@ class TJSONProtocolTest extends TestCase
         $protocol->readMessageBegin($name, $type, $seqid);
     }
 
-    /**
-     * @dataProvider writeAndReadScalarDataProvider
-     */
+    #[DataProvider('writeAndReadScalarDataProvider')]
     public function testWriteAndReadScalar(int $fieldType, string $writeMethod, $value, string $readMethod)
     {
         if ($fieldType === TType::I64 && PHP_INT_SIZE === 4) {
@@ -133,7 +130,7 @@ class TJSONProtocolTest extends TestCase
         }
     }
 
-    public function writeAndReadScalarDataProvider()
+    public static function writeAndReadScalarDataProvider()
     {
         yield 'bool true' => [
             'fieldType' => TType::BOOL,

--- a/lib/php/test/Unit/Lib/Protocol/TMultiplexedProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TMultiplexedProtocolTest.php
@@ -23,6 +23,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TMultiplexedProtocol;
 use Thrift\Protocol\TProtocol;
 use Thrift\Type\TMessageType;
@@ -30,9 +31,7 @@ use Thrift\Type\TMessageType;
 class TMultiplexedProtocolTest extends TestCase
 {
 
-    /**
-     * @dataProvider writeMessageBeginDataProvider
-     */
+    #[DataProvider('writeMessageBeginDataProvider')]
     public function testWriteMessageBegin(
         $serviceName,
         $name,
@@ -50,7 +49,7 @@ class TMultiplexedProtocolTest extends TestCase
         $multiplexedProtocol->writeMessageBegin($name, $type, $seqid);
     }
 
-    public function writeMessageBeginDataProvider()
+    public static function writeMessageBeginDataProvider()
     {
         yield 'messageTypeCall' => [
             'serviceName' => 'serviceName',

--- a/lib/php/test/Unit/Lib/Protocol/TProtocolDecoratorTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TProtocolDecoratorTest.php
@@ -23,15 +23,14 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Protocol\TProtocol;
 use Thrift\Protocol\TProtocolDecorator;
 
 class TProtocolDecoratorTest extends TestCase
 {
 
-    /**
-     * @dataProvider methodDecorationDataProvider
-     */
+    #[DataProvider('methodDecorationDataProvider')]
     public function testMethodDecoration(
         $methodName,
         $methodArguments
@@ -51,7 +50,7 @@ class TProtocolDecoratorTest extends TestCase
         $decorator->$methodName(...$methodArguments);
     }
 
-    public function methodDecorationDataProvider()
+    public static function methodDecorationDataProvider()
     {
         yield 'writeMessageBegin' => ['writeMessageBegin', ['name', 'type', 'seqid']];
         yield 'writeMessageEnd' => ['writeMessageEnd', []];

--- a/lib/php/test/Unit/Lib/Protocol/TProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TProtocolTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TProtocolException;
 use Thrift\Protocol\TBinaryProtocol;
 use Thrift\Protocol\TProtocol;
@@ -30,9 +31,7 @@ use Thrift\Type\TType;
 
 class TProtocolTest extends TestCase
 {
-    /**
-     * @dataProvider skipScalarDataProvider
-     */
+    #[DataProvider('skipScalarDataProvider')]
     public function testSkipScalarValues(int $type, string $writerMethod, $value): void
     {
         $buffer = $this->buildBinaryBuffer(
@@ -47,7 +46,7 @@ class TProtocolTest extends TestCase
         $this->assertSame(0, (int)$transport->available());
     }
 
-    public function skipScalarDataProvider(): iterable
+    public static function skipScalarDataProvider(): iterable
     {
         yield 'bool' => [
             TType::BOOL,
@@ -180,9 +179,7 @@ class TProtocolTest extends TestCase
         $protocol->skip(999);
     }
 
-    /**
-     * @dataProvider skipScalarDataProvider
-     */
+    #[DataProvider('skipScalarDataProvider')]
     public function testSkipBinaryScalarValues(int $type, string $writerMethod, $value): void
     {
         $buffer = $this->buildBinaryBuffer(

--- a/lib/php/test/Unit/Lib/Protocol/TSimpleJSONProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TSimpleJSONProtocolTest.php
@@ -23,6 +23,7 @@
 namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TException;
 use Thrift\Protocol\TSimpleJSONProtocol;
 use Thrift\Protocol\SimpleJSON\CollectionMapKeyException;
@@ -39,8 +40,8 @@ class TSimpleJSONProtocolTest extends TestCase
      * - see http://wiki.apache.org/thrift/ThriftUsageJava
      * - use JSON instead
      *
-     * @dataProvider readDataProvider
      */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $methodName,
         $methodArguments
@@ -48,12 +49,12 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->expectException(TException::class);
         $this->expectExceptionMessage("Not implemented");
 
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = new TSimpleJSONProtocol($transport);
         $protocol->$methodName(...$methodArguments);
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'readMessageBegin' => [
             'methodName' => 'readMessageBegin',
@@ -133,9 +134,7 @@ class TSimpleJSONProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeScalarProvider
-     */
+    #[DataProvider('writeScalarProvider')]
     public function testWriteScalar(string $writeMethod, $value, string $expectedJson)
     {
         $transport = new TMemoryBuffer();
@@ -148,7 +147,7 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->assertSame('[' . $expectedJson . ']', $transport->getBuffer());
     }
 
-    public function writeScalarProvider()
+    public static function writeScalarProvider()
     {
         yield 'bool true' => [
             'writeMethod' => 'writeBool',
@@ -272,9 +271,7 @@ class TSimpleJSONProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeContainerProvider
-     */
+    #[DataProvider('writeContainerProvider')]
     public function testWriteContainer(array $operations, string $expectedJson)
     {
         $transport = new TMemoryBuffer();
@@ -287,7 +284,7 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->assertSame($expectedJson, $transport->getBuffer());
     }
 
-    public function writeContainerProvider()
+    public static function writeContainerProvider()
     {
         yield 'list of integers' => [
             'operations' => [
@@ -350,9 +347,7 @@ class TSimpleJSONProtocolTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeStructuralProvider
-     */
+    #[DataProvider('writeStructuralProvider')]
     public function testWriteStructural(array $operations, string $expectedJson)
     {
         $transport = new TMemoryBuffer();
@@ -365,7 +360,7 @@ class TSimpleJSONProtocolTest extends TestCase
         $this->assertSame($expectedJson, $transport->getBuffer());
     }
 
-    public function writeStructuralProvider()
+    public static function writeStructuralProvider()
     {
         yield 'message begin' => [
             'operations' => [

--- a/lib/php/test/Unit/Lib/Serializer/TBinarySerializerTest.php
+++ b/lib/php/test/Unit/Lib/Serializer/TBinarySerializerTest.php
@@ -24,6 +24,7 @@ namespace Test\Thrift\Unit\Lib\Serializer;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\Fixture\TestSerializerStruct;
 use Thrift\Serializer\TBinarySerializer;
 
@@ -31,9 +32,7 @@ class TBinarySerializerTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @dataProvider serializeDeserializeDataProvider
-     */
+    #[DataProvider('serializeDeserializeDataProvider')]
     public function testSerializeAndDeserialize($stringVal, $intVal)
     {
         $object = new TestSerializerStruct();
@@ -52,7 +51,7 @@ class TBinarySerializerTest extends TestCase
         $this->assertEquals($intVal, $deserialized->intField);
     }
 
-    public function serializeDeserializeDataProvider()
+    public static function serializeDeserializeDataProvider()
     {
         yield 'both fields' => [
             'stringVal' => 'hello',

--- a/lib/php/test/Unit/Lib/Server/TForkingServerTest.php
+++ b/lib/php/test/Unit/Lib/Server/TForkingServerTest.php
@@ -47,11 +47,11 @@ class TForkingServerTest extends TestCase
     ): TForkingServer {
         return new TForkingServer(
             $processor ?? new \stdClass(),
-            $transport ?? $this->createMock(TServerTransport::class),
-            $inputTransportFactory ?? $this->createMock(TTransportFactoryInterface::class),
-            $outputTransportFactory ?? $this->createMock(TTransportFactoryInterface::class),
-            $inputProtocolFactory ?? $this->createMock(TProtocolFactory::class),
-            $outputProtocolFactory ?? $this->createMock(TProtocolFactory::class)
+            $transport ?? $this->createStub(TServerTransport::class),
+            $inputTransportFactory ?? $this->createStub(TTransportFactoryInterface::class),
+            $outputTransportFactory ?? $this->createStub(TTransportFactoryInterface::class),
+            $inputProtocolFactory ?? $this->createStub(TProtocolFactory::class),
+            $outputProtocolFactory ?? $this->createStub(TProtocolFactory::class)
         );
     }
 
@@ -75,11 +75,11 @@ class TForkingServerTest extends TestCase
     public function testConstructorStoresCollaborators()
     {
         $processor = new \stdClass();
-        $transport = $this->createMock(TServerTransport::class);
-        $inputTransportFactory = $this->createMock(TTransportFactoryInterface::class);
-        $outputTransportFactory = $this->createMock(TTransportFactoryInterface::class);
-        $inputProtocolFactory = $this->createMock(TProtocolFactory::class);
-        $outputProtocolFactory = $this->createMock(TProtocolFactory::class);
+        $transport = $this->createStub(TServerTransport::class);
+        $inputTransportFactory = $this->createStub(TTransportFactoryInterface::class);
+        $outputTransportFactory = $this->createStub(TTransportFactoryInterface::class);
+        $inputProtocolFactory = $this->createStub(TProtocolFactory::class);
+        $outputProtocolFactory = $this->createStub(TProtocolFactory::class);
 
         $server = $this->createServer(
             $processor,
@@ -131,7 +131,7 @@ class TForkingServerTest extends TestCase
         $serverTransport = $this->createMock(TServerTransport::class);
         $serverTransport->expects($this->once())->method('listen');
 
-        $clientTransport = $this->createMock(TTransport::class);
+        $clientTransport = $this->createStub(TTransport::class);
         $server = $this->createServer(null, $serverTransport);
 
         $callCount = 0;
@@ -167,7 +167,7 @@ class TForkingServerTest extends TestCase
         $this->expectExceptionMessage('Failed to fork');
 
         $serverTransport = $this->createMock(TServerTransport::class);
-        $clientTransport = $this->createMock(TTransport::class);
+        $clientTransport = $this->createStub(TTransport::class);
 
         $server = $this->createServer(null, $serverTransport);
 
@@ -263,7 +263,7 @@ class TForkingServerTest extends TestCase
     public function testHandleParentStoresChildPid()
     {
         $server = $this->createServer();
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
 
         $method = $this->getAccessibleMethod($server, 'handleParent');
         $method->invoke($server, $transport, 42);

--- a/lib/php/test/Unit/Lib/Server/TServerTest.php
+++ b/lib/php/test/Unit/Lib/Server/TServerTest.php
@@ -35,11 +35,11 @@ class TServerTest extends TestCase
     public function testConstructorStoresCollaborators(): void
     {
         $processor = new \stdClass();
-        $transport = $this->createMock(TServerTransport::class);
-        $inputTransportFactory = $this->createMock(TTransportFactoryInterface::class);
-        $outputTransportFactory = $this->createMock(TTransportFactoryInterface::class);
-        $inputProtocolFactory = $this->createMock(TProtocolFactory::class);
-        $outputProtocolFactory = $this->createMock(TProtocolFactory::class);
+        $transport = $this->createStub(TServerTransport::class);
+        $inputTransportFactory = $this->createStub(TTransportFactoryInterface::class);
+        $outputTransportFactory = $this->createStub(TTransportFactoryInterface::class);
+        $inputProtocolFactory = $this->createStub(TProtocolFactory::class);
+        $outputProtocolFactory = $this->createStub(TProtocolFactory::class);
 
         $server = new ServerStub(
             $processor,

--- a/lib/php/test/Unit/Lib/Server/TServerTransportTest.php
+++ b/lib/php/test/Unit/Lib/Server/TServerTransportTest.php
@@ -30,7 +30,7 @@ class TServerTransportTest extends TestCase
 {
     public function testAcceptReturnsTransportFromImplementation(): void
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $serverTransport = new ServerTransportStub($transport);
 
         $this->assertSame($transport, $serverTransport->accept());

--- a/lib/php/test/Unit/Lib/Server/TSimpleServerTest.php
+++ b/lib/php/test/Unit/Lib/Server/TSimpleServerTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Unit\Lib\Server;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\Server\Fixture\TestProcessor;
 use Thrift\Factory\TProtocolFactory;
 use Thrift\Factory\TTransportFactoryInterface;
@@ -93,14 +94,12 @@ class TSimpleServerTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider serveDataProvider
-     */
+    #[DataProvider('serveDataProvider')]
     public function testServe(
         $serveLoopCount,
         array $processLoopResult
     ): void {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
 
         $this->transport->expects($this->once())
             ->method('listen');
@@ -110,17 +109,17 @@ class TSimpleServerTest extends TestCase
 
         $this->inputTransportFactory->expects($this->exactly($serveLoopCount))
             ->method('getTransport')
-            ->willReturn($this->createMock(TServerTransport::class));
+            ->willReturn($this->createStub(TServerTransport::class));
         $this->outputTransportFactory->expects($this->exactly($serveLoopCount))
             ->method('getTransport')
-            ->willReturn($this->createMock(TServerTransport::class));
+            ->willReturn($this->createStub(TServerTransport::class));
 
-        $inputProtocol = $this->createMock(TServerTransport::class);
+        $inputProtocol = $this->createStub(TServerTransport::class);
         $this->inputProtocolFactory->expects($this->exactly($serveLoopCount))
             ->method('getProtocol')
             ->willReturn($inputProtocol);
 
-        $outputProtocol = $this->createMock(TServerTransport::class);
+        $outputProtocol = $this->createStub(TServerTransport::class);
         $this->outputProtocolFactory->expects($this->exactly($serveLoopCount))
             ->method('getProtocol')
             ->willReturn($outputProtocol);
@@ -130,24 +129,27 @@ class TSimpleServerTest extends TestCase
          * it is a hack to stop the server loop in unit test
          * last call of process can return any value, but should stop server for removing infinite loop
          **/
-        $processLoopResult[] = $this->returnCallback(function () {
-            $this->server->stop();
-
-            return false;
-        });
-
-        $this->processor->expects($this->exactly(count($processLoopResult)))
+        $totalCalls = count($processLoopResult) + 1;
+        $this->processor->expects($this->exactly($totalCalls))
             ->method('process')
             ->with(
                 $this->equalTo($inputProtocol),
                 $this->equalTo($outputProtocol)
             )
-            ->willReturnOnConsecutiveCalls(...$processLoopResult);
+            ->willReturnCallback(function () use ($processLoopResult) {
+                static $iteration = 0;
+                if ($iteration < count($processLoopResult)) {
+                    return $processLoopResult[$iteration++];
+                }
+                $this->server->stop();
+
+                return false;
+            });
 
         $this->server->serve();
     }
 
-    public function serveDataProvider()
+    public static function serveDataProvider()
     {
         yield 'one serve loop' => [
             'serveLoopCount' => 1,

--- a/lib/php/test/Unit/Lib/StoredMessageProtocolTest.php
+++ b/lib/php/test/Unit/Lib/StoredMessageProtocolTest.php
@@ -31,7 +31,7 @@ class StoredMessageProtocolTest extends TestCase
 {
     public function testReadMessageBeginReturnsStoredValues(): void
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $protocol = $this->createMock(TProtocol::class);
         $protocol->expects($this->once())
             ->method('getTransport')

--- a/lib/php/test/Unit/Lib/StringFunc/CoreTest.php
+++ b/lib/php/test/Unit/Lib/StringFunc/CoreTest.php
@@ -23,13 +23,12 @@
 namespace Test\Thrift\Unit\Lib\StringFunc;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\StringFunc\Core;
 
 class CoreTest extends TestCase
 {
-    /**
-     * @dataProvider substrDataProvider
-     */
+    #[DataProvider('substrDataProvider')]
     public function testSubstr(
         $expected,
         $str,
@@ -40,9 +39,7 @@ class CoreTest extends TestCase
         $this->assertEquals($expected, $core->substr($str, $start, $length));
     }
 
-    /**
-     * @dataProvider strlenDataProvider
-     */
+    #[DataProvider('strlenDataProvider')]
     public function testStrlen(
         $expectedLength,
         $str
@@ -51,7 +48,7 @@ class CoreTest extends TestCase
         $this->assertEquals($expectedLength, $core->strlen($str));
     }
 
-    public function substrDataProvider()
+    public static function substrDataProvider()
     {
         yield 'Afrikaans' => [
             'expected' => 'Afrikaans',
@@ -165,7 +162,7 @@ class CoreTest extends TestCase
         ];
     }
 
-    public function strlenDataProvider()
+    public static function strlenDataProvider()
     {
         yield 'Afrikaans' => [
             'expectedLength' => 9,

--- a/lib/php/test/Unit/Lib/StringFunc/MbStringTest.php
+++ b/lib/php/test/Unit/Lib/StringFunc/MbStringTest.php
@@ -23,13 +23,12 @@
 namespace Test\Thrift\Unit\Lib\StringFunc;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\StringFunc\Mbstring;
 
 class MbStringTest extends TestCase
 {
-    /**
-     * @dataProvider substrDataProvider
-     */
+    #[DataProvider('substrDataProvider')]
     public function testSubstr(
         $expected,
         $str,
@@ -40,9 +39,7 @@ class MbStringTest extends TestCase
         $this->assertEquals($expected, $core->substr($str, $start, $length));
     }
 
-    /**
-     * @dataProvider strlenDataProvider
-     */
+    #[DataProvider('strlenDataProvider')]
     public function testStrlen(
         $expectedLength,
         $str
@@ -51,7 +48,7 @@ class MbStringTest extends TestCase
         $this->assertEquals($expectedLength, $core->strlen($str));
     }
 
-    public function substrDataProvider()
+    public static function substrDataProvider()
     {
         yield 'Afrikaans' => [
             'expected' => 'Afrikaans',
@@ -165,7 +162,7 @@ class MbStringTest extends TestCase
         ];
     }
 
-    public function strlenDataProvider()
+    public static function strlenDataProvider()
     {
         yield 'Afrikaans' => [
             'expectedLength' => 9,

--- a/lib/php/test/Unit/Lib/TMultiplexedProcessorTest.php
+++ b/lib/php/test/Unit/Lib/TMultiplexedProcessorTest.php
@@ -34,9 +34,9 @@ class TMultiplexedProcessorTest extends TestCase
 {
     public function testProcessDispatchesToRegisteredService(): void
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $input = $this->createMock(TProtocol::class);
-        $output = $this->createMock(TProtocol::class);
+        $output = $this->createStub(TProtocol::class);
         $processor = $this->createMock(TestProcessor::class);
 
         $input->expects($this->once())
@@ -81,7 +81,7 @@ class TMultiplexedProcessorTest extends TestCase
     public function testProcessRejectsUnexpectedMessageType(): void
     {
         $input = $this->createMock(TProtocol::class);
-        $output = $this->createMock(TProtocol::class);
+        $output = $this->createStub(TProtocol::class);
 
         $input->expects($this->once())
             ->method('readMessageBegin')
@@ -102,7 +102,7 @@ class TMultiplexedProcessorTest extends TestCase
     public function testProcessRequiresServiceSeparator(): void
     {
         $input = $this->createMock(TProtocol::class);
-        $output = $this->createMock(TProtocol::class);
+        $output = $this->createStub(TProtocol::class);
 
         $input->expects($this->once())
             ->method('readMessageBegin')
@@ -123,7 +123,7 @@ class TMultiplexedProcessorTest extends TestCase
     public function testProcessRequiresKnownServiceName(): void
     {
         $input = $this->createMock(TProtocol::class);
-        $output = $this->createMock(TProtocol::class);
+        $output = $this->createStub(TProtocol::class);
 
         $input->expects($this->once())
             ->method('readMessageBegin')
@@ -136,7 +136,7 @@ class TMultiplexedProcessorTest extends TestCase
             });
 
         $multiplexedProcessor = new TMultiplexedProcessor();
-        $multiplexedProcessor->registerProcessor('Other', $this->createMock(TestProcessor::class));
+        $multiplexedProcessor->registerProcessor('Other', $this->createStub(TestProcessor::class));
 
         $this->expectException(TException::class);
         $this->expectExceptionMessage('Service name not found: Missing.');

--- a/lib/php/test/Unit/Lib/Transport/TBufferedTransportTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TBufferedTransportTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Unit\Lib\Transport;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Transport\TBufferedTransport;
 use Thrift\Transport\TTransport;
@@ -71,7 +72,7 @@ class TBufferedTransportTest extends TestCase
 
     public function testPutBack()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $bufferedTransport = new TBufferedTransport($transport);
         $bufferedTransport->putBack('test');
 
@@ -81,9 +82,7 @@ class TBufferedTransportTest extends TestCase
         $this->assertEquals('abcdetest', $this->getPropertyValue($bufferedTransport, 'rBuf_'));
     }
 
-    /**
-     * @dataProvider readAllDataProvider
-     */
+    #[DataProvider('readAllDataProvider')]
     public function testReadAll(
         $startBuffer,
         $readLength,
@@ -107,7 +106,7 @@ class TBufferedTransportTest extends TestCase
         $this->assertEquals($expectedBufferValue, $this->getPropertyValue($bufferedTransport, 'rBuf_'));
     }
 
-    public function readAllDataProvider()
+    public static function readAllDataProvider()
     {
         yield 'buffer empty' => [
             'startBuffer' => '',
@@ -143,9 +142,7 @@ class TBufferedTransportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $readBufferSize,
         $startBuffer,
@@ -169,7 +166,7 @@ class TBufferedTransportTest extends TestCase
         $this->assertEquals($expectedBufferValue, $this->getPropertyValue($bufferedTransport, 'rBuf_'));
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'buffer empty' => [
             'readBufferSize' => 10,
@@ -197,9 +194,7 @@ class TBufferedTransportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $writeBufferSize,
         $writeData,
@@ -220,7 +215,7 @@ class TBufferedTransportTest extends TestCase
         $this->assertEquals($expectedWriteBufferValue, $this->getPropertyValue($bufferedTransport, 'wBuf_'));
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         yield 'store data in buffer' => [
             'writeBufferSize' => 10,
@@ -236,9 +231,7 @@ class TBufferedTransportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider flushDataProvider
-     */
+    #[DataProvider('flushDataProvider')]
     public function testFlush(
         $writeBuffer
     ) {
@@ -262,7 +255,7 @@ class TBufferedTransportTest extends TestCase
         $this->assertEquals('', $this->getPropertyValue($bufferedTransport, 'wBuf_'));
     }
 
-    public function flushDataProvider()
+    public static function flushDataProvider()
     {
         yield 'empty buffer' => [
             'writeBuffer' => '',

--- a/lib/php/test/Unit/Lib/Transport/TCurlClientTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TCurlClientTest.php
@@ -23,6 +23,9 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TCurlClient;
@@ -142,9 +145,7 @@ class TCurlClientTest extends TestCase
         $this->assertEquals(['test' => '1234567890', 'test2' => '12345'], $this->getPropertyValue($transport, 'headers_'));
     }
 
-    /**
-     * @dataProvider flushDataProvider
-     */
+    #[DataProvider('flushDataProvider')]
     public function testFlush(
         $host,
         $port,
@@ -178,22 +179,33 @@ class TCurlClientTest extends TestCase
 
         $this->getFunctionMock('Thrift\\Transport', 'curl_setopt')
              ->expects($this->any())
-             ->withConsecutive(...$curlSetOptCalls)
-             ->willReturn(true);
+             ->willReturnCallback(function (...$args) use ($curlSetOptCalls) {
+                 static $iteration = 0;
+                 $expected = $curlSetOptCalls[$iteration++];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($args[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $args[$i]);
+                    }
+                }
+
+                 return true;
+             });
 
         $this->getFunctionMock('Thrift\\Transport', 'curl_exec')
              ->expects($this->once())
-             ->with($this->anything())
+             ->with(Assert::anything())
              ->willReturn($response);
 
         $this->getFunctionMock('Thrift\\Transport', 'curl_error')
              ->expects($this->once())
-             ->with($this->anything())
+             ->with(Assert::anything())
              ->willReturn($responseError);
 
         $this->getFunctionMock('Thrift\\Transport', 'curl_getinfo')
              ->expects($this->once())
-             ->with($this->anything(), CURLINFO_HTTP_CODE)
+             ->with(Assert::anything(), CURLINFO_HTTP_CODE)
              ->willReturn($responseCode);
 
         if (!is_null($expectedException)) {
@@ -203,7 +215,7 @@ class TCurlClientTest extends TestCase
 
             $this->getFunctionMock('Thrift\\Transport', 'curl_close')
                  ->expects($this->once())
-                 ->with($this->anything());
+                 ->with(Assert::anything());
         }
 
         $transport = new TCurlClient($host, $port, $uri, $scheme);
@@ -221,7 +233,7 @@ class TCurlClientTest extends TestCase
         $transport->flush();
     }
 
-    public function flushDataProvider()
+    public static function flushDataProvider()
     {
         $request = 'request';
 
@@ -235,13 +247,13 @@ class TCurlClientTest extends TestCase
             'timeout' => null,
             'connectionTimeout' => null,
             'curlSetOptCalls' => [
-                [$this->anything(), CURLOPT_RETURNTRANSFER, true],
-                [$this->anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
-                [$this->anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
-                [$this->anything(), CURLOPT_FOLLOWLOCATION, true],
-                [$this->anything(), CURLOPT_MAXREDIRS, 1],
+                [Assert::anything(), CURLOPT_RETURNTRANSFER, true],
+                [Assert::anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
+                [Assert::anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
+                [Assert::anything(), CURLOPT_FOLLOWLOCATION, true],
+                [Assert::anything(), CURLOPT_MAXREDIRS, 1],
                 [
-                    $this->anything(),
+                    Assert::anything(),
                     CURLOPT_HTTPHEADER,
                     [
                         'Accept: application/x-thrift',
@@ -249,8 +261,8 @@ class TCurlClientTest extends TestCase
                         'Content-Length: ' . strlen($request),
                     ],
                 ],
-                [$this->anything(), CURLOPT_POSTFIELDS, $request],
-                [$this->anything(), CURLOPT_URL, 'http://localhost'],
+                [Assert::anything(), CURLOPT_POSTFIELDS, $request],
+                [Assert::anything(), CURLOPT_URL, 'http://localhost'],
             ],
             'response' => 'response',
             'responseError' => '',
@@ -263,13 +275,13 @@ class TCurlClientTest extends TestCase
             [
                 'headers' => ['test' => '1234567890'],
                 'curlSetOptCalls' => [
-                    [$this->anything(), CURLOPT_RETURNTRANSFER, true],
-                    [$this->anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
-                    [$this->anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
-                    [$this->anything(), CURLOPT_FOLLOWLOCATION, true],
-                    [$this->anything(), CURLOPT_MAXREDIRS, 1],
+                    [Assert::anything(), CURLOPT_RETURNTRANSFER, true],
+                    [Assert::anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
+                    [Assert::anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
+                    [Assert::anything(), CURLOPT_FOLLOWLOCATION, true],
+                    [Assert::anything(), CURLOPT_MAXREDIRS, 1],
                     [
-                        $this->anything(),
+                        Assert::anything(),
                         CURLOPT_HTTPHEADER,
                         [
                             'Accept: application/x-thrift',
@@ -278,8 +290,8 @@ class TCurlClientTest extends TestCase
                             'test: 1234567890',
                         ],
                     ],
-                    [$this->anything(), CURLOPT_POSTFIELDS, $request],
-                    [$this->anything(), CURLOPT_URL, 'http://localhost'],
+                    [Assert::anything(), CURLOPT_POSTFIELDS, $request],
+                    [Assert::anything(), CURLOPT_URL, 'http://localhost'],
                 ],
             ]
         );
@@ -288,13 +300,13 @@ class TCurlClientTest extends TestCase
             [
                 'uri' => 'test1234567890',
                 'curlSetOptCalls' => [
-                    [$this->anything(), CURLOPT_RETURNTRANSFER, true],
-                    [$this->anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
-                    [$this->anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
-                    [$this->anything(), CURLOPT_FOLLOWLOCATION, true],
-                    [$this->anything(), CURLOPT_MAXREDIRS, 1],
+                    [Assert::anything(), CURLOPT_RETURNTRANSFER, true],
+                    [Assert::anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
+                    [Assert::anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
+                    [Assert::anything(), CURLOPT_FOLLOWLOCATION, true],
+                    [Assert::anything(), CURLOPT_MAXREDIRS, 1],
                     [
-                        $this->anything(),
+                        Assert::anything(),
                         CURLOPT_HTTPHEADER,
                         [
                             'Accept: application/x-thrift',
@@ -302,8 +314,8 @@ class TCurlClientTest extends TestCase
                             'Content-Length: ' . strlen($request),
                         ],
                     ],
-                    [$this->anything(), CURLOPT_POSTFIELDS, $request],
-                    [$this->anything(), CURLOPT_URL, 'http://localhost/test1234567890'],
+                    [Assert::anything(), CURLOPT_POSTFIELDS, $request],
+                    [Assert::anything(), CURLOPT_URL, 'http://localhost/test1234567890'],
                 ],
             ]
         );
@@ -313,13 +325,13 @@ class TCurlClientTest extends TestCase
                 'timeout' => 10,
                 'connectionTimeout' => 10,
                 'curlSetOptCalls' => [
-                    [$this->anything(), CURLOPT_RETURNTRANSFER, true],
-                    [$this->anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
-                    [$this->anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
-                    [$this->anything(), CURLOPT_FOLLOWLOCATION, true],
-                    [$this->anything(), CURLOPT_MAXREDIRS, 1],
+                    [Assert::anything(), CURLOPT_RETURNTRANSFER, true],
+                    [Assert::anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
+                    [Assert::anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
+                    [Assert::anything(), CURLOPT_FOLLOWLOCATION, true],
+                    [Assert::anything(), CURLOPT_MAXREDIRS, 1],
                     [
-                        $this->anything(),
+                        Assert::anything(),
                         CURLOPT_HTTPHEADER,
                         [
                             'Accept: application/x-thrift',
@@ -327,10 +339,10 @@ class TCurlClientTest extends TestCase
                             'Content-Length: ' . strlen($request),
                         ],
                     ],
-                    [$this->anything(), CURLOPT_TIMEOUT, 10],
-                    [$this->anything(), CURLOPT_CONNECTTIMEOUT, 10],
-                    [$this->anything(), CURLOPT_POSTFIELDS, $request],
-                    [$this->anything(), CURLOPT_URL, 'http://localhost'],
+                    [Assert::anything(), CURLOPT_TIMEOUT, 10],
+                    [Assert::anything(), CURLOPT_CONNECTTIMEOUT, 10],
+                    [Assert::anything(), CURLOPT_POSTFIELDS, $request],
+                    [Assert::anything(), CURLOPT_URL, 'http://localhost'],
                 ],
             ]
         );
@@ -340,13 +352,13 @@ class TCurlClientTest extends TestCase
                 'timeout' => 0.1,
                 'connectionTimeout' => 0.1,
                 'curlSetOptCalls' => [
-                    [$this->anything(), CURLOPT_RETURNTRANSFER, true],
-                    [$this->anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
-                    [$this->anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
-                    [$this->anything(), CURLOPT_FOLLOWLOCATION, true],
-                    [$this->anything(), CURLOPT_MAXREDIRS, 1],
+                    [Assert::anything(), CURLOPT_RETURNTRANSFER, true],
+                    [Assert::anything(), CURLOPT_USERAGENT, 'PHP/TCurlClient'],
+                    [Assert::anything(), CURLOPT_CUSTOMREQUEST, 'POST'],
+                    [Assert::anything(), CURLOPT_FOLLOWLOCATION, true],
+                    [Assert::anything(), CURLOPT_MAXREDIRS, 1],
                     [
-                        $this->anything(),
+                        Assert::anything(),
                         CURLOPT_HTTPHEADER,
                         [
                             'Accept: application/x-thrift',
@@ -354,10 +366,10 @@ class TCurlClientTest extends TestCase
                             'Content-Length: ' . strlen($request),
                         ],
                     ],
-                    [$this->anything(), CURLOPT_TIMEOUT_MS, 100],
-                    [$this->anything(), CURLOPT_CONNECTTIMEOUT_MS, 100],
-                    [$this->anything(), CURLOPT_POSTFIELDS, $request],
-                    [$this->anything(), CURLOPT_URL, 'http://localhost'],
+                    [Assert::anything(), CURLOPT_TIMEOUT_MS, 100.0],
+                    [Assert::anything(), CURLOPT_CONNECTTIMEOUT_MS, 100.0],
+                    [Assert::anything(), CURLOPT_POSTFIELDS, $request],
+                    [Assert::anything(), CURLOPT_URL, 'http://localhost'],
                 ],
             ]
         );

--- a/lib/php/test/Unit/Lib/Transport/TFramedTransportTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TFramedTransportTest.php
@@ -22,6 +22,8 @@
 namespace Test\Thrift\Unit\Lib\Transport;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Transport\TFramedTransport;
 use Thrift\Transport\TTransport;
@@ -71,7 +73,7 @@ class TFramedTransportTest extends TestCase
 
     public function testPutBack()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $framedTransport = new TFramedTransport($transport);
         $framedTransport->putBack('test');
 
@@ -81,9 +83,7 @@ class TFramedTransportTest extends TestCase
         $this->assertEquals('abcdetest', $this->getPropertyValue($framedTransport, 'rBuf_'));
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $readAllowed,
         $readBuffer,
@@ -106,13 +106,24 @@ class TFramedTransportTest extends TestCase
         $transport
             ->expects($this->exactly(count($lowLevelTransportReadAllParams)))
             ->method('readAll')
-            ->withConsecutive(...$lowLevelTransportReadAllParams)
-            ->willReturnOnConsecutiveCalls(...$lowLevelTransportReadAllResult);
+            ->willReturnCallback(function (...$args) use ($lowLevelTransportReadAllParams, $lowLevelTransportReadAllResult) {
+                static $iteration = 0;
+                $expected = $lowLevelTransportReadAllParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($args[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $args[$i]);
+                    }
+                }
+
+                return $lowLevelTransportReadAllResult[$iteration++];
+            });
 
         $this->assertEquals($expectedReadResult, $framedTransport->read($readLength));
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'read not allowed' => [
             'readAllowed' => false,
@@ -143,9 +154,7 @@ class TFramedTransportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $writeAllowed,
         $writeData,
@@ -166,7 +175,7 @@ class TFramedTransportTest extends TestCase
         $this->assertEquals($expectedWriteBufferValue, $this->getPropertyValue($framedTransport, 'wBuf_'));
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         yield 'write not allowed' => [
             'writeAllowed' => false,
@@ -188,9 +197,7 @@ class TFramedTransportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider flushDataProvider
-     */
+    #[DataProvider('flushDataProvider')]
     public function testFlush(
         $writeAllowed,
         $writeBuffer,
@@ -213,7 +220,7 @@ class TFramedTransportTest extends TestCase
         $this->assertNull($framedTransport->flush());
     }
 
-    public function flushDataProvider()
+    public static function flushDataProvider()
     {
         yield 'write not allowed' => [
             'writeAllowed' => false,

--- a/lib/php/test/Unit/Lib/Transport/THttpClientTest.php
+++ b/lib/php/test/Unit/Lib/Transport/THttpClientTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\THttpClient;
@@ -72,9 +73,7 @@ class THttpClientTest extends TestCase
         $this->assertNull($this->getPropertyValue($transport, 'handle_'));
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $readLen,
         $freadResult,
@@ -109,7 +108,7 @@ class THttpClientTest extends TestCase
         $this->assertEquals($expectedResult, $transport->read($readLen));
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'read success' => [
             'readLen' => 10,
@@ -154,9 +153,7 @@ class THttpClientTest extends TestCase
         $this->assertEquals('1234567890', $this->getPropertyValue($transport, 'buf_'));
     }
 
-    /**
-     * @dataProvider flushDataProvider
-     */
+    #[DataProvider('flushDataProvider')]
     public function testFlush(
         $host,
         $port,
@@ -205,7 +202,7 @@ class THttpClientTest extends TestCase
         $this->assertNull($transport->flush());
     }
 
-    public function flushDataProvider()
+    public static function flushDataProvider()
     {
         $default = [
             'host' => 'localhost',

--- a/lib/php/test/Unit/Lib/Transport/TMemoryBufferTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TMemoryBufferTest.php
@@ -22,6 +22,7 @@
 namespace Test\Thrift\Unit\Lib\Transport;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TMemoryBuffer;
 
@@ -54,9 +55,7 @@ class TMemoryBufferTest extends TestCase
         $transport->read(1);
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $startBuffer,
         $readLength,
@@ -68,7 +67,7 @@ class TMemoryBufferTest extends TestCase
         $this->assertEquals($expectedBuffer, $transport->getBuffer());
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'Read part of buffer' => [
             'startBuffer' => '1234567890',
@@ -96,9 +95,7 @@ class TMemoryBufferTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $startBuffer,
         $writeData,
@@ -109,7 +106,7 @@ class TMemoryBufferTest extends TestCase
         $this->assertEquals($expectedBuffer, $transport->getBuffer());
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         yield 'empty start buffer' => [
             'startBuffer' => '',

--- a/lib/php/test/Unit/Lib/Transport/TPhpStreamTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TPhpStreamTest.php
@@ -23,6 +23,9 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TException;
 use Thrift\Transport\TPhpStream;
 
@@ -30,9 +33,7 @@ class TPhpStreamTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @dataProvider fopenDataProvider
-     */
+    #[DataProvider('fopenDataProvider')]
     public function testOpen(
         $mode,
         $sapiName,
@@ -53,8 +54,19 @@ class TPhpStreamTest extends TestCase
 
         $this->getFunctionMock('Thrift\Transport', 'fopen')
              ->expects($this->exactly(count($fopenResult)))
-             ->withConsecutive(...$fopenParams)
-             ->willReturnOnConsecutiveCalls(...$fopenResult);
+             ->willReturnCallback(function (...$args) use ($fopenParams, $fopenResult) {
+                 static $iteration = 0;
+                 $expected = $fopenParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($args[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $args[$i]);
+                    }
+                }
+
+                 return $fopenResult[$iteration++];
+             });
 
         if ($expectedException) {
             $this->expectException($expectedException);
@@ -66,7 +78,7 @@ class TPhpStreamTest extends TestCase
         $transport->open();
     }
 
-    public function fopenDataProvider()
+    public static function fopenDataProvider()
     {
         yield 'readCli' => [
             'mode' => TPhpStream::MODE_R,
@@ -125,9 +137,7 @@ class TPhpStreamTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider closeDataProvider
-     */
+    #[DataProvider('closeDataProvider')]
     public function testClose(
         $mode,
         $fopenParams,
@@ -140,8 +150,19 @@ class TPhpStreamTest extends TestCase
 
         $this->getFunctionMock('Thrift\Transport', 'fopen')
              ->expects($this->exactly(count($fopenParams)))
-             ->withConsecutive(...$fopenParams)
-             ->willReturnOnConsecutiveCalls(...$fopenResult);
+             ->willReturnCallback(function (...$args) use ($fopenParams, $fopenResult) {
+                 static $iteration = 0;
+                 $expected = $fopenParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($args[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $args[$i]);
+                    }
+                }
+
+                 return $fopenResult[$iteration++];
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'fclose')
              ->expects($this->exactly(count($fopenParams)))
@@ -160,7 +181,7 @@ class TPhpStreamTest extends TestCase
         $this->assertFalse($transport->isOpen());
     }
 
-    public function closeDataProvider()
+    public static function closeDataProvider()
     {
         $read = ['php://temp', 'r'];
         $write = ['php://temp', 'w'];
@@ -181,9 +202,7 @@ class TPhpStreamTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider readDataProvider
-     */
+    #[DataProvider('readDataProvider')]
     public function testRead(
         $freadResult,
         $expectedResult,
@@ -193,7 +212,7 @@ class TPhpStreamTest extends TestCase
     ) {
         $this->getFunctionMock('Thrift\Transport', 'fread')
              ->expects($this->once())
-             ->with($this->anything(), 5)
+             ->with(Assert::anything(), 5)
              ->willReturn($freadResult);
 
         if ($expectedException) {
@@ -206,7 +225,7 @@ class TPhpStreamTest extends TestCase
         $this->assertEquals($expectedResult, $transport->read(5));
     }
 
-    public function readDataProvider()
+    public static function readDataProvider()
     {
         yield 'success' => [
             'freadResult' => '12345',
@@ -231,9 +250,7 @@ class TPhpStreamTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider writeDataProvider
-     */
+    #[DataProvider('writeDataProvider')]
     public function testWrite(
         $buf,
         $fwriteParams,
@@ -244,8 +261,19 @@ class TPhpStreamTest extends TestCase
     ) {
         $this->getFunctionMock('Thrift\Transport', 'fwrite')
              ->expects($this->exactly(count($fwriteParams)))
-             ->withConsecutive(...$fwriteParams)
-             ->willReturnOnConsecutiveCalls(...$fwriteResult);
+             ->willReturnCallback(function (...$args) use ($fwriteParams, $fwriteResult) {
+                 static $iteration = 0;
+                 $expected = $fwriteParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($args[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $args[$i]);
+                    }
+                }
+
+                 return $fwriteResult[$iteration++];
+             });
 
         if ($expectedException) {
             $this->expectException($expectedException);
@@ -257,11 +285,11 @@ class TPhpStreamTest extends TestCase
         $transport->write($buf);
     }
 
-    public function writeDataProvider()
+    public static function writeDataProvider()
     {
         yield 'success' => [
             'buf' => '12345',
-            'fwriteParams' => [[$this->anything(), '12345']],
+            'fwriteParams' => [[Assert::anything(), '12345']],
             'fwriteResult' => [5],
             'expectedException' => null,
             'expectedExceptionMessage' => '',
@@ -269,7 +297,7 @@ class TPhpStreamTest extends TestCase
         ];
         yield 'several iteration' => [
             'buf' => '1234567890',
-            'fwriteParams' => [[$this->anything(), '1234567890'], [$this->anything(), '67890']],
+            'fwriteParams' => [[Assert::anything(), '1234567890'], [Assert::anything(), '67890']],
             'fwriteResult' => [5, 5],
             'expectedException' => null,
             'expectedExceptionMessage' => '',
@@ -277,7 +305,7 @@ class TPhpStreamTest extends TestCase
         ];
         yield 'fail' => [
             'buf' => '1234567890',
-            'fwriteParams' => [[$this->anything(), '1234567890']],
+            'fwriteParams' => [[Assert::anything(), '1234567890']],
             'fwriteResult' => [false],
             'expectedException' => TException::class,
             'expectedExceptionMessage' => 'TPhpStream: Could not write 10 bytes',

--- a/lib/php/test/Unit/Lib/Transport/TSSLSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSSLSocketTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TSSLSocket;
@@ -31,9 +32,7 @@ class TSSLSocketTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @dataProvider openExceptionDataProvider
-     */
+    #[DataProvider('openExceptionDataProvider')]
     public function testOpenException(
         $host,
         $port,
@@ -69,7 +68,7 @@ class TSSLSocketTest extends TestCase
         $socket->open();
     }
 
-    public function openExceptionDataProvider()
+    public static function openExceptionDataProvider()
     {
         yield 'host is empty' => [
             'host' => '',
@@ -221,9 +220,7 @@ class TSSLSocketTest extends TestCase
         $this->assertTrue($transport->isOpen());
     }
 
-    /**
-     * @dataProvider hostDataProvider
-     */
+    #[DataProvider('hostDataProvider')]
     public function testGetHost($host, $expected)
     {
         $port = 9090;
@@ -238,7 +235,7 @@ class TSSLSocketTest extends TestCase
         $this->assertEquals($expected, $transport->getHost());
     }
 
-    public function hostDataProvider()
+    public static function hostDataProvider()
     {
         yield 'localhost' => ['localhost', 'ssl://localhost'];
         yield 'ssl_localhost' => ['ssl://localhost', 'ssl://localhost'];

--- a/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
@@ -23,6 +23,9 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TException;
 use Thrift\Transport\TSocketPool;
@@ -38,9 +41,7 @@ class TSocketPoolTest extends TestCase
         self::defineFunctionMock('Thrift\Transport', 'function_exists');
     }
 
-    /**
-     * @dataProvider constructDataProvider
-     */
+    #[DataProvider('constructDataProvider')]
     public function testConstruct(
         $hosts,
         $ports,
@@ -54,7 +55,7 @@ class TSocketPoolTest extends TestCase
     }
 
 
-    public function constructDataProvider()
+    public static function constructDataProvider()
     {
         yield 'one server' => [
             ['localhost'],
@@ -144,9 +145,7 @@ class TSocketPoolTest extends TestCase
         $this->assertEquals(false, $this->getPropertyValue($socketPool, 'alwaysTryLast_'));
     }
 
-    /**
-     * @dataProvider openDataProvider
-     */
+    #[DataProvider('openDataProvider')]
     public function testOpen(
         $hosts,
         $ports,
@@ -172,8 +171,19 @@ class TSocketPoolTest extends TestCase
     ) {
         $this->getFunctionMock('Thrift\Transport', 'function_exists')
              ->expects($this->exactly(count($functionExistCallParams)))
-             ->withConsecutive(...$functionExistCallParams)
-             ->willReturnOnConsecutiveCalls(...$functionExistResult);
+             ->willReturnCallback(function (...$callArgs) use ($functionExistCallParams, $functionExistResult) {
+                 static $iteration = 0;
+                 $expected = $functionExistCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                 return $functionExistResult[$iteration++];
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'shuffle')
              ->expects($randomize ? $this->once() : $this->never())
@@ -186,18 +196,51 @@ class TSocketPoolTest extends TestCase
 
         $this->getFunctionMock('Thrift\Transport', 'apcu_fetch')
              ->expects($this->exactly(count($apcuFetchCallParams)))
-             ->withConsecutive(...$apcuFetchCallParams)
-             ->willReturnOnConsecutiveCalls(...$apcuFetchResult);
+             ->willReturnCallback(function (...$callArgs) use ($apcuFetchCallParams, $apcuFetchResult) {
+                 static $iteration = 0;
+                 $expected = $apcuFetchCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                 return $apcuFetchResult[$iteration++];
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'call_user_func')
              ->expects($this->exactly(count($debugHandlerCall)))
-             ->withConsecutive(...$debugHandlerCall)
-             ->willReturn(true);
+             ->willReturnCallback(function (...$callArgs) use ($debugHandlerCall) {
+                 static $iteration = 0;
+                 $expected = $debugHandlerCall[$iteration++];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                 return true;
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'apcu_store')
              ->expects($this->exactly(count($apcuStoreCallParams)))
-             ->withConsecutive(...$apcuStoreCallParams)
-             ->willReturn(true);
+             ->willReturnCallback(function (...$callArgs) use ($apcuStoreCallParams) {
+                 static $iteration = 0;
+                 $expected = $apcuStoreCallParams[$iteration++];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                 return true;
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'time')
              ->expects($this->exactly(count($timeResult)))
@@ -210,8 +253,19 @@ class TSocketPoolTest extends TestCase
 
         $this->getFunctionMock('Thrift\Transport', $persist ? 'pfsockopen' : 'fsockopen')
              ->expects($this->exactly(count($fsockopenCallParams)))
-             ->withConsecutive(...$fsockopenCallParams)
-             ->willReturnOnConsecutiveCalls(...$fsockopenResult);
+             ->willReturnCallback(function (...$callArgs) use ($fsockopenCallParams, $fsockopenResult) {
+                 static $iteration = 0;
+                 $expected = $fsockopenCallParams[$iteration];
+                foreach ($expected as $i => $exp) {
+                    if ($exp instanceof Constraint) {
+                        $this->assertThat($callArgs[$i], $exp);
+                    } else {
+                        $this->assertSame($exp, $callArgs[$i]);
+                    }
+                }
+
+                 return $fsockopenResult[$iteration++];
+             });
 
         $this->getFunctionMock('Thrift\Transport', 'socket_import_stream')
              ->expects(is_null($expectedException) ? $this->once() : $this->never())
@@ -225,7 +279,7 @@ class TSocketPoolTest extends TestCase
         $this->getFunctionMock('Thrift\Transport', 'socket_set_option')
              ->expects(is_null($expectedException) ? $this->once() : $this->never())
              ->with(
-                 $this->anything(), #$socket,
+                 Assert::anything(), #$socket,
                  SOL_TCP, #$level
                  TCP_NODELAY, #$option
                  1 #$value
@@ -247,7 +301,7 @@ class TSocketPoolTest extends TestCase
         $this->assertNull($socketPool->open());
     }
 
-    public function openDataProvider()
+    public static function openDataProvider()
     {
         $default = [
             'hosts' => ['localhost'],
@@ -273,7 +327,7 @@ class TSocketPoolTest extends TestCase
                 true,
             ],
             'apcuFetchCallParams' => [
-                ['thrift_failtime:localhost:9090~', $this->anything()],
+                ['thrift_failtime:localhost:9090~', Assert::anything()],
             ],
             'apcuFetchResult' => [
                 false,
@@ -285,9 +339,9 @@ class TSocketPoolTest extends TestCase
                 [
                     'localhost',
                     9090,
-                    $this->anything(), #$errno,
-                    $this->anything(), #$errstr,
-                    $this->anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+                    Assert::anything(), #$errno,
+                    Assert::anything(), #$errstr,
+                    Assert::anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
                 ],
             ],
             'fsockopenResult' => [
@@ -308,12 +362,12 @@ class TSocketPoolTest extends TestCase
                     false,
                 ],
                 'apcuFetchCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
-                    ['thrift_consecfails:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
+                    ['thrift_consecfails:localhost:9090~', Assert::anything()],
                 ],
                 'apcuStoreCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
-                    ['thrift_consecfails:localhost:9090~', $this->anything(), 0],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
+                    ['thrift_consecfails:localhost:9090~', Assert::anything(), 0],
                 ],
                 'timeResult' => [
                     1,
@@ -330,16 +384,16 @@ class TSocketPoolTest extends TestCase
                     [
                         'localhost',
                         9090,
-                        $this->anything(), #$errno,
-                        $this->anything(), #$errstr,
-                        $this->anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+                        Assert::anything(), #$errno,
+                        Assert::anything(), #$errstr,
+                        Assert::anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
                     ],
                     [
                         'localhost',
                         9090,
-                        $this->anything(), #$errno,
-                        $this->anything(), #$errstr,
-                        $this->anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+                        Assert::anything(), #$errno,
+                        Assert::anything(), #$errstr,
+                        Assert::anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
                     ],
                 ],
                 'fsockopenResult' => [
@@ -357,7 +411,7 @@ class TSocketPoolTest extends TestCase
                     99,
                 ],
                 'apcuStoreCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
                 ],
                 'timeResult' => [
                     100,
@@ -372,7 +426,7 @@ class TSocketPoolTest extends TestCase
                     90,
                 ],
                 'apcuStoreCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
                 ],
                 'timeResult' => [
                     100,
@@ -394,14 +448,14 @@ class TSocketPoolTest extends TestCase
                     true,
                 ],
                 'apcuFetchCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
-                    ['thrift_consecfails:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
+                    ['thrift_consecfails:localhost:9090~', Assert::anything()],
                 ],
                 'apcuFetchResult' => [
                     90,
                 ],
                 'apcuStoreCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
                     ['thrift_consecfails:localhost:9090~', 0],
                 ],
                 'timeResult' => [
@@ -433,8 +487,8 @@ class TSocketPoolTest extends TestCase
                     true,
                 ],
                 'apcuFetchCallParams' => [
-                    ['thrift_failtime:localhost:9090~', $this->anything()],
-                    ['thrift_consecfails:localhost:9090~', $this->anything()],
+                    ['thrift_failtime:localhost:9090~', Assert::anything()],
+                    ['thrift_consecfails:localhost:9090~', Assert::anything()],
                 ],
                 'apcuStoreCallParams' => [
                     ['thrift_consecfails:localhost:9090~', 1],
@@ -481,16 +535,16 @@ class TSocketPoolTest extends TestCase
                     [
                         'host2',
                         9091,
-                        $this->anything(), #$errno,
-                        $this->anything(), #$errstr,
-                        $this->anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+                        Assert::anything(), #$errno,
+                        Assert::anything(), #$errstr,
+                        Assert::anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
                     ],
                     [
                         'host1',
                         9090,
-                        $this->anything(), #$errno,
-                        $this->anything(), #$errstr,
-                        $this->anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
+                        Assert::anything(), #$errno,
+                        Assert::anything(), #$errstr,
+                        Assert::anything(), #$this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000),
                     ],
                 ],
                 'fsockopenResult' => [
@@ -498,13 +552,13 @@ class TSocketPoolTest extends TestCase
                     ['php://temp', 'r'],
                 ],
                 'apcuFetchCallParams' => [
-                    ['thrift_failtime:host2:9091~', $this->anything()],
-                    ['thrift_consecfails:host2:9091~', $this->anything()],
-                    ['thrift_failtime:host1:9090~', $this->anything()],
+                    ['thrift_failtime:host2:9091~', Assert::anything()],
+                    ['thrift_consecfails:host2:9091~', Assert::anything()],
+                    ['thrift_failtime:host1:9090~', Assert::anything()],
                 ],
                 'apcuStoreCallParams' => [
-                    ['thrift_failtime:host2:9091~', $this->anything()],
-                    ['thrift_consecfails:host2:9091~', $this->anything(), 0],
+                    ['thrift_failtime:host2:9091~', Assert::anything()],
+                    ['thrift_consecfails:host2:9091~', Assert::anything(), 0],
                 ],
                 'timeResult' => [
                     1,

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -23,6 +23,7 @@ namespace Test\Thrift\Unit\Lib\Transport;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
@@ -33,9 +34,7 @@ class TSocketTest extends TestCase
     use PHPMock;
     use ReflectionHelper;
 
-    /**
-     * @dataProvider openExceptionDataProvider
-     */
+    #[DataProvider('openExceptionDataProvider')]
     public function testOpenException(
         $host,
         $port,
@@ -70,7 +69,7 @@ class TSocketTest extends TestCase
         $socket->open();
     }
 
-    public function openExceptionDataProvider()
+    public static function openExceptionDataProvider()
     {
         yield 'host is empty' => [
             'host' => '',
@@ -292,9 +291,7 @@ class TSocketTest extends TestCase
         $transport->open();
     }
 
-    /**
-     * @dataProvider openThrift5132DataProvider
-     */
+    #[DataProvider('openThrift5132DataProvider')]
     public function testOpenThrift5132(
         $socketImportResult
     ) {
@@ -339,7 +336,7 @@ class TSocketTest extends TestCase
         $this->assertTrue($transport->isOpen());
     }
 
-    public function openThrift5132DataProvider()
+    public static function openThrift5132DataProvider()
     {
         yield 'socket_import_stream success' => [
             'socketImportResult' => true,
@@ -403,9 +400,7 @@ class TSocketTest extends TestCase
         $this->assertEquals(999000, $this->getPropertyValue($transport, 'recvTimeoutUsec_'));
     }
 
-    /**
-     * @dataProvider hostDataProvider
-     */
+    #[DataProvider('hostDataProvider')]
     public function testGetHost($host, $expected)
     {
         $port = 9090;
@@ -420,7 +415,7 @@ class TSocketTest extends TestCase
         $this->assertEquals($expected, $transport->getHost());
     }
 
-    public function hostDataProvider()
+    public static function hostDataProvider()
     {
         yield 'localhost' => ['localhost', 'localhost'];
         yield 'ssl_localhost' => ['ssl://localhost', 'ssl://localhost'];
@@ -461,9 +456,7 @@ class TSocketTest extends TestCase
         $this->assertNull($this->getPropertyValue($transport, 'handle_'));
     }
 
-    /**
-     * @dataProvider writeFailDataProvider
-     */
+    #[DataProvider('writeFailDataProvider')]
     public function testWriteFail(
         $streamSelectResult,
         $fwriteCallCount,
@@ -535,7 +528,7 @@ class TSocketTest extends TestCase
         });
     }
 
-    public function writeFailDataProvider()
+    public static function writeFailDataProvider()
     {
         yield 'stream_select timeout' => [
             'streamSelectResult' => 0,
@@ -583,9 +576,7 @@ class TSocketTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider readFailDataProvider
-     */
+    #[DataProvider('readFailDataProvider')]
     public function testReadFail(
         $streamSelectResult,
         $freadResult,
@@ -638,7 +629,7 @@ class TSocketTest extends TestCase
         $transport->read(5);
     }
 
-    public function readFailDataProvider()
+    public static function readFailDataProvider()
     {
         yield 'stream_select timeout' => [
             'streamSelectResult' => 0,

--- a/lib/php/test/Unit/Lib/Transport/TransportErrorScenariosTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TransportErrorScenariosTest.php
@@ -112,7 +112,7 @@ class TransportErrorScenariosTest extends TestCase
 
     public function testBufferedTransportWriteOnUnderlyingTransportErrorThrowsException()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         // Use a small write buffer so that write triggers a flush to underlying transport
         $bufferedTransport = new TBufferedTransport($transport, 512, 10);
 
@@ -130,7 +130,7 @@ class TransportErrorScenariosTest extends TestCase
 
     public function testBufferedTransportFlushOnUnderlyingTransportErrorThrowsException()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $bufferedTransport = new TBufferedTransport($transport);
 
         $transport
@@ -153,7 +153,7 @@ class TransportErrorScenariosTest extends TestCase
 
     public function testFramedTransportReadWithNoFrameAvailableThrowsException()
     {
-        $transport = $this->createMock(TTransport::class);
+        $transport = $this->createStub(TTransport::class);
         $framedTransport = new TFramedTransport($transport);
 
         // readFrame calls transport_->readAll(4) which will throw when no data available


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

> **Note:** This PR is **stacked** on #3435 ([THRIFT-5956](https://github.com/apache/thrift/pull/3435)) and #3436 ([THRIFT-5957](https://github.com/apache/thrift/pull/3436)). The current diff temporarily includes those changes — once they merge this branch will be rebased onto master and the diff will reduce to just the PHPUnit-migration files.

Resolves [THRIFT-5961](https://issues.apache.org/jira/browse/THRIFT-5961) (attribute syntax migration) **and** [THRIFT-5962](https://issues.apache.org/jira/browse/THRIFT-5962) (PHPUnit major upgrade) together — they are not actually separable: PHPUnit 9.6 has no `Framework\Attributes\DataProvider` class, and PHPUnit 10+ dropped support for the `@dataProvider` annotation. Either change in isolation breaks the test suite.

**Composer constraint:**

- `phpunit/phpunit`: `^10.5 || ^11.0 || ^12.0 || ^13.0` — Composer picks the highest version compatible with the runtime PHP (e.g. PHPUnit 13 on PHP 8.4, PHPUnit 11 on PHP 8.2). The migration is forward-compatible with all four PHPUnit majors.
- `php-mock/php-mock-phpunit`: stays at `^2.10`. That is the only stable line published on Packagist and it works against all four PHPUnit majors.

**`lib/php/phpunit.xml`:**

- Schema 10.5.
- Replace the PHPUnit-9-style `<filter><whitelist>…</whitelist></filter>` with PHPUnit 10's `<source><include>…</include></source>`.
- Drop the `convertErrorsToExceptions` / `convertNoticesToExceptions` / `convertWarningsToExceptions` options that PHPUnit 10 removed.

**Test-suite migration:**

- Convert every `@dataProvider` docblock to a `#[DataProvider(...)]` attribute across the unit + integration test suites (~95 attributes in 25 files), adding `use PHPUnit\Framework\Attributes\DataProvider;`.
- Make every data-provider method `static` (PHPUnit 10 requirement).
- Replace the few `$this->anything()` calls inside data providers with `Assert::anything()` so they remain valid in static context.
- Replace every `withConsecutive(...)` chain — removed in PHPUnit 10 — with `willReturnCallback()` that uses a closure-local `static $iteration = 0;` counter to index the expected args and returns. The counter is incremented via post-increment in the array index, so each call site stays compact.
- For arguments matched by PHPUnit `Constraint` instances (e.g. `Assert::anything()`), the callback inlines a `foreach` with `assertThat` / `assertSame` to preserve constraint semantics.
- Use `assertSame` instead of `assertEquals` so type juggling does not silently mask real mismatches.
- **Deliberately does NOT rely on `InvocationOrder::numberOfInvocations()` or any other `@internal` PHPUnit API** that may change between majors.

**PHPUnit 13 compatibility fixes** (PHPUnit 13's strict named-parameter binding turned latent bugs into hard errors):

- Rename `Test\Thrift\Integration\BaseValidatorTest` → `AbstractValidatorTestCase`. PHPUnit 10+ refuses to load abstract test classes whose name ends in `Test`; the `*TestCase` suffix is the standard convention for shared abstract bases.
- Fix data-provider key typos:
  - `exprectedName` → `expectedName`
  - `mbstring.func_overload` → `mbstringFuncOverload`
  - `expected` → `expectedClass` (in `TStringFuncFactoryTest`)
- Fix int-vs-float type mismatch in `TCurlClientTest::flushDataProvider` (`CURLOPT_TIMEOUT_MS` / `CURLOPT_CONNECTTIMEOUT_MS` are floats when the timeout is a float — `100` → `100.0`). `assertSame` caught it.

**Out of scope (separate tickets):**

- PSR-2 → PSR-12 migration / php-cs-fixer.
- `declare(strict_types=1)` and native types in `lib/php/lib/`.
- `t_php_generator.cc` modernization.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  [THRIFT-5961](https://issues.apache.org/jira/browse/THRIFT-5961) and [THRIFT-5962](https://issues.apache.org/jira/browse/THRIFT-5962)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  *(Test-suite refactor only — no library behaviour change. Downstream test suites that subclass our test classes and use `withConsecutive` themselves will need the same migration.)*
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->

Generated-by: Claude Opus 4.7 (1M context)