### PR TITLE
THRIFT-6009: Add PSR-3 logger support and runtime deprecation warnings for PHP transports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "issues": "https://issues.apache.org/jira/browse/THRIFT"
     },
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0",

--- a/lib/php/lib/Server/TSSLServerSocket.php
+++ b/lib/php/lib/Server/TSSLServerSocket.php
@@ -83,10 +83,16 @@ class TSSLServerSocket extends TServerSocket
      * prefix is already present.
      *
      * @deprecated Prefix is now applied automatically by the constructor.
-     *             This method will be removed in a future release.
+     *             This method will be removed in the next version.
      */
     public function getSSLHost(string $host): string
     {
+        trigger_error(
+            __METHOD__ . '() is deprecated; the ssl:// prefix is applied automatically '
+            . 'by the constructor. This method will be removed in the next version.',
+            E_USER_DEPRECATED,
+        );
+
         return $this->ensureSslHostPrefix($host);
     }
 

--- a/lib/php/lib/Transport/TSSLSocket.php
+++ b/lib/php/lib/Transport/TSSLSocket.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace Thrift\Transport;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
 
@@ -45,14 +47,15 @@ class TSSLSocket extends TSocket
     /**
      * Socket constructor
      *
-     * @param resource|null        $context Stream context
-     * @param callable|string|null $debugHandler
+     * @param resource|null                        $context      Stream context
+     * @param LoggerInterface|callable|string|null $debugHandler PSR-3 logger or
+     *        legacy callable; see TSocket::__construct().
      */
     public function __construct(
         string $host = 'localhost',
         int $port = 9090,
         $context = null,
-        $debugHandler = null,
+        LoggerInterface|callable|string|null $debugHandler = null,
     ) {
         parent::__construct($this->ensureSslHostPrefix($host), $port, false, $debugHandler);
         $this->context = $context ?? stream_context_create();
@@ -89,9 +92,7 @@ class TSSLSocket extends TSocket
         if ($this->handle === false) {
             $error = 'TSocket: Could not connect to ' .
                 $this->host . ':' . $this->port . ' (' . $errstr . ' [' . $errno . '])';
-            if ($this->debug) {
-                call_user_func($this->debugHandler, $error);
-            }
+            $this->log(LogLevel::ERROR, $error);
             throw new TException($error);
         }
     }

--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -25,6 +25,10 @@ declare(strict_types=1);
 
 namespace Thrift\Transport;
 
+use Closure;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
 
