### PR TITLE
THRIFT-6065: Make TMemoryStream growable so it can be written and then read

### DIFF
--- a/lib/haxe/src/org/apache/thrift/transport/TMemoryStream.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TMemoryStream.hx
@@ -20,32 +20,36 @@
 package org.apache.thrift.transport;
 
 import haxe.io.Bytes;
-import haxe.io.BytesBuffer;
-import haxe.io.Output;
 
+// An in-memory stream that grows on write. Writing appends at (and reads consume
+// from) Position; a write past the current end enlarges the backing buffer, so a
+// fresh stream can be written to and then read back -- set Position = 0 between
+// the write and the read phase. The backing buffer may over-allocate (capacity
+// doubling) for amortized O(1) appends; Length tracks the logical byte count.
 class TMemoryStream implements TStream {
 
-	private var Data : Bytes;
+	private var Data : Bytes;   // backing store; Data.length is the capacity
+	private var Length : Int;   // number of valid bytes (<= Data.length)
 	public var Position(default,default) : Int;
 
 	public function new( data : Bytes = null) {
-		var target = new BytesBuffer();
 		if ( data != null) {
-			for ( i in 0...data.length) {
-				target.addByte( data.get(i));
-				++Position;
-			}
+			Data = data.sub( 0, data.length);  // defensive copy
+			Length = data.length;
+		} else {
+			Data = Bytes.alloc( 0);
+			Length = 0;
 		}
-		Data = target.getBytes();
+		Position = 0;
 	}
 
 	private function IsEof() : Bool {
-		return (0 > Position) || (Position >= Data.length);
+		return (0 > Position) || (Position >= Length);
 	}
 
 	public function Close() : Void {
-		var target = new BytesBuffer();
-		Data = target.getBytes();
+		Data = Bytes.alloc( 0);
+		Length = 0;
 		Position = 0;
 	}
 
@@ -53,31 +57,55 @@ class TMemoryStream implements TStream {
 		return (! IsEof());
 	}
 
-	// read count bytes into buf starting at offset
+	// read up to count bytes into buf at offset, advancing Position; returns the
+	// number of bytes actually read (0 at end of stream)
 	public function Read( buf : Bytes, offset : Int, count : Int) : Int {
-		var numRead = 0;
-
-		for ( i in 0...count) {
-			if ( IsEof())
-				break;
-
-			buf.set( offset + i, Data.get( Position++));
-			++numRead;
+		var numRead = Length - Position;
+		if ( numRead > count) {
+			numRead = count;
+		}
+		if ( numRead <= 0) {
+			return 0;
 		}
 
+		buf.blit( offset, Data, Position, numRead);
+		Position += numRead;
 		return numRead;
 	}
 
-	// write count bytes from buf starting at offset
+	// write count bytes from buf (starting at offset) at the current Position,
+	// growing the backing buffer as needed and advancing Position
 	public function Write( buf : Bytes, offset : Int, count : Int) : Void {
 		var numBytes = buf.length - offset;
 		if ( numBytes > count) {
 			numBytes = count;
 		}
-
-		for ( i in 0...numBytes) {
-			Data.set( Position + i, buf.get( offset + i));
+		if ( numBytes <= 0) {
+			return;
 		}
+
+		EnsureCapacity( Position + numBytes);
+		Data.blit( Position, buf, offset, numBytes);
+		Position += numBytes;
+		if ( Position > Length) {
+			Length = Position;
+		}
+	}
+
+	// grow the backing buffer to hold at least 'needed' bytes, preserving content
+	private function EnsureCapacity( needed : Int) : Void {
+		if ( needed <= Data.length) {
+			return;
+		}
+
+		var capacity = (Data.length > 0) ? Data.length : 16;
+		while ( capacity < needed) {
+			capacity *= 2;
+		}
+
+		var grown = Bytes.alloc( capacity);
+		grown.blit( 0, Data, 0, Length);
+		Data = grown;
 	}
 
 	public function Flush() : Void {
@@ -85,4 +113,3 @@ class TMemoryStream implements TStream {
 	}
 
 }
-

--- a/lib/haxe/test/src/tests/StreamTest.hx
+++ b/lib/haxe/test/src/tests/StreamTest.hx
@@ -76,6 +76,53 @@ class StreamTest extends tests.TestBase {
         return data;
     }
 
+    // Round-trip the same data through a single in-memory TMemoryStream (no temp
+    // file): the stream is written, rewound (Position = 0) and read back, which
+    // only works if TMemoryStream grows on write.
+    public static function WriteReadViaMemory() : { written : Xtruct, read : Xtruct }
+    {
+        var config : TConfiguration = new TConfiguration();
+        var stream = new TMemoryStream();
+        var trans : TTransport = new TStreamTransport( stream, stream, config);
+        var prot = new TJSONProtocol( trans);
+
+        var written = MakeTestData();
+        written.write(prot);
+
+        stream.Position = 0;  // rewind to read back what was just written
+        var read : Xtruct = new Xtruct();
+        read.read(prot);
+
+        return { written : written, read : read };
+    }
+
+    // A fresh TMemoryStream must grow as bytes are appended and return them
+    // intact after rewinding (directly exercises the grow-on-write path).
+    private static function MemoryStreamGrows() : Bool
+    {
+        var stream = new TMemoryStream();
+        var n = 1000;
+        for ( i in 0...n) {
+            var one = haxe.io.Bytes.alloc(1);
+            one.set( 0, i & 0xFF);
+            stream.Write( one, 0, 1);
+        }
+        if ( stream.Position != n) {
+            return false;
+        }
+        stream.Position = 0;
+        var back = haxe.io.Bytes.alloc(n);
+        if ( stream.Read( back, 0, n) != n) {
+            return false;
+        }
+        for ( i in 0...n) {
+            if ( back.get(i) != (i & 0xFF)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static function Run(server : Bool) : Void
     {
         try {
@@ -87,6 +134,13 @@ class StreamTest extends tests.TestBase {
             tests.TestBase.Expect( read.byte_thing == written.byte_thing, "byte data");
             tests.TestBase.Expect( read.i32_thing == written.i32_thing, "i32 data");
             tests.TestBase.Expect( Int64.compare( read.i64_thing, written.i64_thing) == 0, "i64 data");
+
+            var mem = WriteReadViaMemory();
+            tests.TestBase.Expect( mem.read.string_thing == mem.written.string_thing, "memory: string data");
+            tests.TestBase.Expect( mem.read.byte_thing == mem.written.byte_thing, "memory: byte data");
+            tests.TestBase.Expect( mem.read.i32_thing == mem.written.i32_thing, "memory: i32 data");
+            tests.TestBase.Expect( Int64.compare( mem.read.i64_thing, mem.written.i64_thing) == 0, "memory: i64 data");
+            tests.TestBase.Expect( MemoryStreamGrows(), "memory: grows across many writes");
 
         } catch(e:Dynamic) {
             FileSystem.deleteFile(tmpfile);


### PR DESCRIPTION
## THRIFT-6065: Make TMemoryStream growable so it can be written and then read

### Problem
`TMemoryStream` could not be written to:
- `Write()` did `Data.set(Position + i, …)` into a **fixed-size** `Bytes`, which cannot grow, so writing to a freshly constructed stream was out of bounds. On the **neko** target the no-argument constructor never initialized `Position`, so the first write threw `"Invalid operation (+)"`.
- `Write()` never advanced `Position`.
- The constructor left `Position` at the end of any supplied data, so a stream built from existing bytes could not be read without first doing `Position = 0` (the only existing consumer, `ConstantsTest`, did exactly that workaround).

### Change
Back the stream with a **growable** buffer: writing past the current end enlarges the backing `Bytes` (capacity doubling, amortized O(1) appends) and advances `Position`; a separate `Length` tracks the logical size used by `Read`/`Peek`; the constructor always initializes `Position = 0`. `Read`/`Write` use `blit`. Cross-target `Bytes` API only.

This lets a single `TMemoryStream` serve as an in-memory transport for a write-then-read round-trip (write, set `Position = 0`, read) — the pattern that previously required a temporary file via `TFileStream`.

### Test
Adds to `lib/haxe/test` `StreamTest` (runs in the suite's Normal mode): an `Xtruct` round-trip through a single `TMemoryStream` over `TJSONProtocol` (write → rewind → read) plus a grow-on-write assertion (1000 single-byte appends read back intact).

Validated locally on neko (Haxe lib unit tests have no CI job, as for all Haxe lib testing here): `StreamTest` memory cases pass; a protocol-level round-trip of a recursive struct over a single `TMemoryStream` round-trips; and the existing `ConstantsTest` (the prior consumer, `new TStreamTransport(stream, stream)` + `readUuid`) still passes — confirming no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)