### PR TITLE
THRIFT-5995: Add native method types to TBase / TException internal helpers

### DIFF
--- a/lib/php/lib/Base/TBase.php
+++ b/lib/php/lib/Base/TBase.php
@@ -71,7 +71,7 @@ abstract class TBase
         $this->__construct(get_object_vars($this));
     }
 
-    private function readMap(&$var, $spec, $input)
+    private function readMap(mixed &$var, array $spec, TProtocol $input): int
     {
         $xfer = 0;
         $ktype = $spec['ktype'];
@@ -139,7 +139,7 @@ abstract class TBase
         return $xfer;
     }
 
-    private function readList(&$var, $spec, $input, $set = false)
+    private function readList(mixed &$var, array $spec, TProtocol $input, bool $set = false): int
     {
         $xfer = 0;
         $etype = $spec['etype'];
@@ -194,7 +194,7 @@ abstract class TBase
         return $xfer;
     }
 
-    protected function readStruct($class, $spec, $input)
+    protected function readStruct(string $class, array $spec, TProtocol $input): int
     {
         $xfer = 0;
         $fname = null;
@@ -245,7 +245,7 @@ abstract class TBase
         return $xfer;
     }
 
-    private function writeMap($var, $spec, $output)
+    private function writeMap(array $var, array $spec, TProtocol $output): int
     {
         $xfer = 0;
         $ktype = $spec['ktype'];
@@ -305,7 +305,7 @@ abstract class TBase
         return $xfer;
     }
 
-    private function writeList($var, $spec, $output, $set = false)
+    private function writeList(array $var, array $spec, TProtocol $output, bool $set = false): int
     {
         $xfer = 0;
         $etype = $spec['etype'];
@@ -350,7 +350,7 @@ abstract class TBase
         return $xfer;
     }
 
-    protected function writeStruct($class, $spec, $output)
+    protected function writeStruct(string $class, array $spec, TProtocol $output): int
     {
         $xfer = 0;
         $xfer += $output->writeStructBegin($class);

--- a/lib/php/lib/Exception/TException.php
+++ b/lib/php/lib/Exception/TException.php
@@ -25,8 +25,9 @@ declare(strict_types=1);
 
 namespace Thrift\Exception;
 
-use Thrift\Type\TType;
 use Thrift\Base\TBase;
+use Thrift\Protocol\TProtocol;
+use Thrift\Type\TType;
 
 /**
  * NOTE(mcslee): This currently contains a ton of duplicated code from TBase
@@ -71,7 +72,7 @@ class TException extends \Exception
         TType::STRING => 'String'
     ];
 
-    private function readMap(&$var, $spec, $input)
+    private function readMap(mixed &$var, array $spec, TProtocol $input): int
     {
         $xfer = 0;
         $ktype = $spec['ktype'];
@@ -139,7 +140,7 @@ class TException extends \Exception
         return $xfer;
     }
 
-    private function readList(&$var, $spec, $input, $set = false)
+    private function readList(mixed &$var, array $spec, TProtocol $input, bool $set = false): int
     {
         $xfer = 0;
         $etype = $spec['etype'];
@@ -194,7 +195,7 @@ class TException extends \Exception
         return $xfer;
     }
 
-    protected function readStruct($class, $spec, $input)
+    protected function readStruct(string $class, array $spec, TProtocol $input): int
     {
         $xfer = 0;
         $fname = null;
@@ -245,7 +246,7 @@ class TException extends \Exception
         return $xfer;
     }
 
-    private function writeMap($var, $spec, $output)
+    private function writeMap(array $var, array $spec, TProtocol $output): int
     {
         $xfer = 0;
         $ktype = $spec['ktype'];
@@ -305,7 +306,7 @@ class TException extends \Exception
         return $xfer;
     }
 
-    private function writeList($var, $spec, $output, $set = false)
+    private function writeList(array $var, array $spec, TProtocol $output, bool $set = false): int
     {
         $xfer = 0;
         $etype = $spec['etype'];
@@ -350,7 +351,7 @@ class TException extends \Exception
         return $xfer;
     }
 
-    protected function writeStruct($class, $spec, $output)
+    protected function writeStruct(string $class, array $spec, TProtocol $output): int
     {
         $xfer = 0;
         $xfer += $output->writeStructBegin($class);


### PR DESCRIPTION
Type the protected/private serialization helpers shared by `TBase` and its HackTown duplicate on `TException`.

**Typed signatures:**

```php
protected function readStruct(string $class, array $spec, TProtocol $input): int
protected function writeStruct(string $class, array $spec, TProtocol $output): int
private function readMap(mixed &$var, array $spec, TProtocol $input): int
private function readList(mixed &$var, array $spec, TProtocol $input, bool $set = false): int
private function writeMap(array $var, array $spec, TProtocol $output): int
private function writeList(array $var, array $spec, TProtocol $output, bool $set = false): int
```

**Design notes:**

- **Read by-ref** uses `mixed &$var` because callers commonly pass an uninitialised local (or `null`) which the helper assigns an `array` into. PHP forbids re-typing a non-mixed reference once bound; `mixed` is the only PHP type that admits the "starts as null, becomes array" lifecycle.
- **Write** pins `$var` to `array` since callers always pass a PHP array for map/set/list values.
- The HackTown duplication of helpers between `TBase` and `TException` is preserved as-is (motivated comment is in the source).

**Library changes:**

- `lib/php/lib/Base/TBase.php`: all six helper signatures typed; `TProtocol` import was already there from earlier modernization.
- `lib/php/lib/Exception/TException.php`: all six helper signatures typed. Adds `use Thrift\Protocol\TProtocol;` (re-ordering imports alphabetically).

**Validation (Docker `thrift-php-dev:local`):**
- `phpcs` — 0 errors
- `phpstan` (level 1) — 0 errors
- `phpunit` Unit Suite — 635 tests, 0 failures
- `phpunit` Integration Suite — 108 tests, 0 failures

Completes the in-library typing pass started by [THRIFT-5981](https://issues.apache.org/jira/browse/THRIFT-5981) (TProtocol abstract + concrete protocols) and [THRIFT-5985](https://issues.apache.org/jira/browse/THRIFT-5985) (TException public surface). Part of the umbrella ticket [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960).

- [x] Did you create an Apache Jira ticket? — [THRIFT-5995](https://issues.apache.org/jira/browse/THRIFT-5995)
- [x] PR title follows the pattern "THRIFT-NNNN: describe my issue"
- [x] Squashed to a single commit
- [x] No breaking changes (helpers are `private`/`protected`; subclasses that override via custom transports would have already type-checked through existing fixtures)

Generated-by: Claude Opus 4.7
