### PR TITLE
[c++] Preserve private_optional field order

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_cpp_generator.cc
@@ -1442,15 +1442,28 @@ void t_cpp_generator::generate_struct_declaration(ostream& out,
 
   // Declare all fields
   if (gen_private_optional_ && !pointers) {
-    // When private_optional is enabled, declare non-optional fields first in public section
+    bool fields_are_public = true;
+
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-      if ((*m_iter)->get_req() != t_field::T_OPTIONAL) {
-        generate_java_doc(out, *m_iter);
-        indent(out) << declare_field(*m_iter,
-                                     gen_no_constructors_,
-                                     false,
-                                     !read) << '\n';
+      bool field_is_public = (*m_iter)->get_req() != t_field::T_OPTIONAL;
+      if (field_is_public != fields_are_public) {
+        indent_down();
+        out << '\n' << indent() << (field_is_public ? " public:" : " private:") << '\n';
+        indent_up();
+        fields_are_public = field_is_public;
       }
+
+      generate_java_doc(out, *m_iter);
+      indent(out) << declare_field(*m_iter,
+                                   gen_no_constructors_,
+                                   false,
+                                   !read) << '\n';
+    }
+
+    if (!fields_are_public) {
+      indent_down();
+      out << '\n' << indent() << " public:" << '\n';
+      indent_up();
     }
   } else {
     // Default behavior: all fields in public section
@@ -1563,34 +1576,6 @@ void t_cpp_generator::generate_struct_declaration(ostream& out,
     out << indent();
     generate_exception_what_method_decl(out, tstruct, false);
     out << ";" << '\n';
-  }
-
-  // Generate private section for optional fields when private_optional is enabled
-  if (gen_private_optional_ && !pointers) {
-    bool has_optional_fields = false;
-    for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-      if ((*m_iter)->get_req() == t_field::T_OPTIONAL) {
-        has_optional_fields = true;
-        break;
-      }
-    }
-    
-    if (has_optional_fields) {
-      indent_down();
-      out << '\n' << indent() << " private:" << '\n';
-      indent_up();
-      
-      // Declare optional fields in private section
-      for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-        if ((*m_iter)->get_req() == t_field::T_OPTIONAL) {
-          generate_java_doc(out, *m_iter);
-          indent(out) << declare_field(*m_iter,
-                                       gen_no_constructors_,
-                                       false,
-                                       !read) << '\n';
-        }
-      }
-    }
   }
 
   // When private_optional is enabled, optional members may be private.

