### PR TITLE
THRIFT-6008: Add regression tests for recent PHP fixes

### DIFF
--- a/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
+++ b/lib/php/test/Unit/Lib/Exception/TExceptionTest.php
@@ -111,6 +111,10 @@ class TExceptionTest extends TestCase
         yield 'bool true' => ['field' => 'boolField', 'value' => true];
         yield 'bool false' => ['field' => 'boolField', 'value' => false];
         yield 'double' => ['field' => 'doubleField', 'value' => 3.14];
+        // Guards THRIFT-6001: TException::$tmethod previously omitted
+        // TType::UUID, so UUID-typed fields in `exception` structs fell
+        // through to the slow recursive STRUCT path on write.
+        yield 'uuid' => ['field' => 'uuidField', 'value' => '12345678-1234-5678-1234-567812345678'];
 
         // containers
         yield 'map' => ['field' => 'mapField', 'value' => ['key1' => 100, 'key2' => 200]];

--- a/lib/php/test/Unit/Lib/Fixture/TestRichException.php
+++ b/lib/php/test/Unit/Lib/Fixture/TestRichException.php
@@ -39,6 +39,7 @@ class TestRichException extends TException
     public $mapField = null;
     public $listField = null;
     public $setField = null;
+    public $uuidField = null;
 
     public function __construct($vals = null)
     {
@@ -78,6 +79,10 @@ class TestRichException extends TException
                 'type' => TType::SET,
                 'etype' => TType::I32,
                 'elem' => ['type' => TType::I32],
+            ],
+            8 => [
+                'var' => 'uuidField',
+                'type' => TType::UUID,
             ],
         ];
 

--- a/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TCompactProtocolTest.php
@@ -864,6 +864,42 @@ class TCompactProtocolTest extends TestCase
         $this->assertSame('01234567-89ab-cdef-0123-456789abcdef', $value);
     }
 
+    /**
+     * Guards THRIFT-5987: in STATE_CONTAINER_READ, readBool() previously
+     * passed its `?bool &$bool` reference straight into readByte(?int &$byte),
+     * leaving the caller's variable holding the raw int instead of bool.
+     * The fix routes through a local int and casts (bool) before assignment.
+     *
+     * @dataProvider readBoolInContainerDataProvider
+     */
+    #[DataProvider('readBoolInContainerDataProvider')]
+    public function testReadBoolInContainerState(int $byteOnWire, bool $expected): void
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TCompactProtocol($transport);
+        $this->setPropertyValue($protocol, 'state', TCompactProtocol::STATE_CONTAINER_READ);
+
+        $transport
+            ->expects($this->once())
+            ->method('readAll')
+            ->with(1)
+            ->willReturn(pack('c', $byteOnWire));
+
+        $value = null;
+        $protocol->readBool($value);
+
+        $this->assertIsBool($value);
+        $this->assertSame($expected, $value);
+    }
+
+    public static function readBoolInContainerDataProvider(): \Generator
+    {
+        yield 'wire 0 → false' => ['byteOnWire' => 0, 'expected' => false];
+        yield 'wire 1 → true' => ['byteOnWire' => 1, 'expected' => true];
+        // Anything non-zero is truthy under PHP's (bool) cast.
+        yield 'wire 0x7f → true' => ['byteOnWire' => 0x7f, 'expected' => true];
+    }
+
     #[DataProvider('writeI64DataProvider')]
     public function testWriteI64(
         $value,

--- a/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
@@ -26,7 +26,9 @@ namespace Test\Thrift\Unit\Lib\Protocol;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TProtocolException;
+use Thrift\Protocol\JSON\BaseContext;
 use Thrift\Protocol\TJSONProtocol;
 use Thrift\Transport\TMemoryBuffer;
 use Thrift\Type\TMessageType;
@@ -34,6 +36,8 @@ use Thrift\Type\TType;
 
 class TJSONProtocolTest extends TestCase
 {
+    use ReflectionHelper;
+
     #[DataProvider('writeAndReadMessageBeginDataProvider')]
     public function testWriteAndReadMessageBegin(string $name, int $type, int $seqid)
     {
@@ -722,5 +726,24 @@ class TJSONProtocolTest extends TestCase
         $this->assertSame('two', $val);
 
         $protocol->readMapEnd();
+    }
+
+    /**
+     * Guards the popContext underflow recovery added when the `$context`
+     * property was tightened to non-nullable: an empty stack now yields a
+     * default BaseContext instead of returning null and tripping the typed
+     * property assignment.
+     */
+    public function testPopContextOnEmptyStackFallsBackToBaseContext(): void
+    {
+        $protocol = new TJSONProtocol(new TMemoryBuffer());
+
+        // Reflect into the private popContext()/context to assert the
+        // underflow path completes without TypeError.
+        $popContext = $this->getAccessibleMethod($protocol, 'popContext');
+        $popContext->invoke($protocol);
+
+        $context = $this->getPropertyValue($protocol, 'context');
+        $this->assertInstanceOf(BaseContext::class, $context);
     }
 }


### PR DESCRIPTION
Add targeted unit tests guarding three recently-fixed bugs whose code paths had no direct test coverage. Pure additions — no library code changes.

## Tests added

### 1. UUID round-trip in exception structs (guards [THRIFT-6001](https://issues.apache.org/jira/browse/THRIFT-6001))

`TException::$tmethod` previously omitted `TType::UUID`, so UUID-typed fields in `exception` structs fell through to the slow recursive STRUCT path on write. Extended the `TestRichException` fixture with a `uuidField` and added a `'uuid'` yield to `TExceptionTest::writeAndReadFieldDataProvider`, asserting the value round-trips intact through `TBinaryProtocol`.

### 2. TCompactProtocol readBool in container state (guards [THRIFT-5987](https://issues.apache.org/jira/browse/THRIFT-5987))

In `STATE_CONTAINER_READ`, `readBool()` previously passed its `?bool &$bool` reference straight into `readByte(?int &$byte)`, leaving the caller's variable holding the raw int instead of bool. Added `testReadBoolInContainerState` with three data-provider rows (`0 → false`, `1 → true`, `0x7f → true`) that mock `TTransport`, force `STATE_CONTAINER_READ` via reflection, and assert the value comes back as a real PHP bool.

### 3. TJSONProtocol popContext underflow recovery

When the `$context` property was tightened to non-nullable in THRIFT-5981 / 5985, `popContext()` was patched to fall back to `new BaseContext()` instead of returning null. Added `testPopContextOnEmptyStackFallsBackToBaseContext` that reflects into the private method and asserts the property holds a `BaseContext` after popping an empty stack — no TypeError.

## Validation (Docker `thrift-php-dev:local`)

- `phpcs` — 0 errors
- `phpstan` (level 5) — 0 errors
- `phpunit` Unit Suite — **642 tests, 0 failures** (+5 new vs master's 637)
- `phpunit` Integration Suite — 108 tests, 0 failures

Part of umbrella [THRIFT-5960](https://issues.apache.org/jira/browse/THRIFT-5960).

- [x] Apache Jira ticket — [THRIFT-6008](https://issues.apache.org/jira/browse/THRIFT-6008)
- [x] PR title follows the pattern "THRIFT-NNNN: …"
- [x] Squashed to a single commit
- [x] No behaviour changes — pure additive tests.

Generated-by: Claude Opus 4.7
