### PR TITLE
THRIFT-6025: Harden Ruby protocol negative sizes

### DIFF
--- a/lib/rb/ext/binary_protocol_accelerated.c
+++ b/lib/rb/ext/binary_protocol_accelerated.c
@@ -424,17 +424,24 @@ VALUE rb_thrift_binary_proto_read_field_begin(VALUE self) {
   }
 }
 
+#define CHECK_NEGATIVE_SIZE(size) \
+  if (RB_UNLIKELY((size) < 0)) { \
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_NEGATIVE_SIZE), rb_str_new2("Negative size"))); \
+  }
+
 VALUE rb_thrift_binary_proto_read_map_begin(VALUE self) {
   VALUE ktype = rb_thrift_binary_proto_read_byte(self);
   VALUE vtype = rb_thrift_binary_proto_read_byte(self);
-  VALUE size = rb_thrift_binary_proto_read_i32(self);
-  return rb_ary_new3(3, ktype, vtype, size);
+  int size = read_i32_direct(self);
+  CHECK_NEGATIVE_SIZE(size);
+  return rb_ary_new3(3, ktype, vtype, INT2NUM(size));
 }
 
 VALUE rb_thrift_binary_proto_read_list_begin(VALUE self) {
   VALUE etype = rb_thrift_binary_proto_read_byte(self);
-  VALUE size = rb_thrift_binary_proto_read_i32(self);
-  return rb_ary_new3(2, etype, size);
+  int size = read_i32_direct(self);
+  CHECK_NEGATIVE_SIZE(size);
+  return rb_ary_new3(2, etype, INT2NUM(size));
 }
 
 VALUE rb_thrift_binary_proto_read_set_begin(VALUE self) {
@@ -478,6 +485,7 @@ VALUE rb_thrift_binary_proto_read_string(VALUE self) {
 
 VALUE rb_thrift_binary_proto_read_binary(VALUE self) {
   int size = read_i32_direct(self);
+  CHECK_NEGATIVE_SIZE(size);
   return READ(self, size);
 }
 

--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -28,11 +28,15 @@ ID index_ivar_id;
 ID slice_method_id;
 
 int GARBAGE_BUFFER_SIZE;
+static VALUE transport_exception_class;
+static VALUE transport_negative_size;
+static ID new_method_id;
 
 #define GET_BUF(self) rb_ivar_get(self, buf_ivar_id)
 
 VALUE rb_thrift_memory_buffer_write(VALUE self, VALUE str);
 VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value);
+VALUE rb_thrift_memory_buffer_read_all(VALUE self, VALUE length_value);
 VALUE rb_thrift_memory_buffer_read_byte(VALUE self);
 VALUE rb_thrift_memory_buffer_read_into_buffer(VALUE self, VALUE buffer_value, VALUE size_value);
 
@@ -65,6 +69,33 @@ VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value) {
   if (RSTRING_LEN(data) < length) {
     rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
   }
+
+  return data;
+}
+
+VALUE rb_thrift_memory_buffer_read_all(VALUE self, VALUE length_value) {
+  int length = FIX2INT(length_value);
+
+  if (RB_UNLIKELY(length < 0)) {
+    rb_exc_raise(rb_funcall(transport_exception_class, new_method_id, 2, transport_negative_size, rb_str_new2("Negative size")));
+  }
+
+  VALUE index_value = rb_ivar_get(self, index_ivar_id);
+  int index = FIX2INT(index_value);
+  VALUE buf = GET_BUF(self);
+
+  if (RB_UNLIKELY(length > RSTRING_LEN(buf) - index)) {
+    rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
+  }
+
+  VALUE data = rb_str_subseq(buf, index, length);
+
+  index += length;
+  if (index >= GARBAGE_BUFFER_SIZE) {
+    rb_ivar_set(self, buf_ivar_id, rb_str_subseq(buf, index, RSTRING_LEN(buf) - index));
+    index = 0;
+  }
+  rb_ivar_set(self, index_ivar_id, INT2FIX(index));
 
   return data;
 }
