### PR TITLE
THRIFT-5989: Work around JWT-format GITHUB_TOKEN breaking composer install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,8 @@ jobs:
           ini-values: "error_reporting=E_ALL"
 
       - name: Install Dependencies
+        env:
+          COMPOSER_AUTH: '{}'
         run: composer install
 
       - name: Run bootstrap
@@ -964,6 +966,8 @@ jobs:
           ini-values: "error_reporting=E_ALL"
 
       - name: Install PHP dependencies
+        env:
+          COMPOSER_AUTH: '{}'
         run: composer install --no-progress --prefer-dist
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0


### PR DESCRIPTION
## Summary

GitHub is rolling out a new `GITHUB_TOKEN` format — a JWT (`ghs_<id>_<jwt>`) that contains dots. `shivammathur/setup-php` passes this token verbatim to `composer config --global github-oauth.github.com`. Composer's token validator (`BaseIO.php:143`) rejects any token containing characters outside `[A-Za-z0-9\-_]`, causing `composer install` to fail with:

```
Your github oauth token for github.com contains invalid characters
```

The rollout is gradual: runners provisioned earlier in a workflow run may still receive the old opaque token and succeed, while runners provisioned later receive the JWT format and fail. Affected: `cross-test` jobs; `lib-php` matrix jobs will follow as the rollout completes.

**Fix:** set `COMPOSER_AUTH: '{}'` as an environment variable on both `composer install` steps (`lib-php` and `cross-test`). This env var is the highest-priority Composer auth source and overrides whatever `setup-php` wrote into the global config, without requiring a change to the `setup-php` action pin.

The root incompatibility has been reported upstream to `shivammathur/setup-php`. The incidental token exposure in the Composer error output (the token appeared unmasked in the job log despite GitHub masking it in the `with:` block) has been reported to GitHub Security.

## Test plan

- [ ] CI `lib-php` matrix passes on all PHP versions
- [ ] CI `cross-test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Generated-by: Claude Sonnet 4.6 <noreply@anthropic.com>