### PR TITLE
THRIFT-6044: Limit struct read/write recursion depth in Go library

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -1769,6 +1769,13 @@ void t_go_generator::generate_go_struct_reader(ostream& out,
   out << indent() << "func (p *" << tstruct_name << ") " << read_method_name_ << "(ctx context.Context, iprot thrift.TProtocol) error {"
       << '\n';
   indent_up();
+  out << indent() << "ctx, err := thrift.CheckRecursionDepth(ctx)" << '\n';
+  out << indent() << "if err != nil {" << '\n';
+  indent_up();
+  out << indent() << "return err" << '\n';
+  indent_down();
+  out << indent() << "}" << '\n';
+  out << indent() << "defer thrift.DecrementRecursionDepth(ctx)" << '\n';
   out << indent() << "if _, err := iprot.ReadStructBegin(ctx); err != nil {" << '\n';
   indent_up();
   out << indent() << "return thrift.PrependError(fmt.Sprintf(\"%T read error: \", p), err)"
@@ -1946,6 +1953,13 @@ void t_go_generator::generate_go_struct_writer(ostream& out,
   vector<t_field*>::const_iterator f_iter;
   indent(out) << "func (p *" << tstruct_name << ") " << write_method_name_ << "(ctx context.Context, oprot thrift.TProtocol) error {" << '\n';
   indent_up();
+  out << indent() << "ctx, err := thrift.CheckRecursionDepth(ctx)" << '\n';
+  out << indent() << "if err != nil {" << '\n';
+  indent_up();
+  out << indent() << "return err" << '\n';
+  indent_down();
+  out << indent() << "}" << '\n';
+  out << indent() << "defer thrift.DecrementRecursionDepth(ctx)" << '\n';
   if (tstruct->is_union() && uses_countsetfields) {
     std::string tstruct_name(publicize(tstruct->get_name()));
     out << indent() << "if c := p.CountSetFields" << tstruct_name << "(); c != 1 {" << '\n';

--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -23,11 +23,13 @@ THRIFT_GO_ARGS_BASE = thrift_import=github.com/apache/thrift/lib/go/thrift,packa
 
 THRIFTARGS = -out gopath/src/ --gen go:$(THRIFT_GO_ARGS_BASE)$(COMPILER_EXTRAFLAG)
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
+RECURSIVE = $(top_srcdir)/test/Recursive.thrift
 
 THRIFTARGS_SKIP_REMOTE = -out gopath/src/ --gen go:skip_remote,$(THRIFT_GO_ARGS_BASE)$(COMPILER_EXTRAFLAG)
 
 # Thrift for GO has problems with complex map keys: THRIFT-2063
 gopath: $(THRIFT) $(THRIFTTEST) \
+				$(RECURSIVE) \
 				IncludesTest.thrift \
 				NamespacedTest.thrift \
 				MultiplexedProtocolTest.thrift \
@@ -66,6 +68,7 @@ gopath: $(THRIFT) $(THRIFTTEST) \
 				StringParseAllocationTest.thrift
 	mkdir -p gopath/src
 	grep -v list.*map.*list.*map $(THRIFTTEST) | grep -v 'set<Insanity>' > ThriftTest.thrift
+	$(THRIFT) $(THRIFTARGS) $(RECURSIVE)
 	$(THRIFT) $(THRIFTARGS) -r IncludesTest.thrift
 	$(THRIFT) $(THRIFTARGS) BinaryKeyTest.thrift
 	$(THRIFT) $(THRIFTARGS) MultiplexedProtocolTest.thrift

--- a/lib/go/test/tests/client_error_test.go
+++ b/lib/go/test/tests/client_error_test.go
@@ -20,7 +20,6 @@
 package tests
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -55,84 +54,84 @@ func prepareClientCallReply(protocol *MockTProtocol, failAt int, failWith error)
 	if failAt == 0 {
 		err = failWith
 	}
-	last := protocol.EXPECT().WriteMessageBegin(context.Background(), "testStruct", thrift.CALL, int32(1)).Return(err)
+	last := protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testStruct", thrift.CALL, int32(1)).Return(err)
 	if failAt == 0 {
 		return true
 	}
 	if failAt == 1 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteStructBegin(context.Background(), "testStruct_args").Return(err).After(last)
+	last = protocol.EXPECT().WriteStructBegin(gomock.Any(), "testStruct_args").Return(err).After(last)
 	if failAt == 1 {
 		return true
 	}
 	if failAt == 2 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "thing", thrift.TType(thrift.STRUCT), int16(1)).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "thing", thrift.TType(thrift.STRUCT), int16(1)).Return(err).After(last)
 	if failAt == 2 {
 		return true
 	}
 	if failAt == 3 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteStructBegin(context.Background(), "TestStruct").Return(err).After(last)
+	last = protocol.EXPECT().WriteStructBegin(gomock.Any(), "TestStruct").Return(err).After(last)
 	if failAt == 3 {
 		return true
 	}
 	if failAt == 4 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "m", thrift.TType(thrift.MAP), int16(1)).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "m", thrift.TType(thrift.MAP), int16(1)).Return(err).After(last)
 	if failAt == 4 {
 		return true
 	}
 	if failAt == 5 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteMapBegin(context.Background(), thrift.TType(thrift.STRING), thrift.TType(thrift.STRING), 0).Return(err).After(last)
