### PR TITLE
Add recursion-depth round-trip test for the Haxe library

### DIFF
--- a/lib/haxe/test/Makefile.am
+++ b/lib/haxe/test/Makefile.am
@@ -21,6 +21,8 @@ THRIFTCMD = $(THRIFT) --gen haxe -r
 THRIFTTEST = $(top_srcdir)/test/ThriftTest.thrift
 AGGR = $(top_srcdir)/contrib/async-test/aggr.thrift
 BENCHMARK = $(top_srcdir)/lib/rb/benchmark/Benchmark.thrift
+RECURSIVE = $(top_srcdir)/test/Recursive.thrift
+CONSTANTSDEMO = $(top_srcdir)/test/ConstantsDemo.thrift
 
 BIN_CPP = bin/Main-debug
 BIN_PHP = bin/php/Main-debug.php
@@ -34,6 +36,12 @@ gen-haxe/thrift/test/Aggr.hx: $(AGGR)
 gen-haxe/thrift/test/BenchmarkService.hx: $(BENCHMARK)
 	$(THRIFTCMD) $(BENCHMARK)
 
+gen-haxe/CoRec.hx: $(RECURSIVE)
+	$(THRIFTCMD) $(RECURSIVE)
+
+gen-haxe/constantsDemo/ConstantsDemoConstants.hx: $(CONSTANTSDEMO)
+	$(THRIFTCMD) $(CONSTANTSDEMO)
+
 all-local: $(BIN_CPP) $(BIN_PHP)
 
 $(BIN_CPP): \
@@ -41,7 +49,9 @@ $(BIN_CPP): \
 		../src/org/apache/thrift/**/*.hx \
 		gen-haxe/thrift/test/ThriftTest.hx \
 		gen-haxe/thrift/test/Aggr.hx \
-		gen-haxe/thrift/test/BenchmarkService.hx
+		gen-haxe/thrift/test/BenchmarkService.hx \
+		gen-haxe/CoRec.hx \
+		gen-haxe/constantsDemo/ConstantsDemoConstants.hx
 	$(HAXE) --cwd .  cpp.hxml
 
 $(BIN_PHP): \
@@ -49,7 +59,9 @@ $(BIN_PHP): \
 		../src/org/apache/thrift/**/*.hx \
 		gen-haxe/thrift/test/ThriftTest.hx \
 		gen-haxe/thrift/test/Aggr.hx \
-		gen-haxe/thrift/test/BenchmarkService.hx
+		gen-haxe/thrift/test/BenchmarkService.hx \
+		gen-haxe/CoRec.hx \
+		gen-haxe/constantsDemo/ConstantsDemoConstants.hx
 	$(HAXE) --cwd .  php.hxml
 
 

--- a/lib/haxe/test/src/Main.hx
+++ b/lib/haxe/test/src/Main.hx
@@ -26,6 +26,7 @@ import org.apache.thrift.server.*;
 import org.apache.thrift.transport.*;
 import tests.ConstantsTest;
 import tests.MultiplexTest;
+import tests.RecursionLimitTest;
 import tests.StreamTest;
 import thrift.test.*;
 
@@ -87,6 +88,7 @@ class Main
 				case Normal:
 					#if sys
 					tests.StreamTest.Run(server);
+					tests.RecursionLimitTest.Run(server);
 					#end
 				case Multiplex:
 					#if ! (flash || html5 || js)