@@ -122,6 +153,7 @@ void Init_memory_buffer(void) {
   VALUE thrift_memory_buffer_class = rb_const_get(thrift_module, rb_intern("MemoryBufferTransport"));
   rb_define_method(thrift_memory_buffer_class, "write", rb_thrift_memory_buffer_write, 1);
   rb_define_method(thrift_memory_buffer_class, "read", rb_thrift_memory_buffer_read, 1);
+  rb_define_method(thrift_memory_buffer_class, "read_all", rb_thrift_memory_buffer_read_all, 1);
   rb_define_method(thrift_memory_buffer_class, "read_byte", rb_thrift_memory_buffer_read_byte, 0);
   rb_define_method(thrift_memory_buffer_class, "read_into_buffer", rb_thrift_memory_buffer_read_into_buffer, 2);
 
@@ -129,6 +161,11 @@ void Init_memory_buffer(void) {
   index_ivar_id = rb_intern("@index");
 
   slice_method_id = rb_intern("slice");
+  new_method_id = rb_intern("new");
 
   GARBAGE_BUFFER_SIZE = FIX2INT(rb_const_get(thrift_memory_buffer_class, rb_intern("GARBAGE_BUFFER_SIZE")));
+  transport_exception_class = rb_const_get(thrift_module, rb_intern("TransportException"));
+  transport_negative_size = rb_const_get(transport_exception_class, rb_intern("NEGATIVE_SIZE"));
+  rb_global_variable(&transport_exception_class);
+  rb_global_variable(&transport_negative_size);
 }

--- a/lib/rb/ext/struct.c
+++ b/lib/rb/ext/struct.c
@@ -35,8 +35,8 @@ static ID sorted_field_ids_method_id;
 #define IS_CONTAINER(ttype) ((ttype) == TTYPE_MAP || (ttype) == TTYPE_LIST || (ttype) == TTYPE_SET)
 #define STRUCT_FIELDS(obj) rb_const_get(CLASS_OF(obj), fields_const_id)
 
-static VALUE new_container_array(int size) {
-  if (size < 0) {
+static void validate_container_size(int size) {
+  if (RB_UNLIKELY(size < 0)) {
     rb_exc_raise(
       get_protocol_exception(
         INT2FIX(PROTOERR_NEGATIVE_SIZE),
@@ -44,7 +44,10 @@ static VALUE new_container_array(int size) {
       )
     );
   }
+}
 
+static VALUE new_container_array(int size) {
+  validate_container_size(size);
   return rb_ary_new2(size > 1024 ? 1024 : size);
 }
 
@@ -540,9 +543,11 @@ static VALUE read_anything(VALUE protocol, int ttype, VALUE field_info) {
           rb_ary_push(result, read_anything(protocol, element_ttype, rb_hash_aref(field_info, element_sym)));
         }
       } else {
+        validate_container_size(num_elements);
         skip_list_or_set_contents(protocol, INT2FIX(element_ttype), num_elements);
       }
     } else {
+      validate_container_size(num_elements);
       skip_list_or_set_contents(protocol, INT2FIX(element_ttype), num_elements);
     }
 
@@ -568,9 +573,11 @@ static VALUE read_anything(VALUE protocol, int ttype, VALUE field_info) {
 
         result = rb_class_new_instance(1, &items, rb_cSet);
       } else {
+        validate_container_size(num_elements);
         skip_list_or_set_contents(protocol, INT2FIX(element_ttype), num_elements);
       }
     } else {
+      validate_container_size(num_elements);
       skip_list_or_set_contents(protocol, INT2FIX(element_ttype), num_elements);
     }
 

--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -372,6 +372,7 @@ module Thrift
         read_struct_end
       when Types::MAP
         ktype, vtype, size = read_map_begin
+        validate_container_size(size)
         size.times do
           skip(ktype, max_depth - 1)
           skip(vtype, max_depth - 1)
@@ -379,12 +380,14 @@ module Thrift
         read_map_end
       when Types::SET
         etype, size = read_set_begin
+        validate_container_size(size)
         size.times do
           skip(etype, max_depth - 1)
         end
         read_set_end
       when Types::LIST
         etype, size = read_list_begin
+        validate_container_size(size)
         size.times do
           skip(etype, max_depth - 1)
         end
@@ -392,6 +395,10 @@ module Thrift
       else
         raise ProtocolException.new(ProtocolException::INVALID_DATA, 'Invalid data')
       end
+    end
+
+    def validate_container_size(size)
+      raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
     end
 
     def to_s

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -178,18 +178,21 @@ module Thrift
       ktype = read_byte
       vtype = read_byte
       size = read_i32
+      raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
       [ktype, vtype, size]
     end
 
     def read_list_begin
       etype = read_byte
       size = read_i32
+      raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
       [etype, size]
     end
 
     def read_set_begin
       etype = read_byte
       size = read_i32
+      raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
       [etype, size]
     end
 
@@ -249,7 +252,11 @@ module Thrift
 
     def read_binary
       size = read_i32
-      trans.read_all(size)
+      if size >= 0
+        trans.read_all(size)
+      else
+        raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size')
+      end
     end
 
     def read_uuid

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -712,6 +712,7 @@ module Thrift
       key_type = get_type_id_for_type_name(read_json_string)
       val_type = get_type_id_for_type_name(read_json_string)
       size = read_json_integer
+      validate_container_size(size)
       read_json_object_start
       [key_type, val_type, size]
     end
@@ -723,7 +724,10 @@ module Thrift
 
     def read_list_begin
       read_json_array_start
-      [get_type_id_for_type_name(read_json_string), read_json_integer]
+      type = get_type_id_for_type_name(read_json_string)
+      size = read_json_integer
+      validate_container_size(size)
+      [type, size]
     end
 
     def read_list_end
@@ -732,7 +736,10 @@ module Thrift
 
     def read_set_begin
       read_json_array_start
-      [get_type_id_for_type_name(read_json_string), read_json_integer]
+      type = get_type_id_for_type_name(read_json_string)
+      size = read_json_integer
+      validate_container_size(size)
+      [type, size]
     end
 
     def read_set_end

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -21,12 +21,6 @@ require 'set'
 
 module Thrift
   module Struct_Union
-    def validate_container_size(size)
-      return size unless size < 0
-
-      raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size')
-    end
-
     def name_to_id(name)
       names_to_ids = self.class.instance_variable_get(:@names_to_ids)
       unless names_to_ids
@@ -62,7 +56,7 @@ module Thrift
         value.read(iprot)
       when Types::MAP
         key_type, val_type, size = iprot.read_map_begin
-        validate_container_size(size)
+        raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
         # Skip the map contents if the declared key or value types don't match the expected ones.
         if (size != 0 && (key_type != field[:key][:type] || val_type != field[:value][:type]))
           size.times do
@@ -81,7 +75,7 @@ module Thrift
         iprot.read_map_end
       when Types::LIST
         e_type, size = iprot.read_list_begin
-        validate_container_size(size)
+        raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
         # Skip the list contents if the declared element type doesn't match the expected one.
         if (e_type != field[:element][:type])
           size.times do
@@ -97,7 +91,7 @@ module Thrift
         iprot.read_list_end
       when Types::SET
         e_type, size = iprot.read_set_begin
-        validate_container_size(size)
+        raise ProtocolException.new(ProtocolException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
         # Skip the set contents if the declared element type doesn't match the expected one.
         if (e_type != field[:element][:type])
           size.times do

--- a/lib/rb/lib/thrift/transport/base_transport.rb
+++ b/lib/rb/lib/thrift/transport/base_transport.rb
@@ -26,6 +26,7 @@ module Thrift
     ALREADY_OPEN = 2
     TIMED_OUT = 3
     END_OF_FILE = 4
+    NEGATIVE_SIZE = 5
 
     attr_reader :type
 
@@ -81,7 +82,8 @@ module Thrift
     end
 
     def read_all(size)
-      return Bytes.empty_byte_buffer if size <= 0
+      raise TransportException.new(TransportException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
+      return Bytes.empty_byte_buffer if size == 0
       buf = Bytes.force_binary_encoding(read(size))
       while (buf.length < size)
         chunk = read(size - buf.length)

--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -71,6 +71,12 @@ module Thrift
       data
     end
 
+    def read_all(size)
+      raise TransportException.new(TransportException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
+
+      read(size)
+    end
+
     def read_byte
       raise EOFError.new("Not enough bytes remain in buffer") if @index >= @buf.size
       val = Bytes.get_string_byte(@buf, @index)

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -221,6 +221,14 @@ describe 'BaseProtocol' do
       expect(@prot).to receive(:read_bool).once
       expect { @prot.skip(Thrift::Types::BOOL, 1) }.not_to raise_error
     end
+
+    it "should reject negative container sizes while skipping" do
+      expect(@prot).to receive(:read_list_begin).and_return([Thrift::Types::I32, -1])
+
+      expect { @prot.skip(Thrift::Types::LIST) }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+      end
+    end
   end
 
   describe Thrift::BaseProtocolFactory do

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -48,6 +48,15 @@ describe 'BaseTransport' do
       expect(buf.encoding).to eq(Encoding::BINARY)
     end
 
+    it "should reject negative read sizes" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).not_to receive(:read)
+
+      expect { transport.read_all(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)
+      end
+    end
+
     it "should stub out the rest of the methods" do
       # can't test for stubbiness, so just make sure they're defined
       [:open?, :open, :close, :read, :write, :flush].each do |sym|
@@ -370,6 +379,12 @@ describe 'BaseTransport' do
 
       @buffer.reset_buffer("1234")
       expect{ @buffer.read(5) }.to raise_error(EOFError)
+    end
+
+    it "should reject negative read_all sizes" do
+      expect { @buffer.read_all(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)
+      end
     end
   end
 

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -320,6 +320,13 @@ shared_examples_for 'a binary protocol' do
     expect(@prot.read_map_begin).to eq([Thrift::Types::DOUBLE, Thrift::Types::I64, 42])
   end
 
+  it "should reject a negative map size" do
+    @trans.write([Thrift::Types::DOUBLE, Thrift::Types::I64, 0xffffffff].pack("ccN"))
+    expect { @prot.read_map_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+      expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+    end
+  end
+
   # map footer is a noop
 
   it "should read a list header" do
@@ -327,11 +334,25 @@ shared_examples_for 'a binary protocol' do
     expect(@prot.read_list_begin).to eq([Thrift::Types::STRING, 17])
   end
 
+  it "should reject a negative list size" do
+    @trans.write([Thrift::Types::STRING, 0xffffffff].pack("cN"))
+    expect { @prot.read_list_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+      expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+    end
+  end
+
   # list footer is a noop
 
   it "should read a set header" do
     @trans.write([Thrift::Types::STRING, 17].pack("cN"))
     expect(@prot.read_set_begin).to eq([Thrift::Types::STRING, 17])
+  end
+
+  it "should reject a negative set size" do
+    @trans.write([Thrift::Types::STRING, 0xffffffff].pack("cN"))
+    expect { @prot.read_set_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+      expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+    end
   end
 
   # set footer is a noop
@@ -405,6 +426,13 @@ shared_examples_for 'a binary protocol' do
     a = @prot.read_binary
     expect(a).to eq([0x00, 0x01, 0x02, 0x03].pack('C*'))
     expect(a.encoding).to eq(Encoding::BINARY)
+  end
+
+  it "should reject a negative binary size" do
+    @trans.write([0xff, 0xff, 0xff, 0xff].pack('C*'))
+    expect { @prot.read_binary }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+      expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+    end
   end
 
   it "should perform a complete rpc with no args or return" do

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -443,6 +443,13 @@ describe 'JsonProtocol' do
       expect(@prot.read_map_begin).to eq([12, 15, 2])
     end
 
+    it "should reject a negative map size" do
+      @trans.write("[\"rec\",\"lst\",-1,{")
+      expect { @prot.read_map_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+      end
+    end
+
     it "should read map end" do
       @trans.write("}]")
       expect(@prot.read_map_end).to eq(nil)
@@ -453,6 +460,13 @@ describe 'JsonProtocol' do
       expect(@prot.read_list_begin).to eq([12, 2])
     end
 
+    it "should reject a negative list size" do
+      @trans.write("[\"rec\",-1\"\"")
+      expect { @prot.read_list_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+      end
+    end
+
     it "should read list end" do
       @trans.write("]")
       expect(@prot.read_list_end).to eq(nil)
@@ -461,6 +475,13 @@ describe 'JsonProtocol' do
     it "should read set begin" do
       @trans.write("[\"rec\",2\"\"")
       expect(@prot.read_set_begin).to eq([12, 2])
+    end
+
+    it "should reject a negative set size" do
+      @trans.write("[\"rec\",-1\"\"")
+      expect { @prot.read_set_begin }.to raise_error(Thrift::ProtocolException, "Negative size") do |e|
+        expect(e.type).to eq(Thrift::ProtocolException::NEGATIVE_SIZE)
+      end
     end
 
     it "should read set end" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby was not consistently rejecting negative sizes while reading Thrift payloads.

Size values appear in binary/string fields and in map/list/set headers. Those values must be non-negative. Before this change, malformed input could declare a negative size and reach Ruby or native C code paths that assumed the size was valid.

This was a protocol hardening gap compared with other runtimes.

## Solution

This change rejects negative sizes in the Ruby library read paths.

It adds validation for:

- binary protocol map/list/set headers
- binary/string payload sizes
- JSON protocol container sizes
- `BaseProtocol#skip` container handling
- generated struct/union container reads
- `BaseTransport#read_all`
- `MemoryBufferTransport#read_all`
- native accelerated binary protocol and struct paths

The native memory buffer path also gets a direct `read_all` implementation so the added guard does not force hot binary reads through the slower generic transport path.

The public protocol interface stays unchanged.

## Performance

Pure Ruby benchmark, helper-call baseline vs inline guard:
```
rb-bin-read-large  -3.39%
rb-bin-read-small  -2.01%
```

Native-enabled sanity run:

```
c-bin-read-large   +1.18%  (3-sample noisy run)
c-bin-read-small   -1.25%
rb-bin-read-large  -1.00%
rb-bin-read-small  -1.01%
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6025](https://issues.apache.org/jira/browse/THRIFT-6025)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
