### PR TITLE
THRIFT-6006: Implement MESSAGE_SIZE_LIMIT exception type for Haxe library

### DIFF
--- a/lib/haxe/src/org/apache/thrift/transport/TEndpointTransport.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TEndpointTransport.hx
@@ -60,7 +60,7 @@ class TEndpointTransport extends TTransport
 
 		// update only: message size can shrink, but not grow
 		if (newSize > KnownMessageSize)
-			throw new TTransportException(TTransportException.END_OF_FILE, "ResetConsumedMessageSize: MaxMessageSize reached");
+			throw new TTransportException(TTransportException.MESSAGE_SIZE_LIMIT, 'ResetConsumedMessageSize: message size exceeds limit ${MaxMessageSize}');
 
 		KnownMessageSize = newSize;
 		RemainingMessageSize = newSize;
@@ -79,7 +79,7 @@ class TEndpointTransport extends TTransport
 	public override function CheckReadBytesAvailable(numBytes : Int64) : Void
 	{
 		if (RemainingMessageSize < numBytes || numBytes < 0)
-			throw new TTransportException(TTransportException.END_OF_FILE, 'CheckReadBytesAvailable(${numBytes}): MaxMessageSize reached, only ${RemainingMessageSize} bytes available');
+			throw new TTransportException(TTransportException.MESSAGE_SIZE_LIMIT, 'CheckReadBytesAvailable(${numBytes}): message size exceeds limit ${MaxMessageSize}, only ${RemainingMessageSize} bytes available');
 	}
 
 	// Consumes numBytes from the RemainingMessageSize.
@@ -92,7 +92,7 @@ class TEndpointTransport extends TTransport
 		else
 		{
 			RemainingMessageSize = 0;
-			throw new TTransportException(TTransportException.END_OF_FILE, 'CountConsumedMessageBytes(${numBytes}): MaxMessageSize reached');
+			throw new TTransportException(TTransportException.MESSAGE_SIZE_LIMIT, 'CountConsumedMessageBytes(${numBytes}): message size exceeds limit ${MaxMessageSize}');
 		}
 	}
 }

--- a/lib/haxe/src/org/apache/thrift/transport/TTransportException.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TTransportException.hx
@@ -30,6 +30,8 @@ class TTransportException extends TException {
     public static inline var ALREADY_OPEN : Int = 2;
     public static inline var TIMED_OUT : Int = 3;
     public static inline var END_OF_FILE : Int = 4;
+    public static inline var CORRUPTED_DATA : Int = 5;
+    public static inline var MESSAGE_SIZE_LIMIT : Int = 6;
 
     public function new(error : Int = UNKNOWN, message : String = "") {
         super(message, error);


### PR DESCRIPTION
## Summary

Implements the `MESSAGE_SIZE_LIMIT` transport exception type for the Haxe library, analogous to the Java fix in [THRIFT-5858](https://issues.apache.org/jira/browse/THRIFT-5858) / PR #3115.

**Problem:** When a transport reads more bytes than the configured maximum message size, it threw a `TTransportException` with type `END_OF_FILE`. This makes debugging difficult — servers swallow the exception silently and clients only see "socket closed by peer", with no indication that a message size limit was exceeded.

**Changes:**
- `TTransportException.hx`: Add `CORRUPTED_DATA = 5` and `MESSAGE_SIZE_LIMIT = 6` constants (matching Java values for cross-language consistency)
- `TEndpointTransport.hx`: Replace `END_OF_FILE` throws with `MESSAGE_SIZE_LIMIT` in `ResetConsumedMessageSize`, `CheckReadBytesAvailable`, and `CountConsumedMessageBytes`; improve error messages to include the configured limit and actual byte counts

## Test plan

- [x] Haxe library compiles without errors
- [x] Existing Haxe transport tests pass
- [x] Exception type is `MESSAGE_SIZE_LIMIT` (6) when message size limit is exceeded

Subtask of [THRIFT-5858](https://issues.apache.org/jira/browse/THRIFT-5858) — tracked as [THRIFT-6006](https://issues.apache.org/jira/browse/THRIFT-6006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>