@@ -37,6 +41,10 @@ class TSocket extends TTransport
 {
     /**
      * Default debug handler used when none is supplied to the constructor.
+     *
+     * @deprecated Callable / function-name debug handlers are deprecated and
+     *             will be removed in the next version. Pass a
+     *             Psr\Log\LoggerInterface to the constructor instead.
      */
     public const DEFAULT_DEBUG_HANDLER = 'error_log';
 
@@ -78,27 +86,61 @@ class TSocket extends TTransport
     protected int $recvTimeoutUsec = 750000;
 
     /**
-     * Debugging on?
+     * Debugging on? Gates the legacy callable $debugHandler. Has no effect
+     * when a Psr\Log\LoggerInterface is used — that path is always invoked
+     * and the logger is responsible for level filtering.
+     *
+     * @deprecated Used only with the legacy callable $debugHandler, which
+     *             is itself deprecated. Will be removed alongside it in
+     *             the next version.
      */
     protected bool $debug = false;
 
     /**
-     * Debug handler
+     * PSR-3 logger used for diagnostic output. Defaults to a NullLogger so the
+     * transport is silent unless the caller supplies a real logger.
      */
-    protected mixed $debugHandler;
+    protected LoggerInterface $logger;
+
+    /**
+     * Legacy debug callback. Only populated when the caller passed a callable
+     * (or, deprecated, a function-name string) instead of a LoggerInterface.
+     */
+    protected ?Closure $debugHandler = null;
 
     /**
      * Socket constructor
      *
-     * @param callable|string|null $debugHandler
+     * @param LoggerInterface|callable|string|null $debugHandler PSR-3 logger
+     *        for diagnostic output. Passing a callable or function-name string
+     *        is deprecated and triggers E_USER_DEPRECATED; pass a
+     *        Psr\Log\LoggerInterface instead.
      */
     public function __construct(
         protected string $host = 'localhost',
         protected int $port = 9090,
         protected bool $persist = false,
-        $debugHandler = null,
+        LoggerInterface|callable|string|null $debugHandler = null,
     ) {
-        $this->debugHandler = $debugHandler ?? self::DEFAULT_DEBUG_HANDLER;
+        if ($debugHandler instanceof LoggerInterface) {
+            $this->logger = $debugHandler;
+            return;
+        }
+
+        $this->logger = new NullLogger();
+
+        if ($debugHandler === null) {
+            return;
+        }
+
+        trigger_error(
+            'Passing a callable as $debugHandler is deprecated and will be '
+            . 'removed in the next version; pass a Psr\\Log\\LoggerInterface '
+            . 'instead.',
+            E_USER_DEPRECATED,
+        );
+
+        $this->debugHandler = Closure::fromCallable($debugHandler);
     }
 
     /**
@@ -130,9 +172,55 @@ class TSocket extends TTransport
             ($timeout - ($this->recvTimeoutSec * 1000)) * 1000;
     }
 
+    /**
+     * Enables or disables emission via the legacy callable $debugHandler.
+     * Has no effect when a Psr\Log\LoggerInterface is in use — configure
+     * the logger's level filter instead.
+     *
+     * @deprecated The full LoggerInterface migration is planned for the
+     *             next version, at which point this gate becomes
+     *             redundant and will be removed. Pass a configured
+     *             Psr\Log\LoggerInterface to the constructor instead.
+     */
     public function setDebug(bool $debug): void
     {
+        trigger_error(
+            __METHOD__ . '() is deprecated; pass a Psr\\Log\\LoggerInterface '
+            . 'to the constructor and let the logger filter by level. This '
+            . 'method will be removed in the next version.',
+            E_USER_DEPRECATED,
+        );
+
         $this->debug = $debug;
+    }
+
+    /**
+     * Dispatches a diagnostic message.
+     *
+     * - Legacy callable $debugHandler: gated by setDebug() for BC.
+     * - User-supplied Psr\Log\LoggerInterface: always invoked; the logger
+     *   filters by level.
+     * - No handler supplied (default NullLogger): falls back to PHP's
+     *   error_log() when setDebug(true) is in effect, matching master.
+     */
+    protected function log(string $level, string $message): void
+    {
+        if ($this->debugHandler !== null) {
+            if (!$this->debug) {
+                return;
+            }
+            ($this->debugHandler)($message);
+            return;
+        }
+
+        if (!($this->logger instanceof NullLogger)) {
+            $this->logger->log($level, $message);
+            return;
+        }
+
+        if ($this->debug) {
+            error_log($message);
+        }
     }
 
     public function getHost(): string
@@ -189,9 +277,7 @@ class TSocket extends TTransport
         if ($this->handle === false) {
             $error = 'TSocket: Could not connect to ' .
                 $this->host . ':' . $this->port . ' (' . $errstr . ' [' . $errno . '])';
-            if ($this->debug) {
-                call_user_func($this->debugHandler, $error);
-            }
+            $this->log(LogLevel::ERROR, $error);
             throw new TException($error);
         }
 

--- a/lib/php/lib/Transport/TSocketPool.php
+++ b/lib/php/lib/Transport/TSocketPool.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace Thrift\Transport;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Thrift\Exception\TException;
 
 /**
@@ -73,15 +75,16 @@ class TSocketPool extends TSocket
     /**
      * Socket pool constructor
      *
-     * @param list<string>           $hosts        List of remote hostnames
-     * @param int|list<int>          $ports        Array of remote ports, or a single common port
-     * @param callable|string|null   $debugHandler Function for error logging
+     * @param list<string>                         $hosts        List of remote hostnames
+     * @param int|list<int>                        $ports        Array of remote ports, or a single common port
+     * @param LoggerInterface|callable|string|null $debugHandler PSR-3 logger or legacy callable;
+     *        see TSocket::__construct().
      */
     public function __construct(
         array $hosts = ['localhost'],
         int|array $ports = [9090],
         bool $persist = false,
-        $debugHandler = null
+        LoggerInterface|callable|string|null $debugHandler = null
     ) {
         parent::__construct('', 0, $persist, $debugHandler);
 
@@ -170,14 +173,12 @@ class TSocketPool extends TSocket
                 $elapsed = time() - $lastFailtime;
                 if ($elapsed > $this->retryInterval) {
                     $retryIntervalPassed = true;
-                    if ($this->debug) {
-                        call_user_func(
-                            $this->debugHandler,
-                            'TSocketPool: retryInterval ' .
-                            '(' . $this->retryInterval . ') ' .
-                            'has passed for host ' . $host . ':' . $port
-                        );
-                    }
+                    $this->log(
+                        LogLevel::DEBUG,
+                        'TSocketPool: retryInterval ' .
+                        '(' . $this->retryInterval . ') ' .
+                        'has passed for host ' . $host . ':' . $port
+                    );
                 }
             }
 
@@ -229,14 +230,12 @@ class TSocketPool extends TSocket
 
                 // Log and cache this failure
                 if ($consecfails >= $this->maxConsecutiveFailures) {
-                    if ($this->debug) {
-                        call_user_func(
-                            $this->debugHandler,
-                            'TSocketPool: marking ' . $host . ':' . $port .
-                            ' as down for ' . $this->retryInterval . ' secs ' .
-                            'after ' . $consecfails . ' failed attempts.'
-                        );
-                    }
+                    $this->log(
+                        LogLevel::WARNING,
+                        'TSocketPool: marking ' . $host . ':' . $port .
+                        ' as down for ' . $this->retryInterval . ' secs ' .
+                        'after ' . $consecfails . ' failed attempts.'
+                    );
                     // Store the failure time
                     $this->apcuStore($failtimeKey, time());
 
@@ -256,9 +255,7 @@ class TSocketPool extends TSocket
         }
         $hostlist = implode(',', $hosts);
         $error .= '(' . $hostlist . ')';
-        if ($this->debug) {
-            call_user_func($this->debugHandler, $error);
-        }
+        $this->log(LogLevel::ERROR, $error);
         throw new TException($error);
     }
 

