### PR TITLE
Prevent concurrent calls to socketConn.Close() in Go

### DIFF
--- a/lib/go/thrift/socket_conn.go
+++ b/lib/go/thrift/socket_conn.go
@@ -114,11 +114,16 @@ func (sc *socketConn) Read(p []byte) (n int, err error) {
 	return sc.Conn.Read(p)
 }
 
+// Close closes the connection and the underlying net.Conn.
+//
+// Only the first call will actually close the underlying connection;
+// subsequent calls return net.ErrClosed error.
 func (sc *socketConn) Close() error {
-	if !sc.isValid() {
-		// Already closed
+	if sc == nil || sc.Conn == nil {
 		return net.ErrClosed
 	}
-	sc.closed.Store(1)
-	return sc.Conn.Close()
+	if sc.closed.CompareAndSwap(0, 1) {
+		return sc.Conn.Close()
+	}
+	return net.ErrClosed
 }

--- a/lib/go/thrift/socket_conn_test.go
+++ b/lib/go/thrift/socket_conn_test.go
@@ -20,9 +20,12 @@
 package thrift
 
 import (
+	"errors"
 	"io"
 	"net"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -122,4 +125,83 @@ func TestSocketConnNilSafe(t *testing.T) {
 	if sc.IsOpen() {
 		t.Error("Expected false for nil.IsOpen(), got true")
 	}
+}
+
+func TestSocketConnClose(t *testing.T) {
+	t.Run("concurrent calls", func(t *testing.T) {
+		c := &mockCloseCounterConn{}
+		sc := &socketConn{
+			Conn: c,
+		}
+
+		var g sync.WaitGroup
+		for range 4 {
+			g.Go(func() { sc.Close() })
+		}
+		g.Wait()
+
+		cnt := c.closeCounter.Load()
+		if cnt != 1 {
+			t.Errorf("Expected conn.Close() to be called once, got %d calls", cnt)
+		}
+	})
+
+	t.Run("socketConn nilSafe", func(t *testing.T) {
+		sc := (*socketConn)(nil)
+
+		err := sc.Close()
+
+		if !errors.Is(err, net.ErrClosed) {
+			t.Errorf("Expected %v, got %v ", net.ErrClosed, err)
+		}
+	})
+
+	t.Run("netConn nilSafe", func(t *testing.T) {
+		sc := &socketConn{
+			Conn: nil,
+		}
+
+		err := sc.Close()
+
+		if !errors.Is(err, net.ErrClosed) {
+			t.Errorf("Expected %v, got %v ", net.ErrClosed, err)
+		}
+	})
+}
+
+type mockCloseCounterConn struct {
+	closeCounter atomic.Int32
+}
+
+func (m *mockCloseCounterConn) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *mockCloseCounterConn) Write(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *mockCloseCounterConn) Close() error {
+	m.closeCounter.Add(1)
+	return nil
+}
+
+func (m *mockCloseCounterConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (m *mockCloseCounterConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (m *mockCloseCounterConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockCloseCounterConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockCloseCounterConn) SetWriteDeadline(t time.Time) error {
+	return nil
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Client: go

Multiple goroutines calling Close() simultaneously could result in
sc.closed.Store() being called concurrently. Use CompareAndSwap instead
to atomically check and set the closed flag, ensuring only the first
caller closes the underlying net.Conn

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
