### PR TITLE
THRIFT-1209: Regression test for PHP-reserved words as Thrift enum names

### DIFF
--- a/lib/php/test/Resources/ThriftTest.thrift
+++ b/lib/php/test/Resources/ThriftTest.thrift
@@ -26,6 +26,17 @@ union UnionOfStrings {
   2: string bb;
 }
 
+// Regression for THRIFT-1209: PHP reserved words must round-trip through the
+// generator as class constants. PHP 7.1+ permits reserved identifiers as
+// class constants (except `class`); the generator must not mangle or reject
+// them. See lib/php/test/Unit/Compiler/ReservedKeywordEnumTest.php.
+enum ReservedKeywordEnum {
+  GLOBAL = 1,
+  STATIC = 2,
+  LIST = 3,
+  RETURN = 4,
+}
+
 service TestService {
     void test() throws(1: ThriftTest.Xception xception);
 }

--- a/lib/php/test/Unit/Compiler/ReservedKeywordEnumTest.php
+++ b/lib/php/test/Unit/Compiler/ReservedKeywordEnumTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Thrift\Unit\Compiler;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression for THRIFT-1209: PHP-reserved identifiers (GLOBAL, STATIC, LIST,
+ * RETURN) must round-trip through the generator as `public const` declarations
+ * on the emitted enum class. PHP 7.1+ permits reserved identifiers as class
+ * constants (except `class`); historically the generator emitted code that
+ * triggered a parse error here.
+ *
+ * The matching `ReservedKeywordEnum` is declared in
+ * lib/php/test/Resources/ThriftTest.thrift and generated into
+ * lib/php/test/Resources/packages/php by the build before phpunit runs.
+ */
+class ReservedKeywordEnumTest extends TestCase
+{
+    public function testReservedKeywordsRoundTripAsClassConstants(): void
+    {
+        $this->assertSame(1, \Basic\TestValidators\ReservedKeywordEnum::GLOBAL);
+        $this->assertSame(2, \Basic\TestValidators\ReservedKeywordEnum::STATIC);
+        $this->assertSame(3, \Basic\TestValidators\ReservedKeywordEnum::LIST);
+        $this->assertSame(4, \Basic\TestValidators\ReservedKeywordEnum::RETURN);
+    }
+}


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Resolves [THRIFT-1209](https://issues.apache.org/jira/browse/THRIFT-1209).

The original bug: an IDL `enum { GLOBAL = 1, ... }` produced PHP code (`class Foo { const GLOBAL = 1; }`) that failed to parse on older PHP. PHP 7.1+ permits reserved identifiers as class constants (except `class`), so the historical breakage is gone — but there is no test pinning that behaviour. This adds one:

- `lib/php/test/Resources/ThriftTest.thrift` gains `enum ReservedKeywordEnum { GLOBAL, STATIC, LIST, RETURN }` (PHP-only test thrift, won't affect cross-tests).
- New `lib/php/test/Unit/Compiler/ReservedKeywordEnumTest.php` references `\Basic\TestValidators\ReservedKeywordEnum::GLOBAL` etc., forcing the generated stub to be parsed by PHP. If the generator ever regresses and emits unparseable code for these names, phpunit will surface it.

- [x] [Apache JIRA](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket: THRIFT-1209
- [x] Title follows `THRIFT-NNNN: …`
- [x] Single squashed commit
- [x] No breaking change — test-only
- [ ] `[skip ci]` (n/a — test addition)