+	last = protocol.EXPECT().WriteMapBegin(gomock.Any(), thrift.TType(thrift.STRING), thrift.TType(thrift.STRING), 0).Return(err).After(last)
 	if failAt == 5 {
 		return true
 	}
 	if failAt == 6 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteMapEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteMapEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 6 {
 		return true
 	}
 	if failAt == 7 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 7 {
 		return true
 	}
 	if failAt == 8 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "l", thrift.TType(thrift.LIST), int16(2)).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "l", thrift.TType(thrift.LIST), int16(2)).Return(err).After(last)
 	if failAt == 8 {
 		return true
 	}
 	if failAt == 9 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteListBegin(context.Background(), thrift.TType(thrift.STRING), 0).Return(err).After(last)
+	last = protocol.EXPECT().WriteListBegin(gomock.Any(), thrift.TType(thrift.STRING), 0).Return(err).After(last)
 	if failAt == 9 {
 		return true
 	}
 	if failAt == 10 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteListEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteListEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 10 {
 		return true
 	}
 	if failAt == 11 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 11 {
 		return true
 	}
@@ -140,266 +139,266 @@ func prepareClientCallReply(protocol *MockTProtocol, failAt int, failWith error)
 		err = failWith
 	}
 
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.SET), int16(3)).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.SET), int16(3)).Return(err).After(last)
 	if failAt == 12 {
 		return true
 	}
 	if failAt == 13 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteSetBegin(context.Background(), thrift.TType(thrift.STRING), 0).Return(err).After(last)
+	last = protocol.EXPECT().WriteSetBegin(gomock.Any(), thrift.TType(thrift.STRING), 0).Return(err).After(last)
 	if failAt == 13 {
 		return true
 	}
 	if failAt == 14 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteSetEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteSetEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 14 {
 		return true
 	}
 	if failAt == 15 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 15 {
 		return true
 	}
 	if failAt == 16 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "i", thrift.TType(thrift.I32), int16(4)).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "i", thrift.TType(thrift.I32), int16(4)).Return(err).After(last)
 	if failAt == 16 {
 		return true
 	}
 	if failAt == 17 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteI32(context.Background(), int32(3)).Return(err).After(last)
+	last = protocol.EXPECT().WriteI32(gomock.Any(), int32(3)).Return(err).After(last)
 	if failAt == 17 {
 		return true
 	}
 	if failAt == 18 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 18 {
 		return true
 	}
 	if failAt == 19 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldStop(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldStop(gomock.Any()).Return(err).After(last)
 	if failAt == 19 {
 		return true
 	}
 	if failAt == 20 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteStructEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteStructEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 20 {
 		return true
 	}
 	if failAt == 21 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 21 {
 		return true
 	}
 	if failAt == 22 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteFieldStop(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteFieldStop(gomock.Any()).Return(err).After(last)
 	if failAt == 22 {
 		return true
 	}
 	if failAt == 23 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteStructEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteStructEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 23 {
 		return true
 	}
 	if failAt == 24 {
 		err = failWith
 	}
-	last = protocol.EXPECT().WriteMessageEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().WriteMessageEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 24 {
 		return true
 	}
 	if failAt == 25 {
 		err = failWith
 	}
-	last = protocol.EXPECT().Flush(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().Flush(gomock.Any()).Return(err).After(last)
 	if failAt == 25 {
 		return true
 	}
 	if failAt == 26 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testStruct", thrift.REPLY, int32(1), err).After(last)
+	last = protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testStruct", thrift.REPLY, int32(1), err).After(last)
 	if failAt == 26 {
 		return true
 	}
 	if failAt == 27 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructBegin(context.Background()).Return("testStruct_args", err).After(last)
+	last = protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("testStruct_args", err).After(last)
 	if failAt == 27 {
 		return true
 	}
 	if failAt == 28 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STRUCT), int16(0), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STRUCT), int16(0), err).After(last)
 	if failAt == 28 {
 		return true
 	}
 	if failAt == 29 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructBegin(context.Background()).Return("TestStruct", err).After(last)