--- a/lib/php/test/Unit/Lib/Server/TSSLServerSocketTest.php
+++ b/lib/php/test/Unit/Lib/Server/TSSLServerSocketTest.php
@@ -146,4 +146,30 @@ class TSSLServerSocketTest extends TestCase
         $socket->listen();
         $socket->accept();
     }
+
+    public function testGetSSLHostTriggersDeprecation(): void
+    {
+        $socket = new TSSLServerSocket();
+
+        $errors = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$errors): bool {
+                $errors[] = ['errno' => $errno, 'errstr' => $errstr];
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $result = $socket->getSSLHost('example.com');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('ssl://example.com', $result);
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString('getSSLHost() is deprecated', $errors[0]['errstr']);
+    }
 }

--- a/lib/php/test/Unit/Lib/Transport/TSSLSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSSLSocketTest.php
@@ -26,6 +26,9 @@ namespace Test\Thrift\Unit\Lib\Transport;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Test\Thrift\Unit\Lib\UserDeprecationCapture;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TSSLSocket;
@@ -33,6 +36,7 @@ use Thrift\Transport\TSSLSocket;
 class TSSLSocketTest extends TestCase
 {
     use PHPMock;
+    use UserDeprecationCapture;
 
     #[DataProvider('openExceptionDataProvider')]
     public function testOpenException(
@@ -173,13 +177,14 @@ class TSSLSocketTest extends TestCase
         $this->expectExceptionMessage('TSocket: Could not connect to');
         $this->expectExceptionCode(0);
 
-        $transport = new TSSLSocket(
-            $host,
-            $port,
-            $context,
-            $debugHandler
+        $transport = null;
+        $deprecations = self::captureUserDeprecations(
+            static function () use (&$transport, $host, $port, $context, $debugHandler): void {
+                $transport = new TSSLSocket($host, $port, $context, $debugHandler);
+                $transport->setDebug(true);
+            },
         );
-        $transport->setDebug(true);
+        $this->assertCount(2, $deprecations);
         $transport->open();
     }
 
@@ -242,5 +247,69 @@ class TSSLSocketTest extends TestCase
         yield 'localhost' => ['localhost', 'ssl://localhost'];
         yield 'ssl_localhost' => ['ssl://localhost', 'ssl://localhost'];
         yield 'http_localhost' => ['http://localhost', 'http://localhost'];
+    }
+
+    public function testDebugHandlerWithLoggerInterface(): void
+    {
+        $host = 'nonexistent-host';
+        $port = 9090;
+        $expectedMessage = 'TSocket: Could not connect to ssl://nonexistent-host:9090 (Connection refused [999])';
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+               ->method('log')
+               ->with(LogLevel::ERROR, $expectedMessage);
+
+        $this->getFunctionMock('Thrift\Transport', 'stream_socket_client')
+            ->expects($this->once())
+            ->willReturnCallback(
+                function (
+                    string $address,
+                    &$error_code,
+                    &$error_message,
+                    ?float $timeout,
+                    int $flags,
+                    $context
+                ) {
+                    $error_code = 999;
+                    $error_message = 'Connection refused';
+
+                    return false;
+                }
+            );
+
+        $transport = new TSSLSocket($host, $port, null, $logger);
+
+        $this->expectException(TException::class);
+        $transport->open();
+    }
+
+    public function testStringDebugHandlerTriggersDeprecation(): void
+    {
+        $errors = self::captureUserDeprecations(static function (): void {
+            new TSSLSocket('localhost', 9090, null, 'error_log');
+        });
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString(
+            'Passing a callable as $debugHandler is deprecated',
+            $errors[0]['errstr'],
+        );
+    }
+
+    public function testClosureDebugHandlerTriggersDeprecation(): void
+    {
+        $errors = self::captureUserDeprecations(static function (): void {
+            new TSSLSocket('localhost', 9090, null, static function (string $m): void {
+            });
+        });
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString(
+            'Passing a callable as $debugHandler is deprecated',
+            $errors[0]['errstr'],
+        );
     }
 }

