### PR TITLE
THRIFT-5064: Introduce Perl::Critic into the SCA

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -275,6 +275,46 @@ jobs:
         run: |
           ./vendor/bin/phpstan analyse -c lib/php/phpstan.neon --no-progress --error-format=github
 
+  lib-perl:
+    needs: compiler
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yq
+          # shellcheck disable=SC2086
+          sudo apt-get install -y --no-install-recommends g++ $BUILD_DEPS libperl-critic-perl
+
+      - name: Configure
+        run: |
+          ./bootstrap.sh
+          # shellcheck disable=SC2086
+          ./configure $CONFIG_ARGS_FOR_SCA
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Generate Perl thrift files
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+          make -j"$(nproc)" -C lib/perl precross
+          make -j"$(nproc)" -C test/perl precross
+          make -j"$(nproc)" -C tutorial/perl
+
+      - name: Run perlcritic
+        run: |
+          find lib/perl test/perl tutorial/perl test/audit -iname '*.p[lm]' -type f \
+            ! -path 'lib/perl/blib/*' \
+            ! -path 'lib/perl/t/*' \
+            -print0 | xargs -0 perlcritic
+
   lib-ruby:
     needs: compiler
     runs-on: ubuntu-24.04

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,1 @@
+verbose = 1

--- a/compiler/cpp/src/thrift/generate/t_perl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_perl_generator.cc
@@ -244,7 +244,8 @@ void t_perl_generator::init_generator() {
   f_types_ << autogen_comment() << perl_includes();
 
   // Print header
-  f_consts_ << autogen_comment() << "package " << perl_namespace(program_) << "Constants;" << '\n'
+  f_consts_ << autogen_comment() << "package " << perl_namespace(program_)
+            << "Constants;  ## no critic (RequireFilenameMatchesPackage)" << '\n'
             << perl_includes() << '\n';
 }
 