+	last = protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("TestStruct", err).After(last)
 	if failAt == 29 {
 		return true
 	}
 	if failAt == 30 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("m", thrift.TType(thrift.MAP), int16(1), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("m", thrift.TType(thrift.MAP), int16(1), err).After(last)
 	if failAt == 30 {
 		return true
 	}
 	if failAt == 31 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadMapBegin(context.Background()).Return(thrift.TType(thrift.STRING), thrift.TType(thrift.STRING), 0, err).After(last)
+	last = protocol.EXPECT().ReadMapBegin(gomock.Any()).Return(thrift.TType(thrift.STRING), thrift.TType(thrift.STRING), 0, err).After(last)
 	if failAt == 31 {
 		return true
 	}
 	if failAt == 32 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadMapEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadMapEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 32 {
 		return true
 	}
 	if failAt == 33 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 33 {
 		return true
 	}
 	if failAt == 34 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("l", thrift.TType(thrift.LIST), int16(2), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("l", thrift.TType(thrift.LIST), int16(2), err).After(last)
 	if failAt == 34 {
 		return true
 	}
 	if failAt == 35 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadListBegin(context.Background()).Return(thrift.TType(thrift.STRING), 0, err).After(last)
+	last = protocol.EXPECT().ReadListBegin(gomock.Any()).Return(thrift.TType(thrift.STRING), 0, err).After(last)
 	if failAt == 35 {
 		return true
 	}
 	if failAt == 36 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadListEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadListEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 36 {
 		return true
 	}
 	if failAt == 37 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 37 {
 		return true
 	}
 	if failAt == 38 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("s", thrift.TType(thrift.SET), int16(3), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("s", thrift.TType(thrift.SET), int16(3), err).After(last)
 	if failAt == 38 {
 		return true
 	}
 	if failAt == 39 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadSetBegin(context.Background()).Return(thrift.TType(thrift.STRING), 0, err).After(last)
+	last = protocol.EXPECT().ReadSetBegin(gomock.Any()).Return(thrift.TType(thrift.STRING), 0, err).After(last)
 	if failAt == 39 {
 		return true
 	}
 	if failAt == 40 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadSetEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadSetEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 40 {
 		return true
 	}
 	if failAt == 41 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 41 {
 		return true
 	}
 	if failAt == 42 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("i", thrift.TType(thrift.I32), int16(4), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("i", thrift.TType(thrift.I32), int16(4), err).After(last)
 	if failAt == 42 {
 		return true
 	}
 	if failAt == 43 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadI32(context.Background()).Return(int32(3), err).After(last)
+	last = protocol.EXPECT().ReadI32(gomock.Any()).Return(int32(3), err).After(last)
 	if failAt == 43 {
 		return true
 	}
 	if failAt == 44 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 44 {
 		return true
 	}
 	if failAt == 45 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(5), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(5), err).After(last)
 	if failAt == 45 {
 		return true
 	}
 	if failAt == 46 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 46 {
 		return true
 	}
 	if failAt == 47 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 47 {
 		return true
 	}
 	if failAt == 48 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(1), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(1), err).After(last)
 	if failAt == 48 {
 		return true
 	}
 	if failAt == 49 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 49 {
 		return true
 	}
@@ -407,7 +406,7 @@ func prepareClientCallReply(protocol *MockTProtocol, failAt int, failWith error)
 		err = failWith
 	}
 	//lint:ignore SA4006 to keep it consistent with other checks above
-	last = protocol.EXPECT().ReadMessageEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadMessageEnd(gomock.Any()).Return(err).After(last)
 	//lint:ignore S1008 to keep it consistent with other checks above
 	if failAt == 50 {
 		return true
@@ -549,84 +548,84 @@ func prepareClientCallException(protocol *MockTProtocol, failAt int, failWith er
 	var err error = nil
 
 	// No need to test failure in this block, because it is covered in other test cases
-	last := protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1))
-	last = protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args").After(last)
-	last = protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)).After(last)
-	last = protocol.EXPECT().WriteString(context.Background(), "test").After(last)
-	last = protocol.EXPECT().WriteFieldEnd(context.Background()).After(last)
-	last = protocol.EXPECT().WriteFieldStop(context.Background()).After(last)
-	last = protocol.EXPECT().WriteStructEnd(context.Background()).After(last)
-	last = protocol.EXPECT().WriteMessageEnd(context.Background()).After(last)
-	last = protocol.EXPECT().Flush(context.Background()).After(last)
+	last := protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1))
+	last = protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args").After(last)
+	last = protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)).After(last)
+	last = protocol.EXPECT().WriteString(gomock.Any(), "test").After(last)
+	last = protocol.EXPECT().WriteFieldEnd(gomock.Any()).After(last)
+	last = protocol.EXPECT().WriteFieldStop(gomock.Any()).After(last)
+	last = protocol.EXPECT().WriteStructEnd(gomock.Any()).After(last)
+	last = protocol.EXPECT().WriteMessageEnd(gomock.Any()).After(last)
+	last = protocol.EXPECT().Flush(gomock.Any()).After(last)
 
 	// Reading the exception, might fail.
 	if failAt == 0 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testString", thrift.EXCEPTION, int32(1), err).After(last)
+	last = protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testString", thrift.EXCEPTION, int32(1), err).After(last)
 	if failAt == 0 {
 		return true
 	}
 	if failAt == 1 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructBegin(context.Background()).Return("TApplicationException", err).After(last)
+	last = protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("TApplicationException", err).After(last)
 	if failAt == 1 {
 		return true
 	}
 	if failAt == 2 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("message", thrift.TType(thrift.STRING), int16(1), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("message", thrift.TType(thrift.STRING), int16(1), err).After(last)
 	if failAt == 2 {
 		return true
 	}
 	if failAt == 3 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadString(context.Background()).Return("test", err).After(last)
+	last = protocol.EXPECT().ReadString(gomock.Any()).Return("test", err).After(last)
 	if failAt == 3 {
 		return true
 	}
 	if failAt == 4 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 4 {
 		return true
 	}
 	if failAt == 5 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("type", thrift.TType(thrift.I32), int16(2), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("type", thrift.TType(thrift.I32), int16(2), err).After(last)
 	if failAt == 5 {
 		return true
 	}
 	if failAt == 6 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadI32(context.Background()).Return(int32(thrift.PROTOCOL_ERROR), err).After(last)
+	last = protocol.EXPECT().ReadI32(gomock.Any()).Return(int32(thrift.PROTOCOL_ERROR), err).After(last)
 	if failAt == 6 {
 		return true
 	}
 	if failAt == 7 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 7 {
 		return true
 	}
 	if failAt == 8 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(2), err).After(last)
+	last = protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(2), err).After(last)
 	if failAt == 8 {
 		return true
 	}
 	if failAt == 9 {
 		err = failWith
 	}
