### PR TITLE
Add cpp.ref (&) to the recursive exception in Recursive.thrift (fix lib-cpp)

### DIFF
--- a/test/Recursive.thrift
+++ b/test/Recursive.thrift
@@ -44,7 +44,7 @@ union CoUnion2 {
 }
 
 exception CoError {
-  1: CoError2 other
+  1: CoError2 & other
 }
 
 exception CoError2 {


### PR DESCRIPTION
The recursive exception `CoError`/`CoError2` in `test/Recursive.thrift` recurse by value with no reference annotation, so the C++ generator emits a by-value member of an incomplete type and `lib/cpp/test` fails to compile:

    gen-cpp/Recursive_types.h: error: field 'other' has incomplete type 'CoError2'

This breaks `lib-cpp` on master (and on every PR based on it). The fix mirrors the recursive struct `CoRec` (`1: CoRec2 & other`) and union `CoUnion` (`1: CoUnion2 & other`) already in the same file: break the cycle with `&` on one side. With it, C++ generates `::std::shared_ptr<CoError2> other;` (cycle broken, compiles). Reference-type languages (C#, Java, Go, …) are unaffected — the annotation is a no-op there (verified: generated netstd `CoError.cs` is byte-identical with and without `&`).

This is **also a prerequisite for fixing `lib-rust`** (without `&`, the recursive exception is infinite-size in Rust). The separate Rust union-read codegen bug is THRIFT-6064 (#3570). **Merge this PR first**, then the Rust PR's CI can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)