### PR TITLE
THRIFT-4171: Add setConnectTimeout to PHP TSocket

### DIFF
--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -87,6 +87,13 @@ class TSocket extends TTransport
     protected int $sendTimeoutUsec = 100000;
 
     /**
+     * True once a caller invoked setSendTimeout(). Used to fire a deprecation
+     * notice in open() when the caller relies on the send-timeout-as-
+     * connect-timeout coupling that this class used to enforce.
+     */
+    private bool $sendTimeoutCustomized = false;
+
+    /**
      * Recv timeout in seconds
      *
      * Combined with recvTimeoutUsec this is used for recv timeouts.
@@ -192,6 +199,7 @@ class TSocket extends TTransport
         $this->sendTimeoutSec = intdiv($timeout, 1000);
         $this->sendTimeoutUsec =
             ($timeout - ($this->sendTimeoutSec * 1000)) * 1000;
+        $this->sendTimeoutCustomized = true;
     }
 
     /**
@@ -287,9 +295,19 @@ class TSocket extends TTransport
             throw new TTransportException('Cannot open without port', TTransportException::NOT_OPEN);
         }
 
-        $connectTimeout = $this->connectTimeoutSec !== null
-            ? $this->connectTimeoutSec + ($this->connectTimeoutUsec / 1000000)
-            : $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000);
+        if ($this->connectTimeoutSec !== null) {
+            $connectTimeout = $this->connectTimeoutSec + ($this->connectTimeoutUsec / 1000000);
+        } else {
+            if ($this->sendTimeoutCustomized) {
+                trigger_error(
+                    'TSocket::open() reusing setSendTimeout() for the connect '
+                    . 'step is deprecated and will be removed in the next '
+                    . 'version; call setConnectTimeout() explicitly.',
+                    E_USER_DEPRECATED,
+                );
+            }
+            $connectTimeout = $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000);
+        }
 
         if ($this->persist) {
             $this->handle = @pfsockopen(

--- a/lib/php/lib/Transport/TSocket.php
+++ b/lib/php/lib/Transport/TSocket.php
@@ -58,6 +58,21 @@ class TSocket extends TTransport
     protected $handle = null;
 
     /**
+     * Connect timeout in seconds.
+     *
+     * Combined with connectTimeoutUsec this is used for the fsockopen()
+     * timeout. Null means "use the send timeout" for backwards compatibility
+     * with callers that only configure setSendTimeout().
+     */
+    protected ?int $connectTimeoutSec = null;
+
+    /**
+     * Connect timeout in microseconds. Only consulted when connectTimeoutSec
+     * is non-null.
+     */
+    protected int $connectTimeoutUsec = 0;
+
+    /**
      * Send timeout in seconds.
      *
      * Combined with sendTimeoutUsec this is used for send timeouts.
@@ -150,6 +165,23 @@ class TSocket extends TTransport
     {
         $this->handle = $handle;
         stream_set_blocking($this->handle, false);
+    }
+
+    /**
+     * Sets the timeout used while establishing the TCP connection (the
+     * `timeout` argument passed to fsockopen()/pfsockopen()).
+     *
+     * When unset, the send timeout is used for the connect step too, for
+     * backwards compatibility with callers that only ever set
+     * setSendTimeout().
+     *
+     * @param int $timeout Timeout in milliseconds.
+     */
+    public function setConnectTimeout(int $timeout): void
+    {
+        $this->connectTimeoutSec = intdiv($timeout, 1000);
+        $this->connectTimeoutUsec =
+            ($timeout - ($this->connectTimeoutSec * 1000)) * 1000;
     }
 
     /**
@@ -255,13 +287,17 @@ class TSocket extends TTransport
             throw new TTransportException('Cannot open without port', TTransportException::NOT_OPEN);
         }
 
+        $connectTimeout = $this->connectTimeoutSec !== null
+            ? $this->connectTimeoutSec + ($this->connectTimeoutUsec / 1000000)
+            : $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000);
+
         if ($this->persist) {
             $this->handle = @pfsockopen(
                 $this->host,
                 $this->port,
                 $errno,
                 $errstr,
-                $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000)
+                $connectTimeout
             );
         } else {
             $this->handle = @fsockopen(
@@ -269,7 +305,7 @@ class TSocket extends TTransport
                 $this->port,
                 $errno,
                 $errstr,
-                $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000)
+                $connectTimeout
             );
         }
 

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -782,4 +782,45 @@ class TSocketTest extends TestCase
 
         $this->assertSame([], $errors);
     }
+
+    public function testSendTimeoutUsedForConnectWhenConnectTimeoutNotSet(): void
+    {
+        $handle = fopen('php://memory', 'r+');
+        $this->getFunctionMock('Thrift\Transport', 'fsockopen')
+             ->expects($this->once())
+             ->with(
+                 'localhost',
+                 9090,
+                 $this->anything(),
+                 $this->anything(),
+                 2.5, // 2500ms send timeout (no connect timeout set)
+             )
+             ->willReturn($handle);
+
+        $socket = new TSocket('localhost', 9090, false, null);
+        $socket->setSendTimeout(2500);
+
+        $socket->open();
+    }
+
+    public function testConnectTimeoutOverridesSendTimeoutDuringOpen(): void
+    {
+        $handle = fopen('php://memory', 'r+');
+        $this->getFunctionMock('Thrift\Transport', 'fsockopen')
+             ->expects($this->once())
+             ->with(
+                 'localhost',
+                 9090,
+                 $this->anything(),
+                 $this->anything(),
+                 0.75, // 750ms connect timeout, NOT the 5s sendTimeout below
+             )
+             ->willReturn($handle);
+
+        $socket = new TSocket('localhost', 9090, false, null);
+        $socket->setSendTimeout(5000);
+        $socket->setConnectTimeout(750);
+
+        $socket->open();
+    }
 }

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -800,7 +800,28 @@ class TSocketTest extends TestCase
         $socket = new TSocket('localhost', 9090, false, null);
         $socket->setSendTimeout(2500);
 
-        $socket->open();
+        $deprecations = self::captureUserDeprecations(static function () use ($socket): void {
+            $socket->open();
+        });
+
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('setConnectTimeout()', $deprecations[0]);
+    }
+
+    public function testOpenWithDefaultTimeoutsDoesNotTriggerDeprecation(): void
+    {
+        $handle = fopen('php://memory', 'r+');
+        $this->getFunctionMock('Thrift\Transport', 'fsockopen')
+             ->expects($this->once())
+             ->willReturn($handle);
+
+        $socket = new TSocket('localhost', 9090, false, null);
+
+        $deprecations = self::captureUserDeprecations(static function () use ($socket): void {
+            $socket->open();
+        });
+
+        $this->assertSame([], $deprecations);
     }
 
     public function testConnectTimeoutOverridesSendTimeoutDuringOpen(): void
@@ -821,6 +842,10 @@ class TSocketTest extends TestCase
         $socket->setSendTimeout(5000);
         $socket->setConnectTimeout(750);
 
-        $socket->open();
+        $deprecations = self::captureUserDeprecations(static function () use ($socket): void {
+            $socket->open();
+        });
+
+        $this->assertSame([], $deprecations);
     }
 }


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Resolves [THRIFT-4171](https://issues.apache.org/jira/browse/THRIFT-4171).

`TSocket::setSendTimeout()` was the only way to set the timeout passed to `fsockopen()`/`pfsockopen()`, so callers had to choose between a short connect timeout (good) and a short write timeout (often unwanted). Adds a separate `setConnectTimeout(int $timeout)` method; if it is not called, `open()` falls back to the send timeout, preserving today's behaviour.

Two unit tests cover both paths: the BC fallback and the override.

This addresses the same problem as the original PR #744, restructured around the typed properties introduced in recent PHP-library refactors.

- [x] [Apache JIRA](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket: THRIFT-4171
- [x] Title follows `THRIFT-NNNN: …`
- [x] Squashed to a single commit
- [x] No breaking change — additive method; existing callers keep current behaviour
- [ ] `[skip ci]` (n/a — code change)