-	last = protocol.EXPECT().ReadStructEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(err).After(last)
 	if failAt == 9 {
 		return true
 	}
@@ -634,7 +633,7 @@ func prepareClientCallException(protocol *MockTProtocol, failAt int, failWith er
 		err = failWith
 	}
 	//lint:ignore SA4006 to keep it consistent with other checks above
-	last = protocol.EXPECT().ReadMessageEnd(context.Background()).Return(err).After(last)
+	last = protocol.EXPECT().ReadMessageEnd(gomock.Any()).Return(err).After(last)
 	//lint:ignore S1008 to keep it consistent with other checks above
 	if failAt == 10 {
 		return true
@@ -719,16 +718,16 @@ func TestClientSeqIdMismatch(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testString", thrift.REPLY, int32(2), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testString", thrift.REPLY, int32(2), nil),
 	)
 
 	client := errortest.NewErrorTestClient(thrift.NewTStandardClient(protocol, protocol))
@@ -750,16 +749,16 @@ func TestClientSeqIdMismatchLegeacy(t *testing.T) {
 	transport := thrift.NewTMemoryBuffer()
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testString", thrift.REPLY, int32(2), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testString", thrift.REPLY, int32(2), nil),
 	)
 
 	client := errortest.NewErrorTestClientProtocol(transport, protocol, protocol)
