### PR TITLE
THRIFT-6046: Limit struct read/write recursion depth in JavaScript library

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -1142,6 +1142,10 @@ void t_js_generator::generate_js_struct_reader(ostream& out, t_struct* tstruct) 
 
   indent_up();
 
+  indent(out) << "input.incrementRecursionDepth();" << '\n';
+  indent(out) << "try {" << '\n';
+  indent_up();
+
   indent(out) << "input.readStructBegin();" << '\n';
 
   // Loop over reading in fields
@@ -1204,6 +1208,13 @@ void t_js_generator::generate_js_struct_reader(ostream& out, t_struct* tstruct) 
 
   indent(out) << "input.readStructEnd();" << '\n';
 
+  indent_down();
+  indent(out) << "} finally {" << '\n';
+  indent_up();
+  indent(out) << "input.decrementRecursionDepth();" << '\n';
+  indent_down();
+  indent(out) << "}" << '\n';
+
   indent(out) << "return;" << '\n';
 
   indent_down();
@@ -1232,6 +1243,10 @@ void t_js_generator::generate_js_struct_writer(ostream& out, t_struct* tstruct) 
 
   indent_up();
 
+  indent(out) << "output.incrementRecursionDepth();" << '\n';
+  indent(out) << "try {" << '\n';
+  indent_up();
+
   indent(out) << "output.writeStructBegin('" << name << "');" << '\n';
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
@@ -1254,6 +1269,13 @@ void t_js_generator::generate_js_struct_writer(ostream& out, t_struct* tstruct) 
 
   out << indent() << "output.writeFieldStop();" << '\n' << indent() << "output.writeStructEnd();"
       << '\n';
+
+  indent_down();
+  out << indent() << "} finally {" << '\n';
+  indent_up();
+  out << indent() << "output.decrementRecursionDepth();" << '\n';
+  indent_down();
+  out << indent() << "}" << '\n';
 
   out << indent() << "return;" << '\n';
 

--- a/lib/js/Gruntfile.js
+++ b/lib/js/Gruntfile.js
@@ -85,6 +85,10 @@ module.exports = function (grunt) {
         command:
           "../../compiler/cpp/thrift -gen js -o test ../../test/JsDeepConstructorTest.thrift",
       },
