### PR TITLE
THRIFT-6036: Harden JavaME binary protocol negative sizes

### DIFF
--- a/lib/javame/src/org/apache/thrift/protocol/TBinaryProtocol.java
+++ b/lib/javame/src/org/apache/thrift/protocol/TBinaryProtocol.java
@@ -231,6 +231,9 @@ public class TBinaryProtocol extends TProtocol {
     map.keyType = readByte();
     map.valueType = readByte();
     map.size = readI32();
+    if (map.size < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative size");
+    }
     return map;
   }
 
@@ -240,6 +243,9 @@ public class TBinaryProtocol extends TProtocol {
     TList list = new TList();
     list.elemType = readByte();
     list.size = readI32();
+    if (list.size < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative size");
+    }
     return list;
   }
 
@@ -249,6 +255,9 @@ public class TBinaryProtocol extends TProtocol {
     TSet set = new TSet();
     set.elemType = readByte();
     set.size = readI32();
+    if (set.size < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative size");
+    }
     return set;
   }
 
@@ -307,6 +316,9 @@ public class TBinaryProtocol extends TProtocol {
   }
 
   public String readStringBody(int size) throws TException {
+    if (size < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative size");
+    }
     try {
       byte[] buf = new byte[size];
       trans_.readAll(buf, 0, size);
@@ -318,6 +330,9 @@ public class TBinaryProtocol extends TProtocol {
 
   public byte[] readBinary() throws TException {
     int size = readI32();
+    if (size < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative size");
+    }
     byte[] buf = new byte[size];
     trans_.readAll(buf, 0, size);
     return buf;


### PR DESCRIPTION
## Summary

- Adds negative-size guards in `readMapBegin`, `readListBegin`, `readSetBegin`, `readStringBody`, and `readBinary` in the JavaME `TBinaryProtocol`
- Throws `TProtocolException(NEGATIVE_SIZE, ...)` for negative sizes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>