@@ -779,16 +778,16 @@ func TestClientWrongMethodName(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("unknown", thrift.REPLY, int32(1), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("unknown", thrift.REPLY, int32(1), nil),
 	)
 
 	client := errortest.NewErrorTestClient(thrift.NewTStandardClient(protocol, protocol))
@@ -810,16 +809,16 @@ func TestClientWrongMethodNameLegacy(t *testing.T) {
 	transport := thrift.NewTMemoryBuffer()
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("unknown", thrift.REPLY, int32(1), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("unknown", thrift.REPLY, int32(1), nil),
 	)
 
 	client := errortest.NewErrorTestClientProtocol(transport, protocol, protocol)
@@ -839,16 +838,16 @@ func TestClientWrongMessageType(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testString", thrift.INVALID_TMESSAGE_TYPE, int32(1), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testString", thrift.INVALID_TMESSAGE_TYPE, int32(1), nil),
 	)
 
 	client := errortest.NewErrorTestClient(thrift.NewTStandardClient(protocol, protocol))
@@ -870,16 +869,16 @@ func TestClientWrongMessageTypeLegacy(t *testing.T) {
 	transport := thrift.NewTMemoryBuffer()
 	protocol := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		protocol.EXPECT().WriteMessageBegin(context.Background(), "testString", thrift.CALL, int32(1)),
-		protocol.EXPECT().WriteStructBegin(context.Background(), "testString_args"),
-		protocol.EXPECT().WriteFieldBegin(context.Background(), "s", thrift.TType(thrift.STRING), int16(1)),
-		protocol.EXPECT().WriteString(context.Background(), "test"),
-		protocol.EXPECT().WriteFieldEnd(context.Background()),
-		protocol.EXPECT().WriteFieldStop(context.Background()),
-		protocol.EXPECT().WriteStructEnd(context.Background()),
-		protocol.EXPECT().WriteMessageEnd(context.Background()),
-		protocol.EXPECT().Flush(context.Background()),
-		protocol.EXPECT().ReadMessageBegin(context.Background()).Return("testString", thrift.INVALID_TMESSAGE_TYPE, int32(1), nil),
+		protocol.EXPECT().WriteMessageBegin(gomock.Any(), "testString", thrift.CALL, int32(1)),
+		protocol.EXPECT().WriteStructBegin(gomock.Any(), "testString_args"),
+		protocol.EXPECT().WriteFieldBegin(gomock.Any(), "s", thrift.TType(thrift.STRING), int16(1)),
+		protocol.EXPECT().WriteString(gomock.Any(), "test"),
+		protocol.EXPECT().WriteFieldEnd(gomock.Any()),
+		protocol.EXPECT().WriteFieldStop(gomock.Any()),
+		protocol.EXPECT().WriteStructEnd(gomock.Any()),
+		protocol.EXPECT().WriteMessageEnd(gomock.Any()),
+		protocol.EXPECT().Flush(gomock.Any()),
+		protocol.EXPECT().ReadMessageBegin(gomock.Any()).Return("testString", thrift.INVALID_TMESSAGE_TYPE, int32(1), nil),
 	)
 
 	client := errortest.NewErrorTestClientProtocol(transport, protocol, protocol)

--- a/lib/go/test/tests/optional_fields_test.go
+++ b/lib/go/test/tests/optional_fields_test.go
@@ -188,9 +188,9 @@ func TestNoOptionalUnsetFieldsOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.Write(context.Background(), proto)
@@ -201,9 +201,9 @@ func TestNoSetToDefaultFieldsOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.I = 42
@@ -216,12 +216,12 @@ func TestOneISetFieldOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldBegin(context.Background(), "i", thrift.TType(thrift.I64), int16(2)).Return(nil),
-		proto.EXPECT().WriteI64(context.Background(), int64(123)).Return(nil),
-		proto.EXPECT().WriteFieldEnd(context.Background()).Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldBegin(gomock.Any(), "i", thrift.TType(thrift.I64), int16(2)).Return(nil),
+		proto.EXPECT().WriteI64(gomock.Any(), int64(123)).Return(nil),
+		proto.EXPECT().WriteFieldEnd(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.I = 123
@@ -233,15 +233,15 @@ func TestOneLSetFieldOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldBegin(context.Background(), "l", thrift.TType(thrift.LIST), int16(9)).Return(nil),
-		proto.EXPECT().WriteListBegin(context.Background(), thrift.TType(thrift.I64), 2).Return(nil),
-		proto.EXPECT().WriteI64(context.Background(), int64(1)).Return(nil),
-		proto.EXPECT().WriteI64(context.Background(), int64(2)).Return(nil),
-		proto.EXPECT().WriteListEnd(context.Background()).Return(nil),
-		proto.EXPECT().WriteFieldEnd(context.Background()).Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldBegin(gomock.Any(), "l", thrift.TType(thrift.LIST), int16(9)).Return(nil),
+		proto.EXPECT().WriteListBegin(gomock.Any(), thrift.TType(thrift.I64), 2).Return(nil),
+		proto.EXPECT().WriteI64(gomock.Any(), int64(1)).Return(nil),
+		proto.EXPECT().WriteI64(gomock.Any(), int64(2)).Return(nil),
+		proto.EXPECT().WriteListEnd(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteFieldEnd(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.L = []int64{1, 2}
@@ -253,12 +253,12 @@ func TestOneBinSetFieldOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldBegin(context.Background(), "bin", thrift.TType(thrift.STRING), int16(13)).Return(nil),
-		proto.EXPECT().WriteBinary(context.Background(), []byte("somebytestring")).Return(nil),
-		proto.EXPECT().WriteFieldEnd(context.Background()).Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldBegin(gomock.Any(), "bin", thrift.TType(thrift.STRING), int16(13)).Return(nil),
+		proto.EXPECT().WriteBinary(gomock.Any(), []byte("somebytestring")).Return(nil),
+		proto.EXPECT().WriteFieldEnd(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.Bin = []byte("somebytestring")
@@ -270,12 +270,12 @@ func TestOneEmptyBinSetFieldOnWire(t *testing.T) {
 	defer mockCtrl.Finish()
 	proto := NewMockTProtocol(mockCtrl)
 	gomock.InOrder(
-		proto.EXPECT().WriteStructBegin(context.Background(), "all_optional").Return(nil),
-		proto.EXPECT().WriteFieldBegin(context.Background(), "bin", thrift.TType(thrift.STRING), int16(13)).Return(nil),
-		proto.EXPECT().WriteBinary(context.Background(), []byte{}).Return(nil),
-		proto.EXPECT().WriteFieldEnd(context.Background()).Return(nil),
-		proto.EXPECT().WriteFieldStop(context.Background()).Return(nil),
-		proto.EXPECT().WriteStructEnd(context.Background()).Return(nil),
+		proto.EXPECT().WriteStructBegin(gomock.Any(), "all_optional").Return(nil),
+		proto.EXPECT().WriteFieldBegin(gomock.Any(), "bin", thrift.TType(thrift.STRING), int16(13)).Return(nil),
+		proto.EXPECT().WriteBinary(gomock.Any(), []byte{}).Return(nil),
+		proto.EXPECT().WriteFieldEnd(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteFieldStop(gomock.Any()).Return(nil),
+		proto.EXPECT().WriteStructEnd(gomock.Any()).Return(nil),
 	)
 	ao := optionalfieldstest.NewAllOptional()
 	ao.Bin = []byte{}

--- a/lib/go/test/tests/recursion_depth_test.go
+++ b/lib/go/test/tests/recursion_depth_test.go
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests
+
+// These tests exercise the recursion-depth limit through the *generated* struct
+// read/write path (RecTree.Read / RecTree.Write) -- the real path a hostile
+// payload would hit -- rather than the depth counter (CheckRecursionDepth) in
+// isolation. The whole point of the fix is that the generator threads the
+// per-context tracker into every nested .Read/.Write call, so only a round-trip
+// over generated code actually proves it.
+//
+// RecTree comes from test/Recursive.thrift. A linear chain of nested RecTree
+// structs adds exactly one struct level per node, so a chain of N nodes reaches
+// recursion depth N. The limit is thrift.DEFAULT_RECURSION_DEPTH.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/test/gopath/src/recursive"
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+var recursionProtocols = []struct {
+	name string
+	make func(thrift.TTransport) thrift.TProtocol
+}{
+	{"binary", func(t thrift.TTransport) thrift.TProtocol { return thrift.NewTBinaryProtocolConf(t, nil) }},
+	{"compact", func(t thrift.TTransport) thrift.TProtocol { return thrift.NewTCompactProtocolConf(t, nil) }},
+	{"json", func(t thrift.TTransport) thrift.TProtocol { return thrift.NewTJSONProtocol(t) }},
+}
+
+// buildChain returns a linearly nested RecTree that is depth struct levels deep.
+func buildChain(depth int) *recursive.RecTree {
+	node := &recursive.RecTree{Item: int16(depth)}
+	if depth > 1 {
+		node.Children = []*recursive.RecTree{buildChain(depth - 1)}
+	}
+	return node
+}
+
+// chainDepth counts the struct nesting depth of a linear RecTree chain.
+func chainDepth(t *recursive.RecTree) int {
+	n := 0
+	for t != nil {
+		n++
+		if len(t.Children) == 0 {
+			break
+		}
+		t = t.Children[0]
+	}
+	return n
+}
+
+// writeRawChain emits, via raw protocol calls (which carry no depth guard), the
+// wire image of a RecTree chain depth levels deep. This lets the read test feed
+// an over-limit payload that the guarded writer would itself refuse to produce.
+func writeRawChain(ctx context.Context, oprot thrift.TProtocol, depth int) error {
+	if err := oprot.WriteStructBegin(ctx, "RecTree"); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldBegin(ctx, "children", thrift.LIST, 1); err != nil {
+		return err
+	}
+	if depth > 1 {
+		if err := oprot.WriteListBegin(ctx, thrift.STRUCT, 1); err != nil {
+			return err
+		}
+		if err := writeRawChain(ctx, oprot, depth-1); err != nil {
+			return err
+		}
+	} else {
+		if err := oprot.WriteListBegin(ctx, thrift.STRUCT, 0); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteListEnd(ctx); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldBegin(ctx, "item", thrift.I16, 2); err != nil {
+		return err
+	}
+	if err := oprot.WriteI16(ctx, int16(depth)); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return err
+	}
+	return oprot.WriteStructEnd(ctx)
+}
+
+func isDepthLimit(err error) bool {
+	var pe thrift.TProtocolException
+	return errors.As(err, &pe) && pe.TypeId() == thrift.DEPTH_LIMIT
+}
+
+// A chain exactly at the limit must round-trip cleanly through generated
+// Write and Read (off-by-one guard, and proof the counter unwinds on the way
+// back out so the read does not inherit the writer's depth).
+func TestRecursionDepthRoundTripAtLimit(t *testing.T) {
+	ctx := context.Background()
+	limit := thrift.DEFAULT_RECURSION_DEPTH
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			wp := proto.make(trans)
+			if err := buildChain(limit).Write(ctx, wp); err != nil {
+				t.Fatalf("write at limit (%d) failed: %v", limit, err)
+			}
+			if err := wp.Flush(ctx); err != nil {
+				t.Fatalf("flush failed: %v", err)
+			}
+			out := &recursive.RecTree{}
+			if err := out.Read(ctx, proto.make(trans)); err != nil {
+				t.Fatalf("read at limit (%d) failed: %v", limit, err)
+			}
+			if got := chainDepth(out); got != limit {
+				t.Fatalf("round-trip depth mismatch: got %d, want %d", got, limit)
+			}
+		})
+	}
+}
+
+// Writing a chain one level over the limit must be rejected with DEPTH_LIMIT.
+func TestRecursionDepthWriteOverLimit(t *testing.T) {
+	ctx := context.Background()
+	limit := thrift.DEFAULT_RECURSION_DEPTH
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			p := proto.make(trans)
+			err := buildChain(limit+1).Write(ctx, p)
+			if !isDepthLimit(err) {
+				t.Fatalf("write over limit (%d): want DEPTH_LIMIT, got %v", limit+1, err)
+			}
+		})
+	}
+}
+
+// Reading a payload one level over the limit must be rejected with DEPTH_LIMIT.
+// The payload is hand-serialized so the over-limit bytes exist on the wire,
+// mimicking a hostile message from the network.
+func TestRecursionDepthReadOverLimit(t *testing.T) {
+	ctx := context.Background()
+	limit := thrift.DEFAULT_RECURSION_DEPTH
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			wp := proto.make(trans)
+			if err := writeRawChain(ctx, wp, limit+1); err != nil {
+				t.Fatalf("crafting over-limit payload failed: %v", err)
+			}
+			if err := wp.Flush(ctx); err != nil {
+				t.Fatalf("flush failed: %v", err)
+			}
+			err := (&recursive.RecTree{}).Read(ctx, proto.make(trans))
+			if !isDepthLimit(err) {
+				t.Fatalf("read over limit (%d): want DEPTH_LIMIT, got %v", limit+1, err)
+			}
+		})
+	}
+}
+
+// A wide but shallow tree whose total number of struct read/writes far exceeds
+// the limit must still round-trip. This only holds if the depth counter is
+// decremented for every sibling, i.e. it tracks nesting depth, not a running
+// total of structs seen.
+func TestRecursionDepthWideStructureRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	width := thrift.DEFAULT_RECURSION_DEPTH * 3
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			root := &recursive.RecTree{Item: 0, Children: make([]*recursive.RecTree, 0, width)}
+			for i := 0; i < width; i++ {
+				root.Children = append(root.Children, &recursive.RecTree{Item: int16(i)})
+			}
+			trans := thrift.NewTMemoryBuffer()
+			wp := proto.make(trans)
+			if err := root.Write(ctx, wp); err != nil {
+				t.Fatalf("write wide structure failed: %v", err)
+			}
+			if err := wp.Flush(ctx); err != nil {
+				t.Fatalf("flush failed: %v", err)
+			}
+			out := &recursive.RecTree{}
+			if err := out.Read(ctx, proto.make(trans)); err != nil {
+				t.Fatalf("read wide structure failed: %v", err)
+			}
+			if len(out.Children) != width {
+				t.Fatalf("wide structure child count mismatch: got %d, want %d", len(out.Children), width)
+			}
+		})
+	}
+}
+
+// The same bound must apply to recursive exceptions. CoError <-> CoError2 (from
+// test/Recursive.thrift) form a mutually recursive exception chain through the
+// "other" field (id 1, type STRUCT). Exceptions are read/written through the
+// same generated path as structs, so the guard reaches them too.
+//
+// Unlike the list-based RecTree, the chain terminates in a struct-typed field,
+// and Go serializes a non-optional struct field even when nil, so a built chain
+// of N nodes writes one level deeper than N. These tests therefore use generous
+// depth margins rather than the exact limit boundary (which the struct cases
+// above already pin): within-limit exceptions must round-trip, over-limit ones
+// must be rejected in both directions.
+
+// buildErrorChain returns a CoError/CoError2 chain that is depth nodes deep.
+func buildErrorChain(depth int) *recursive.CoError {
+	if depth <= 1 {
+		return &recursive.CoError{}
+	}
+	return &recursive.CoError{Other: buildError2Chain(depth - 1)}
+}
+
+func buildError2Chain(depth int) *recursive.CoError2 {
+	if depth <= 1 {
+		return &recursive.CoError2{}
+	}
+	return &recursive.CoError2{Other: buildErrorChain(depth - 1)}
+}
+
+// writeRawErrorChain emits, via raw protocol calls (no depth guard), the wire
+// image of a CoError chain depth levels deep, using the real recursive field
+// (id 1, type STRUCT) so the reader recurses through the guarded generated Read
+// rather than Skip.
+func writeRawErrorChain(ctx context.Context, oprot thrift.TProtocol, depth int) error {
+	if err := oprot.WriteStructBegin(ctx, "CoError"); err != nil {
+		return err
+	}
+	if depth > 1 {
+		if err := oprot.WriteFieldBegin(ctx, "other", thrift.STRUCT, 1); err != nil {
+			return err
+		}
+		if err := writeRawErrorChain(ctx, oprot, depth-1); err != nil {
+			return err
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return err
+	}
+	return oprot.WriteStructEnd(ctx)
+}
+
+// A recursive exception comfortably within the limit must round-trip. The depth
+// (well above limit/2) also confirms the bound is the full limit, not a halved one.
+func TestRecursionDepthExceptionWithinLimitRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	depth := thrift.DEFAULT_RECURSION_DEPTH - 16
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			wp := proto.make(trans)
+			if err := buildErrorChain(depth).Write(ctx, wp); err != nil {
+				t.Fatalf("write exception within limit (%d) failed: %v", depth, err)
+			}
+			if err := wp.Flush(ctx); err != nil {
+				t.Fatalf("flush failed: %v", err)
+			}
+			out := &recursive.CoError{}
+			if err := out.Read(ctx, proto.make(trans)); err != nil {
+				t.Fatalf("read exception within limit (%d) failed: %v", depth, err)
+			}
+			if out.Other == nil {
+				t.Fatalf("round-trip lost the nested exception chain")
+			}
+		})
+	}
+}
+
+func TestRecursionDepthExceptionWriteOverLimit(t *testing.T) {
+	ctx := context.Background()
+	depth := thrift.DEFAULT_RECURSION_DEPTH * 2
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			p := proto.make(trans)
+			err := buildErrorChain(depth).Write(ctx, p)
+			if !isDepthLimit(err) {
+				t.Fatalf("write exception over limit (%d): want DEPTH_LIMIT, got %v", depth, err)
+			}
+		})
+	}
+}
+
+func TestRecursionDepthExceptionReadOverLimit(t *testing.T) {
+	ctx := context.Background()
+	depth := thrift.DEFAULT_RECURSION_DEPTH * 2
+	for _, proto := range recursionProtocols {
+		t.Run(proto.name, func(t *testing.T) {
+			trans := thrift.NewTMemoryBuffer()
+			wp := proto.make(trans)
+			if err := writeRawErrorChain(ctx, wp, depth); err != nil {
+				t.Fatalf("crafting over-limit exception payload failed: %v", err)
+			}
+			if err := wp.Flush(ctx); err != nil {
+				t.Fatalf("flush failed: %v", err)
+			}
+			err := (&recursive.CoError{}).Read(ctx, proto.make(trans))
+			if !isDepthLimit(err) {
+				t.Fatalf("read exception over limit (%d): want DEPTH_LIMIT, got %v", depth, err)
+			}
+		})
+	}
+}