+      ThriftGenRecursionDepth: {
+        command:
+          "../../compiler/cpp/thrift -gen js -o test ../../test/JsRecursionDepthTest.thrift",
+      },
       ThriftBrowserifyNodeInt64: {
         command: [
           "./node_modules/browserify/bin/cmd.js ./node_modules/node-int64/Int64.js -s Int64 -o test/build/js/lib/Int64.js",
@@ -312,6 +316,7 @@ module.exports = function (grunt) {
     "shell:InstallThriftNodeJSDep",
     "shell:ThriftGen",
     "shell:ThriftGenDeepConstructor",
+    "shell:ThriftGenRecursionDepth",
     "shell:ThriftGenDoubleConstants",
     "shell:InstallTestLibs",
     "shell:ThriftBrowserifyNodeInt64",

--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -282,6 +282,8 @@ Thrift.TProtocolExceptionType = {
     DEPTH_LIMIT: 6
 };
 
+Thrift.DEFAULT_RECURSION_DEPTH = 64;
+
 Thrift.TProtocolException = function TProtocolException(type, message) {
     Error.call(this);
     if (Error.captureStackTrace !== undefined) {
@@ -737,6 +739,7 @@ Thrift.TJSONProtocol = Thrift.Protocol = function(transport) {
     this.tstack = [];
     this.tpos = [];
     this.transport = transport;
+    this._recursion_depth = 0;
 };
 
 /**
@@ -1515,6 +1518,21 @@ Thrift.Protocol.prototype = {
                 throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.INVALID_DATA);
         }
     }
+};
+
+Thrift.Protocol.prototype.incrementRecursionDepth = function() {
+    this._recursion_depth += 1;
+    if (this._recursion_depth > Thrift.DEFAULT_RECURSION_DEPTH) {
+        this._recursion_depth -= 1;
+        throw new Thrift.TProtocolException(
+            Thrift.TProtocolExceptionType.DEPTH_LIMIT,
+            'Maximum recursion depth exceeded'
+        );
+    }
+};
+
+Thrift.Protocol.prototype.decrementRecursionDepth = function() {
+    this._recursion_depth -= 1;
 };
 
 

--- a/lib/js/test/test-skip-depth.html
+++ b/lib/js/test/test-skip-depth.html
@@ -25,6 +25,9 @@
   <script src="build/js/lib/JSONInt64.js" type="text/javascript" charset="utf-8"></script>
   <script src="build/js/thrift.js"         type="text/javascript" charset="utf-8"></script>
 
+  <!-- Generated recursive types exercised by the round-trip tests -->
+  <script src="gen-js/JsRecursionDepthTest_types.js" type="text/javascript" charset="utf-8"></script>
+
   <!-- QUnit Test framework-->
   <script type="text/javascript" src="build/js/lib/qunit.js" charset="utf-8"></script>
   <link rel="stylesheet" href="build/js/lib/qunit.css" type="text/css" media="screen" />

--- a/lib/js/test/test-skip-depth.js
+++ b/lib/js/test/test-skip-depth.js
@@ -43,3 +43,93 @@ QUnit.test('skip does not throw below the depth limit', function(assert) {
     assert.ok(protocol.skip(Thrift.Type.I32, 63) !== undefined || true,
         'skip at depth 63 does not throw');
 });
+
+// Round-trip the recursion-depth limit through the generated read/write code
+// (RecTree struct, RecUnion union and RecError exception from
+// JsRecursionDepthTest.thrift) rather than exercising the protocol counter in
+// isolation.
+QUnit.module('Protocol recursion depth limit');
+
+(function() {
+    var LIMIT = Thrift.DEFAULT_RECURSION_DEPTH;
+    var DEPTH_LIMIT = Thrift.TProtocolExceptionType.DEPTH_LIMIT;
+    var WRITE = Symbol.for('write');
+    var READ = Symbol.for('read');
+
+    // Build a linear chain "depth" levels deep. A union needs exactly one field
+    // set, so inner nodes set "children" and the innermost one sets its leaf.
+    function makeChain(Type, depth, leafField) {
+        var leafArgs = {};
+        leafArgs[leafField] = 1;
+        var node = new Type(leafArgs);
+        for (var i = 1; i < depth; i++) {
+            node = new Type({children: [node]});
+        }
+        return node;
+    }
+
+    function chainDepth(node) {
+        var d = 0;
+        while (node) {
+            d++;
+            node = (node.children && node.children.length) ? node.children[0] : null;
+        }
+        return d;
+    }
+
+    // Serialize through the generated writer. When "unbounded" is set the guard
+    // is neutralised on this protocol instance only, so we can craft an
+    // over-limit payload and feed it back into a fresh (bounded) reader.
+    function serialize(obj, unbounded) {
+        var transport = new Thrift.Transport('/service');
+        var protocol = new Thrift.Protocol(transport);
+        if (unbounded) {
+            protocol.incrementRecursionDepth = function() {};
+            protocol.decrementRecursionDepth = function() {};
+        }
+        protocol.writeMessageBegin('', 0, 0);
+        obj[WRITE](protocol);
+        protocol.writeMessageEnd();
+        return transport.send_buf;
+    }
+
+    function deserialize(serialized, Type) {
+        var transport = new Thrift.Transport('/service');
+        transport.setRecvBuffer(serialized);
+        var protocol = new Thrift.Protocol(transport);
+        protocol.readMessageBegin();
+        var obj = new Type();
+        obj[READ](protocol);
+        protocol.readMessageEnd();
+        return obj;
+    }
+
+    function isDepthLimit(e) {
+        return e instanceof Thrift.TProtocolException && e.type === DEPTH_LIMIT;
+    }
+
+    [['RecTree', RecTree, 'item'], ['RecUnion', RecUnion, 'leaf'], ['RecError', RecError, 'leaf']].forEach(function(tc) {
+        var tname = tc[0], Type = tc[1], leafField = tc[2];
+
+        QUnit.test(tname + ' round-trips a chain at the depth limit', function(assert) {
+            var decoded = deserialize(serialize(makeChain(Type, LIMIT, leafField)), Type);
+            assert.equal(chainDepth(decoded), LIMIT,
+                'decoded chain has the same depth as the original');
+        });
+
+        QUnit.test(tname + ' writing past the depth limit throws DEPTH_LIMIT', function(assert) {
+            assert.throws(
+                function() { serialize(makeChain(Type, LIMIT + 5, leafField)); },
+                isDepthLimit,
+                'write throws TProtocolException with DEPTH_LIMIT');
+        });
+
+        QUnit.test(tname + ' reading past the depth limit throws DEPTH_LIMIT', function(assert) {
+            var serialized = serialize(makeChain(Type, LIMIT + 5, leafField), true);
+            assert.throws(
+                function() { deserialize(serialized, Type); },
+                isDepthLimit,
+                'read throws TProtocolException with DEPTH_LIMIT');
+        });
+    });
+})();

--- a/lib/nodejs/lib/thrift/binary_protocol.js
+++ b/lib/nodejs/lib/thrift/binary_protocol.js
@@ -44,6 +44,7 @@ function TBinaryProtocol(trans, strictRead, strictWrite) {
   this.strictRead = strictRead !== undefined ? strictRead : false;
   this.strictWrite = strictWrite !== undefined ? strictWrite : true;
   this._seqid = null;
+  this._recursion_depth = 0;
 }
 
 TBinaryProtocol.prototype.flush = function () {
@@ -387,4 +388,19 @@ TBinaryProtocol.prototype.skip = function (type, depth) {
     default:
       throw new Error("Invalid type: " + type);
   }
+};
+
+TBinaryProtocol.prototype.incrementRecursionDepth = function () {
+  this._recursion_depth += 1;
+  if (this._recursion_depth > Thrift.DEFAULT_RECURSION_DEPTH) {
+    this._recursion_depth -= 1;
+    throw new Thrift.TProtocolException(
+      Thrift.TProtocolExceptionType.DEPTH_LIMIT,
+      "Maximum recursion depth exceeded"
+    );
+  }
+};
+
+TBinaryProtocol.prototype.decrementRecursionDepth = function () {
+  this._recursion_depth -= 1;
 };

--- a/lib/nodejs/lib/thrift/compact_protocol.js
+++ b/lib/nodejs/lib/thrift/compact_protocol.js
@@ -58,6 +58,7 @@ function TCompactProtocol(trans) {
     hasBoolValue: false,
     boolValue: false,
   };
+  this._recursion_depth = 0;
 }
 
 //
@@ -899,6 +900,21 @@ TCompactProtocol.prototype.zigzagToI64 = function (n) {
   hi = (hi >>> 1) ^ hi_neg;
   lo = ((lo >>> 1) | hi_lo) ^ lo_neg;
   return new Int64(hi, lo);
+};
+
+TCompactProtocol.prototype.incrementRecursionDepth = function () {
+  this._recursion_depth += 1;
+  if (this._recursion_depth > Thrift.DEFAULT_RECURSION_DEPTH) {
+    this._recursion_depth -= 1;
+    throw new Thrift.TProtocolException(
+      Thrift.TProtocolExceptionType.DEPTH_LIMIT,
+      "Maximum recursion depth exceeded"
+    );
+  }
+};
+
+TCompactProtocol.prototype.decrementRecursionDepth = function () {
+  this._recursion_depth -= 1;
 };
 
 TCompactProtocol.prototype.skip = function (type, depth) {

--- a/lib/nodejs/lib/thrift/header_protocol.js
+++ b/lib/nodejs/lib/thrift/header_protocol.js
@@ -180,6 +180,16 @@ THeaderProtocol.prototype.readStructEnd = function () {
   return this.protocol.readStructEnd();
 };
 
+// Recursion-depth tracking is delegated to the wrapped protocol so the
+// generated struct read/write code works through THeaderProtocol as well.
+THeaderProtocol.prototype.incrementRecursionDepth = function () {
+  return this.protocol.incrementRecursionDepth();
+};
+
+THeaderProtocol.prototype.decrementRecursionDepth = function () {
+  return this.protocol.decrementRecursionDepth();
+};
+
 THeaderProtocol.prototype.readFieldBegin = function () {
   return this.protocol.readFieldBegin();
 };

--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -43,6 +43,7 @@ function TJSONProtocol(trans) {
   this.tstack = [];
   this.tpos = [];
   this.trans = trans;
+  this._recursion_depth = 0;
 }
 
 /**
@@ -781,6 +782,21 @@ TJSONProtocol.prototype.getTransport = function () {
 /**
  * Method to arbitrarily skip over data
  */
+TJSONProtocol.prototype.incrementRecursionDepth = function () {
+  this._recursion_depth += 1;
+  if (this._recursion_depth > Thrift.DEFAULT_RECURSION_DEPTH) {
+    this._recursion_depth -= 1;
+    throw new Thrift.TProtocolException(
+      Thrift.TProtocolExceptionType.DEPTH_LIMIT,
+      "Maximum recursion depth exceeded"
+    );
+  }
+};
+
+TJSONProtocol.prototype.decrementRecursionDepth = function () {
+  this._recursion_depth -= 1;
+};
+
 TJSONProtocol.prototype.skip = function (type, depth) {
   depth = (depth || 0) + 1;
   if (depth > 64) {

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -150,6 +150,8 @@ var TProtocolExceptionType = (exports.TProtocolExceptionType = {
   DEPTH_LIMIT: 6,
 });
 
+exports.DEFAULT_RECURSION_DEPTH = 64;
+
 exports.TProtocolException = TProtocolException;
 
 function TProtocolException(type, message) {

--- a/lib/nodejs/test/recursion_depth.test.js
+++ b/lib/nodejs/test/recursion_depth.test.js
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Round-trip regression test for the struct/union/exception read/write
+// recursion-depth limit. Exercises the generated read/write code (not the
+// protocol methods in isolation) over a recursive struct (RecTree), union
+// (RecUnion) and exception (RecError) across every protocol that carries the
+// limit.
+
+const test = require("tape");
+const thrift = require("thrift");
+const THeaderTransport = require("thrift/lib/nodejs/lib/thrift/header_transport");
+const ttypes = require("./gen-nodejs/JsRecursionDepthTest_types");
+
+const RecTree = ttypes.RecTree;
+const RecUnion = ttypes.RecUnion;
+const RecError = ttypes.RecError;
+
+const WRITE = Symbol.for("write");
+const READ = Symbol.for("read");
+const LIMIT = thrift.Thrift.DEFAULT_RECURSION_DEPTH; // 64
+const DEPTH_LIMIT = thrift.Thrift.TProtocolExceptionType.DEPTH_LIMIT;
+
+// Build a linear chain "depth" levels deep. Reading or writing it drives the
+// generated code "depth" recursion levels deep. A union must have exactly one
+// field set, so every node but the innermost one sets "children" and the
+// innermost one sets its scalar leaf field.
+function makeChain(Type, depth) {
+  const leaf = new Type();
+  leaf[Type === RecTree ? "item" : "leaf"] = 1;
+  let node = leaf;
+  for (let i = 1; i < depth; i++) {
+    const parent = new Type();
+    parent.children = [node];
+    node = parent;
+  }
+  return node;
+}
+
+function chainDepth(node) {
+  let d = 0;
+  while (node) {
+    d++;
+    node = node.children && node.children.length ? node.children[0] : null;
+  }
+  return d;
+}
+
+function isJSON(ProtoCtor) {
+  return ProtoCtor === thrift.TJSONProtocol;
+}
+
+// Serialize through the generated writer. When "unbounded" is set the depth
+// guard is neutralised on this protocol instance only, so we can craft an
+// over-limit payload to feed back into a fresh (bounded) reader.
+function serialize(ProtoCtor, obj, unbounded) {
+  let buff;
+  const transport = new thrift.TBufferedTransport(null, function (msg) {
+    buff = msg;
+  });
+  const proto = new ProtoCtor(transport);
+  if (unbounded) {
+    proto.incrementRecursionDepth = function () {};
+    proto.decrementRecursionDepth = function () {};
+  }
+  if (isJSON(ProtoCtor)) {
+    proto.writeMessageBegin("", 0, 0);
+  }
+  obj[WRITE](proto);
+  if (isJSON(ProtoCtor)) {
+    proto.writeMessageEnd();
+  }
+  proto.flush();
+  return buff;
+}
+
+function deserialize(ProtoCtor, buff, Type) {
+  const transport = new thrift.TFramedTransport(buff);
+  const proto = new ProtoCtor(transport);
+  if (isJSON(ProtoCtor)) {
+    proto.readMessageBegin();
+  }
+  const obj = new Type();
+  obj[READ](proto);
+  if (isJSON(ProtoCtor)) {
+    proto.readMessageEnd();
+  }
+  return obj;
+}
+
+function depthLimitError(fn) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  return null;
+}
+
+const PROTOCOLS = {
+  TBinaryProtocol: thrift.TBinaryProtocol,
+  TCompactProtocol: thrift.TCompactProtocol,
+  TJSONProtocol: thrift.TJSONProtocol,
+};
+
+const TYPES = { RecTree: RecTree, RecUnion: RecUnion, RecError: RecError };
+
+Object.keys(PROTOCOLS).forEach(function (pname) {
+  const ProtoCtor = PROTOCOLS[pname];
+
+  Object.keys(TYPES).forEach(function (tname) {
+    const Type = TYPES[tname];
+
+    test(
+      pname + "/" + tname + ": round-trips a chain at the depth limit",
+      function (assert) {
+        const original = makeChain(Type, LIMIT);
+        const buff = serialize(ProtoCtor, original);
+        const decoded = deserialize(ProtoCtor, buff, Type);
+        assert.equal(
+          chainDepth(decoded),
+          LIMIT,
+          "decoded chain has the same depth as the original",
+        );
+        assert.end();
+      },
+    );
+
+    test(
+      pname + "/" + tname + ": writing past the depth limit throws DEPTH_LIMIT",
+      function (assert) {
+        const tooDeep = makeChain(Type, LIMIT + 5);
+        const err = depthLimitError(function () {
+          serialize(ProtoCtor, tooDeep);
+        });
+        assert.ok(
+          err instanceof thrift.Thrift.TProtocolException,
+          "write throws TProtocolException",
+        );
+        assert.equal(err && err.type, DEPTH_LIMIT, "error type is DEPTH_LIMIT");
+        assert.end();
+      },
+    );
+
+    test(
+      pname + "/" + tname + ": reading past the depth limit throws DEPTH_LIMIT",
+      function (assert) {
+        // Craft an over-limit payload with the guard neutralised, then read it
+        // back through a normal, bounded reader.
+        const tooDeep = makeChain(Type, LIMIT + 5);
+        const buff = serialize(ProtoCtor, tooDeep, true);
+        const err = depthLimitError(function () {
+          deserialize(ProtoCtor, buff, Type);
+        });
+        assert.ok(
+          err instanceof thrift.Thrift.TProtocolException,
+          "read throws TProtocolException",
+        );
+        assert.equal(err && err.type, DEPTH_LIMIT, "error type is DEPTH_LIMIT");
+        assert.end();
+      },
+    );
+  });
+});
+
+// THeaderProtocol forwards the generated struct calls (including the recursion
+// guard) to a wrapped TBinaryProtocol/TCompactProtocol. Without that
+// delegation the generated code crashes with "is not a function", so exercise
+// the generated writer straight through it.
+function newHeaderProtocol() {
+  const transport = new thrift.TFramedTransport();
+  transport.setProtocolId(THeaderTransport.SubprotocolId.BINARY);
+  return new thrift.THeaderProtocol(transport);
+}
+
+test("THeaderProtocol/RecTree: generated struct write within the limit works", function (assert) {
+  const proto = newHeaderProtocol();
+  const tree = makeChain(RecTree, LIMIT);
+  assert.doesNotThrow(function () {
+    tree[WRITE](proto);
+  }, "generated write through THeaderProtocol does not crash");
+  assert.end();
+});
+
+test("THeaderProtocol/RecTree: generated struct write past the limit throws DEPTH_LIMIT", function (assert) {
+  const proto = newHeaderProtocol();
+  const tooDeep = makeChain(RecTree, LIMIT + 5);
+  const err = depthLimitError(function () {
+    tooDeep[WRITE](proto);
+  });
+  assert.ok(
+    err instanceof thrift.Thrift.TProtocolException,
+    "write through THeaderProtocol throws TProtocolException",
+  );
+  assert.equal(err && err.type, DEPTH_LIMIT, "error type is DEPTH_LIMIT");
+  assert.end();
+});

--- a/lib/nodejs/test/testAll.sh
+++ b/lib/nodejs/test/testAll.sh
@@ -90,6 +90,7 @@ TESTOK=0
 
 ${THRIFT_COMPILER} -o ${DIR} --gen js:node ${THRIFT_FILES_DIR}/ThriftTest.thrift
 ${THRIFT_COMPILER} -o ${DIR} --gen js:node ${THRIFT_FILES_DIR}/JsDeepConstructorTest.thrift
+${THRIFT_COMPILER} -o ${DIR} --gen js:node ${THRIFT_FILES_DIR}/JsRecursionDepthTest.thrift
 ${THRIFT_COMPILER} -o ${DIR} --gen js:node ${THRIFT_FILES_DIR}/Int64Test.thrift
 ${THRIFT_COMPILER} -o ${DIR} --gen js:node ${THRIFT_FILES_DIR}/Include.thrift
 mkdir ${DIR}/gen-nodejs-es6
@@ -134,6 +135,7 @@ node ${DIR}/check_set_uniqueness.test.js || TESTOK=1
 node ${DIR}/header.test.js || TESTOK=1
 node ${DIR}/int64.test.js || TESTOK=1
 node ${DIR}/deep-constructor.test.js || TESTOK=1
+node ${DIR}/recursion_depth.test.js || TESTOK=1
 node ${DIR}/generated-exceptions.test.js || TESTOK=1
 node ${DIR}/include.test.mjs || TESTOK=1
 node ${DIR}/thrift_4987_xhr_protocol.test.mjs || TESTOK=1

--- a/test/JsRecursionDepthTest.thrift
+++ b/test/JsRecursionDepthTest.thrift
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Recursive types used to exercise the struct/union/exception read/write
+// recursion-depth limit in the JavaScript (node) library.
+
+struct RecTree {
+  1: list<RecTree> children
+  2: i16 item
+}
+
+union RecUnion {
+  1: list<RecUnion> children
+  2: i32 leaf
+}
+
+exception RecError {
+  1: list<RecError> children
+  2: i32 leaf
+}


### PR DESCRIPTION
## THRIFT-6046: Limit struct read/write recursion depth in the JavaScript library

### Change
The JS generator wraps each generated struct **and union** read/write body with `incrementRecursionDepth()` / `try` / `finally` / `decrementRecursionDepth()` (limit `DEFAULT_RECURSION_DEPTH` = 64, `TProtocolException.DEPTH_LIMIT` on excess), for both **lib/js** (browser) and **lib/nodejs**. Previously only `skip()` was bounded. **Exceptions** are generated through the same struct reader/writer, so they are bounded too. The nodejs `THeaderProtocol` delegating wrapper forwards `increment`/`decrement` so generated read/write through it is bounded as well.

### Test
Replaces the isolated counter tests with generated-code round-trips over a recursive struct (`RecTree`), union (`RecUnion`) and exception (`RecError`) from `JsRecursionDepthTest.thrift`:
- **nodejs** (`lib/nodejs/test/recursion_depth.test.js`, wired into `testAll.sh`) over Binary, Compact and JSON, plus a generated write through `THeaderProtocol`;
- **browser** (`lib/js/test/test-skip-depth.js`) over `Thrift.Protocol`.

For each kind: a chain at the limit round-trips; a chain past it is rejected with `DEPTH_LIMIT` on write; a payload crafted with the guard neutralised (so the over-limit bytes exist) is rejected on read — crafted with the real recursive field (id 1 = `list<self>`) so the reader recurses through the guarded path rather than `skip()`.

Validated in thrift:jammy: nodejs **48/48**; the browser exception path confirmed headless (DEPTH_LIMIT on over-limit write). Only `lib-nodejs` is CI-gated; the browser test has no CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)