--- a/compiler/cpp/tests/cpp/expected_TestStruct_private_optional.txt
+++ b/compiler/cpp/tests/cpp/expected_TestStruct_private_optional.txt
@@ -24,8 +24,17 @@ class TestStruct : public virtual ::apache::thrift::TBase {
 
   virtual ~TestStruct() noexcept;
   int32_t required_field;
+
+ private:
+  int32_t optional_field;
+
+ public:
   int32_t default_field;
 
+ private:
+  std::string optional_string;
+
+ public:
   _TestStruct__isset __isset;
 
   void __set_required_field(const int32_t val);
@@ -55,10 +64,6 @@ class TestStruct : public virtual ::apache::thrift::TBase {
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const override;
 
   virtual void printTo(std::ostream& out) const;
-
- private:
-  int32_t optional_field;
-  std::string optional_string;
 
   friend void swap(TestStruct &a, TestStruct &b) noexcept;
 

--- a/compiler/cpp/tests/cpp/t_cpp_generator_private_optional_tests.cc
+++ b/compiler/cpp/tests/cpp/t_cpp_generator_private_optional_tests.cc
@@ -40,6 +40,27 @@ string extract_class_definition(const string& content, const string& class_name)
     return content.substr(class_start, class_end - class_start + 2);
 }
 
+// Helper function to extract the declaration and initializer list before a function body.
+string extract_function_header(const string& content, const string& function_signature) {
+    size_t function_start = content.find(function_signature);
+    if (function_start == string::npos) {
+        return "";
+    }
+
+    size_t function_body_start = content.find("{", function_start);
+    if (function_body_start == string::npos) {
+        return "";
+    }
+
+    return content.substr(function_start, function_body_start - function_start);
+}
+
+size_t require_ordered_text(const string& content, const string& expected, size_t after = 0) {
+    size_t position = content.find(expected, after);
+    REQUIRE(position != string::npos);
+    return position + expected.size();
+}
+
 TEST_CASE("t_cpp_generator default behavior generates all public fields", "[functional]")
 {
     string path = join_path(source_dir(), "test_private_optional.thrift");
@@ -71,7 +92,52 @@ TEST_CASE("t_cpp_generator default behavior generates all public fields", "[func
     REQUIRE(!expected_content.empty());
 
     REQUIRE(normalize_for_compare(class_def) == normalize_for_compare(expected_content));
-    
+
+}
+
+TEST_CASE("t_cpp_generator with private_optional preserves thrift field order", "[functional]")
+{
+    string path = join_path(source_dir(), "test_private_optional.thrift");
+    string name = "test_private_optional";
+    map<string, string> parsed_options = {{"private_optional", ""}};
+    string option_string = "";
+
+    std::unique_ptr<t_program> program(new t_program(path, name));
+    parse_thrift_for_test(program.get());
+
+    std::unique_ptr<t_generator> gen(
+        t_generator_registry::get_generator(program.get(), "cpp", parsed_options, option_string));
+    REQUIRE(gen != nullptr);
+
+    REQUIRE_NOTHROW(gen->generate_program());
+
+    string generated_header = read_file("gen-cpp/test_private_optional_types.h");
+    REQUIRE(!generated_header.empty());
+
+    string class_def = extract_class_definition(generated_header, "TestStruct");
+    REQUIRE(!class_def.empty());
+
+    size_t member_position = 0;
+    member_position = require_ordered_text(class_def, "int32_t required_field;", member_position);
+    member_position = require_ordered_text(class_def, "int32_t optional_field;", member_position);
+    member_position = require_ordered_text(class_def, "int32_t default_field;", member_position);
+    require_ordered_text(class_def, "std::string optional_string;", member_position);
+
+    string generated_impl = read_file("gen-cpp/test_private_optional_types.cpp");
+    REQUIRE(!generated_impl.empty());
+
+    string constructor_header =
+        extract_function_header(generated_impl, "TestStruct::TestStruct() noexcept");
+    REQUIRE(!constructor_header.empty());
+
+    size_t initializer_position = 0;
+    initializer_position =
+        require_ordered_text(constructor_header, "required_field(0)", initializer_position);
+    initializer_position =
+        require_ordered_text(constructor_header, "optional_field(0)", initializer_position);
+    initializer_position =
+        require_ordered_text(constructor_header, "default_field(0)", initializer_position);
+    require_ordered_text(constructor_header, "optional_string()", initializer_position);
 }
 
 TEST_CASE("t_cpp_generator with private_optional generates private optional fields", "[functional]")

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -40,6 +40,14 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/gen-cpp")
 include_directories("${PROJECT_SOURCE_DIR}/lib/cpp/src")
 
+function(enable_reorder_warnings_as_errors target_name)
+    if(MSVC)
+        target_compile_options(${target_name} PRIVATE /w15038 /we5038)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU)$")
+        target_compile_options(${target_name} PRIVATE -Werror=reorder)
+    endif()
+endfunction()
+
 set(crosstestgencpp_SOURCES
     gen-cpp/SecondService.cpp
     gen-cpp/ThriftTest.cpp
@@ -125,6 +133,7 @@ set(privateoptonaltestgencpp_SOURCES
     src/ThriftTest_extras.cpp
 )
 add_library(privateoptonaltestgencpp STATIC ${privateoptonaltestgencpp_SOURCES})
+enable_reorder_warnings_as_errors(privateoptonaltestgencpp)
 target_include_directories(privateoptonaltestgencpp BEFORE PRIVATE 
     "${CMAKE_CURRENT_BINARY_DIR}/gen-cpp-private"
     "${CMAKE_CURRENT_BINARY_DIR}"
@@ -194,6 +203,7 @@ set(privateopttemplstreamoptestgencpp_SOURCES
     src/ThriftTest_extras.cpp
 )
 add_library(privateopttemplstreamoptestgencpp STATIC ${privateopttemplstreamoptestgencpp_SOURCES})
+enable_reorder_warnings_as_errors(privateopttemplstreamoptestgencpp)
 target_include_directories(privateopttemplstreamoptestgencpp BEFORE PRIVATE 
     "${CMAKE_CURRENT_BINARY_DIR}/gen-cpp-private-templatestreamop"
     "${CMAKE_CURRENT_BINARY_DIR}"

--- a/test/cpp/Makefile.am
+++ b/test/cpp/Makefile.am
@@ -79,6 +79,7 @@ nodist_libprivateoptonaltestgencpp_la_SOURCES = \
 	src/ThriftTest_extras.cpp
 
 libprivateoptonaltestgencpp_la_LIBADD = $(top_builddir)/lib/cpp/libthrift.la
+libprivateoptonaltestgencpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Werror=reorder
 
 nodist_libenumclasstestgencpp_la_SOURCES = \
 	gen-cpp-enumclass/ThriftTest_types.cpp \
@@ -108,6 +109,7 @@ nodist_libprivateopttemplstreamoptestgencpp_la_SOURCES = \
 	src/ThriftTest_extras.cpp
 
 libprivateopttemplstreamoptestgencpp_la_LIBADD = $(top_builddir)/lib/cpp/libthrift.la
+libprivateopttemplstreamoptestgencpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Werror=reorder
 
 nodist_libstresstestgencpp_la_SOURCES = \
 	gen-cpp/StressTest_types.h \


### PR DESCRIPTION


<!-- Explain the changes in the pull request below: -->
  Preserve `private_optional` field order, currently with `private_optional` enabled, the order of member variable declaration will be different than their order in the initializer. This change fixes this behavior change. Enabled related C++ compiler warnings in tests.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