@@ -292,7 +293,8 @@ void t_perl_generator::generate_typedef(t_typedef* ttypedef) {
  * @param tenum The enumeration
  */
 void t_perl_generator::generate_enum(t_enum* tenum) {
-  f_types_ << "package " << perl_namespace(program_) << tenum->get_name() << ";" << '\n';
+  f_types_ << "package " << perl_namespace(program_) << tenum->get_name()
+           << ";  ## no critic (RequireFilenameMatchesPackage)" << '\n';
 
   vector<t_enum_value*> constants = tenum->get_constants();
   vector<t_enum_value*>::iterator c_iter;
@@ -458,7 +460,8 @@ void t_perl_generator::generate_perl_struct_definition(ostream& out,
   const vector<t_field*>& members = tstruct->get_members();
   vector<t_field*>::const_iterator m_iter;
 
-  out << "package " << perl_namespace(tstruct->get_program()) << tstruct->get_name() << ";\n";
+  out << "package " << perl_namespace(tstruct->get_program()) << tstruct->get_name()
+      << ";  ## no critic (RequireFilenameMatchesPackage)\n";
   if (is_exception) {
     out << "use base qw(Thrift::TException);\n";
   }
@@ -719,7 +722,8 @@ void t_perl_generator::generate_service_processor(t_service* tservice) {
   indent_up();
 
   // Generate the header portion
-  f_service_ << "package " << perl_namespace(program_) << service_name_ << "Processor;" << '\n'
+  f_service_ << "package " << perl_namespace(program_) << service_name_
+             << "Processor;  ## no critic (RequireFilenameMatchesPackage)" << '\n'
              << '\n' << "use strict;" << '\n' << extends_processor << '\n' << '\n';
 
   if (extends.empty()) {
@@ -943,7 +947,8 @@ void t_perl_generator::generate_service_interface(t_service* tservice) {
                  + "If);";
   }
 
-  f_service_ << "package " << perl_namespace(program_) << service_name_ << "If;" << '\n' << '\n'
+  f_service_ << "package " << perl_namespace(program_) << service_name_
+             << "If;  ## no critic (RequireFilenameMatchesPackage)" << '\n' << '\n'
              << "use strict;" << '\n' << extends_if << '\n' << '\n';
 
   indent_up();
@@ -968,7 +973,8 @@ void t_perl_generator::generate_service_rest(t_service* tservice) {
     extends_if = "use base qw(" + perl_namespace(extends_s->get_program()) + extends_s->get_name()
                  + "Rest);";
   }
-  f_service_ << "package " << perl_namespace(program_) << service_name_ << "Rest;" << '\n' << '\n'
+  f_service_ << "package " << perl_namespace(program_) << service_name_
+             << "Rest;  ## no critic (RequireFilenameMatchesPackage)" << '\n' << '\n'
              << "use strict;" << '\n' << extends_if << '\n' << '\n';
 
   if (extends.empty()) {
@@ -1030,7 +1036,8 @@ void t_perl_generator::generate_service_client(t_service* tservice) {
     extends_client = "use base qw(" + extends + "Client);";
   }
 
-  f_service_ << "package " << perl_namespace(program_) << service_name_ << "Client;" << '\n' << '\n'
+  f_service_ << "package " << perl_namespace(program_) << service_name_
+             << "Client;  ## no critic (RequireFilenameMatchesPackage)" << '\n' << '\n'
              << extends_client << '\n' << "use base qw(" << perl_namespace(program_)
              << service_name_ << "If);" << '\n';
 

--- a/lib/perl/Makefile.am
+++ b/lib/perl/Makefile.am
@@ -96,7 +96,14 @@ PERL_GEN = \
 	$(BENCHMARK_GEN) \
 	$(AGGR_GEN)
 
+PERL_PRECROSS_GEN = \
+	gen-perl/ThriftTest/Constants.pm \
+	gen-perl/BenchmarkService.pm \
+	gen-perl2/Aggr.pm
+
 BUILT_SOURCES = $(PERL_GEN)
+
+precross: $(PERL_PRECROSS_GEN)
 
 check-local: $(PERL_GEN)
 	$(PERL) -Iblib/lib -I@abs_srcdir@ -I@builddir@/gen-perl2 -I@builddir@/gen-perl \

--- a/lib/perl/lib/Thrift/Exception.pm
+++ b/lib/perl/lib/Thrift/Exception.pm
@@ -24,7 +24,7 @@ use warnings;
 use Thrift;
 use Thrift::Type;
 
-package Thrift::TException;
+package Thrift::TException;  ## no critic (RequireFilenameMatchesPackage)
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 use overload '""' => sub {
@@ -42,7 +42,7 @@ sub new {
     return bless($self,$classname);
 }
 
-package Thrift::TApplicationException;
+package Thrift::TApplicationException;  ## no critic (RequireFilenameMatchesPackage)
 use parent -norequire, 'Thrift::TException';
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 

--- a/lib/perl/lib/Thrift/MessageType.pm
+++ b/lib/perl/lib/Thrift/MessageType.pm
@@ -26,7 +26,7 @@ use Thrift;
 #
 # Message types for RPC
 #
-package Thrift::TMessageType;
+package Thrift::TMessageType;  ## no critic (RequireFilenameMatchesPackage)
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 use constant CALL      => 1;

--- a/lib/perl/lib/Thrift/MultiplexedProcessor.pm
+++ b/lib/perl/lib/Thrift/MultiplexedProcessor.pm
@@ -27,7 +27,7 @@ use Thrift::MultiplexedProtocol;
 use Thrift::Protocol;
 use Thrift::ProtocolDecorator;
 
-package Thrift::StoredMessageProtocol;
+package Thrift::StoredMessageProtocol;  ## no critic (RequireFilenameMatchesPackage)
 use base qw(Thrift::ProtocolDecorator);
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 

--- a/lib/perl/lib/Thrift/Protocol.pm
+++ b/lib/perl/lib/Thrift/Protocol.pm
@@ -28,7 +28,7 @@ use Thrift::Type;
 #
 # Protocol exceptions
 #
-package Thrift::TProtocolException;
+package Thrift::TProtocolException;  ## no critic (RequireFilenameMatchesPackage)
 use base('Thrift::TException');
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 

--- a/lib/perl/lib/Thrift/ServerSocket.pm
+++ b/lib/perl/lib/Thrift/ServerSocket.pm
@@ -89,7 +89,7 @@ sub accept
         return $result;
     }
 
-    return undef;
+    return;
 }
 
 sub close

--- a/lib/perl/lib/Thrift/Transport.pm
+++ b/lib/perl/lib/Thrift/Transport.pm
@@ -27,7 +27,7 @@ use Thrift::Exception;
 #
 # Transport exceptions
 #
-package Thrift::TTransportException;
+package Thrift::TTransportException;  ## no critic (RequireFilenameMatchesPackage)
 use base('Thrift::TException');
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
@@ -130,7 +130,7 @@ sub flush {}
 #
 # TransportFactory creates transport objects from transports
 #
-package Thrift::TransportFactory;
+package Thrift::TransportFactory;  ## no critic (RequireFilenameMatchesPackage)
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 sub new {
@@ -157,7 +157,7 @@ sub getTransport
 #
 #  ServerTransport base class module
 #
-package Thrift::ServerTransport;
+package Thrift::ServerTransport;  ## no critic (RequireFilenameMatchesPackage)
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 sub listen
@@ -177,4 +177,3 @@ sub close
 
 
 1;
-

--- a/lib/perl/lib/Thrift/Type.pm
+++ b/lib/perl/lib/Thrift/Type.pm
@@ -26,7 +26,7 @@ use Thrift;
 #
 # Data types that can be sent via Thrift
 #
-package Thrift::TType;
+package Thrift::TType;  ## no critic (RequireFilenameMatchesPackage)
 use version 0.77; our $VERSION = version->declare("$Thrift::VERSION");
 
 use constant STOP   => 0;

--- a/test/audit/thrift_audit_test.pl
+++ b/test/audit/thrift_audit_test.pl
@@ -199,7 +199,7 @@ sub auditNonBreakingChanges
 
 # -----------------------------------------------------------------------------------------------------
 # call thriftAuditTool script
-sub callThriftAuditTool ( $ )
+sub callThriftAuditTool
 {
     my $args = shift;
 
@@ -210,7 +210,7 @@ sub callThriftAuditTool ( $ )
     return ($exitCode,$output);
 }
 
-sub getMessageSubString( $ )
+sub getMessageSubString
 {
     my $fileName = shift;
     my %lookupTable = (


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Introduce Perl::Critic into the SCA build. Extends on the prior art #1982, but additionally introduces Perl::Critic tags into the generated code, so it also passes validations.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-5064](https://issues.apache.org/jira/browse/THRIFT-5064)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
