### PR TITLE
THRIFT-6031: Harden Lua protocol negative sizes

### DIFF
--- a/lib/lua/TBinaryProtocol.lua
+++ b/lib/lua/TBinaryProtocol.lua
@@ -188,6 +188,9 @@ function TBinaryProtocol:readMapBegin()
   local ktype = self:readByte()
   local vtype = self:readByte()
   local size = self:readI32()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   return ktype, vtype, size
 end
 
@@ -197,6 +200,9 @@ end
 function TBinaryProtocol:readListBegin()
   local etype = self:readByte()
   local size = self:readI32()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   return etype, size
 end
 
@@ -206,6 +212,9 @@ end
 function TBinaryProtocol:readSetBegin()
   local etype = self:readByte()
   local size = self:readI32()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   return etype, size
 end
 
@@ -258,6 +267,9 @@ end
 
 function TBinaryProtocol:readString()
   local len = self:readI32()
+  if len < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   local str = self.trans:readAll(len)
   return str
 end

--- a/lib/lua/TCompactProtocol.lua
+++ b/lib/lua/TCompactProtocol.lua
@@ -332,6 +332,9 @@ end
 
 function TCompactProtocol:readMapBegin()
   local size = self:readVarint32()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   local kvtype = 0
   if size > 0 then
     kvtype = self:readSignByte()
@@ -351,7 +354,7 @@ function TCompactProtocol:readListBegin()
     size = self:readVarint32()
   end
   if size < 0 then
-    return nil,nil
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
   end
   local etype = self:getTType(libluabitwise.band(size_and_type, 0x0f))
   return etype, size
@@ -437,7 +440,10 @@ end
 
 function TCompactProtocol:readBinary()
   local size = self:readVarint32()
-  if size <= 0 then
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
+  if size == 0 then
     return ""
   end
   return self.trans:readAll(size)

--- a/lib/lua/TJsonProtocol.lua
+++ b/lib/lua/TJsonProtocol.lua
@@ -646,6 +646,9 @@ function TJSONProtocol:readMapBegin()
   typeName = self:readJSONString()
   local vtype = StringToTType[typeName]
   local size = self:readJSONInteger()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   self:readJSONObjectBegin()
   return ktype, vtype, size
 end
@@ -660,6 +663,9 @@ function TJSONProtocol:readListBegin()
   local typeName = self:readJSONString()
   local etype = StringToTType[typeName]
   local size = self:readJSONInteger()
+  if size < 0 then
+    terror(TProtocolException:new{errorCode = TProtocolException.NEGATIVE_SIZE})
+  end
   return etype, size
 end
 


### PR DESCRIPTION
## Summary

- Adds negative-size guards in `TBinaryProtocol.lua` (`readMapBegin`, `readListBegin`, `readSetBegin`, `readString`)
- Adds negative-size guards in `TCompactProtocol.lua` (`readMapBegin`, `readListBegin`, `readBinary`)
- Adds negative-size guards in `TJsonProtocol.lua` (`readMapBegin`, `readListBegin`)
- Fixes a pre-existing issue in `TCompactProtocol.readListBegin` which returned `nil,nil` for negative sizes instead of raising an error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>