### PR TITLE
THRIFT-6029: Replace deprecated willReturnOnConsecutiveCalls in TBinaryProtocol tests

### DIFF
--- a/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TBinaryProtocolTest.php
@@ -1166,11 +1166,16 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
-        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+        $readAllReturns = [
             pack('c', TType::I32),
             pack('c', TType::STRING),
-            pack('N', 0xffffffff)
-        );
+            pack('N', 0xffffffff),
+        ];
+        $transport->method('readAll')
+            ->willReturnCallback(function () use ($readAllReturns) {
+                static $iteration = 0;
+                return $readAllReturns[$iteration++];
+            });
 
         $this->expectException(TProtocolException::class);
         $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
@@ -1182,10 +1187,15 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
-        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+        $readAllReturns = [
             pack('c', TType::I32),
-            pack('N', 0xffffffff)
-        );
+            pack('N', 0xffffffff),
+        ];
+        $transport->method('readAll')
+            ->willReturnCallback(function () use ($readAllReturns) {
+                static $iteration = 0;
+                return $readAllReturns[$iteration++];
+            });
 
         $this->expectException(TProtocolException::class);
         $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
@@ -1197,10 +1207,15 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
-        $transport->method('readAll')->willReturnOnConsecutiveCalls(
+        $readAllReturns = [
             pack('c', TType::I32),
-            pack('N', 0xffffffff)
-        );
+            pack('N', 0xffffffff),
+        ];
+        $transport->method('readAll')
+            ->willReturnCallback(function () use ($readAllReturns) {
+                static $iteration = 0;
+                return $readAllReturns[$iteration++];
+            });
 
         $this->expectException(TProtocolException::class);
         $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);
@@ -1212,9 +1227,8 @@ class TBinaryProtocolTest extends TestCase
         $transport = $this->createMock(TTransport::class);
         $protocol = new TBinaryProtocol($transport, false, false);
 
-        $transport->method('readAll')->willReturnOnConsecutiveCalls(
-            pack('N', 0xffffffff)
-        );
+        $transport->method('readAll')
+            ->willReturn(pack('N', 0xffffffff));
 
         $this->expectException(TProtocolException::class);
         $this->expectExceptionCode(TProtocolException::NEGATIVE_SIZE);


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Follow-up to #3535 (THRIFT-6029, merged in `32369120a`).

`willReturnOnConsecutiveCalls` was used in the 4 new negative-size tests in `TBinaryProtocolTest`. That PHPUnit API was deprecated in 10.3 and removed in 12.x. Since `composer.json` declares `phpunit/phpunit: ^10.5 || ^11.0 || ^12.0 || ^13.0`, the suite would break on 12+.

Switches the 4 tests to the `willReturnCallback` + static iteration counter pattern that is already used throughout the rest of `TBinaryProtocolTest`. `testReadStringRejectsNegativeSize` only needs a single return, so it uses plain `willReturn`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? — reuses [THRIFT-6029](https://issues.apache.org/jira/browse/THRIFT-6029) since the regression was introduced by that ticket's tests.
- [x] Did your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?