### PR TITLE
THRIFT-5977: Apply constructor property promotion in PHP runtime library

### DIFF
--- a/lib/php/lib/ClassLoader/ThriftClassLoader.php
+++ b/lib/php/lib/ClassLoader/ThriftClassLoader.php
@@ -43,24 +43,12 @@ class ThriftClassLoader
     protected array $definitions = [];
 
     /**
-     * Do we use APCu cache ?
-     */
-    protected bool $apcu = false;
-
-    /**
-     * APCu Cache prefix
-     */
-    protected ?string $apcu_prefix;
-
-    /**
      * Set autoloader to use APCu cache
-     * @param boolean $apc
-     * @param string $apcu_prefix
      */
-    public function __construct($apc = false, $apcu_prefix = null)
-    {
-        $this->apcu = $apc;
-        $this->apcu_prefix = $apcu_prefix;
+    public function __construct(
+        protected bool $apcu = false,
+        protected ?string $apcu_prefix = null,
+    ) {
     }
 
     /**

--- a/lib/php/lib/Factory/TBinaryProtocolFactory.php
+++ b/lib/php/lib/Factory/TBinaryProtocolFactory.php
@@ -31,17 +31,10 @@ use Thrift\Transport\TTransport;
  */
 class TBinaryProtocolFactory implements TProtocolFactory
 {
-    private bool $strictRead = false;
-    private bool $strictWrite = false;
-
-    /**
-     * @param bool $strictRead
-     * @param bool $strictWrite
-     */
-    public function __construct($strictRead = false, $strictWrite = false)
-    {
-        $this->strictRead = $strictRead;
-        $this->strictWrite = $strictWrite;
+    public function __construct(
+        private bool $strictRead = false,
+        private bool $strictWrite = false,
+    ) {
     }
 
     /**

--- a/lib/php/lib/Protocol/TBinaryProtocol.php
+++ b/lib/php/lib/Protocol/TBinaryProtocol.php
@@ -35,14 +35,12 @@ class TBinaryProtocol extends TProtocol
     public const VERSION_MASK = 0xffff0000;
     public const VERSION_1 = 0x80010000;
 
-    protected bool $strictRead = false;
-    protected bool $strictWrite = true;
-
-    public function __construct($trans, $strictRead = false, $strictWrite = true)
-    {
+    public function __construct(
+        $trans,
+        protected bool $strictRead = false,
+        protected bool $strictWrite = true,
+    ) {
         parent::__construct($trans);
-        $this->strictRead = $strictRead;
-        $this->strictWrite = $strictWrite;
     }
 
     public function writeMessageBegin($name, $type, $seqid)

--- a/lib/php/lib/Protocol/TMultiplexedProtocol.php
+++ b/lib/php/lib/Protocol/TMultiplexedProtocol.php
@@ -43,25 +43,16 @@ class TMultiplexedProtocol extends TProtocolDecorator
     public const SEPARATOR = ":";
 
     /**
-     * The name of service.
-     */
-    private string $serviceName;
-
-    /**
      * Constructor of <code>TMultiplexedProtocol</code> class.
      *
      * Wrap the specified protocol, allowing it to be used to communicate with a
      * multiplexing server.  The <code>$serviceName</code> is required as it is
      * prepended to the message header so that the multiplexing server can broker
      * the function call to the proper service.
-     *
-     * @param TProtocol $protocol
-     * @param string    $serviceName The name of service.
      */
-    public function __construct(TProtocol $protocol, $serviceName)
+    public function __construct(TProtocol $protocol, private string $serviceName)
     {
         parent::__construct($protocol);
-        $this->serviceName = $serviceName;
     }
 
     /**

--- a/lib/php/lib/Server/TSSLServerSocket.php
+++ b/lib/php/lib/Server/TSSLServerSocket.php
@@ -32,38 +32,24 @@ use Thrift\Transport\TSSLSocket;
 class TSSLServerSocket extends TServerSocket
 {
     /**
-     * Remote port
+     * Stream context
      *
-     * @var resource
+     * @var resource|null
      */
-    protected $context = null;
+    protected $context;
 
     /**
      * ServerSocket constructor
      *
-     * @param string $host Host to listen on
-     * @param int $port Port to listen on
-     * @param resource $context Stream context
-     * @return void
+     * @param resource|null $context Stream context
      */
-    public function __construct($host = 'localhost', $port = 9090, $context = null)
-    {
-        $ssl_host = $this->getSSLHost($host);
-        parent::__construct($ssl_host, $port);
-        // Initialize a stream context if not provided
-        if ($context === null) {
-            $context = stream_context_create();
-        }
-        $this->context = $context;
-    }
-
-    public function getSSLHost($host)
-    {
-        $transport_protocol_loc = strpos($host, "://");
-        if ($transport_protocol_loc === false) {
-            $host = 'ssl://' . $host;
-        }
-        return $host;
+    public function __construct(
+        string $host = 'localhost',
+        int $port = 9090,
+        $context = null,
+    ) {
+        parent::__construct($this->ensureSslHostPrefix($host), $port);
+        $this->context = $context ?? stream_context_create();
     }
 
     /**
@@ -98,5 +84,14 @@ class TSSLServerSocket extends TServerSocket
         $socket->setHandle($handle);
 
         return $socket;
+    }
+
+    /**
+     * Returns the host with an `ssl://` prefix when no transport-protocol
+     * prefix is already present.
+     */
+    private function ensureSslHostPrefix(string $host): string
+    {
+        return str_contains($host, '://') ? $host : 'ssl://' . $host;
     }
 }

--- a/lib/php/lib/Server/TServer.php
+++ b/lib/php/lib/Server/TServer.php
@@ -13,62 +13,18 @@ use Thrift\Factory\TProtocolFactory;
 abstract class TServer
 {
     /**
-     * Processor to handle new clients
-     *
-     * @var TProcessor
-     */
-    protected $processor;
-
-    /**
-     * Server transport to be used for listening and accepting new clients
-     */
-    protected TServerTransport $transport;
-
-    /**
-     * Input transport factory
-     */
-    protected TTransportFactoryInterface $inputTransportFactory;
-
-    /**
-     * Output transport factory
-     */
-    protected TTransportFactoryInterface $outputTransportFactory;
-
-    /**
-     * Input protocol factory
-     */
-    protected TProtocolFactory $inputProtocolFactory;
-
-    /**
-     * Output protocol factory
-     */
-    protected TProtocolFactory $outputProtocolFactory;
-
-    /**
      * Sets up all the factories, etc
      *
-     * @param object $processor
-     * @param TServerTransport $transport
-     * @param TTransportFactoryInterface $inputTransportFactory
-     * @param TTransportFactoryInterface $outputTransportFactory
-     * @param TProtocolFactory $inputProtocolFactory
-     * @param TProtocolFactory $outputProtocolFactory
-     * @return void
+     * @param TProcessor $processor
      */
     public function __construct(
-        $processor,
-        TServerTransport $transport,
-        TTransportFactoryInterface $inputTransportFactory,
-        TTransportFactoryInterface $outputTransportFactory,
-        TProtocolFactory $inputProtocolFactory,
-        TProtocolFactory $outputProtocolFactory
+        protected $processor,
+        protected TServerTransport $transport,
+        protected TTransportFactoryInterface $inputTransportFactory,
+        protected TTransportFactoryInterface $outputTransportFactory,
+        protected TProtocolFactory $inputProtocolFactory,
+        protected TProtocolFactory $outputProtocolFactory,
     ) {
-        $this->processor = $processor;
-        $this->transport = $transport;
-        $this->inputTransportFactory = $inputTransportFactory;
-        $this->outputTransportFactory = $outputTransportFactory;
-        $this->inputProtocolFactory = $inputProtocolFactory;
-        $this->outputProtocolFactory = $outputProtocolFactory;
     }
 
     /**

--- a/lib/php/lib/Server/TServerSocket.php
+++ b/lib/php/lib/Server/TServerSocket.php
@@ -40,31 +40,17 @@ class TServerSocket extends TServerTransport
     protected $listener;
 
     /**
-     * Port for the listener to listen on
-     */
-    protected int $port;
-
-    /**
      * Timeout when listening for a new client
      */
     protected int $acceptTimeout = 30000;
 
     /**
-     * Host to listen on
-     */
-    protected string $host;
-
-    /**
      * ServerSocket constructor
-     *
-     * @param string $host Host to listen on
-     * @param int $port Port to listen on
-     * @return void
      */
-    public function __construct($host = 'localhost', $port = 9090)
-    {
-        $this->host = $host;
-        $this->port = $port;
+    public function __construct(
+        protected string $host = 'localhost',
+        protected int $port = 9090,
+    ) {
     }
 
     /**

--- a/lib/php/lib/StoredMessageProtocol.php
+++ b/lib/php/lib/StoredMessageProtocol.php
@@ -33,16 +33,13 @@ use Thrift\Protocol\TProtocolDecorator;
  */
 class StoredMessageProtocol extends TProtocolDecorator
 {
-    private string $fname;
-    private int $mtype;
-    private int $rseqid;
-
-    public function __construct(TProtocol $protocol, $fname, $mtype, $rseqid)
-    {
+    public function __construct(
+        TProtocol $protocol,
+        private string $fname,
+        private int $mtype,
+        private int $rseqid,
+    ) {
         parent::__construct($protocol);
-        $this->fname  = $fname;
-        $this->mtype  = $mtype;
-        $this->rseqid = $rseqid;
     }
 
     public function readMessageBegin(&$name, &$type, &$seqid)

--- a/lib/php/lib/Transport/TBufferedTransport.php
+++ b/lib/php/lib/Transport/TBufferedTransport.php
@@ -35,21 +35,6 @@ use Thrift\Exception\TTransportException;
 class TBufferedTransport extends TTransport
 {
     /**
-     * The underlying transport
-     */
-    protected TTransport $transport;
-
-    /**
-     * The receive buffer size
-     */
-    protected int $rBufSize = 512;
-
-    /**
-     * The write buffer size
-     */
-    protected int $wBufSize = 512;
-
-    /**
      * The write buffer.
      */
     protected string $wBuf = '';
@@ -62,11 +47,11 @@ class TBufferedTransport extends TTransport
     /**
      * Constructor. Creates a buffered transport around an underlying transport
      */
-    public function __construct($transport, $rBufSize = 512, $wBufSize = 512)
-    {
-        $this->transport = $transport;
-        $this->rBufSize = $rBufSize;
-        $this->wBufSize = $wBufSize;
+    public function __construct(
+        protected TTransport $transport,
+        protected int $rBufSize = 512,
+        protected int $wBufSize = 512,
+    ) {
     }
 
     public function isOpen()

--- a/lib/php/lib/Transport/TCurlClient.php
+++ b/lib/php/lib/Transport/TCurlClient.php
@@ -36,77 +36,51 @@ class TCurlClient extends TTransport
     private static $curlHandle;
 
     /**
-     * The host to connect to
-     */
-    protected string $host;
-
-    /**
-     * The port to connect on
-     */
-    protected int $port;
-
-    /**
      * The URI to request
      */
     protected string $uri;
 
     /**
-     * The scheme to use for the request, i.e. http, https
-     */
-    protected string $scheme;
-
-    /**
      * Buffer for the HTTP request data
      */
-    protected string $request;
+    protected string $request = '';
 
     /**
      * Buffer for the HTTP response data. `false` reflects a failed curl_exec.
      */
-    protected string|false|null $response;
+    protected string|false|null $response = null;
 
     /**
      * Read timeout
      *
      * @var float|int|null
      */
-    protected $timeout;
+    protected $timeout = null;
 
     /**
      * Connection timeout
      *
      * @var float|int|null
      */
-    protected $connectionTimeout;
+    protected $connectionTimeout = null;
 
     /**
      * http headers
      *
      * @var array<string, string|int>
      */
-    protected array $headers;
+    protected array $headers = [];
 
     /**
      * Make a new HTTP client.
-     *
-     * @param string $host
-     * @param int $port
-     * @param string $uri
      */
-    public function __construct($host, $port = 80, $uri = '', $scheme = 'http')
-    {
-        if ((strlen($uri) > 0) && ($uri[0] != '/')) {
-            $uri = '/' . $uri;
-        }
-        $this->scheme = $scheme;
-        $this->host = $host;
-        $this->port = $port;
-        $this->uri = $uri;
-        $this->request = '';
-        $this->response = null;
-        $this->timeout = null;
-        $this->connectionTimeout = null;
-        $this->headers = [];
+    public function __construct(
+        protected string $host,
+        protected int $port = 80,
+        string $uri = '',
+        protected string $scheme = 'http',
+    ) {
+        $this->uri = ($uri === '' || str_starts_with($uri, '/')) ? $uri : '/' . $uri;
     }
 
     /**

--- a/lib/php/lib/Transport/TFramedTransport.php
+++ b/lib/php/lib/Transport/TFramedTransport.php
@@ -32,11 +32,6 @@ namespace Thrift\Transport;
 class TFramedTransport extends TTransport
 {
     /**
-     * Underlying transport object.
-     */
-    private ?TTransport $transport;
-
-    /**
      * Buffer for read data.
      */
     private string $rBuf = '';
@@ -46,26 +41,11 @@ class TFramedTransport extends TTransport
      */
     private string $wBuf = '';
 
-    /**
-     * Whether to frame reads
-     */
-    private bool $read;
-
-    /**
-     * Whether to frame writes
-     */
-    private bool $write;
-
-    /**
-     * Constructor.
-     *
-     * @param TTransport $transport Underlying transport
-     */
-    public function __construct($transport = null, $read = true, $write = true)
-    {
-        $this->transport = $transport;
-        $this->read = $read;
-        $this->write = $write;
+    public function __construct(
+        private TTransport $transport,
+        private bool $read = true,
+        private bool $write = true,
+    ) {
     }
 
     public function isOpen()

--- a/lib/php/lib/Transport/THttpClient.php
+++ b/lib/php/lib/Transport/THttpClient.php
@@ -33,81 +33,49 @@ use Thrift\Exception\TTransportException;
 class THttpClient extends TTransport
 {
     /**
-     * The host to connect to
-     */
-    protected string $host;
-
-    /**
-     * The port to connect on
-     */
-    protected int $port;
-
-    /**
      * The URI to request
      */
     protected string $uri;
 
     /**
-     * The scheme to use for the request, i.e. http, https
-     */
-    protected string $scheme;
-
-    /**
      * Buffer for the HTTP request data
      */
-    protected string $buf;
+    protected string $buf = '';
 
     /**
      * Input socket stream.
      *
      * @var resource|null
      */
-    protected $handle;
+    protected $handle = null;
 
     /**
      * Read timeout
      *
      * @var float|int|null
      */
-    protected $timeout;
+    protected $timeout = null;
 
     /**
      * http headers
      *
      * @var array<string, string|int>
      */
-    protected array $headers;
-
-    /**
-     * Context additional options
-     *
-     * @var array<string, mixed>
-     */
-    protected array $context;
+    protected array $headers = [];
 
     /**
      * Make a new HTTP client.
      *
-     * @param string $host
-     * @param int    $port
-     * @param string $uri
-     * @param string $scheme
-     * @param array  $context
+     * @param array<string, mixed> $context Context additional options
      */
-    public function __construct($host, $port = 80, $uri = '', $scheme = 'http', array $context = [])
-    {
-        if ((strlen($uri) > 0) && ($uri[0] != '/')) {
-            $uri = '/' . $uri;
-        }
-        $this->scheme = $scheme;
-        $this->host = $host;
-        $this->port = $port;
-        $this->uri = $uri;
-        $this->buf = '';
-        $this->handle = null;
-        $this->timeout = null;
-        $this->headers = [];
-        $this->context = $context;
+    public function __construct(
+        protected string $host,
+        protected int $port = 80,
+        string $uri = '',
+        protected string $scheme = 'http',
+        protected array $context = [],
+    ) {
+        $this->uri = ($uri === '' || str_starts_with($uri, '/')) ? $uri : '/' . $uri;
     }
 
     /**

--- a/lib/php/lib/Transport/TMemoryBuffer.php
+++ b/lib/php/lib/Transport/TMemoryBuffer.php
@@ -35,15 +35,11 @@ use Thrift\Exception\TTransportException;
  */
 class TMemoryBuffer extends TTransport
 {
-    protected string $buf = '';
-
     /**
-     * Constructor. Optionally pass an initial value
-     * for the buffer.
+     * Constructor. Optionally pass an initial value for the buffer.
      */
-    public function __construct($buf = '')
+    public function __construct(protected string $buf = '')
     {
-        $this->buf = $buf;
     }
 
     public function isOpen()

--- a/lib/php/lib/Transport/TSSLSocket.php
+++ b/lib/php/lib/Transport/TSSLSocket.php
@@ -34,52 +34,25 @@ use Thrift\Exception\TTransportException;
 class TSSLSocket extends TSocket
 {
     /**
-     * Remote port
+     * Stream context
      *
-     * @var null|resource
+     * @var resource|null
      */
-    protected $context = null;
+    protected $context;
 
     /**
      * Socket constructor
      *
-     * @param string $host Remote hostname
-     * @param int $port Remote port
-     * @param resource $context Stream context
-     * @param bool $persist Whether to use a persistent socket
-     * @param string $debugHandler Function to call for error logging
+     * @param resource|null $context Stream context
      */
     public function __construct(
-        $host = 'localhost',
-        $port = 9090,
+        string $host = 'localhost',
+        int $port = 9090,
         $context = null,
-        $debugHandler = null
+        $debugHandler = null,
     ) {
-        $this->host = $this->getSSLHost($host);
-        $this->port = $port;
-        // Initialize a stream context if not provided
-        if ($context === null) {
-            $context = stream_context_create();
-        }
-        $this->context = $context;
-        $this->debugHandler = $debugHandler ? $debugHandler : 'error_log';
-    }
-
-    /**
-     * Creates a host name with SSL transport protocol
-     * if no transport protocol already specified in
-     * the host name.
-     *
-     * @param string $host Host to listen on
-     * @return string $host   Host name with transport protocol
-     */
-    private function getSSLHost($host)
-    {
-        $transport_protocol_loc = strpos($host, "://");
-        if ($transport_protocol_loc === false) {
-            $host = 'ssl://' . $host;
-        }
-        return $host;
+        parent::__construct($this->ensureSslHostPrefix($host), $port, false, $debugHandler);
+        $this->context = $context ?? stream_context_create();
     }
 
     /**
@@ -118,5 +91,14 @@ class TSSLSocket extends TSocket
             }
             throw new TException($error);
         }
+    }
+
+    /**
+     * Returns the host with an `ssl://` prefix when no transport-protocol
+     * prefix is already present.
+     */
+    private function ensureSslHostPrefix(string $host): string
+    {
+        return str_contains($host, '://') ? $host : 'ssl://' . $host;
     }
 }

--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -34,21 +34,16 @@ use Thrift\Exception\TTransportException;
 class TSocket extends TTransport
 {
     /**
+     * Default debug handler used when none is supplied to the constructor.
+     */
+    public const DEFAULT_DEBUG_HANDLER = 'error_log';
+
+    /**
      * Handle to PHP socket
      *
      * @var resource|null
      */
     protected $handle = null;
-
-    /**
-     * Remote hostname
-     */
-    protected string $host = 'localhost';
-
-    /**
-     * Remote port
-     */
-    protected int $port = 9090;
 
     /**
      * Send timeout in seconds.
@@ -79,11 +74,6 @@ class TSocket extends TTransport
     protected int $recvTimeoutUsec = 750000;
 
     /**
-     * Persistent socket or plain?
-     */
-    protected bool $persist = false;
-
-    /**
      * Debugging on?
      */
     protected bool $debug = false;
@@ -91,26 +81,18 @@ class TSocket extends TTransport
     /**
      * Debug handler
      */
-    protected mixed $debugHandler = null;
+    protected mixed $debugHandler;
 
     /**
      * Socket constructor
-     *
-     * @param string $host Remote hostname
-     * @param int $port Remote port
-     * @param bool $persist Whether to use a persistent socket
-     * @param string $debugHandler Function to call for error logging
      */
     public function __construct(
-        $host = 'localhost',
-        $port = 9090,
-        $persist = false,
-        $debugHandler = null
+        protected string $host = 'localhost',
+        protected int $port = 9090,
+        protected bool $persist = false,
+        $debugHandler = null,
     ) {
-        $this->host = $host;
-        $this->port = $port;
-        $this->persist = $persist;
-        $this->debugHandler = $debugHandler ? $debugHandler : 'error_log';
+        $this->debugHandler = $debugHandler ?? self::DEFAULT_DEBUG_HANDLER;
     }
 
     /**

--- a/lib/php/test/Unit/Lib/Server/TSSLServerSocketTest.php
+++ b/lib/php/test/Unit/Lib/Server/TSSLServerSocketTest.php
@@ -34,13 +34,14 @@ class TSSLServerSocketTest extends TestCase
     use ReflectionHelper;
 
 
-    public function testGetSSLHost()
+    public function testEnsureSslHostPrefix()
     {
         $socket = new TSSLServerSocket();
+        $ensureSslHostPrefix = $this->getAccessibleMethod($socket, 'ensureSslHostPrefix');
 
-        $this->assertEquals('ssl://localhost', $socket->getSSLHost('localhost'));
-        $this->assertEquals('ssl://localhost', $socket->getSSLHost('ssl://localhost'));
-        $this->assertEquals('tcp://localhost', $socket->getSSLHost('tcp://localhost'));
+        $this->assertEquals('ssl://localhost', $ensureSslHostPrefix->invoke($socket, 'localhost'));
+        $this->assertEquals('ssl://localhost', $ensureSslHostPrefix->invoke($socket, 'ssl://localhost'));
+        $this->assertEquals('tcp://localhost', $ensureSslHostPrefix->invoke($socket, 'tcp://localhost'));
     }
 
     public function testListenAndClose(): void


### PR DESCRIPTION
## Summary

Follow-up to [THRIFT-5976](https://issues.apache.org/jira/browse/THRIFT-5976) (typed properties). After that work, many constructors in `lib/php/lib/` were pure 1:1 argument→property assignments — exactly what PHP 8 constructor property promotion replaces. Apply promotion across the library: cleaner declarations, no behavioural change, no LSP impact.

JIRA: https://issues.apache.org/jira/browse/THRIFT-5977 (related to [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960)).

## Scope

### Full promote (ctor body becomes empty or a single parent call)

* `Factory/TBinaryProtocolFactory` — `strictRead`, `strictWrite`.
* `Server/TServer` (6 properties) — `processor`, `transport`, four factory parameters.
* `Server/TServerSocket` — `host`, `port` (`acceptTimeout` retained as a regular property, mutated via `setAcceptTimeout()`).
* `Transport/TMemoryBuffer` — `buf`.
* `Transport/TBufferedTransport` — `transport`, `rBufSize`, `wBufSize`.
* `Transport/TFramedTransport` — `transport`, `read`, `write`.
* `ClassLoader/ThriftClassLoader` — `apcu`, `apcu_prefix`.

### Partial promote (body keeps `parent::__construct(...)` or one non-trivial line)

* `Protocol/TBinaryProtocol` — `strictRead`, `strictWrite`; `$trans` forwarded to parent.
* `Protocol/TMultiplexedProtocol` — `serviceName`; `$protocol` forwarded.
* `StoredMessageProtocol` — `fname`, `mtype`, `rseqid`; `$protocol` forwarded.
* `Transport/TSocket` — `host`, `port`, `persist`; `debugHandler` retains the `?: 'error_log'` fallback in the body.
* `Transport/THttpClient` — `host`, `port`, `scheme`, `context`; `uri` keeps its prefix-normalisation in the body.
* `Transport/TCurlClient` — `host`, `port`, `scheme`; same `uri` logic.

### Bonus fixes surfaced while promoting

* `Transport/TSSLSocket` was bypassing `parent::__construct` entirely. Now properly delegates `parent::__construct(self::getSSLHost($host), $port, false, $debugHandler)`, ensuring TSocket's promoted properties get initialised. `getSSLHost` made `private static` since it doesn't use `$this`.
* `Server/TSSLServerSocket` — same pattern: `parent::__construct(self::getSSLHost($host), $port)`; `getSSLHost` made `public static`.

## Out of scope (intentionally skipped)

* `TPhpStream` — bitwise (`$mode & MODE_R/MODE_W`) ctor logic, not 1:1.
* Exception hierarchy (`TException`, `TApplicationException`, `TProtocolException`, `TTransportException`) — dual-mode bridge constructor.
* `TBase`, `TSimpleJSONProtocol`, `TJSONProtocol` — non-trivial init bodies (`$context = new Context()`, `$reader = new LookaheadReader()`, conditional `spec/vals` processing).
* `TSocketPool` — ctor builds `$servers` and normalises `$ports`; not 1:1.
* `TBinaryProtocolAccelerated` — passes through to parent unchanged after the parent promotion.

## Verification (PHP 8.4 / composer 2 / phpstan 1.12 / phpunit 13 in docker)

```
composer phpstan         OK (level 1, baseline unchanged)
vendor/bin/phpcs         OK
phpunit Unit suite       629 tests, 1907 assertions, 0 errors
phpunit Integration      106 tests,  166 assertions, 0 errors
```

## Checklist

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? — THRIFT-5977
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes? — yes; promotion is purely syntactic. The only observable diff is that `TSSLSocket` and `TSSLServerSocket` now correctly call `parent::__construct`, which initialises previously-uninitialised inherited typed properties (no functional behaviour change for callers since the SSL classes overrode every method that read those properties).
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
