### PR TITLE
THRIFT-6012: Precompile regex patterns in Go struct validator

### DIFF
--- a/compiler/cpp/src/thrift/generate/go_validator_generator.cc
+++ b/compiler/cpp/src/thrift/generate/go_validator_generator.cc
@@ -679,15 +679,29 @@ void go_validator_generator::generate_string_field_validator(std::ostream& out,
       }
       out << ")";
     } else if (key == "vt.pattern") {
-      out << indent() << "if ok, _ := regexp.MatchString(" << target << ", ";
       if (values[0]->is_field_reference()) {
+        out << indent() << "if ok, _ := regexp.MatchString(";
         out << "string(";
         out << get_field_reference_name(values[0]->get_field_reference());
         out << ")";
+        out << ", " << target << "); !ok";
       } else {
-        out << "\"" << values[0]->get_string() << "\"";
+        std::string pattern = values[0]->get_string();
+        std::string var_name;
+        bool found = false;
+        for (auto& entry : pattern_cache_) {
+          if (entry.first == pattern) {
+            var_name = entry.second;
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          var_name = "vtRe" + current_struct_name_ + std::to_string(pattern_cache_.size());
+          pattern_cache_.push_back({pattern, var_name});
+        }
+        out << indent() << "if !" << var_name << ".MatchString(" << target << ")";
       }
-      out << "); ok";
     } else if (key == "vt.prefix") {
       out << indent() << "if !strings.HasPrefix(" << target << ", ";
       if (values[0]->is_field_reference()) {
@@ -851,6 +865,25 @@ void go_validator_generator::generate_map_field_validator(std::ostream& out,
       out << indent() << "}" << '\n';
     }
   }
+}
+
+void go_validator_generator::generate_regexp_vars(std::ostream& out) {
+  if (pattern_cache_.empty()) {
+    return;
+  }
+  out << "// Precompiled regex patterns for " << current_struct_name_ << " vt.pattern validation" << '\n';
+  if (pattern_cache_.size() == 1) {
+    out << "var " << pattern_cache_[0].second << " = regexp.MustCompile(`"
+        << pattern_cache_[0].first << "`)" << '\n' << '\n';
+    return;
+  }
+  out << "var (" << '\n';
+  indent_up();
+  for (auto& entry : pattern_cache_) {
+    out << indent() << entry.second << " = regexp.MustCompile(`" << entry.first << "`)" << '\n';
+  }
+  indent_down();
+  out << ")" << '\n' << '\n';
 }
 
 void go_validator_generator::generate_struct_field_validator(std::ostream& out,

--- a/compiler/cpp/src/thrift/generate/go_validator_generator.h
+++ b/compiler/cpp/src/thrift/generate/go_validator_generator.h
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -33,6 +34,7 @@ class go_validator_generator {
 public:
   go_validator_generator(t_go_generator* gg) : go_generator(gg){};
   void generate_struct_validator(std::ostream& out, t_struct* tstruct);
+  void generate_regexp_vars(std::ostream& out);
 
   struct generator_context {
     std::string field_symbol;
@@ -42,6 +44,8 @@ public:
     t_type* type;
     std::vector<validation_rule*> rules;
   };
+
+  void set_struct_name(const std::string& name) { current_struct_name_ = name; }
 
 private:
   void generate_field_validator(std::ostream& out, const generator_context& context);
@@ -66,6 +70,8 @@ private:
 
   t_go_generator* go_generator;
 
+  std::string current_struct_name_;
+  std::vector<std::pair<std::string, std::string>> pattern_cache_;
   std::map<std::string, int> tmp_;
 };
 

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1326,11 +1326,18 @@ void t_go_generator::generate_go_struct(t_struct* tstruct, bool is_exception) {
   // generate Validate function
   f_types_ << '\n';
   std::string tstruct_name(publicize(tstruct->get_name(), false));
-  f_types_ << "func (p *" << tstruct_name << ") Validate() error {" << '\n';
+
+  go_validator_generator validator_gen(this);
+  validator_gen.set_struct_name(tstruct_name);
+  std::ostringstream validate_body;
   indent_up();
-  go_validator_generator(this).generate_struct_validator(f_types_, tstruct);
-  f_types_ << indent() << "return nil" << '\n';
+  validator_gen.generate_struct_validator(validate_body, tstruct);
+  validate_body << indent() << "return nil" << '\n';
   indent_down();
+
+  validator_gen.generate_regexp_vars(f_types_);
+  f_types_ << "func (p *" << tstruct_name << ") Validate() error {" << '\n';
+  f_types_ << validate_body.str();
   f_types_ << "}" << '\n';
 }
 

--- a/lib/go/test/ValidateTest.thrift
+++ b/lib/go/test/ValidateTest.thrift
@@ -50,6 +50,7 @@ struct BasicTest {
         19: i8 Byte2 = 1 (vt.in = "1", vt.not_in = "2")
         20: double Double2 = 3.0 (vt.in = "3.0", vt.not_in = "4.0")
         21: EnumFoo Enum2 = EnumFoo.e2 (vt.in = "EnumFoo.e2", vt.not_in = "EnumFoo.e1")
+        22: optional string StringPattern (vt.pattern = "^[a-z]+$")
 }
 
 struct FieldReferenceTest {
@@ -83,6 +84,8 @@ struct FieldReferenceTest {
         28: binary Binary3 = "other binary"
         29: binary Binary4 = ".*"
         30: i64 MaxSize = 10
+        31: string StringPatternRef = "^[a-z]+$"
+        32: optional string StringPattern (vt.pattern = "$StringPatternRef")
 }
 
 struct ValidationFunctionTest {

--- a/lib/go/test/tests/validate_test.go
+++ b/lib/go/test/tests/validate_test.go
@@ -191,6 +191,27 @@ func TestBasicValidator(t *testing.T) {
 	} else {
 		t.Errorf("Error cannot be unwrapped into *ValidationError: %v", err)
 	}
+
+	t.Run("pattern-valid", func(t *testing.T) {
+		bt = validatetest.NewBasicTest()
+		bt.StringPattern = thrift.StringPtr("abcd")
+		if err := bt.Validate(); err != nil {
+			t.Errorf("Expected no error for StringPattern, but got %v", err)
+		}
+	})
+
+	t.Run("pattern-invalid", func(t *testing.T) {
+		bt = validatetest.NewBasicTest()
+		bt.StringPattern = thrift.StringPtr("1234")
+		err := bt.Validate()
+		if err == nil {
+			t.Error("Expected error for StringPattern, but got none")
+			return
+		}
+		if errors.As(err, &ve) && ve.Field() != "StringPattern" {
+			t.Errorf("Expected field StringPattern, but got %v", ve.Field())
+		}
+	})
 }
 
 func TestFieldReference(t *testing.T) {
@@ -321,6 +342,27 @@ func TestFieldReference(t *testing.T) {
 	} else {
 		t.Errorf("Error cannot be unwrapped into *ValidationError: %v", err)
 	}
+
+	t.Run("pattern-valid", func(t *testing.T) {
+		frt = validatetest.NewFieldReferenceTest()
+		frt.StringPattern = thrift.StringPtr("abcd")
+		if err := frt.Validate(); err != nil {
+			t.Errorf("Expected no error for StringPattern, but got %v", err)
+		}
+	})
+
+	t.Run("pattern-invalid", func(t *testing.T) {
+		frt = validatetest.NewFieldReferenceTest()
+		frt.StringPattern = thrift.StringPtr("1234")
+		err := frt.Validate()
+		if err == nil {
+			t.Error("Expected error for StringPattern, but got none")
+			return
+		}
+		if errors.As(err, &ve) && ve.Field() != "StringPattern" {
+			t.Errorf("Expected field StringPattern, but got %v", ve.Field())
+		}
+	})
 }
 
 func TestValidationFunction(t *testing.T) {

--- a/test/go/genmock.sh
+++ b/test/go/genmock.sh
@@ -6,6 +6,7 @@ export GOPATH=$(mktemp -d -t gopath-XXXXXXXXXX)
 
 go install github.com/golang/mock/mockgen
 
-`go env GOPATH`/bin/mockgen -destination=src/common/mock_handler.go -package=common github.com/apache/thrift/test/go/src/gen/thrifttest ThriftTest
+gobin=$(go env GOBIN); [ -z "$gobin" ] && gobin=$(go env GOPATH)/bin
+"$gobin/mockgen" -destination=src/common/mock_handler.go -package=common github.com/apache/thrift/test/go/src/gen/thrifttest ThriftTest
 
 chmod a+w -R $GOPATH && rm -Rf $GOPATH


### PR DESCRIPTION
Client: go

Replace inline regexp.MatchString calls with precompiled
regexp.MustCompile variables for literal vt.pattern annotations.
This avoids recompiling the same regex on every Validate() call.

Also fixes two bugs in the original regexp.MatchString usage:

- Arguments were swapped: MatchString(target, pattern) instead
  of MatchString(pattern, target)
- Used ; ok instead of ; !ok, causing validation to fail when the
  pattern matched instead of when it didn't

---

- [x ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  - THRIFT-6012
### Example

```thrift
struct StarSystem {
  1: string id ( vt.pattern = "^[a-z_-]+$", vt.pattern = ".*")
  2: string hash (vt.pattern = "$id")
}
```

### Output
```go

// Precompiled regex patterns for StarSystem vt.pattern validation
var (
	vtReStarSystem0 = regexp.MustCompile(`^[a-z_-]+$`)
	vtReStarSystem1 = regexp.MustCompile(`.*`)
)

func (p *StarSystem) Validate() error {
	if !vtReStarSystem0.MatchString(p.ID){
		return thrift.NewValidationException(thrift.VALIDATION_FAILED, "vt.pattern", "StarSystem.id", "StarSystem.id not valid, rule vt.pattern check failed")
	}
	if !vtReStarSystem1.MatchString(p.ID){
		return thrift.NewValidationException(thrift.VALIDATION_FAILED, "vt.pattern", "StarSystem.id", "StarSystem.id not valid, rule vt.pattern check failed")
	}
	if ok, _ := regexp.MatchString(string(p.ID), p.Hash); !ok {
		return thrift.NewValidationException(thrift.VALIDATION_FAILED, "vt.pattern", "StarSystem.hash", "StarSystem.hash not valid, rule vt.pattern check failed")
	}
	return nil
}
```
