### PR TITLE
THRIFT-5987: Fix PHP protocol type-safety bugs in readBool and popContext

### DIFF
--- a/lib/php/lib/Protocol/TCompactProtocol.php
+++ b/lib/php/lib/Protocol/TCompactProtocol.php
@@ -568,7 +568,11 @@ class TCompactProtocol extends TProtocol
 
             return 0;
         } elseif ($this->state == TCompactProtocol::STATE_CONTAINER_READ) {
-            return $this->readByte($bool);
+            $byte = null;
+            $result = $this->readByte($byte);
+            $bool = (bool) $byte;
+
+            return $result;
         } else {
             throw new TProtocolException('Invalid state in compact protocol');
         }

--- a/lib/php/lib/Protocol/TJSONProtocol.php
+++ b/lib/php/lib/Protocol/TJSONProtocol.php
@@ -182,9 +182,9 @@ class TJSONProtocol extends TProtocol
         $this->context = $c;
     }
 
-    private function popContext()
+    private function popContext(): void
     {
-        $this->context = array_pop($this->contextStack);
+        $this->context = array_pop($this->contextStack) ?? new BaseContext();
     }
 
     public function __construct($trans)

--- a/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
@@ -577,7 +577,7 @@ class TCompactProtocolTest extends TestCase
 
         $protocol->expects($this->once())
                  ->method('writeCollectionBegin')
-                 ->with(TType::STRING)
+                 ->with(TType::STRING, 1)
                  ->willReturn(1);
 
         $this->assertSame(1, $protocol->writeListBegin(TType::STRING, 1));
@@ -600,7 +600,7 @@ class TCompactProtocolTest extends TestCase
 
         $protocol->expects($this->once())
                  ->method('writeCollectionBegin')
-                 ->with(TType::STRING)
+                 ->with(TType::STRING, 1)
                  ->willReturn(1);
 
         $this->assertSame(1, $protocol->writeSetBegin(TType::STRING, 1));


### PR DESCRIPTION
## Summary

- **`TCompactProtocol::readBool`** passes its `?bool &$bool` reference directly to `readByte(?int &$byte)`. In `STATE_CONTAINER_READ`, `readByte` unpacks a raw byte and writes an integer back through the reference — leaving a `?bool`-declared variable holding an integer. Fix routes through a local `?int $byte` variable and casts to `(bool)` before assignment.

- **`TJSONProtocol::popContext`** assigns `array_pop($this->contextStack)` — whose return type is `BaseContext|null` — to the non-nullable `private BaseContext $context` property. On any context-stack underflow this causes a `TypeError`. Fix uses `?? new BaseContext()` as a null-safe fallback.

- **`TCompactProtocolTest`** — `testWriteListBegin` and `testWriteSettBegin` dropped the `$size` argument from the `writeCollectionBegin` mock expectation, so forwarding of the element-count parameter was no longer verified. Restored `->with(TType::STRING, 1)`.

## Test plan

- [ ] `lib/php`: `composer install && vendor/bin/phpunit`
- [ ] `make style` passes in `lib/php`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Generated-by: Claude Sonnet 4.6 <noreply@anthropic.com>