### PR TITLE
THRIFT-6004: Emit native types on generated PHP service-level methods

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_php_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_php_generator.cc
@@ -279,6 +279,7 @@ public:
   std::string declare_field(t_field* tfield, bool init = false, bool obj = false);
   std::string function_signature(t_function* tfunction, std::string prefix = "");
   std::string argument_list(t_struct* tstruct, bool addTypeHints = true);
+  std::string type_to_return(t_type* ttype);
   std::string type_to_cast(t_type* ttype);
   std::string type_to_enum(t_type* ttype);
   std::string type_to_phpdoc(t_type* ttype);
@@ -1498,10 +1499,10 @@ void t_php_generator::generate_service_processor(t_service* tservice) {
   indent_up();
 
   if (extends.empty()) {
-    f_service_processor << indent() << "protected $handler_ = null;" << '\n';
+    f_service_processor << indent() << "protected ?object $handler_ = null;" << '\n';
   }
 
-  f_service_processor << indent() << "public function __construct($handler)"<< '\n'
+  f_service_processor << indent() << "public function __construct(object $handler)"<< '\n'
                       << indent() << "{" << '\n';
 
   indent_up();
@@ -1515,7 +1516,7 @@ void t_php_generator::generate_service_processor(t_service* tservice) {
   f_service_processor << indent() << "}" << '\n' << '\n';
 
   // Generate the server implementation
-  f_service_processor << indent() << "public function process($input, $output)" << '\n'
+  f_service_processor << indent() << "public function process(TProtocol $input, TProtocol $output): bool" << '\n'
                       << indent() << "{" << '\n';
   indent_up();
 
@@ -1551,7 +1552,7 @@ void t_php_generator::generate_service_processor(t_service* tservice) {
                         << indent() << "$x->write($output);" << '\n'
                         << indent() << "$output->writeMessageEnd();" << '\n'
                         << indent() << "$output->getTransport()->flush();" << '\n'
-                        << indent() << "return;" << '\n';
+                        << indent() << "return false;" << '\n';
   }
 
   indent_down();
@@ -1582,7 +1583,8 @@ void t_php_generator::generate_service_processor(t_service* tservice) {
  */
 void t_php_generator::generate_process_function(std::ostream& out, t_service* tservice, t_function* tfunction) {
   // Open function
-  out << indent() << "protected function process_" << tfunction->get_name() << "($seqid, $input, $output)" << '\n'
+  out << indent() << "protected function process_" << tfunction->get_name()
+      << "(int $seqid, TProtocol $input, TProtocol $output): void" << '\n'
       << indent() << "{" << '\n';
   indent_up();
 
@@ -1882,10 +1884,10 @@ void t_php_generator::generate_service_rest(t_service* tservice) {
   indent_up();
 
   if (extends.empty()) {
-    f_service_rest << indent() << "protected $impl;" << '\n' << '\n';
+    f_service_rest << indent() << "protected object $impl;" << '\n' << '\n';
   }
 
-  f_service_rest << indent() << "public function __construct($impl)" << '\n'
+  f_service_rest << indent() << "public function __construct(object $impl)" << '\n'
                  << indent() << "{" << '\n'
                  << indent() << "    $this->impl = $impl;" << '\n'
                  << indent() << "}" << '\n' << '\n';
@@ -1893,7 +1895,8 @@ void t_php_generator::generate_service_rest(t_service* tservice) {
   vector<t_function*> functions = tservice->get_functions();
   vector<t_function*>::iterator f_iter;
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
-    indent(f_service_rest) << "public function " << (*f_iter)->get_name() << "($request)" << '\n';
+    indent(f_service_rest) << "public function " << (*f_iter)->get_name()
+                           << "(array $request)" << type_to_return((*f_iter)->get_returntype()) << '\n';
     indent(f_service_rest) << "{" << '\n';
     indent_up();
     const vector<t_field*>& args = (*f_iter)->get_arglist()->get_members();
@@ -1927,7 +1930,8 @@ void t_php_generator::generate_service_rest(t_service* tservice) {
                        << (*a_iter)->get_name() << ", true));" << '\n' << indent() << "}" << '\n';
       }
     }
-    f_service_rest << indent() << "return $this->impl->" << (*f_iter)->get_name() << "("
+    const std::string return_kw = (*f_iter)->get_returntype()->is_void() ? "" : "return ";
+    f_service_rest << indent() << return_kw << "$this->impl->" << (*f_iter)->get_name() << "("
                << argument_list((*f_iter)->get_arglist(), false) << ");" << '\n';
     indent_down();
     indent(f_service_rest) << "}" << '\n';
@@ -1970,13 +1974,13 @@ void t_php_generator::generate_service_client(t_service* tservice) {
 
   // Private members
   if (extends.empty()) {
-    f_service_client << indent() << "protected $input = null;" << '\n' << indent()
-               << "protected $output = null;" << '\n' << '\n';
-    f_service_client << indent() << "protected $seqid = 0;" << '\n' << '\n';
+    f_service_client << indent() << "protected ?TProtocol $input = null;" << '\n' << indent()
+               << "protected ?TProtocol $output = null;" << '\n' << '\n';
+    f_service_client << indent() << "protected int $seqid = 0;" << '\n' << '\n';
   }
 
   // Constructor function
-  f_service_client << indent() << "public function __construct($input, $output = null)" << '\n'
+  f_service_client << indent() << "public function __construct(TProtocol $input, ?TProtocol $output = null)" << '\n'
                    << indent() << "{" << '\n';
 
   indent_up();
@@ -2027,7 +2031,8 @@ void t_php_generator::generate_service_client(t_service* tservice) {
     scope_down(f_service_client);
     f_service_client << '\n';
 
-    indent(f_service_client) << "public function send_" << function_signature(*f_iter) << '\n';
+    t_function send_function(g_type_void, "send_" + funname, (*f_iter)->get_arglist());
+    indent(f_service_client) << "public function " << function_signature(&send_function) << '\n';
     scope_up(f_service_client);
 
     std::string argsname = php_namespace(tservice->get_program()) + service_name_ + "_"
@@ -2905,7 +2910,9 @@ string t_php_generator::declare_field(t_field* tfield, bool init, bool obj) {
  * @return String of rendered function definition
  */
 string t_php_generator::function_signature(t_function* tfunction, string prefix) {
-  return prefix + tfunction->get_name() + "(" + argument_list(tfunction->get_arglist()) + ")";
+  return prefix + tfunction->get_name()
+         + "(" + argument_list(tfunction->get_arglist()) + ")"
+         + type_to_return(tfunction->get_returntype());
 }
 
 /**
@@ -2926,22 +2933,28 @@ string t_php_generator::argument_list(t_struct* tstruct, bool addTypeHints) {
 
     t_type* type = (*f_iter)->get_type();
 
-    // Set type name
     if (addTypeHints) {
-      if (type->is_struct()) {
-        string className = php_namespace(type->get_program())
-                           + php_namespace_directory("Definition", false)
-                           + classify(type->get_name());
-
-        result += className + " ";
-      } else if (type->is_container()) {
-        result += "array ";
-      }
+      // Thrift fields admit null at construction (`?T`); same convention
+      // for service-method parameters keeps PHP callers BC-compatible
+      // while still narrowing accepted types under strict_types.
+      result += "?" + type_to_native(type) + " ";
     }
 
     result += "$" + (*f_iter)->get_name();
   }
   return result;
+}
+
+/**
+ * Renders a PHP return-type clause for the given Thrift type, e.g. ": void"
+ * for `void` returns or ": ?T" for value returns (nullable to allow the
+ * exception-result idiom). Used by function_signature.
+ */
+string t_php_generator::type_to_return(t_type* type) {
+  if (type->is_void()) {
+    return ": void";
+  }
+  return ": ?" + type_to_native(type);
 }
 
 /**

--- a/lib/php/lib/ClassLoader/ThriftClassLoader.php
+++ b/lib/php/lib/ClassLoader/ThriftClassLoader.php
@@ -99,11 +99,13 @@ class ThriftClassLoader
      */
     protected function findFileInApcu(string $class): ?string
     {
-        if (false === $file = apcu_fetch($this->apcu_prefix . $class)) {
-            apcu_store($this->apcu_prefix . $class, $file = $this->findFile($class));
+        $file = apcu_fetch($this->apcu_prefix . $class);
+        if ($file === false) {
+            $file = $this->findFile($class);
+            apcu_store($this->apcu_prefix . $class, $file);
         }
 
-        return $file !== false ? $file : null;
+        return is_string($file) ? $file : null;
     }
 
     /**

--- a/test/php/Handler.php
+++ b/test/php/Handler.php
@@ -1,93 +1,101 @@
 <?php
 
-class Handler implements \ThriftTest\ThriftTestIf
+use Thrift\Exception\TException;
+use ThriftTest\Insanity;
+use ThriftTest\Numberz;
+use ThriftTest\ThriftTestIf;
+use ThriftTest\Xception;
+use ThriftTest\Xception2;
+use ThriftTest\Xtruct;
+use ThriftTest\Xtruct2;
+
+class Handler implements ThriftTestIf
 {
-    public function testVoid()
+    public function testVoid(): void
     {
-        return;
     }
 
-    public function testString($thing)
-    {
-        return $thing;
-    }
-
-    public function testBool($thing)
+    public function testString(?string $thing): ?string
     {
         return $thing;
     }
 
-    public function testByte($thing)
+    public function testBool(?bool $thing): ?bool
     {
         return $thing;
     }
 
-    public function testI32($thing)
+    public function testByte(?int $thing): ?int
     {
         return $thing;
     }
 
-    public function testI64($thing)
+    public function testI32(?int $thing): ?int
     {
         return $thing;
     }
 
-    public function testDouble($thing)
+    public function testI64(?int $thing): ?int
     {
         return $thing;
     }
 
-    public function testBinary($thing)
+    public function testDouble(?float $thing): ?float
     {
         return $thing;
     }
 
-    public function testUuid($thing)
+    public function testBinary(?string $thing): ?string
     {
         return $thing;
     }
 
-    public function testStruct(\ThriftTest\Xtruct $thing)
+    public function testUuid(?string $thing): ?string
     {
         return $thing;
     }
 
-    public function testNest(\ThriftTest\Xtruct2 $thing)
+    public function testStruct(?Xtruct $thing): ?Xtruct
     {
         return $thing;
     }
 
-    public function testMap(array $thing)
+    public function testNest(?Xtruct2 $thing): ?Xtruct2
     {
         return $thing;
     }
 
-    public function testStringMap(array $thing)
+    public function testMap(?array $thing): ?array
     {
         return $thing;
     }
 
-    public function testSet(array $thing)
+    public function testStringMap(?array $thing): ?array
     {
         return $thing;
     }
 
-    public function testList(array $thing)
+    public function testSet(?array $thing): ?array
     {
         return $thing;
     }
 
-    public function testEnum($thing)
+    public function testList(?array $thing): ?array
     {
         return $thing;
     }
 
-    public function testTypedef($thing)
+    public function testEnum(?int $thing): ?int
     {
         return $thing;
     }
 
-    public function testMapMap($hello)
+    public function testTypedef(?int $thing): ?int
+    {
+        return $thing;
+    }
+
+    public function testMapMap(?int $hello): ?array
     {
         return [
             -4 => [
@@ -105,24 +113,30 @@ class Handler implements \ThriftTest\ThriftTestIf
         ];
     }
 
-    public function testInsanity(\ThriftTest\Insanity $argument)
+    public function testInsanity(?Insanity $argument): ?array
     {
-        $looney = new \ThriftTest\Insanity();
+        $looney = new Insanity();
 
         return [
             1 => [
-                \ThriftTest\Numberz::TWO => $argument,
-                \ThriftTest\Numberz::THREE => $argument,
+                Numberz::TWO => $argument,
+                Numberz::THREE => $argument,
             ],
             2 => [
-                \ThriftTest\Numberz::SIX => $looney,
+                Numberz::SIX => $looney,
             ],
         ];
     }
 
-    public function testMulti($arg0, $arg1, $arg2, array $arg3, $arg4, $arg5)
-    {
-        $result = new \ThriftTest\Xtruct();
+    public function testMulti(
+        ?int $arg0,
+        ?int $arg1,
+        ?int $arg2,
+        ?array $arg3,
+        ?int $arg4,
+        ?int $arg5
+    ): ?Xtruct {
+        $result = new Xtruct();
         $result->string_thing = 'Hello2';
         $result->byte_thing = $arg0;
         $result->i32_thing = $arg1;
@@ -131,47 +145,47 @@ class Handler implements \ThriftTest\ThriftTestIf
         return $result;
     }
 
-    public function testException($arg)
+    public function testException(?string $arg): void
     {
         if ($arg === 'Xception') {
-            $exception = new \ThriftTest\Xception();
+            $exception = new Xception();
             $exception->errorCode = 1001;
             $exception->message = $arg;
             throw $exception;
         }
 
         if ($arg === 'TException') {
-            throw new \Thrift\Exception\TException('This is a TException');
+            throw new TException('This is a TException');
         }
     }
 
-    public function testMultiException($arg0, $arg1)
+    public function testMultiException(?string $arg0, ?string $arg1): ?Xtruct
     {
         if ($arg0 === 'Xception') {
-            $exception = new \ThriftTest\Xception();
+            $exception = new Xception();
             $exception->errorCode = 1001;
             $exception->message = 'This is an Xception';
             throw $exception;
         }
 
         if ($arg0 === 'Xception2') {
-            $exception = new \ThriftTest\Xception2();
+            $exception = new Xception2();
             $exception->errorCode = 2002;
-            $exception->struct_thing = new \ThriftTest\Xtruct();
+            $exception->struct_thing = new Xtruct();
             $exception->struct_thing->string_thing = 'This is an Xception2';
             throw $exception;
         }
 
-        $result = new \ThriftTest\Xtruct();
+        $result = new Xtruct();
         $result->string_thing = $arg1;
 
         return $result;
     }
 
-    public function testOneway($secondsToSleep)
+    public function testOneway(?int $secondsToSleep): void
     {
         // Keep the oneway test quick so the cross-test matrix measures fire-and-forget behavior,
         // not a full second of handler blocking in the single-threaded PHP test server.
-        usleep($secondsToSleep * 300000);
+        usleep((int)$secondsToSleep * 300000);
     }
 }


### PR DESCRIPTION
Update the PHP generator to emit native parameter and return types on every generated service-level method. Completes the typing pass on the generator side after [THRIFT-5986](https://issues.apache.org/jira/browse/THRIFT-5986) (declare strict_types), [THRIFT-5990](https://issues.apache.org/jira/browse/THRIFT-5990) (struct return types), and [THRIFT-5991](https://issues.apache.org/jira/browse/THRIFT-5991) (struct property types).

## Generated signatures (before → after)

```diff
-public function testString($thing)                      // Interface
+public function testString(?string $thing): ?string

-public function __construct($input, $output = null)     // Client ctor
+public function __construct(TProtocol $input, ?TProtocol $output = null)

-public function send_testString($thing)                 // Client
+public function send_testString(?string $thing): void

-public function recv_testString()                       // Client
+public function recv_testString(): ?string

-public function __construct($handler)                   // Processor ctor
+public function __construct(object $handler)

-public function process($input, $output)                // Processor
+public function process(TProtocol $input, TProtocol $output): bool

-protected function process_testString($seqid, $input, $output)
+protected function process_testString(int $seqid, TProtocol $input, TProtocol $output): void

-public function __construct($impl)                      // Rest ctor
+public function __construct(object $impl)

-public function testString($request)                    // Rest method
+public function testString(array $request): ?string
```

## Implementation

- New helper `type_to_return(t_type*)` returning `: void` or `: ?T`. Shares the existing `type_to_native()` mapping introduced by THRIFT-5991.
- `function_signature()` now appends `type_to_return()` for the return clause.
- `argument_list()` now emits `?type_to_native()` on every parameter — previously only struct/container parameters were typed.
- `send_*` constructs a synthetic `t_function(g_type_void, ...)` so `function_signature()` produces the correct `: void` for the writer half.
- Processor `process()` early "method not found" path now `return false;` instead of bare `return;` to satisfy `: bool`.
- Rest method emission gates `return ` on whether the underlying impl is void.

## Drive-by cleanup

`ThriftClassLoader::findFileInApcu()` (merged in [THRIFT-6001](https://issues.apache.org/jira/browse/THRIFT-6001)) was flagged by PHPStan: the trailing `$file !== false ? $file : null` was unreachable because the if-branch reassigns `$file` to `findFile()` (`?string`). Rewrote the body to a clear two-step fetch-or-recompute and narrowed the return via `is_string()`.

## Validation (Docker `thrift-php-dev:local` + `thrift/thrift-build:ubuntu-focal`)

- Built compiler with the patched generator.
- Regenerated all 6 fixture variants under `lib/php/test/Resources/packages/` (gitignored — regen happens in CI).
- `phpcs` — 0 errors
- `phpstan` (level 5) — 0 errors
- `phpunit` Unit Suite — 637 tests, 0 failures
- `phpunit` Integration Suite — 108 tests, 0 failures

Part of umbrella [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960).

- [x] Apache Jira ticket — [THRIFT-6004](https://issues.apache.org/jira/browse/THRIFT-6004)
- [x] PR title follows the pattern "THRIFT-NNNN: …"
- [x] Squashed to a single commit
- [ ] Did you do your best to avoid breaking changes? — third-party user code calling generated services with the wrong types will now fail loudly under strict types. Required regen of generated code against the new compiler.

Generated-by: Claude Opus 4.7
