### PR TITLE
THRIFT-6024: Use DEFAULT_MAX_FRAME_SIZE as default in Python THeaderTransport and TZlibTransport

### DIFF
--- a/lib/py/src/transport/THeaderTransport.py
+++ b/lib/py/src/transport/THeaderTransport.py
@@ -34,7 +34,8 @@ from thrift.transport.TTransport import (
 U16 = struct.Struct("!H")
 I32 = struct.Struct("!i")
 HEADER_MAGIC = 0x0FFF
-HARD_MAX_FRAME_SIZE = 0x3FFFFFFF
+DEFAULT_MAX_FRAME_SIZE = 16384000   # matches all other Thrift bindings
+HARD_MAX_FRAME_SIZE = 0x3FFFFFFF    # protocol hard cap (30-bit length field)
 
 
 class THeaderClientType(object):
@@ -99,8 +100,8 @@ class THeaderTransport(TTransportBase, CReadableTransport):
         self.flags = 0
         self.sequence_id = 0
         self._protocol_id = default_protocol
-        self._max_frame_size = HARD_MAX_FRAME_SIZE
-        self._max_decompressed_size = HARD_MAX_FRAME_SIZE
+        self._max_frame_size = DEFAULT_MAX_FRAME_SIZE
+        self._max_decompressed_size = DEFAULT_MAX_FRAME_SIZE
 
     def isOpen(self):
         return self._transport.isOpen()

--- a/lib/py/src/transport/TZlibTransport.py
+++ b/lib/py/src/transport/TZlibTransport.py
@@ -26,7 +26,7 @@ import zlib
 from io import BytesIO
 
 from .TTransport import TTransportBase, CReadableTransport, TTransportException
-from .THeaderTransport import HARD_MAX_FRAME_SIZE
+from .THeaderTransport import DEFAULT_MAX_FRAME_SIZE
 
 
 class TZlibTransportFactory:
@@ -49,7 +49,7 @@ class TZlibTransportFactory:
     _last_z = None
 
     def getTransport(self, trans, compresslevel=9,
-                     max_decompressed_size=HARD_MAX_FRAME_SIZE):
+                     max_decompressed_size=DEFAULT_MAX_FRAME_SIZE):
         """Wrap a transport, trans, with the TZlibTransport
         compressed transport class, returning a new
         transport to the caller.
@@ -79,7 +79,7 @@ class TZlibTransport(TTransportBase, CReadableTransport):
     DEFAULT_BUFFSIZE = 4096
 
     def __init__(self, trans, compresslevel=9,
-                 max_decompressed_size=HARD_MAX_FRAME_SIZE):
+                 max_decompressed_size=DEFAULT_MAX_FRAME_SIZE):
         """Create a new TZlibTransport, wrapping C{trans}, another
         TTransport derived object.
 
@@ -90,7 +90,7 @@ class TZlibTransport(TTransportBase, CReadableTransport):
         @type compresslevel: int
         @param max_decompressed_size: Maximum total decompressed bytes
         allowed per session before a SIZE_LIMIT exception is raised.
-        Defaults to HARD_MAX_FRAME_SIZE (0x3FFFFFFF bytes).
+        Defaults to DEFAULT_MAX_FRAME_SIZE (16384000 bytes).
         @type max_decompressed_size: int
         """
         self.__trans = trans

--- a/lib/py/test/thrift_TZlibTransport.py
+++ b/lib/py/test/thrift_TZlibTransport.py
@@ -95,7 +95,6 @@ class TestTZlibTransport(unittest.TestCase):
         except AssertionError:
             raise
 
-
     def test_decompressed_size_limit_exceeded(self):
         data = b'a' * 4096  # highly compressible
         buff_w = TTransport.TMemoryBuffer()


### PR DESCRIPTION
## Summary

- `HARD_MAX_FRAME_SIZE` (`0x3FFFFFFF`, ~1 GB) is a protocol-level structural constraint — the THeader frame length field is 30 bits wide. It is not a policy default.
- All other Thrift bindings use `DEFAULT_MAX_FRAME_SIZE` (`16384000`, ~16 MB) as the default, matching the value in `TConfiguration` (C++, Java, Go, etc.).
- Python's `THeaderTransport` and `TZlibTransport` were constructed with `HARD_MAX_FRAME_SIZE` as their default, leaving applications unprotected against oversized or malformed frames unless the caller explicitly called `set_max_frame_size()`.

**Changes:**
- Add `DEFAULT_MAX_FRAME_SIZE = 16384000` constant to `THeaderTransport.py` alongside `HARD_MAX_FRAME_SIZE`
- Use `DEFAULT_MAX_FRAME_SIZE` as the constructor default for `_max_frame_size` and `_max_decompressed_size` in `THeaderTransport`
- Use `DEFAULT_MAX_FRAME_SIZE` as the default for `max_decompressed_size` in `TZlibTransport` and `TZlibTransportFactory`
- `HARD_MAX_FRAME_SIZE` is retained as the validation ceiling in `set_max_frame_size()` / `set_max_decompressed_size()`
- Fix a pre-existing flake8 `E303` (too many blank lines) in `thrift_TZlibTransport.py`

## Test plan

- [ ] Existing `THeaderTransport` and `TZlibTransport` tests pass
- [ ] `flake8` clean on modified files
- [ ] Verify default behaviour: a `THeaderTransport` constructed without arguments now rejects frames larger than 16384000 bytes without needing an explicit `set_max_frame_size()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)