### PR TITLE
THRIFT-6007: Implement MESSAGE_SIZE_LIMIT exception type for Delphi library

### DIFF
--- a/lib/delphi/src/Thrift.Transport.pas
+++ b/lib/delphi/src/Thrift.Transport.pas
@@ -142,7 +142,8 @@ type
         EndOfFile,
         BadArgs,
         Interrupted,
-        CorruptedData
+        CorruptedData,
+        MessageSizeLimit
       );
   strict protected
     constructor HiddenCreate(const Msg: string);
@@ -197,6 +198,11 @@ type
 
   TTransportExceptionCorruptedData = class (TTransportExceptionSpecialized)
   protected
+    class function GetType: TTransportException.TExceptionType;  override;
+  end;
+
+  TTransportExceptionMessageSizeLimit = class (TTransportExceptionSpecialized)
+  strict protected
     class function GetType: TTransportException.TExceptionType;  override;
   end;
 
@@ -594,7 +600,7 @@ begin
   // update only: message size can shrink, but not grow
   ASSERT( KnownMessageSize <= MaxMessageSize);
   if newSize > KnownMessageSize
-  then raise TTransportExceptionEndOfFile.Create('MaxMessageSize reached');
+  then raise TTransportExceptionMessageSizeLimit.Create('ResetConsumedMessageSize: message size exceeds limit '+IntToStr(MaxMessageSize));
 
   FKnownMessageSize := newSize;
   FRemainingMessageSize := newSize;
@@ -616,7 +622,7 @@ procedure TEndpointTransportBase.CheckReadBytesAvailable( const numBytes : Int64
 // Throws if there are not enough bytes in the input stream to satisfy a read of numBytes bytes of data
 begin
   if (RemainingMessageSize < numBytes) or (numBytes < 0)
-  then raise TTransportExceptionEndOfFile.Create('MaxMessageSize reached');
+  then raise TTransportExceptionMessageSizeLimit.Create('CheckReadBytesAvailable('+IntToStr(numBytes)+'): message size exceeds limit '+IntToStr(MaxMessageSize)+', only '+IntToStr(RemainingMessageSize)+' bytes available');
 end;
 
 
@@ -627,7 +633,7 @@ begin
   then Dec( FRemainingMessageSize, numBytes)
   else begin
     FRemainingMessageSize := 0;
-    raise TTransportExceptionEndOfFile.Create('MaxMessageSize reached');
+    raise TTransportExceptionMessageSizeLimit.Create('CountConsumedMessageBytes('+IntToStr(numBytes)+'): message size exceeds limit '+IntToStr(MaxMessageSize));
   end;
 end;
 
@@ -692,12 +698,13 @@ end;
 class function TTransportException.Create(aType: TExceptionType; const msg: string): TTransportException;
 begin
   case aType of
-    TExceptionType.NotOpen:     Result := TTransportExceptionNotOpen.Create(msg);
-    TExceptionType.AlreadyOpen: Result := TTransportExceptionAlreadyOpen.Create(msg);
-    TExceptionType.TimedOut:    Result := TTransportExceptionTimedOut.Create(msg);
-    TExceptionType.EndOfFile:   Result := TTransportExceptionEndOfFile.Create(msg);
-    TExceptionType.BadArgs:     Result := TTransportExceptionBadArgs.Create(msg);
-    TExceptionType.Interrupted: Result := TTransportExceptionInterrupted.Create(msg);
+    TExceptionType.NotOpen:          Result := TTransportExceptionNotOpen.Create(msg);
+    TExceptionType.AlreadyOpen:      Result := TTransportExceptionAlreadyOpen.Create(msg);
+    TExceptionType.TimedOut:         Result := TTransportExceptionTimedOut.Create(msg);
+    TExceptionType.EndOfFile:        Result := TTransportExceptionEndOfFile.Create(msg);
+    TExceptionType.BadArgs:          Result := TTransportExceptionBadArgs.Create(msg);
+    TExceptionType.Interrupted:      Result := TTransportExceptionInterrupted.Create(msg);
+    TExceptionType.MessageSizeLimit: Result := TTransportExceptionMessageSizeLimit.Create(msg);
   else
     ASSERT( TExceptionType.Unknown = aType);
     Result := TTransportExceptionUnknown.Create(msg);
@@ -756,6 +763,11 @@ end;
 class function TTransportExceptionCorruptedData.GetType: TTransportException.TExceptionType;
 begin
   result := TExceptionType.CorruptedData;
+end;
+
+class function TTransportExceptionMessageSizeLimit.GetType: TTransportException.TExceptionType;
+begin
+  result := TExceptionType.MessageSizeLimit;
 end;
 
 { TTransportFactoryImpl }


### PR DESCRIPTION
## Summary

Implements the `MESSAGE_SIZE_LIMIT` transport exception type for the Delphi library, analogous to the Java fix in [THRIFT-5858](https://issues.apache.org/jira/browse/THRIFT-5858) / PR #3115.

**Problem:** When a transport reads more bytes than the configured maximum message size, it raised a `TTransportExceptionEndOfFile`. This makes debugging difficult — servers swallow the exception silently and clients only see "socket closed by peer", with no indication that a message size limit was exceeded.

**Changes (`Thrift.Transport.pas`):**
- Add `MessageSizeLimit` to the `TExceptionType` enum
- Add `TTransportExceptionMessageSizeLimit` class with `GetType` implementation
- Handle `MessageSizeLimit` in the deprecated `TTransportException.Create` factory method
- Replace `TTransportExceptionEndOfFile` raises with `TTransportExceptionMessageSizeLimit` in `TEndpointTransportBase`: `ResetMessageSizeAndConsumedBytes`, `CheckReadBytesAvailable`, `CountConsumedMessageBytes`
- Improve error messages to include the configured limit and actual byte counts

## Test plan

- [x] Delphi library compiles without errors (Win32/Win64)
- [x] Existing Delphi transport tests pass
- [x] Exception type is `MessageSizeLimit` when message size limit is exceeded

Subtask of [THRIFT-5858](https://issues.apache.org/jira/browse/THRIFT-5858) — tracked as [THRIFT-6007](https://issues.apache.org/jira/browse/THRIFT-6007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>