### PR TITLE
THRIFT-5989: Work around JWT-format GITHUB_TOKEN breaking composer install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,9 @@ jobs:
           ini-values: "error_reporting=E_ALL"
 
       - name: Install Dependencies
-        run: composer install
+        run: |
+          composer config --global --unset github-oauth.github.com || true
+          composer install
 
       - name: Run bootstrap
         run: ./bootstrap.sh
@@ -964,7 +966,9 @@ jobs:
           ini-values: "error_reporting=E_ALL"
 
       - name: Install PHP dependencies
-        run: composer install --no-progress --prefer-dist
+        run: |
+          composer config --global --unset github-oauth.github.com || true
+          composer install --no-progress --prefer-dist
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:


### PR DESCRIPTION
## Summary

Follow-up to #3469: the `COMPOSER_AUTH='{}'` env-var approach in that PR does not work because it only overrides Composer's *local* auth.json. The global auth.json written by `shivammathur/setup-php` (which holds the invalid JWT token) is read and validated independently, before the env var takes effect.

This PR replaces the env-var workaround with an explicit `composer config --global --unset github-oauth.github.com || true` before each `composer install` call, removing the bad token at the source.

Affected steps: `lib-php` matrix ("Install Dependencies") and `cross-test` ("Install PHP dependencies").

## Test plan

- [ ] `lib-php (8.x)` jobs pass
- [ ] `cross-test` job passes

🤖 Generated with [Claude Code](https://claude.ai/code)