### PR TITLE
THRIFT-6027: Fix UB/assertion in t_markdown_generator::str_to_id

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_markdown_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_markdown_generator.cc
@@ -129,10 +129,9 @@ private:
  */
 std::string t_markdown_generator::str_to_id(const std::string& s) {
   std::string id;
-  for(auto chr=s.begin();chr<=s.end(); ++chr) {
-    if(*chr == '.' || *chr == 0)
-      continue;
-    id += tolower(*chr);
+  for (char c : s) {
+    if (c != '.')
+      id += tolower(c);
   }
   return id;
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -98,18 +98,21 @@ PRECROSS_TARGET += precross-swift
 endif
 
 #
-# generate html for ThriftTest.thrift
+# generate html and markdown for ThriftTest.thrift
 #
 check-local:
 	$(top_builddir)/compiler/cpp/thrift --gen html -r $(top_srcdir)/test/ThriftTest.thrift
+	$(top_builddir)/compiler/cpp/thrift --gen markdown -r $(top_srcdir)/test/ThriftTest.thrift
 
 clean-local:
 	$(RM) -r $(top_srcdir)/test/gen-html/
+	$(RM) -r $(top_srcdir)/test/gen-markdown/
 	find . -type d -name "__pycache__" | xargs rm -rf
 	find . -type f -name "*.pyc" | xargs rm -f
 
 dist-hook:
 	$(RM) -r $(distdir)/gen-html/
+	$(RM) -r $(distdir)/gen-markdown/
 	find $(distdir) -type d -name "__pycache__" | xargs rm -rf
 	find $(distdir) -type f -name "*.pyc" | xargs rm -f
 


### PR DESCRIPTION
## Summary

- `str_to_id` used `chr<=s.end()` as loop condition, causing the body to execute when `chr==end()`. Dereferencing the end iterator is undefined behaviour and triggers a hard assertion in debug builds (`_GLIBCXX_DEBUG`).
- Removes the dead `*chr == 0` check — a C-string-style null-terminator guard that can never be true for a `std::string` iterator.
- Rewrites the loop as a range-for to eliminate both issues.
- Adds `--gen markdown` to the `check-local` target in `test/Makefile.am`, matching the existing `--gen html` smoke test.

## Test plan

- [x] Debug build (`CMAKE_BUILD_TYPE=Debug`) no longer aborts with STL assertion on `--gen markdown`
- [x] `--gen markdown test/ThriftTest.thrift` produces valid output
- [x] `make check` (autotools) now covers `--gen markdown` via the updated `check-local` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)