### PR TITLE
THRIFT-6013: Add recursion depth limit to skip() in Ruby library

### DIFF
--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -342,7 +342,8 @@ module Thrift
       end
     end
 
-    def skip(type)
+    def skip(type, max_depth = 64)
+      raise ProtocolException.new(ProtocolException::DEPTH_LIMIT, 'Maximum skip depth exceeded') if max_depth <= 0
       case type
       when Types::BOOL
         read_bool
@@ -365,27 +366,27 @@ module Thrift
         while true
           name, type, id = read_field_begin
           break if type == Types::STOP
-          skip(type)
+          skip(type, max_depth - 1)
           read_field_end
         end
         read_struct_end
       when Types::MAP
         ktype, vtype, size = read_map_begin
         size.times do
-          skip(ktype)
-          skip(vtype)
+          skip(ktype, max_depth - 1)
+          skip(vtype, max_depth - 1)
         end
         read_map_end
       when Types::SET
         etype, size = read_set_begin
         size.times do
-          skip(etype)
+          skip(etype, max_depth - 1)
         end
         read_set_end
       when Types::LIST
         etype, size = read_list_begin
         size.times do
-          skip(etype)
+          skip(etype, max_depth - 1)
         end
         read_list_end
       else

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -210,6 +210,17 @@ describe 'BaseProtocol' do
       expect(@prot).to receive(:read_list_end)
       real_skip.call(Thrift::Types::LIST)
     end
+
+    it "should raise DEPTH_LIMIT when max_depth is exhausted" do
+      expect { @prot.skip(Thrift::Types::STRUCT, 0) }.to raise_error(Thrift::ProtocolException) do |e|
+        expect(e.type).to eq(Thrift::ProtocolException::DEPTH_LIMIT)
+      end
+    end
+
+    it "should skip at max_depth=1 without raising" do
+      expect(@prot).to receive(:read_bool).once
+      expect { @prot.skip(Thrift::Types::BOOL, 1) }.not_to raise_error
+    end
   end
 
   describe Thrift::BaseProtocolFactory do


### PR DESCRIPTION
## Summary

- Adds a `max_depth` parameter (default 64) to `BaseProtocol#skip`
- Raises `ProtocolException::DEPTH_LIMIT` when the depth limit is exceeded
- Aligns the Ruby implementation with Java, Python, Go and netstd, which already enforce this limit
- Adds two unit tests to `base_protocol_spec.rb` covering the limit boundary

## Test plan

- [ ] `spec/base_protocol_spec.rb` — new tests: raises `DEPTH_LIMIT` at `max_depth=0`, no raise at `max_depth=1` for a leaf type
- [ ] Existing skip tests (`should skip structs/maps/sets/lists`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)