--- a/lib/go/test/tests/required_fields_test.go
+++ b/lib/go/test/tests/required_fields_test.go
@@ -68,9 +68,9 @@ func TestStructReadRequiredFields(t *testing.T) {
 
 	// None of required fields are set
 	gomock.InOrder(
-		protocol.EXPECT().ReadStructBegin(context.Background()).Return("StructC", nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
-		protocol.EXPECT().ReadStructEnd(context.Background()).Return(nil),
+		protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("StructC", nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
+		protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(nil),
 	)
 
 	err := testStruct.Read(context.Background(), protocol)
@@ -89,12 +89,12 @@ func TestStructReadRequiredFields(t *testing.T) {
 
 	// One of the required fields is set
 	gomock.InOrder(
-		protocol.EXPECT().ReadStructBegin(context.Background()).Return("StructC", nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("I", thrift.TType(thrift.I32), int16(2), nil),
-		protocol.EXPECT().ReadI32(context.Background()).Return(int32(1), nil),
-		protocol.EXPECT().ReadFieldEnd(context.Background()).Return(nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
-		protocol.EXPECT().ReadStructEnd(context.Background()).Return(nil),
+		protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("StructC", nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("I", thrift.TType(thrift.I32), int16(2), nil),
+		protocol.EXPECT().ReadI32(gomock.Any()).Return(int32(1), nil),
+		protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
+		protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(nil),
 	)
 
 	err = testStruct.Read(context.Background(), protocol)
@@ -113,15 +113,15 @@ func TestStructReadRequiredFields(t *testing.T) {
 
 	// Both of the required fields are set
 	gomock.InOrder(
-		protocol.EXPECT().ReadStructBegin(context.Background()).Return("StructC", nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("i", thrift.TType(thrift.I32), int16(2), nil),
-		protocol.EXPECT().ReadI32(context.Background()).Return(int32(1), nil),
-		protocol.EXPECT().ReadFieldEnd(context.Background()).Return(nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("s2", thrift.TType(thrift.STRING), int16(4), nil),
-		protocol.EXPECT().ReadString(context.Background()).Return("test", nil),
-		protocol.EXPECT().ReadFieldEnd(context.Background()).Return(nil),
-		protocol.EXPECT().ReadFieldBegin(context.Background()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
-		protocol.EXPECT().ReadStructEnd(context.Background()).Return(nil),
+		protocol.EXPECT().ReadStructBegin(gomock.Any()).Return("StructC", nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("i", thrift.TType(thrift.I32), int16(2), nil),
+		protocol.EXPECT().ReadI32(gomock.Any()).Return(int32(1), nil),
+		protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("s2", thrift.TType(thrift.STRING), int16(4), nil),
+		protocol.EXPECT().ReadString(gomock.Any()).Return("test", nil),
+		protocol.EXPECT().ReadFieldEnd(gomock.Any()).Return(nil),
+		protocol.EXPECT().ReadFieldBegin(gomock.Any()).Return("_", thrift.TType(thrift.STOP), int16(1), nil),
+		protocol.EXPECT().ReadStructEnd(gomock.Any()).Return(nil),
 	)
 
 	err = testStruct.Read(context.Background(), protocol)

--- a/lib/go/thrift/recursion_tracker.go
+++ b/lib/go/thrift/recursion_tracker.go
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"context"
+	"errors"
+)
+
+type recursionDepthKey struct{}
+
+type recursionDepthTracker struct {
+	depth int
+	limit int
+}
+
+// CheckRecursionDepth increments the per-context struct nesting depth and
+// returns an error when it exceeds DEFAULT_RECURSION_DEPTH.  The returned
+// context must be passed to DecrementRecursionDepth when the struct is done
+// being read or written.
+func CheckRecursionDepth(ctx context.Context) (context.Context, error) {
+	tracker, _ := ctx.Value(recursionDepthKey{}).(*recursionDepthTracker)
+	if tracker == nil {
+		tracker = &recursionDepthTracker{limit: DEFAULT_RECURSION_DEPTH}
+		ctx = context.WithValue(ctx, recursionDepthKey{}, tracker)
+	}
+	tracker.depth++
+	if tracker.depth > tracker.limit {
+		tracker.depth--
+		return ctx, NewTProtocolExceptionWithType(DEPTH_LIMIT, errors.New("maximum recursion depth exceeded"))
+	}
+	return ctx, nil
+}
+
+// DecrementRecursionDepth decrements the per-context struct nesting depth.
+// It must be called after CheckRecursionDepth returns nil, typically via defer.
+func DecrementRecursionDepth(ctx context.Context) {
+	if tracker, ok := ctx.Value(recursionDepthKey{}).(*recursionDepthTracker); ok && tracker != nil {
+		tracker.depth--
+	}
+}


### PR DESCRIPTION
## THRIFT-6044: Limit struct read/write recursion depth in the Go library

### Change
The Go generator wraps every generated struct `Read`/`Write` with a per-context recursion-depth tracker (`thrift.CheckRecursionDepth` / `DecrementRecursionDepth`), returning `TProtocolException(DEPTH_LIMIT)` once nesting exceeds `DEFAULT_RECURSION_DEPTH` (64). Previously only `Skip()` was bounded, so a deeply nested struct was read or written without limit. **Unions and exceptions are generated through the same `Read`/`Write` path, so they are bounded too.**

### Test
Replaces the isolated tracker unit test with a generated-code round-trip in `lib/go/test` over `test/Recursive.thrift`, across Binary, Compact and JSON:
- **struct `RecTree`** — a chain at the limit round-trips; a chain one level over is rejected on both write and read (the read payload is hand-serialized so the over-limit bytes exist on the wire, using the real recursive field so the reader recurses through the guarded `Read`, not `Skip`); a wide shallow tree still round-trips (the counter unwinds per sibling).
- **exception `CoError`/`CoError2`** — a chain within the limit round-trips; over-limit chains are rejected on both write and read. These use generous depth margins rather than the exact boundary, because a non-optional recursive struct field serializes one trailing (empty) level unlike the list-based `RecTree`; the struct cases above already pin the exact limit.

`Recursive.thrift` is wired into the `lib/go/test` gopath generation.

### Notes for committer review
- The limit is hardcoded at `DEFAULT_RECURSION_DEPTH` (64); it is not yet configurable via `TConfiguration` (Go's `TProtocol` is a public interface with several implementations and no shared base, so a per-protocol counter would be a breaking change — the context-based tracker avoids that).
- Because the generated `Read`/`Write` now derive a child context for depth tracking, the protocol calls they make no longer receive the caller's exact context object. The gomock matchers in `client_error_test.go`, `optional_fields_test.go` and `required_fields_test.go` that asserted `context.Background()` are relaxed to `gomock.Any()` (sequence, argument types and values are still asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)