### PR TITLE
Fixing bundler on ruby-head build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -865,6 +865,7 @@ jobs:
       fail-fast: false
     env:
       SKIP_BUILD_EXT: ${{ matrix.skip-build-ext && '1' || '' }}
+      BUNDLER_VERSION: ${{ case(matrix.ruby-version == 'head', '0', '2.2.34') }} # Bundler version is managed via setup-ruby action, not Bundler itself
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -874,6 +875,9 @@ jobs:
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          # Old bundler used the internal constant of Pathname, that was not private due to a typo.
+          # https://github.com/ruby/rubygems/pull/9529
+          bundler: ${{ case(matrix.ruby-version == 'head', 'default', 'Gemfile.lock') }}
           bundler-cache: true
           working-directory: lib/rb
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

One of the constants in `Pathname` was [marked as private](https://github.com/ruby/ruby/commit/4e243c709e45eb0d115b7875cae25dff86184b59). The constants is used in all Bundler versions, and only [landed on master](https://github.com/ruby/rubygems/pull/9529) and is not released as of today ([4.0.11](https://rubygems.org/gems/bundler/versions/4.0.11) is the current version). This makes ruby-head incompatible with any Bundler released to date.

This change switched ruby-head to use bundled Bundler instead of the version locked in our `Gemfile.lock`.

I personally don't like this and my best guess is that [the change](https://github.com/ruby/ruby/pull/16895) will be reverted (or made backwards-compatible), as the scale is large, but for now this MR fixed Thrift builds.

There is an active discussion going on to [deprecate instead of breaking things](https://github.com/ruby/ruby/pull/16909), will monitor.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
