### PR TITLE
THRIFT-5999: Raise PHPStan level from 1 to 5 on PHP library

### DIFF
--- a/lib/php/lib/ClassLoader/ThriftClassLoader.php
+++ b/lib/php/lib/ClassLoader/ThriftClassLoader.php
@@ -116,10 +116,8 @@ class ThriftClassLoader
 
     /**
      * Find class in namespaces or definitions directories
-     * @param  string $class
-     * @return string
      */
-    public function findFile($class)
+    public function findFile(string $class): ?string
     {
         // Remove first backslash
         if ('\\' == $class[0]) {
@@ -158,8 +156,7 @@ class ThriftClassLoader
 
             // Ignore wrong call
             if (count($m) <= 1) {
-                #HOW TO TEST THIS? HOW TEST CASE SHOULD LOOK LIKE?
-                return;
+                return null;
             }
 
             $class = array_pop($m);
@@ -196,5 +193,7 @@ class ThriftClassLoader
                 }
             }
         }
+
+        return null;
     }
 }

--- a/lib/php/lib/Protocol/TBinaryProtocol.php
+++ b/lib/php/lib/Protocol/TBinaryProtocol.php
@@ -383,8 +383,8 @@ class TBinaryProtocol extends TProtocol
         // 64-bit twos-complement arithmetic since PHP wants to treat all ints
         // as signed and any int over 2^31 - 1 as a float
         if (PHP_INT_SIZE == 4) {
-            $hi = $arr[1];
-            $lo = $arr[2];
+            $hi = (int)$arr[1];
+            $lo = (int)$arr[2];
             $isNeg = $hi < 0;
 
             // Check for a negative

--- a/lib/php/lib/TMultiplexedProcessor.php
+++ b/lib/php/lib/TMultiplexedProcessor.php
@@ -64,12 +64,10 @@ class TMultiplexedProcessor
      * allows us to broker requests to individual services by using the service
      * name to select them at request time.
      *
-     * @param serviceName Name of a service, has to be identical to the name
-     * declared in the Thrift IDL, e.g. "WeatherReport".
-     * @param processor Implementation of a service, usually referred to
-     * as "handlers", e.g. WeatherReportHandler implementing WeatherReport.Iface.
+     * @param string $serviceName Must match the name declared in the Thrift IDL, e.g. "WeatherReport".
+     * @param object $processor Service implementation, e.g. WeatherReportHandler implementing WeatherReport.Iface.
      */
-    public function registerProcessor($serviceName, $processor)
+    public function registerProcessor(string $serviceName, object $processor): void
     {
         $this->serviceProcessorMap[$serviceName] = $processor;
     }

--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -273,7 +273,7 @@ class TSocket extends TTransport
                 // write buffer to stream
                 $written = fwrite($this->handle, $buf);
                 $closed_socket = $written === 0 && feof($this->handle);
-                if ($written === -1 || $written === false || $closed_socket) {
+                if ($written === false || $closed_socket) {
                     throw new TTransportException(
                         'TSocket: Could not write ' . strlen($buf) . ' bytes ' .
                         $this->host . ':' . $this->port

--- a/lib/php/phpstan-baseline.neon
+++ b/lib/php/phpstan-baseline.neon
@@ -1,6 +1,14 @@
 parameters:
 	ignoreErrors:
+		# The non-scalar map-key path in writeMap mirrors the Thrift IDL
+		# `map<Struct|Map|List|Set, V>` semantics, but PHP arrays only
+		# admit int|string keys so this arm is defensive dead code and
+		# unreachable at runtime.
 		-
-			message: "#^Method Thrift\\\\ClassLoader\\\\ThriftClassLoader\\:\\:findFile\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: lib/ClassLoader/ThriftClassLoader.php
+			message: "#^(Cannot call method write\\(\\) on \\(int\\|string\\)|Parameter \\#1 \\$var of method Thrift\\\\(Base\\\\TBase|Exception\\\\TException)::write(Map|List)\\(\\) expects array, \\(int\\|string\\) given)\\.$#"
+			count: 4
+			path: lib/Base/TBase.php
+		-
+			message: "#^(Cannot call method write\\(\\) on \\(int\\|string\\)|Parameter \\#1 \\$var of method Thrift\\\\(Base\\\\TBase|Exception\\\\TException)::write(Map|List)\\(\\) expects array, \\(int\\|string\\) given)\\.$#"
+			count: 4
+			path: lib/Exception/TException.php

--- a/lib/php/phpstan.neon
+++ b/lib/php/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 5
     paths:
         - lib
     bootstrapFiles:

--- a/lib/php/test/Unit/Lib/ClassLoader/ThriftClassLoaderTest.php
+++ b/lib/php/test/Unit/Lib/ClassLoader/ThriftClassLoaderTest.php
@@ -108,4 +108,10 @@ class ThriftClassLoaderTest extends TestCase
             'apcuPrefix' => 'APCU_PREFIX',
         ];
     }
+
+    public function testFindFileReturnsNullWhenClassHasNoBackslash(): void
+    {
+        $loader = new ThriftClassLoader();
+        $this->assertNull($loader->findFile('UnnamespacedClassName'));
+    }
 }


### PR DESCRIPTION
Final phase of the umbrella ticket [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960) PHP modernization. Step `lib/php/phpstan.neon` level from 1 to 5 and address every issue PHPStan surfaces along the way.

## Real fixes

- **`TBinaryProtocol::readI64`** — cast `$arr[1]` / `$arr[2]` to `int` before bitwise-NOT on 32-bit hosts. `unpack('N2', …)` is documented to return ints but the static return type is `array|false`; the explicit casts silence PHPStan and document intent.
- **`TSocket::write`** — drop the dead `$written === -1` branch from the post-`fwrite()` check. `fwrite()` returns `int|false`, never `-1`, so the comparison was strict-false at every call.
- **`ThriftClassLoader::findFile`** — convert return type to `?string` (was documented `string` but the body had an empty `return;` for the "wrong call" path) and change `return;` / implicit fall-through to explicit `return null;`. Drops a `#HOW TO TEST THIS?` rhetorical comment.
- **`TMultiplexedProcessor::registerProcessor`** — type the parameters as `(string $serviceName, object $processor): void` and reformat the Javadoc-style `@param` tags to PHP convention.

## Defensive dead-code baseline

The non-scalar map-key path in `TBase::writeMap` / `TException::writeMap` mirrors the Thrift IDL `map<Struct|Map|List|Set, V>` semantics, but PHP arrays only admit `int|string` keys so this arm is unreachable at runtime. The four corresponding messages are baselined with an explanatory comment.

The pre-existing `ThriftClassLoader::findFile` baseline entry is removed since the real fix above closes it.

## Validation

- `phpcs` — 0 errors (lib + test)
- `phpstan` level 5 — 0 errors
- `phpunit` Unit Suite — 635 tests, 0 failures
- `phpunit` Integration Suite — 108 tests, 0 failures

Completes the umbrella [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960).

- [x] Did you create an Apache Jira ticket? — [THRIFT-5999](https://issues.apache.org/jira/browse/THRIFT-5999)
- [x] PR title follows the pattern "THRIFT-NNNN: describe my issue"
- [x] Squashed to a single commit
- [x] No breaking changes (`findFile`'s return type now correctly reflects existing behavior; `registerProcessor`'s typed parameters were the documented contract)

Generated-by: Claude Opus 4.7