--- a/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
 use Thrift\Exception\TException;
 use Thrift\Transport\TSocket;
@@ -163,7 +165,6 @@ class TSocketPoolTest extends TestCase
         $retryInterval,
         $numRetries,
         $maxConsecutiveFailures,
-        $debug,
         $servers,
         $functionExistCallParams,
         $functionExistResult,
@@ -218,21 +219,24 @@ class TSocketPoolTest extends TestCase
                  return $apcuFetchResult[$iteration++];
              });
 
-        $this->getFunctionMock('Thrift\Transport', 'call_user_func')
-             ->expects($this->exactly(count($debugHandlerCall)))
-             ->willReturnCallback(function (...$callArgs) use ($debugHandlerCall) {
-                 static $iteration = 0;
-                 $expected = $debugHandlerCall[$iteration++];
-                foreach ($expected as $i => $exp) {
-                    if ($exp instanceof Constraint) {
-                        $this->assertThat($callArgs[$i], $exp);
-                    } else {
-                        $this->assertSame($exp, $callArgs[$i]);
+        $logger = $this->createMock(LoggerInterface::class);
+        if (count($debugHandlerCall) > 0) {
+            $logger->expects($this->exactly(count($debugHandlerCall)))
+                   ->method('log')
+                   ->willReturnCallback(function (...$callArgs) use ($debugHandlerCall) {
+                       static $iteration = 0;
+                       $expected = $debugHandlerCall[$iteration++];
+                    foreach ($expected as $i => $exp) {
+                        if ($exp instanceof Constraint) {
+                            $this->assertThat($callArgs[$i], $exp);
+                        } else {
+                            $this->assertSame($exp, $callArgs[$i]);
+                        }
                     }
-                }
-
-                 return true;
-             });
+                   });
+        } else {
+            $logger->expects($this->never())->method('log');
+        }
 
         $this->getFunctionMock('Thrift\Transport', 'apcu_store')
              ->expects($this->exactly(count($apcuStoreCallParams)))
@@ -299,12 +303,11 @@ class TSocketPoolTest extends TestCase
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
-        $socketPool = new TSocketPool($hosts, $ports, $persist, $debugHandler);
+        $socketPool = new TSocketPool($hosts, $ports, $persist, $debugHandler ?? $logger);
         $socketPool->setRandomize($randomize);
         $socketPool->setRetryInterval($retryInterval);
         $socketPool->setNumRetries($numRetries);
         $socketPool->setMaxConsecutiveFailures($maxConsecutiveFailures);
-        $socketPool->setDebug($debug);
 
         $this->assertNull($socketPool->open());
     }
