### PR TITLE
THRIFT-5988: PHP 8.1 follow-up: float constants, README, and API compat

### DIFF
--- a/lib/php/README.md
+++ b/lib/php/README.md
@@ -21,7 +21,7 @@ under the License.
 
 # Using Thrift with PHP
 
-Thrift requires PHP 7.1 Thrift makes as few assumptions about your PHP
+Thrift requires PHP 8.1 Thrift makes as few assumptions about your PHP
 environment as possible while trying to make some more advanced PHP
 features (i.e. APCu cacheing using asbolute path URLs) as simple as possible.
 

--- a/lib/php/lib/Server/TSSLServerSocket.php
+++ b/lib/php/lib/Server/TSSLServerSocket.php
@@ -81,7 +81,15 @@ class TSSLServerSocket extends TServerSocket
     /**
      * Returns the host with an `ssl://` prefix when no transport-protocol
      * prefix is already present.
+     *
+     * @deprecated Prefix is now applied automatically by the constructor.
+     *             This method will be removed in a future release.
      */
+    public function getSSLHost(string $host): string
+    {
+        return $this->ensureSslHostPrefix($host);
+    }
+
     private function ensureSslHostPrefix(string $host): string
     {
         return str_contains($host, '://') ? $host : 'ssl://' . $host;

--- a/lib/php/test/Unit/Lib/Protocol/BoundaryValuesTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/BoundaryValuesTest.php
@@ -70,10 +70,9 @@ class BoundaryValuesTest extends TestCase
             // doubles
             'double zero' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => 0.0],
             'double negative zero' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => -0.0],
-            // TODO: replace literals with PHP_FLOAT_MAX/MIN/EPSILON when PHP 7.1 support is dropped (available since PHP 7.2)
-            'double max' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => 1.7976931348623158e+308],
-            'double min' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => 2.2250738585072014e-308],
-            'double epsilon' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => 2.2204460492503131e-16],
+            'double max' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => PHP_FLOAT_MAX],
+            'double min' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => PHP_FLOAT_MIN],
+            'double epsilon' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => PHP_FLOAT_EPSILON],
             'double very small' => ['writeMethod' => 'writeDouble', 'readMethod' => 'readDouble', 'value' => 1e-300],
 
             // strings


### PR DESCRIPTION
## Summary

- **`BoundaryValuesTest`** — replace three magic double literals (`1.7976931348623158e+308`, `2.2250738585072014e-308`, `2.2204460492503131e-16`) with `PHP_FLOAT_MAX`, `PHP_FLOAT_MIN`, and `PHP_FLOAT_EPSILON`. Named constants available since PHP 7.2; blocker lifted now that minimum is 8.1. Stale TODO removed.

- **`lib/php/README.md`** — still stated "Thrift requires PHP 7.1". Updated to 8.1.

- **`TSSLServerSocket`** — `getSSLHost(string $host): string` was a public method silently replaced by a private `ensureSslHostPrefix()`. A `@deprecated` public shim is restored so existing callers are not broken without notice.

## Test plan

- [x] `lib/php`: `composer install && vendor/bin/phpunit`
- [x] `make style` passes in `lib/php`
- [x] CI `cross-test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Generated-by: Claude Sonnet 4.6 <noreply@anthropic.com>