### PR TITLE
THRIFT-6030: Harden Erlang binary protocol negative sizes

### DIFF
--- a/lib/erl/src/thrift_binary_protocol.erl
+++ b/lib/erl/src/thrift_binary_protocol.erl
@@ -220,6 +220,7 @@ read(This0, map_begin) ->
     {This1, {ok, Ktype}} = read(This0, byte),
     {This2, {ok, Vtype}} = read(This1, byte),
     {This3, {ok, Size}} = read(This2, i32),
+    if Size < 0 -> error({protocol_error, negative_size}); true -> ok end,
     {This3, #protocol_map_begin{
         ktype = Ktype,
         vtype = Vtype,
@@ -230,6 +231,7 @@ read(This, map_end) ->
 read(This0, list_begin) ->
     {This1, {ok, Etype}} = read(This0, byte),
     {This2, {ok, Size}} = read(This1, i32),
+    if Size < 0 -> error({protocol_error, negative_size}); true -> ok end,
     {This2, #protocol_list_begin{
         etype = Etype,
         size = Size
@@ -239,6 +241,7 @@ read(This, list_end) ->
 read(This0, set_begin) ->
     {This1, {ok, Etype}} = read(This0, byte),
     {This2, {ok, Size}} = read(This1, i32),
+    if Size < 0 -> error({protocol_error, negative_size}); true -> ok end,
     {This2, #protocol_set_begin{
         etype = Etype,
         size = Size
@@ -298,6 +301,7 @@ read(This0, double) ->
 % returns a binary directly, call binary_to_list if necessary
 read(This0, string) ->
     {This1, {ok, Sz}} = read(This0, i32),
+    if Sz < 0 -> error({protocol_error, negative_size}); true -> ok end,
     read_data(This1, Sz).
 
 -spec read_data(#binary_protocol{}, non_neg_integer()) ->

--- a/lib/erl/test/test_thrift_binary_protocol.erl
+++ b/lib/erl/test/test_thrift_binary_protocol.erl
@@ -1,0 +1,49 @@
+%%
+%% Licensed to the Apache Software Foundation (ASF) under one
+%% or more contributor license agreements. See the NOTICE file
+%% distributed with this work for additional information
+%% regarding copyright ownership. The ASF licenses this file
+%% to you under the Apache License, Version 2.0 (the
+%% "License"); you may not use this file except in compliance
+%% with the License. You may obtain a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(test_thrift_binary_protocol).
+-include_lib("eunit/include/eunit.hrl").
+-include("thrift_protocol.hrl").
+
+new(Buf) ->
+    {ok, Transport} = thrift_membuffer_transport:new(Buf),
+    {ok, Protocol} = thrift_binary_protocol:new(Transport),
+    Protocol.
+
+read(This, Type) -> thrift_protocol:read(This, Type).
+
+negative_map_size_test() ->
+    %% ktype=8 (I32), vtype=11 (STRING), size=-1 (0xffffffff big-endian)
+    P = new(<<8, 11, 255, 255, 255, 255>>),
+    ?assertError({protocol_error, negative_size}, read(P, map_begin)).
+
+negative_list_size_test() ->
+    %% etype=11 (STRING), size=-1
+    P = new(<<11, 255, 255, 255, 255>>),
+    ?assertError({protocol_error, negative_size}, read(P, list_begin)).
+
+negative_set_size_test() ->
+    %% etype=11 (STRING), size=-1
+    P = new(<<11, 255, 255, 255, 255>>),
+    ?assertError({protocol_error, negative_size}, read(P, set_begin)).
+
+negative_string_size_test() ->
+    %% size=-1
+    P = new(<<255, 255, 255, 255>>),
+    ?assertError({protocol_error, negative_size}, read(P, string)).


### PR DESCRIPTION
## Summary

- Adds negative-size guards in `read(map_begin)`, `read(list_begin)`, `read(set_begin)`, and `read(string)` in `thrift_binary_protocol.erl` using `error({protocol_error, negative_size})`
- Adds `test/test_thrift_binary_protocol.erl` with 4 EUnit tests

## Test plan

- [ ] `rebar3 eunit --module=test_thrift_binary_protocol` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>