--- a/lib/haxe/test/src/tests/RecursionLimitTest.hx
+++ b/lib/haxe/test/src/tests/RecursionLimitTest.hx
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tests;
+
+#if sys
+
+import tests.TestBase;
+
+import org.apache.thrift.*;
+import org.apache.thrift.protocol.*;
+import org.apache.thrift.transport.*;
+
+// recursive types from test/Recursive.thrift (no namespace -> root package)
+import CoRec;
+import CoRec2;
+import CoUnion;
+import CoUnion2;
+import CoError;
+import CoError2;
+
+// Exercises the struct read/write recursion-depth guard (TConfiguration.RecursionLimit,
+// default 64) through full round-trips over the recursive types in test/Recursive.thrift,
+// for a struct (CoRec), a union (CoUnion) and an exception (CoError).
+//
+// A chain exactly at the limit must round-trip (this is what would fail if the guard
+// double-counted, e.g. also incremented in writeStructBegin), while one level past the
+// limit must be rejected with DEPTH_LIMIT on both write and read.
+class RecursionLimitTest extends tests.TestBase {
+
+    private static inline var LIMIT : Int = TConfiguration.DEFAULT_RECURSION_DEPTH; // 64
+    private static inline var tmpfile : String = "recursion.tmp";
+
+    // ---- builders (alternating Co* / Co*2, null leaf) ----
+    private static function buildCoRec(d : Int) : CoRec {
+        var n = new CoRec();
+        if (d > 1) n.other = buildCoRec2(d - 1);
+        return n;
+    }
+    private static function buildCoRec2(d : Int) : CoRec2 {
+        var n = new CoRec2();
+        if (d > 1) n.other = buildCoRec(d - 1);
+        return n;
+    }
+    private static function depthCoRec(n : CoRec) : Int {
+        return (n.other == null) ? 1 : 1 + depthCoRec2(n.other);
+    }
+    private static function depthCoRec2(n : CoRec2) : Int {
+        return (n.other == null) ? 1 : 1 + depthCoRec(n.other);
+    }
+
+    private static function buildCoUnion(d : Int) : CoUnion {
+        var n = new CoUnion();
+        if (d > 1) n.other = buildCoUnion2(d - 1);
+        return n;
+    }
+    private static function buildCoUnion2(d : Int) : CoUnion2 {
+        var n = new CoUnion2();
+        if (d > 1) n.other = buildCoUnion(d - 1);
+        return n;
+    }
+
+    private static function buildCoError(d : Int) : CoError {
+        var n = new CoError();
+        if (d > 1) n.other = buildCoError2(d - 1);
+        return n;
+    }
+    private static function buildCoError2(d : Int) : CoError2 {
+        var n = new CoError2();
+        if (d > 1) n.other = buildCoError(d - 1);
+        return n;
+    }
+
+    private static function oprot() : TProtocol {
+        if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
+        var stream = new TFileStream(tmpfile, CreateNew);
+        return new TBinaryProtocol(new TStreamTransport(null, stream, new TConfiguration()));
+    }
+    private static function iprot() : TProtocol {
+        var stream = new TFileStream(tmpfile, Read);
+        return new TBinaryProtocol(new TStreamTransport(stream, null, new TConfiguration()));
+    }
+
+    // Raw nested struct (field id 1, type STRUCT) written with the unguarded protocol
+    // primitives (writeStructBegin does not increment the depth -- single-count), used to
+    // craft an over-limit payload that trips the guard only on read.
+    private static function craftDeep(p : TProtocol, d : Int) : Void {
+        p.writeStructBegin(new TStruct("Rec"));
+        if (d > 1) {
+            p.writeFieldBegin(new TField("other", TType.STRUCT, 1));
+            craftDeep(p, d - 1);
+            p.writeFieldEnd();
+        }
+        p.writeFieldStop();
+        p.writeStructEnd();
+    }
+
+    private static function isDepthLimit(e : Dynamic) : Bool {
+        return Std.isOfType(e, TProtocolException)
+            && (cast(e, TProtocolException).errorID == TProtocolException.DEPTH_LIMIT);
+    }
+
+    // Close a protocol's transport, ignoring errors, so the underlying file
+    // handle is always released. Windows refuses to delete or re-create a file
+    // that still has an open handle (POSIX allows it), so a read/write that
+    // throws DEPTH_LIMIT must not leave the stream open for the next case.
+    private static function closeQuietly(p : TProtocol) : Void {
+        try {
+            p.getTransport().close();
+        } catch (e : Dynamic) {
+            // ignore
+        }
+    }
+
+    public static function Run(server : Bool) : Void {
+        try {
+            // ---- struct (CoRec) ----
+            var op = oprot();
+            buildCoRec(LIMIT).write(op);
+            closeQuietly(op);
+            var back = new CoRec();
+            var ip = iprot();
+            back.read(ip);
+            closeQuietly(ip);
+            TestBase.Expect(depthCoRec(back) == LIMIT, 'struct: $LIMIT-deep round-trip preserves depth');
+
+            ExpectDepthLimitOnWrite(buildCoRec(LIMIT + 1), 'struct');
+            ExpectDepthLimitOnRead(function(p) return new CoRec().read(p), 'struct');
+
+            // ---- union (CoUnion) ----
+            var op2 = oprot();
+            buildCoUnion(LIMIT).write(op2);
+            closeQuietly(op2);
+            var ip2 = iprot();
+            new CoUnion().read(ip2);
+            closeQuietly(ip2);
+            TestBase.Expect(true, 'union: $LIMIT-deep round-trip succeeds');
+
+            ExpectDepthLimitOnWrite(buildCoUnion(LIMIT + 1), 'union');
+            ExpectDepthLimitOnRead(function(p) return new CoUnion().read(p), 'union');
+
+            // ---- exception (CoError) ----
+            var op3 = oprot();
+            buildCoError(LIMIT).write(op3);
+            closeQuietly(op3);
+            var ip3 = iprot();
+            new CoError().read(ip3);
+            closeQuietly(ip3);
+            TestBase.Expect(true, 'exception: $LIMIT-deep round-trip succeeds');
+
+            ExpectDepthLimitOnWrite(buildCoError(LIMIT + 1), 'exception');
+            ExpectDepthLimitOnRead(function(p) return new CoError().read(p), 'exception');
+
+            if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
+        } catch (e : Dynamic) {
+            if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
+            throw e;
+        }
+    }
+
+    private static function ExpectDepthLimitOnWrite(obj : TBase, what : String) : Void {
+        var threw = false;
+        var op = oprot();
+        try {
+            obj.write(op);
+        } catch (e : Dynamic) {
+            threw = isDepthLimit(e);
+        }
+        closeQuietly(op); // close even when write threw, so the file can be reused/deleted
+        TestBase.Expect(threw, '$what: write ${LIMIT + 1}-deep throws DEPTH_LIMIT');
+    }
+
+    private static function ExpectDepthLimitOnRead(readInto : TProtocol -> Void, what : String) : Void {
+        // craftDeep uses raw primitives (no depth guard on write), so the write side
+        // does not throw; only the guarded read below trips the limit.
+        var op = oprot();
+        craftDeep(op, LIMIT + 1);
+        closeQuietly(op);
+        var threw = false;
+        var ip = iprot();
+        try {
+            readInto(ip);
+        } catch (e : Dynamic) {
+            threw = isDepthLimit(e);
+        }
+        closeQuietly(ip); // close even when read threw, so the file can be reused/deleted
+        TestBase.Expect(threw, '$what: read ${LIMIT + 1}-deep throws DEPTH_LIMIT');
+    }
+
+}
+
+#end


