### PR TITLE
THRIFT-6034: Harden Dart binary protocol negative sizes

### DIFF
--- a/lib/dart/lib/src/protocol/t_binary_protocol.dart
+++ b/lib/dart/lib/src/protocol/t_binary_protocol.dart
@@ -232,7 +232,9 @@ class TBinaryProtocol extends TProtocol {
     int keyType = readByte();
     int valueType = readByte();
     int length = readI32();
-
+    if (length < 0) {
+      throw TProtocolError(TProtocolErrorType.NEGATIVE_SIZE, 'Negative size');
+    }
     return TMap(keyType, valueType, length);
   }
 
@@ -243,7 +245,9 @@ class TBinaryProtocol extends TProtocol {
   TList readListBegin() {
     int elementType = readByte();
     int length = readI32();
-
+    if (length < 0) {
+      throw TProtocolError(TProtocolErrorType.NEGATIVE_SIZE, 'Negative size');
+    }
     return TList(elementType, length);
   }
 
@@ -254,7 +258,9 @@ class TBinaryProtocol extends TProtocol {
   TSet readSetBegin() {
     int elementType = readByte();
     int length = readI32();
-
+    if (length < 0) {
+      throw TProtocolError(TProtocolErrorType.NEGATIVE_SIZE, 'Negative size');
+    }
     return TSet(elementType, length);
   }
 
@@ -308,6 +314,9 @@ class TBinaryProtocol extends TProtocol {
   @override
   String readString() {
     int size = readI32();
+    if (size < 0) {
+      throw TProtocolError(TProtocolErrorType.NEGATIVE_SIZE, 'Negative size');
+    }
     return _readString(size);
   }
 
@@ -320,6 +329,9 @@ class TBinaryProtocol extends TProtocol {
   @override
   Uint8List readBinary() {
     int length = readI32();
+    if (length < 0) {
+      throw TProtocolError(TProtocolErrorType.NEGATIVE_SIZE, 'Negative size');
+    }
     Uint8List binaryIn = Uint8List(length);
     transport.readAll(binaryIn, 0, length);
     return binaryIn;

--- a/lib/dart/test/protocol/t_protocol_test.dart
+++ b/lib/dart/test/protocol/t_protocol_test.dart
@@ -386,6 +386,67 @@ void main() {
     });
 
     group('shared tests', sharedTests);
+
+    test('readMapBegin rejects negative size', () async {
+      final trans = TBufferedTransport();
+      final proto = TBinaryProtocol(trans);
+      // ktype=I32(8), vtype=STRING(11), size=-1 (0xffffffff big-endian)
+      final bytes = Uint8List.fromList([8, 11, 0xff, 0xff, 0xff, 0xff]);
+      trans.write(bytes, 0, bytes.length);
+      await trans.flush();
+      expect(
+        () => proto.readMapBegin(),
+        throwsA(isA<TProtocolError>().having(
+          (e) => e.type, 'type', TProtocolErrorType.NEGATIVE_SIZE)));
+    });
+
+    test('readListBegin rejects negative size', () async {
+      final trans = TBufferedTransport();
+      final proto = TBinaryProtocol(trans);
+      final bytes = Uint8List.fromList([11, 0xff, 0xff, 0xff, 0xff]);
+      trans.write(bytes, 0, bytes.length);
+      await trans.flush();
+      expect(
+        () => proto.readListBegin(),
+        throwsA(isA<TProtocolError>().having(
+          (e) => e.type, 'type', TProtocolErrorType.NEGATIVE_SIZE)));
+    });
+
+    test('readSetBegin rejects negative size', () async {
+      final trans = TBufferedTransport();
+      final proto = TBinaryProtocol(trans);
+      final bytes = Uint8List.fromList([11, 0xff, 0xff, 0xff, 0xff]);
+      trans.write(bytes, 0, bytes.length);
+      await trans.flush();
+      expect(
+        () => proto.readSetBegin(),
+        throwsA(isA<TProtocolError>().having(
+          (e) => e.type, 'type', TProtocolErrorType.NEGATIVE_SIZE)));
+    });
+
+    test('readString rejects negative size', () async {
+      final trans = TBufferedTransport();
+      final proto = TBinaryProtocol(trans);
+      final bytes = Uint8List.fromList([0xff, 0xff, 0xff, 0xff]);
+      trans.write(bytes, 0, bytes.length);
+      await trans.flush();
+      expect(
+        () => proto.readString(),
+        throwsA(isA<TProtocolError>().having(
+          (e) => e.type, 'type', TProtocolErrorType.NEGATIVE_SIZE)));
+    });
+
+    test('readBinary rejects negative size', () async {
+      final trans = TBufferedTransport();
+      final proto = TBinaryProtocol(trans);
+      final bytes = Uint8List.fromList([0xff, 0xff, 0xff, 0xff]);
+      trans.write(bytes, 0, bytes.length);
+      await trans.flush();
+      expect(
+        () => proto.readBinary(),
+        throwsA(isA<TProtocolError>().having(
+          (e) => e.type, 'type', TProtocolErrorType.NEGATIVE_SIZE)));
+    });
   });
 
   group('compact', () {


### PR DESCRIPTION
## Summary

- Adds negative-size guards in `readMapBegin`, `readListBegin`, `readSetBegin`, `readString`, and `readBinary` in `TBinaryProtocol`
- Adds 5 `dart test` tests in `t_protocol_test.dart` covering all guarded methods

## Test plan

- [ ] `dart test test/protocol/t_protocol_test.dart` — new tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>