### PR TITLE
THRIFT-6016: Move jsdoc from dependencies to devDependencies in lib/ts

### DIFF
--- a/lib/ts/package-lock.json
+++ b/lib/ts/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
-        "jsdoc": "^3.6.7",
         "json-int64": "^1.0.0",
         "nopt": "^4.0.1"
       },
@@ -28,6 +27,7 @@
         "grunt-contrib-uglify": "^1.0.1",
         "grunt-jsdoc": "^2.4.1",
         "grunt-shell-spawn": "^0.3.12",
+        "jsdoc": "^3.6.7",
         "jslint": "^0.12.0",
         "node-int64": "^0.4.0",
         "phantom": "^6.0.3",
@@ -38,6 +38,7 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
       "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -68,12 +69,14 @@
     "node_modules/@types/linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "dev": true
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "dev": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -82,7 +85,8 @@
     "node_modules/@types/mdurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.10.5",
@@ -427,7 +431,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.11.8",
@@ -835,6 +840,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
       "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -1967,7 +1973,8 @@
     "node_modules/graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "node_modules/grunt": {
       "version": "1.5.3",
@@ -2965,6 +2972,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
       "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
       "dependencies": {
         "xmlcreate": "^2.0.4"
       }
@@ -2979,6 +2987,7 @@
       "version": "3.6.11",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
       "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
         "@types/markdown-it": "^12.2.3",
@@ -3007,6 +3016,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3015,6 +3025,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -3233,6 +3244,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -3320,6 +3332,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -3344,6 +3357,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -3428,6 +3442,7 @@
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
       "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -3443,6 +3458,7 @@
       "version": "8.6.5",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
       "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
+      "dev": true,
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
@@ -3451,12 +3467,14 @@
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -3465,6 +3483,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
       "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+      "dev": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3545,7 +3564,8 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "node_modules/meow": {
       "version": "3.7.0",
@@ -4531,6 +4551,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
       "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -4940,6 +4961,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -4980,7 +5002,8 @@
     "node_modules/taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
+      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
+      "dev": true
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -5181,7 +5204,8 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "2.6.4",
@@ -5250,6 +5274,7 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/underscore.string": {
@@ -5527,7 +5552,8 @@
     "node_modules/xmlcreate": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.1",

--- a/lib/ts/package.json
+++ b/lib/ts/package.json
@@ -24,6 +24,7 @@
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-jsdoc": "^2.4.1",
     "grunt-shell-spawn": "^0.3.12",
+    "jsdoc": "^3.6.7",
     "jslint": "^0.12.0",
     "node-int64": "^0.4.0",
     "phantom": "^6.0.3",
@@ -31,7 +32,6 @@
   },
   "dependencies": {
     "bufferutil": "^4.0.1",
-    "jsdoc": "^3.6.7",
     "json-int64": "^1.0.0",
     "nopt": "^4.0.1"
   },


### PR DESCRIPTION
## Summary

- `jsdoc` is a documentation generator and must not be a runtime dependency of the Thrift TypeScript library.
- Having it under `dependencies` caused `taffydb` (abandoned, HIGH) and `lodash` to be classified as production transitive dependencies, inflating the vulnerability surface of the published npm package.
- Moved `jsdoc` to `devDependencies` and regenerated `package-lock.json`; `taffydb` and `lodash` are now correctly classified as dev-only.

## Test plan

- [ ] Verify `npm install --omit=dev` in `lib/ts` no longer installs jsdoc, taffydb, or lodash.
- [ ] Verify `npm install` (with devDependencies) still succeeds and doc generation via `grunt jsdoc` still works.
- [ ] Confirm Dependabot alerts #61 (taffydb) and #229 (lodash HIGH) are resolved or reclassified after merge.

## Related

- THRIFT-6017: Upgrade jsdoc 3.6 → 4.x (eliminates taffydb entirely)
- THRIFT-6018: Remove phantom/phantomjs-prebuilt from lib/ts
- THRIFT-6019: Replace html-validator-cli in root package
- THRIFT-6020: Address remaining transitive npm vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)