### PR TITLE
THRIFT-5985: Add native method types to PHP Exception hierarchy

### DIFF
--- a/lib/php/lib/Exception/TApplicationException.php
+++ b/lib/php/lib/Exception/TApplicationException.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Thrift\Exception;
 
+use Thrift\Protocol\TProtocol;
 use Thrift\Type\TType;
 
 class TApplicationException extends TException
@@ -53,17 +54,17 @@ class TApplicationException extends TException
     public const INVALID_PROTOCOL = 9;
     public const UNSUPPORTED_CLIENT_TYPE = 10;
 
-    public function __construct($message = null, $code = 0)
+    public function __construct(?string $message = null, int $code = 0)
     {
         parent::__construct($message, $code);
     }
 
-    public function read($output)
+    public function read(TProtocol $input): int
     {
-        return $this->readStruct('TApplicationException', self::$tspec, $output);
+        return $this->readStruct('TApplicationException', self::$tspec, $input);
     }
 
-    public function write($output)
+    public function write(TProtocol $output): int
     {
         $xfer = 0;
         $xfer += $output->writeStructBegin('TApplicationException');

--- a/lib/php/lib/Exception/TException.php
+++ b/lib/php/lib/Exception/TException.php
@@ -38,13 +38,13 @@ use Thrift\Base\TBase;
  * Can be called with standard Exception constructor (message, code) or with
  * Thrift Base object constructor (spec, vals).
  *
- * @param mixed $p1 Message (string) or type-spec (array)
- * @param mixed $p2 Code (integer) or values (array)
+ * @param string|array|null $p1 Message (string) or type-spec (array)
+ * @param int|array          $p2 Code (integer) or values (array)
  */
 #[\AllowDynamicProperties]
 class TException extends \Exception
 {
-    public function __construct($p1 = null, $p2 = 0)
+    public function __construct(string|array|null $p1 = null, int|array $p2 = 0)
     {
         if (is_array($p1) && is_array($p2)) {
             $spec = $p1;
@@ -56,7 +56,7 @@ class TException extends \Exception
                 }
             }
         } else {
-            parent::__construct((string)$p1, $p2);
+            parent::__construct($p1 ?? '', $p2);
         }
     }
 

--- a/lib/php/lib/Exception/TProtocolException.php
+++ b/lib/php/lib/Exception/TProtocolException.php
@@ -46,7 +46,7 @@ class TProtocolException extends TException
     public const NOT_IMPLEMENTED = 5;
     public const DEPTH_LIMIT = 6;
 
-    public function __construct($message = null, $code = 0)
+    public function __construct(?string $message = null, int $code = 0)
     {
         parent::__construct($message, $code);
     }

--- a/lib/php/lib/Exception/TTransportException.php
+++ b/lib/php/lib/Exception/TTransportException.php
@@ -36,7 +36,7 @@ class TTransportException extends TException
     public const TIMED_OUT = 3;
     public const END_OF_FILE = 4;
 
-    public function __construct($message = null, $code = 0)
+    public function __construct(?string $message = null, int $code = 0)
     {
         parent::__construct($message, $code);
     }


### PR DESCRIPTION
Type the public surface of the PHP exception hierarchy in `lib/php/lib/Exception/`.

**Changes:**

- `TException::__construct(string|array|null $p1 = null, int|array $p2 = 0)` — preserves the **bridge constructor** that accepts either standard Exception args (`message`, `code`) or Thrift Base `spec`/`vals`. Union types capture the polymorphism explicitly.
- `TApplicationException` — typed `__construct(?string $message = null, int $code = 0)` plus `read(TProtocol $output): int` and `write(TProtocol $output): int`. Added `use Thrift\Protocol\TProtocol;`.
- `TProtocolException` — typed `__construct(?string $message = null, int $code = 0)`.
- `TTransportException` — typed `__construct(?string $message = null, int $code = 0)`.

**Out of scope:**

The internal serialization helpers in `TException` (`readMap`, `readList`, `readStruct`, `writeMap`, `writeList`, `writeStruct`) mirror the same untyped helpers on `TBase`. Typing those is a separate concern (would need to be applied consistently across both classes and would touch broader by-ref dynamic-dispatch behavior).

**Validation (Docker `thrift-php-dev:local`):**
- `phpcs` — 0 errors
- `phpstan` (level 1) — 0 errors
- `phpunit` Unit Suite — 635 tests, 0 failures
- `phpunit` Integration Suite — 108 tests, 0 failures

Part of the umbrella ticket [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960) (PHP modernization).

- [x] Did you create an Apache Jira ticket? — [THRIFT-5985](https://issues.apache.org/jira/browse/THRIFT-5985)
- [x] PR title follows the pattern "THRIFT-NNNN: describe my issue"
- [x] Squashed to a single commit
- [x] No breaking changes (subclass narrowing `string|null` from `string|array|null` is a no-op for the standard `new TXxx($msg, $code)` call pattern; the bridge `new TException($spec, $vals)` still works at the base class)

Generated-by: Claude Opus 4.7