@@ -320,7 +323,6 @@ class TSocketPoolTest extends TestCase
             'retryInterval' => 5,
             'numRetries' => 1,
             'maxConsecutiveFailures' => 1,
-            'debug' => false,
             'servers' => [
                 ['host' => 'localhost', 'port' => 9090],
             ],
@@ -379,6 +381,11 @@ class TSocketPoolTest extends TestCase
                 ],
                 'timeResult' => [
                     1,
+                ],
+                'debugHandlerCall' => [
+                    [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
+                    [LogLevel::WARNING, 'TSocketPool: marking localhost:9090 as down for 5 secs after 1 failed attempts.'],
+                    [LogLevel::ERROR, 'TSocketPool: All hosts in pool are down. (localhost:9090)'],
                 ],
                 'expectedException' => TException::class,
                 'expectedExceptionMessage' => 'TSocketPool: All hosts in pool are down. (localhost:9090)',
@@ -439,9 +446,8 @@ class TSocketPoolTest extends TestCase
                 'timeResult' => [
                     100,
                 ],
-                'debug' => true,
                 'debugHandlerCall' => [
-                    ['error_log', 'TSocketPool: retryInterval (5) has passed for host localhost:9090'],
+                    [LogLevel::DEBUG, 'TSocketPool: retryInterval (5) has passed for host localhost:9090'],
                 ],
             ]
         );
@@ -473,12 +479,11 @@ class TSocketPoolTest extends TestCase
                 'fsockopenResult' => [
                     false,
                 ],
-                'debug' => true,
                 'debugHandlerCall' => [
-                    ['error_log', 'TSocketPool: retryInterval (5) has passed for host localhost:9090'],
-                    ['error_log', 'TSocket: Could not connect to localhost:9090 ( [])'],
-                    ['error_log', 'TSocketPool: marking localhost:9090 as down for 5 secs after 1 failed attempts.'],
-                    ['error_log', 'TSocketPool: All hosts in pool are down. (localhost:9090)'],
+                    [LogLevel::DEBUG, 'TSocketPool: retryInterval (5) has passed for host localhost:9090'],
+                    [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
+                    [LogLevel::WARNING, 'TSocketPool: marking localhost:9090 as down for 5 secs after 1 failed attempts.'],
+                    [LogLevel::ERROR, 'TSocketPool: All hosts in pool are down. (localhost:9090)'],
                 ],
                 'expectedException' => TException::class,
                 'expectedExceptionMessage' => 'TSocketPool: All hosts in pool are down. (localhost:9090)',
@@ -505,6 +510,10 @@ class TSocketPoolTest extends TestCase
                 'fsockopenResult' => [
                     false,
                 ],
+                'debugHandlerCall' => [
+                    [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
+                    [LogLevel::ERROR, 'TSocketPool: All hosts in pool are down. (localhost:9090)'],
+                ],
                 'expectedException' => TException::class,
                 'expectedExceptionMessage' => 'TSocketPool: All hosts in pool are down. (localhost:9090)',
             ]
@@ -526,6 +535,11 @@ class TSocketPoolTest extends TestCase
                 ],
                 'apcuFetchCallParams' => [],
                 'apcuStoreCallParams' => [],
+                'debugHandlerCall' => [
+                    [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
+                    [LogLevel::WARNING, 'TSocketPool: marking localhost:9090 as down for 5 secs after 1 failed attempts.'],
+                    [LogLevel::ERROR, 'TSocketPool: All hosts in pool are down. (localhost:9090)'],
+                ],
                 'expectedException' => TException::class,
                 'expectedExceptionMessage' => 'TSocketPool: All hosts in pool are down. (localhost:9090)',
             ]
@@ -571,7 +585,36 @@ class TSocketPoolTest extends TestCase
                 'timeResult' => [
                     1,
                 ],
+                'debugHandlerCall' => [
+                    [LogLevel::ERROR, 'TSocket: Could not connect to host2:9091 ( [])'],
+                    [LogLevel::WARNING, 'TSocketPool: marking host2:9091 as down for 5 secs after 1 failed attempts.'],
+                ],
             ]
         );