### PR DESCRIPTION
## Summary

The Haxe library already enforces a struct read/write recursion-depth limit (`TConfiguration.RecursionLimit`, default 64, added in THRIFT-5370): the generator wraps every struct reader/writer with `IncrementRecursionDepth`/`DecrementRecursionDepth`, `TProtocolImplBase` holds the counter, and `TProtocolException.DEPTH_LIMIT` is raised on excess. There was, however, **no test** covering it. This adds one.

Verified — by inspection and by the new test — that the guard is:

- **single-count, not double-count**: `readStructBegin`/`writeStructBegin` do not increment (only the generated `read()`/`write()` do), so a chain exactly at the limit (64) still round-trips and is *not* rejected at 32.
- applied to **struct, union, and exception** alike (all route through the same generated reader/writer), on **both read and write**.

## Test

`lib/haxe/test/src/tests/RecursionLimitTest.hx` performs full round-trips over the recursive types in `test/Recursive.thrift` — `CoRec` (struct), `CoUnion` (union), `CoError` (exception):

- a 64-deep chain round-trips (struct depth preserved);
- writing a 65-deep chain throws `DEPTH_LIMIT`;
- reading a crafted 65-deep payload throws `DEPTH_LIMIT` (asserting the specific `DEPTH_LIMIT` code).

It is wired into `Main` so it runs as part of the default test mode.

The test `Makefile.am` previously did not generate `ConstantsDemo` (needed by the existing `ConstantsTest`, and therefore by `Main`), so the unit-test harness did not build; this PR also adds that missing generation rule alongside the new `Recursive.thrift` rule.

## Validation

Built and run on the **neko** target in the project's `thrift:jammy` image: **13 / 13** assertions pass (the existing `StreamTest` plus the 9 new recursion-depth checks). `lib/haxe/test` is not exercised by CI (`--without-haxe`; the `lib-haxe-codegen` job is codegen-only), so this is validated locally.

No JIRA ticket — the depth limit already shipped (THRIFT-5370); this is a test (plus a one-line harness fix) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>