### PR TITLE
Fix netstd CI .NET SDK setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,34 +423,13 @@ jobs:
           sudo apt-get install -y --no-install-recommends $BUILD_DEPS
           sudo apt-get install -y --no-install-recommends curl openssl ca-certificates
 
-# This whole setup is getting worse: https://github.com/dotnet/core/discussions/9258
-      - name: Set up .NET SDK (via install script)
-        run: |
-          # remove any existing install
-          sudo apt remove dotnet*
-          # install key
-          sudo apt install gpg
-          wget https://dot.net/v1/dotnet-install.asc
-          gpg --import dotnet-install.asc
-          # download and verify
-          wget https://dot.net/v1/dotnet-install.sh
-          wget https://dot.net/v1/dotnet-install.sig
-          gpg --verify dotnet-install.sig dotnet-install.sh
-          # run install script
-          chmod +x dotnet-install.sh
-          ./dotnet-install.sh --channel 10.0
-          # export env vars
-          export DOTNET_ROOT=$HOME/.dotnet
-          export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
-          dotnet --list-sdks
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "10.0.x"
 
-#      the sdk is installed by default, but keep this step for reference
-#      especially newer versions are NOT always pre-installed, so manually again
-#      - name: Set up .NET SDK
-#        run: |
-#          sudo add-apt-repository -y ppa:dotnet/backports
-#          sudo apt-get install -y --no-install-recommends dotnet-sdk-10.0
-#      end
+      - name: Show .NET SDKs
+        run: dotnet --list-sdks
 
       - name: Run bootstrap
         run: ./bootstrap.sh


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Use the pinned `setup-dotnet` action instead of downloading and verifying the `dotnet-install` script manually. The manual path fails when the hosted script signature does not match the downloaded script. https://github.com/apache/thrift/actions/runs/26131051709/job/76858059843?pr=3500
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