+    }
+
+    public function testSetDebugIsDeprecated(): void
+    {
+        $pool = new TSocketPool(['localhost'], 9090);
+
+        $errors = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$errors): bool {
+                $errors[] = ['errno' => $errno, 'errstr' => $errstr];
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $pool->setDebug(true);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString('setDebug() is deprecated', $errors[0]['errstr']);
     }
 }

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -26,7 +26,10 @@ namespace Test\Thrift\Unit\Lib\Transport;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Test\Thrift\Unit\Lib\ReflectionHelper;
+use Test\Thrift\Unit\Lib\UserDeprecationCapture;
 use Thrift\Exception\TException;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TSocket;
@@ -35,6 +38,7 @@ class TSocketTest extends TestCase
 {
     use PHPMock;
     use ReflectionHelper;
+    use UserDeprecationCapture;
 
     protected function setUp(): void
     {
@@ -195,13 +199,14 @@ class TSocketTest extends TestCase
                 }
             );
 
-        $transport = new TSocket(
-            $host,
-            $port,
-            $false,
-            $debugHandler
+        $transport = null;
+        $deprecations = self::captureUserDeprecations(
+            static function () use (&$transport, $host, $port, $false, $debugHandler): void {
+                $transport = new TSocket($host, $port, $false, $debugHandler);
+                $transport->setDebug(true);
+            },
         );
-        $transport->setDebug(true);
+        $this->assertCount(2, $deprecations);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('TSocket: Could not connect to');
@@ -694,5 +699,87 @@ class TSocketTest extends TestCase
             $debugHandler
         );
         $this->assertNUll($transport->flush());
+    }
+
+    public function testDebugHandlerWithLoggerInterface(): void
+    {
+        $host = 'nonexistent-host';
+        $port = 9090;
+        $expectedMessage = 'TSocket: Could not connect to nonexistent-host:9090 (Connection refused [999])';
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+               ->method('log')
+               ->with(LogLevel::ERROR, $expectedMessage);
+
+        $this->getFunctionMock('Thrift\Transport', 'fsockopen')
+            ->expects($this->once())
+            ->willReturnCallback(
+                function (
+                    string $hostname,
+                    int $port,
+                    &$error_code,
+                    &$error_message,
+                    ?float $timeout
+                ) {
+                    $error_code = 999;
+                    $error_message = 'Connection refused';
+
+                    return false;
+                }
+            );
+
+        $transport = new TSocket($host, $port, false, $logger);
+
+        $this->expectException(TException::class);
+        $transport->open();
+    }
+
+    public function testStringDebugHandlerTriggersDeprecation(): void
+    {
+        $errors = self::captureUserDeprecations(static function (): void {
+            new TSocket('localhost', 9090, false, 'error_log');
+        });
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString(
+            'Passing a callable as $debugHandler is deprecated',
+            $errors[0]['errstr'],
+        );
+    }
+
+    public function testClosureDebugHandlerTriggersDeprecation(): void
+    {
+        $errors = self::captureUserDeprecations(static function (): void {
+            new TSocket('localhost', 9090, false, static function (string $m): void {
+            });
+        });
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_DEPRECATED, $errors[0]['errno']);
+        $this->assertStringContainsString(
+            'Passing a callable as $debugHandler is deprecated',
+            $errors[0]['errstr'],
+        );
+    }
+
+    public function testNullDebugHandlerDoesNotTriggerDeprecation(): void
+    {
+        $errors = self::captureUserDeprecations(static function (): void {
+            new TSocket('localhost', 9090, false, null);
+        });
+
+        $this->assertSame([], $errors);
+    }
+
+    public function testLoggerInterfaceDebugHandlerDoesNotTriggerDeprecation(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $errors = self::captureUserDeprecations(function () use ($logger): void {
+            new TSocket('localhost', 9090, false, $logger);
+        });
+
+        $this->assertSame([], $errors);
     }
 }

--- a/lib/php/test/Unit/Lib/UserDeprecationCapture.php
+++ b/lib/php/test/Unit/Lib/UserDeprecationCapture.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Thrift\Unit\Lib;
+
+trait UserDeprecationCapture
+{
+    /**
+     * @param callable():void $action
+     * @return list<array{errno:int,errstr:string}>
+     */
+    private static function captureUserDeprecations(callable $action): array
+    {
+        $errors = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$errors): bool {
+                $errors[] = ['errno' => $errno, 'errstr' => $errstr];
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $action();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $errors;
+    }
+}

