### PR TITLE
THRIFT-6029: Harden PHP binary protocol negative sizes

### DIFF
--- a/lib/php/lib/Protocol/TBinaryProtocol.php
+++ b/lib/php/lib/Protocol/TBinaryProtocol.php
@@ -296,10 +296,14 @@ class TBinaryProtocol extends TProtocol
 
     public function readMapBegin(?int &$keyType, ?int &$valType, ?int &$size): int
     {
-        return
+        $result =
             $this->readByte($keyType) +
             $this->readByte($valType) +
             $this->readI32($size);
+        if ($size < 0) {
+            throw new TProtocolException('Negative size', TProtocolException::NEGATIVE_SIZE);
+        }
+        return $result;
     }
 
     public function readMapEnd(): int
@@ -309,9 +313,13 @@ class TBinaryProtocol extends TProtocol
 
     public function readListBegin(?int &$elemType, ?int &$size): int
     {
-        return
+        $result =
             $this->readByte($elemType) +
             $this->readI32($size);
+        if ($size < 0) {
+            throw new TProtocolException('Negative size', TProtocolException::NEGATIVE_SIZE);
+        }
+        return $result;
     }
 
     public function readListEnd(): int
@@ -321,9 +329,13 @@ class TBinaryProtocol extends TProtocol
 
     public function readSetBegin(?int &$elemType, ?int &$size): int
     {
-        return
+        $result =
             $this->readByte($elemType) +
             $this->readI32($size);
+        if ($size < 0) {
+            throw new TProtocolException('Negative size', TProtocolException::NEGATIVE_SIZE);
+        }
+        return $result;
     }
 
     public function readSetEnd(): int
@@ -450,6 +462,9 @@ class TBinaryProtocol extends TProtocol
     public function readString(?string &$str): int
     {
         $result = $this->readI32($len);
+        if ($len < 0) {
+            throw new TProtocolException('Negative size', TProtocolException::NEGATIVE_SIZE);
+        }
         if ($len) {
             $str = $this->trans->readAll($len);
         } else {

--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
@@ -1160,4 +1160,64 @@ class TBinaryProtocolTest extends TestCase
             'expectedValue' => 'string',
         ];
     }
+
+    public function testReadMapBeginRejectsNegativeSize()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+            pack('c', TType::I32),
+            pack('c', TType::STRING),
+            pack('N', 0xffffffff)
+        );
+
+        $this->expectException(TProtocolException::class);
+        $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
+        $protocol->readMapBegin($keyType, $valType, $size);
+    }
+
+    public function testReadListBeginRejectsNegativeSize()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+            pack('c', TType::I32),
+            pack('N', 0xffffffff)
+        );
+
+        $this->expectException(TProtocolException::class);
+        $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
+        $protocol->readListBegin($elemType, $size);
+    }
+
+    public function testReadSetBeginRejectsNegativeSize()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+            pack('c', TType::I32),
+            pack('N', 0xffffffff)
+        );
+
+        $this->expectException(TProtocolException::class);
+        $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
+        $protocol->readSetBegin($elemType, $size);
+    }
+
+    public function testReadStringRejectsNegativeSize()
+    {
+        $transport = $this->createMock(TTransport::class);
+        $protocol = new TBinaryProtocol($transport, false, false);
+
+        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+            pack('N', 0xffffffff)
+        );
+
+        $this->expectException(TProtocolException::class);
+        $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
+        $protocol->readString($value);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds negative-size guards in `readMapBegin`, `readListBegin`, `readSetBegin`, and `readString` in `TBinaryProtocol`
- Adds 4 PHPUnit tests in `TBinaryProtocolTest.php` covering all guarded methods

## Test plan

- [ ] `phpunit --filter 'testRead.*NegativeSize' test/Unit/Lib/Protocol/TBinaryProtocolTest.php` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>