### PR TITLE
THRIFT-6058: fix Rust codegen for list<union> and set<union> deserialization

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -2013,7 +2013,7 @@ void t_rs_generator::render_list_sync_read(t_list* tlist, const string& list_var
     string read_call(resolved_type + "::read_from_in_protocol(i_prot)");
     f_gen_ << indent() << "match " << read_call << " {" << '\n';
     indent_up();
-    f_gen_ << indent() << "Ok(val) => { " << list_var << ".push(val); }," << '\n';
+    f_gen_ << indent() << "Ok(elem) => { " << list_var << ".push(Box::new(elem)); }," << '\n';
     f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => { continue; }," << '\n';
     f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
     indent_down();
@@ -2048,7 +2048,7 @@ void t_rs_generator::render_set_sync_read(t_set* tset, const string& set_var) {
     string read_call(resolved_type + "::read_from_in_protocol(i_prot)");
     f_gen_ << indent() << "match " << read_call << " {" << '\n';
     indent_up();
-    f_gen_ << indent() << "Ok(val) => { " << set_var << ".insert(val); }," << '\n';
+    f_gen_ << indent() << "Ok(elem) => { " << set_var << ".insert(Box::new(elem)); }," << '\n';
     f_gen_ << indent() << "Err(thrift::Error::Protocol(ref e)) if e.kind == ProtocolErrorKind::UnknownUnionVariant => { continue; }," << '\n';
     f_gen_ << indent() << "Err(e) => return Err(e)," << '\n';
     indent_down();


### PR DESCRIPTION
## Problem

The Rust code generator produces incorrect deserialization code for `list<UnionType>` and `set<UnionType>` fields in structs.

In `t_rs_generator::render_list_sync_read`, when the list element type is a union, the generated code is:

```rust
match UnionType::read_from_in_protocol(i_prot) {
    Ok(val) => { val.push(val); },
    ...
}
```

Two bugs:

1. **Variable shadowing**: the match binding `Ok(val)` shadows the outer list variable `val`, so `val.push(val)` calls `.push()` on the union element instead of the `Vec`.
2. **Missing `Box::new()`**: the list type is `Vec<Box<UnionType>>` but the element is not wrapped in `Box::new()` before pushing.

Same bug in `render_set_sync_read` (line 2051).

The single-field deserialization path (`render_struct_sync_read`, line 1718) already handles boxing correctly; only the collection paths were affected.

## Fix

Rename the match binding from `val` to `elem` and wrap with `Box::new()`:

```rust
Ok(elem) => { val.push(Box::new(elem)); },
```

## Reproduction

Any `.thrift` file with a struct containing a `list<MyUnion>` field where `MyUnion` is a `union` type produces uncompilable Rust code.