### PR TITLE
THRIFT-6064: Box recursive union variant on read in the Rust generator

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -1840,7 +1840,20 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
     f_gen_ << indent() << rust_safe_field_id(member->get_key()) << " => {" << '\n';
     indent_up();
     if (member_is_union) {
+      // Use the resolved (non-Box) type since Box<T>::read_from_in_protocol()
+      // isn't valid syntax; a recursive union variant is stored as Box<T>, so the
+      // value read via the resolved type is re-boxed here. Mirrors the struct
+      // reader (see render_struct_sync_read).
       string member_type = to_rust_type(member_resolved);
+      bool is_boxed = false;
+      {
+        t_type* t = member->get_type();
+        while (t->is_typedef()) {
+          if (((t_typedef*)t)->is_forward_typedef()) { is_boxed = true; break; }
+          t = ((t_typedef*)t)->get_type();
+        }
+      }
+      string val_expr = is_boxed ? "Box::new(val)" : "val";
       string member_read(member_type + "::read_from_in_protocol(i_prot)");
       f_gen_ << indent() << "match " << member_read << " {" << '\n';
       indent_up();
@@ -1849,7 +1862,7 @@ void t_rs_generator::render_union_sync_read(const string& union_name, t_struct* 
       f_gen_ << indent() << "if ret.is_none() {" << '\n';
       indent_up();
       f_gen_ << indent() << "ret = Some(" << union_name << "::" << rust_union_field_name(member)
-             << "(val));" << '\n';
+             << "(" << val_expr << "));" << '\n';
       indent_down();
       f_gen_ << indent() << "}" << '\n';
       f_gen_ << indent() << "received_field_count += 1;" << '\n';

--- a/lib/rs/test/src/bin/kitchen_sink_server.rs
+++ b/lib/rs/test/src/bin/kitchen_sink_server.rs
@@ -334,4 +334,9 @@ impl recursive::TestServiceSyncHandler for RecursiveTestServerHandler {
         println!("{:?}", item);
         Ok(item)
     }
+
+    fn handle_echo_co_union(&self, item: recursive::CoUnion) -> thrift::Result<recursive::CoUnion> {
+        println!("{:?}", item);
+        Ok(item)
+    }
 }


### PR DESCRIPTION
Fixes a Rust code-generator bug (THRIFT-6064) exposed by the recursive `union CoUnion` recently added to `test/Recursive.thrift`.

A recursive union variant is generated as `Box<T>`, but `render_union_sync_read` constructed the variant from the *unboxed* value when the variant type was itself a union:

    ret = Some(CoUnion::Other(val));   // val: CoUnion2, but the variant is Box<CoUnion2>

→ `error[E0308]: mismatched types` (expected `Box<...>`). The fix mirrors `render_struct_sync_read`: detect the forward typedef and wrap the read value in `Box::new(...)`.

Also implements the `echo_co_union` handler in the kitchen-sink test server, required by the new `echoCoUnion` `TestService` method in `Recursive.thrift`.

**Depends on #3569**: the recursive exception `CoError` is infinite-size in Rust without the `&` ref added there, so `lib-rust` goes green only with both changes. Merge #3569 first. Validated locally with both applied — `make check` for rust passes end to end (`cargo fmt --check`, `clippy -D warnings`, `build`, `test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