--- a/test/php/TestClient.php
+++ b/test/php/TestClient.php
@@ -42,6 +42,9 @@ if ($GEN_DIR == 'gen-php') {
  * under the License.
  */
 
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
 /** Include the Thrift base */
 /** Include the protocols */
 use Thrift\Protocol\TBinaryProtocol;
@@ -56,6 +59,24 @@ use Thrift\Transport\TSocketPool;
 /** Include the socket layer */
 use Thrift\Transport\TFramedTransport;
 use Thrift\Transport\TBufferedTransport;
+
+/**
+ * Minimal PSR-3 logger that forwards every message to PHP's error_log
+ * (stderr in CLI mode). Used here to exercise the new logger-aware
+ * debugHandler path on the cross-test client.
+ */
+final class StderrLogger extends AbstractLogger implements LoggerInterface
+{
+    /**
+     * @param string|\Stringable $level
+     * @param string|\Stringable $message
+     * @param array<mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        error_log('[' . (string) $level . '] ' . (string) $message);
+    }
+}
 
 function makeProtocol($transport, $PROTO)
 {
@@ -100,9 +121,9 @@ foreach ($argv as $arg) {
 
 $hosts = array('localhost');
 
-$socket = new TSocket($host, $port);
-$socket = new TSocketPool($hosts, $port);
-$socket->setDebug(TRUE);
+$logger = new StderrLogger();
+$socket = new TSocket($host, $port, false, $logger);
+$socket = new TSocketPool($hosts, $port, false, $logger);
 
 if ($MODE == 'inline') {
   $transport = $socket;


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Resolves [THRIFT-6009](https://issues.apache.org/jira/browse/THRIFT-6009).

The PHP socket transports (`TSocket`, `TSSLSocket`, `TSocketPool`) previously accepted only `callable|string|null` for `$debugHandler`, defaulting to `'error_log'`, invoked via `call_user_func()`. There was no way to wire in a PSR-3 logger directly and the only `@deprecated` API in the PHP library (`TSSLServerSocket::getSSLHost()`) emitted nothing at runtime.

## What this PR does

- Adds `psr/log: ^1.0 || ^2.0 || ^3.0` to `composer.json`. Thrift is a *consumer* of `LoggerInterface`, so the multi-major constraint is safe.
- Widens `$debugHandler` on the three transports to `Psr\Log\LoggerInterface|callable|string|null`.
- Routes diagnostics through a single `protected log(string $level, string $message)` helper on `TSocket`:
  - **`LoggerInterface`** — always invoked; the logger is responsible for level filtering. Per-call-site `LogLevel` constants are used: `DEBUG` for the retry-interval-elapsed message, `WARNING` for marking a host down, `ERROR` for connection failures and all-hosts-down.
  - **legacy callable / string** — gated by `setDebug()` for BC; constructor emits `E_USER_DEPRECATED`.
  - **no handler + `setDebug(true)`** — falls back to PHP `error_log()`, preserving master's stderr output.
- `setDebug()` is kept (still gates the legacy callable path) but marked `@deprecated` and emits `E_USER_DEPRECATED`. It has **no effect on the PSR-3 path**.
- `TSSLServerSocket::getSSLHost()` now emits `E_USER_DEPRECATED` at runtime.
- `test/php/TestClient.php` demonstrates the new API by injecting a tiny `StderrLogger extends AbstractLogger`.

## Test coverage

- LoggerInterface dispatch with per-call-site levels (`TSocket`, `TSSLSocket`, `TSocketPool`).
- Constructor deprecation triggers for string- and Closure-form `$debugHandler`.
- `setDebug()` deprecation regression guard.
- `TSSLServerSocket::getSSLHost()` runtime deprecation.
- Null / LoggerInterface paths assert *no* deprecation (regression guards).
- New `Test\Thrift\Unit\Lib\UserDeprecationCapture` trait shared between tests.

646 unit tests pass; PHPStan (level 6) clean; `phpcs` clean; `cross-test (java, go,rs,cpp,py,php,nodejs,nodets)` passes.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? — THRIFT-6009
- [x] Pull request title follows `THRIFT-NNNN: …`?
- [x] Single squashed commit?
- [x] Avoided breaking changes? — runtime behaviour preserved for the common cases (no handler + no setDebug; legacy callable + setDebug); legacy paths are runtime-deprecated rather than removed.
- [ ] `[skip ci]` — N/A.
