### PR TITLE
THRIFT-5965: Added zizmor to run static analysis on GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,17 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/lib/java"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/lib/kotlin"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@main
+      - uses: apache/infrastructure-actions/allowlist-check@8056239fafd626c8a4e2d6679506ba0d8e60f196 # main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -120,6 +122,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -157,6 +161,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # master
@@ -234,6 +240,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -290,6 +298,8 @@ jobs:
       GRADLE_VERSION: "8.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -402,6 +412,8 @@ jobs:
         shell: bash  # required by net install script
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -486,6 +498,8 @@ jobs:
     if: false                     # swift is currently broken and no maintainers around -> see THRIFT-5864
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run bootstrap
         run: ./bootstrap.sh
@@ -524,6 +538,8 @@ jobs:
       TOOLCHAIN_VERSION: 1.85.1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -591,6 +607,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -666,6 +684,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -720,6 +740,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run bootstrap
         run: ./bootstrap.sh
@@ -767,6 +789,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -843,6 +867,8 @@ jobs:
       SKIP_BUILD_EXT: ${{ matrix.skip-build-ext && '1' || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
@@ -914,6 +940,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         timeout-minutes: 10

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Ensure expected workspace path
         shell: pwsh

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -34,6 +34,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
-          bundler-cache: true
+          bundler-cache: false
           ruby-version: "4.0"
           working-directory: lib/rb
 

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -34,11 +34,22 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: false   # currently broken and no maintainers around -> see THRIFT-5917        
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Dryrun
         working-directory: lib/rs
         run: cargo publish --dry-run
+
+      - name: Authenticate to crates.io
+        # Only publish if it's a tag and the tag is not a pre-release
+        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish
         working-directory: lib/rs
@@ -46,4 +57,4 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -2,7 +2,7 @@ name: "Static Code Analysis"
 
 on:
   push:
-    branches: ["*"]
+    branches: ["master"]
   pull_request:
     branches: ["*"]
   workflow_dispatch:
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -243,3 +245,19 @@ jobs:
           fi
 
           exit $failed
+
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read # Only needed for private repos. Needed to clone the repo.
+      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

zizmor is a static analysis tool for GitHub Actions. It can find and fix many common security issues in typical GitHub Actions CI/CD setups. See https://docs.zizmor.sh/

> [!NOTE]
> ASF Infrastructure recommends running zizmor static analysis on GitHub Actions workflows to detect security issues (see [GitHub Actions Security](https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+Security)).

Our workflows had a few common themes, which were addressed:

* Added Dependabot cooldowns.
* Added persist-credentials: false to checkout steps flagged by artipacked.
* Disabled Ruby release Bundler cache.
* Pinned ASF allowlist action to a commit SHA.
* Switched Rust publishing to crates.io trusted publishing with explicit id-token: write.

`zizmor .` initially reported 63 findings, including 37 pre-existing suppressed findings and 26 active findings. This change addresses all active findings; the final `zizmor .` run reports no findings, with the same 37 suppressed findings still suppressed.

## Dependabot Cooldown

Findings:

- `.github/dependabot.yml`: `dependabot-cooldown` warned that the `github-actions`, `gradle` for `lib/java`, and `gradle` for `lib/kotlin` updaters had no cooldown.

Remediation:

- Added `cooldown.default-days: 7` to each updater so Dependabot waits before opening updates for freshly released dependencies.

## Checkout Credential Persistence

Findings:

- `artipacked` warned that checkout steps did not explicitly disable persisted GitHub credentials in `.github/workflows/build.yml`, `.github/workflows/cmake.yml`, `.github/workflows/msvc.yml`, `.github/workflows/pypi.yml`, `.github/workflows/release_rust.yml`, and `.github/workflows/sca.yml`.

Remediation:

- Added `with: persist-credentials: false` to affected `actions/checkout` steps that do not need to push back to the repository.

## Release Cache Poisoning

Findings:

- `.github/workflows/release_ruby.yml`: `cache-poisoning` warned that the Ruby release workflow restored Bundler cache state before publishing the gem.

Remediation:

- Disabled `bundler-cache` for the Ruby release job so publish-time artifacts are not built or released from restored CI cache state.

## Unpinned Action Reference

Findings:

- `.github/workflows/asf-allowlist-check.yml`: `unpinned-uses` warned that `apache/infrastructure-actions/allowlist-check@main` used a mutable branch reference.

Remediation:

- Pinned the allowlist check action to commit `8056239fafd626c8a4e2d6679506ba0d8e60f196`.

## Rust Release Permissions and Publishing Token

Findings:

- `.github/workflows/release_rust.yml`: `excessive-permissions` warned that the publish job used default permissions.
- `.github/workflows/release_rust.yml`: `use-trusted-publishing` recommended replacing the long-lived `CARGO_REGISTRY_TOKEN` secret with trusted publishing.

Remediation:

- Added explicit job permissions: `contents: read` and `id-token: write`.
- Replaced the long-lived crates.io secret flow with `rust-lang/crates-io-auth-action`, pinned to commit `bbd81622f20ce9e2dd9622e3218b975523e45bbe`, and passed the action's temporary token to `cargo publish`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5965](https://issues.apache.org/jira/browse/THRIFT-5965)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
