### PR TITLE
THRIFT-6065: Use TMemoryStream in the Haxe recursion-depth test

### DIFF
--- a/lib/haxe/src/org/apache/thrift/transport/TMemoryStream.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TMemoryStream.hx
@@ -20,32 +20,36 @@
 package org.apache.thrift.transport;
 
 import haxe.io.Bytes;
-import haxe.io.BytesBuffer;
-import haxe.io.Output;
 
+// An in-memory stream that grows on write. Writing appends at (and reads consume
+// from) Position; a write past the current end enlarges the backing buffer, so a
+// fresh stream can be written to and then read back -- set Position = 0 between
+// the write and the read phase. The backing buffer may over-allocate (capacity
+// doubling) for amortized O(1) appends; Length tracks the logical byte count.
 class TMemoryStream implements TStream {
 
-	private var Data : Bytes;
+	private var Data : Bytes;   // backing store; Data.length is the capacity
+	private var Length : Int;   // number of valid bytes (<= Data.length)
 	public var Position(default,default) : Int;
 
 	public function new( data : Bytes = null) {
-		var target = new BytesBuffer();
 		if ( data != null) {
-			for ( i in 0...data.length) {
-				target.addByte( data.get(i));
-				++Position;
-			}
+			Data = data.sub( 0, data.length);  // defensive copy
+			Length = data.length;
+		} else {
+			Data = Bytes.alloc( 0);
+			Length = 0;
 		}
-		Data = target.getBytes();
+		Position = 0;
 	}
 
 	private function IsEof() : Bool {
-		return (0 > Position) || (Position >= Data.length);
+		return (0 > Position) || (Position >= Length);
 	}
 
 	public function Close() : Void {
-		var target = new BytesBuffer();
-		Data = target.getBytes();
+		Data = Bytes.alloc( 0);
+		Length = 0;
 		Position = 0;
 	}
 
@@ -53,31 +57,55 @@ class TMemoryStream implements TStream {
 		return (! IsEof());
 	}
 
-	// read count bytes into buf starting at offset
+	// read up to count bytes into buf at offset, advancing Position; returns the
+	// number of bytes actually read (0 at end of stream)
 	public function Read( buf : Bytes, offset : Int, count : Int) : Int {
-		var numRead = 0;
-
-		for ( i in 0...count) {
-			if ( IsEof())
-				break;
-
-			buf.set( offset + i, Data.get( Position++));
-			++numRead;
+		var numRead = Length - Position;
+		if ( numRead > count) {
+			numRead = count;
+		}
+		if ( numRead <= 0) {
+			return 0;
 		}
 
+		buf.blit( offset, Data, Position, numRead);
+		Position += numRead;
 		return numRead;
 	}
 
-	// write count bytes from buf starting at offset
+	// write count bytes from buf (starting at offset) at the current Position,
+	// growing the backing buffer as needed and advancing Position
 	public function Write( buf : Bytes, offset : Int, count : Int) : Void {
 		var numBytes = buf.length - offset;
 		if ( numBytes > count) {
 			numBytes = count;
 		}
-
-		for ( i in 0...numBytes) {
-			Data.set( Position + i, buf.get( offset + i));
+		if ( numBytes <= 0) {
+			return;
 		}
+
+		EnsureCapacity( Position + numBytes);
+		Data.blit( Position, buf, offset, numBytes);
+		Position += numBytes;
+		if ( Position > Length) {
+			Length = Position;
+		}
+	}
+
+	// grow the backing buffer to hold at least 'needed' bytes, preserving content
+	private function EnsureCapacity( needed : Int) : Void {
+		if ( needed <= Data.length) {
+			return;
+		}
+
+		var capacity = (Data.length > 0) ? Data.length : 16;
+		while ( capacity < needed) {
+			capacity *= 2;
+		}
+
+		var grown = Bytes.alloc( capacity);
+		grown.blit( 0, Data, 0, Length);
+		Data = grown;
 	}
 
 	public function Flush() : Void {
@@ -85,4 +113,3 @@ class TMemoryStream implements TStream {
 	}
 
 }
-

--- a/lib/haxe/test/src/tests/RecursionLimitTest.hx
+++ b/lib/haxe/test/src/tests/RecursionLimitTest.hx
@@ -45,7 +45,6 @@ import CoError2;
 class RecursionLimitTest extends tests.TestBase {
 
     private static inline var LIMIT : Int = TConfiguration.DEFAULT_RECURSION_DEPTH; // 64
-    private static inline var tmpfile : String = "recursion.tmp";
 
     // ---- builders (alternating Co* / Co*2, null leaf) ----
     private static function buildCoRec(d : Int) : CoRec {
@@ -87,14 +86,13 @@ class RecursionLimitTest extends tests.TestBase {
         return n;
     }
 
-    private static function oprot() : TProtocol {
-        if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
-        var stream = new TFileStream(tmpfile, CreateNew);
-        return new TBinaryProtocol(new TStreamTransport(null, stream, new TConfiguration()));
+    // A single growable in-memory stream backs both directions: write into it,
+    // rewind (Position = 0), then read back -- no temporary file required.
+    private static function newStream() : TMemoryStream {
+        return new TMemoryStream();
     }
-    private static function iprot() : TProtocol {
-        var stream = new TFileStream(tmpfile, Read);
-        return new TBinaryProtocol(new TStreamTransport(stream, null, new TConfiguration()));
+    private static function protOf(s : TMemoryStream) : TProtocol {
+        return new TBinaryProtocol(new TStreamTransport(s, s, new TConfiguration()));
     }
 
     // Raw nested struct (field id 1, type STRUCT) written with the unguarded protocol
@@ -116,90 +114,66 @@ class RecursionLimitTest extends tests.TestBase {
             && (cast(e, TProtocolException).errorID == TProtocolException.DEPTH_LIMIT);
     }
 
-    // Close a protocol's transport, ignoring errors, so the underlying file
-    // handle is always released. Windows refuses to delete or re-create a file
-    // that still has an open handle (POSIX allows it), so a read/write that
-    // throws DEPTH_LIMIT must not leave the stream open for the next case.
-    private static function closeQuietly(p : TProtocol) : Void {
-        try {
-            p.getTransport().close();
-        } catch (e : Dynamic) {
-            // ignore
-        }
-    }
-
     public static function Run(server : Bool) : Void {
-        try {
-            // ---- struct (CoRec) ----
-            var op = oprot();
-            buildCoRec(LIMIT).write(op);
-            closeQuietly(op);
-            var back = new CoRec();
-            var ip = iprot();
-            back.read(ip);
-            closeQuietly(ip);
-            TestBase.Expect(depthCoRec(back) == LIMIT, 'struct: $LIMIT-deep round-trip preserves depth');
+        // ---- struct (CoRec) ----
+        var s = newStream();
+        var p = protOf(s);
+        buildCoRec(LIMIT).write(p);
+        s.Position = 0;
+        var back = new CoRec();
+        back.read(p);
+        TestBase.Expect(depthCoRec(back) == LIMIT, 'struct: $LIMIT-deep round-trip preserves depth');
 
-            ExpectDepthLimitOnWrite(buildCoRec(LIMIT + 1), 'struct');
-            ExpectDepthLimitOnRead(function(p) return new CoRec().read(p), 'struct');
+        ExpectDepthLimitOnWrite(buildCoRec(LIMIT + 1), 'struct');
+        ExpectDepthLimitOnRead(function(pr) return new CoRec().read(pr), 'struct');
 
-            // ---- union (CoUnion) ----
-            var op2 = oprot();
-            buildCoUnion(LIMIT).write(op2);
-            closeQuietly(op2);
-            var ip2 = iprot();
-            new CoUnion().read(ip2);
-            closeQuietly(ip2);
-            TestBase.Expect(true, 'union: $LIMIT-deep round-trip succeeds');
+        // ---- union (CoUnion) ----
+        var s2 = newStream();
+        var p2 = protOf(s2);
+        buildCoUnion(LIMIT).write(p2);
+        s2.Position = 0;
+        new CoUnion().read(p2);
+        TestBase.Expect(true, 'union: $LIMIT-deep round-trip succeeds');
 
-            ExpectDepthLimitOnWrite(buildCoUnion(LIMIT + 1), 'union');
-            ExpectDepthLimitOnRead(function(p) return new CoUnion().read(p), 'union');
+        ExpectDepthLimitOnWrite(buildCoUnion(LIMIT + 1), 'union');
+        ExpectDepthLimitOnRead(function(pr) return new CoUnion().read(pr), 'union');
 
-            // ---- exception (CoError) ----
-            var op3 = oprot();
-            buildCoError(LIMIT).write(op3);
-            closeQuietly(op3);
-            var ip3 = iprot();
-            new CoError().read(ip3);
-            closeQuietly(ip3);
-            TestBase.Expect(true, 'exception: $LIMIT-deep round-trip succeeds');
+        // ---- exception (CoError) ----
+        var s3 = newStream();
+        var p3 = protOf(s3);
+        buildCoError(LIMIT).write(p3);
+        s3.Position = 0;
+        new CoError().read(p3);
+        TestBase.Expect(true, 'exception: $LIMIT-deep round-trip succeeds');
 
-            ExpectDepthLimitOnWrite(buildCoError(LIMIT + 1), 'exception');
-            ExpectDepthLimitOnRead(function(p) return new CoError().read(p), 'exception');
-
-            if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
-        } catch (e : Dynamic) {
-            if (sys.FileSystem.exists(tmpfile)) sys.FileSystem.deleteFile(tmpfile);
-            throw e;
-        }
+        ExpectDepthLimitOnWrite(buildCoError(LIMIT + 1), 'exception');
+        ExpectDepthLimitOnRead(function(pr) return new CoError().read(pr), 'exception');
     }
 
     private static function ExpectDepthLimitOnWrite(obj : TBase, what : String) : Void {
         var threw = false;
-        var op = oprot();
+        var p = protOf(newStream());
         try {
-            obj.write(op);
+            obj.write(p);
         } catch (e : Dynamic) {
             threw = isDepthLimit(e);
         }
-        closeQuietly(op); // close even when write threw, so the file can be reused/deleted
         TestBase.Expect(threw, '$what: write ${LIMIT + 1}-deep throws DEPTH_LIMIT');
     }
 
     private static function ExpectDepthLimitOnRead(readInto : TProtocol -> Void, what : String) : Void {
         // craftDeep uses raw primitives (no depth guard on write), so the write side
         // does not throw; only the guarded read below trips the limit.
-        var op = oprot();
-        craftDeep(op, LIMIT + 1);
-        closeQuietly(op);
+        var s = newStream();
+        var p = protOf(s);
+        craftDeep(p, LIMIT + 1);
+        s.Position = 0;
         var threw = false;
-        var ip = iprot();
         try {
-            readInto(ip);
+            readInto(p);
         } catch (e : Dynamic) {
             threw = isDepthLimit(e);
         }
-        closeQuietly(ip); // close even when read threw, so the file can be reused/deleted
         TestBase.Expect(threw, '$what: read ${LIMIT + 1}-deep throws DEPTH_LIMIT');
     }
 

--- a/lib/haxe/test/src/tests/StreamTest.hx
+++ b/lib/haxe/test/src/tests/StreamTest.hx
@@ -76,6 +76,53 @@ class StreamTest extends tests.TestBase {
         return data;
     }
 
+    // Round-trip the same data through a single in-memory TMemoryStream (no temp
+    // file): the stream is written, rewound (Position = 0) and read back, which
+    // only works if TMemoryStream grows on write.
+    public static function WriteReadViaMemory() : { written : Xtruct, read : Xtruct }
+    {
+        var config : TConfiguration = new TConfiguration();
+        var stream = new TMemoryStream();
+        var trans : TTransport = new TStreamTransport( stream, stream, config);
+        var prot = new TJSONProtocol( trans);
+
+        var written = MakeTestData();
+        written.write(prot);
+
+        stream.Position = 0;  // rewind to read back what was just written
+        var read : Xtruct = new Xtruct();
+        read.read(prot);
+
+        return { written : written, read : read };
+    }
+
+    // A fresh TMemoryStream must grow as bytes are appended and return them
+    // intact after rewinding (directly exercises the grow-on-write path).
+    private static function MemoryStreamGrows() : Bool
+    {
+        var stream = new TMemoryStream();
+        var n = 1000;
+        for ( i in 0...n) {
+            var one = haxe.io.Bytes.alloc(1);
+            one.set( 0, i & 0xFF);
+            stream.Write( one, 0, 1);
+        }
+        if ( stream.Position != n) {
+            return false;
+        }
+        stream.Position = 0;
+        var back = haxe.io.Bytes.alloc(n);
+        if ( stream.Read( back, 0, n) != n) {
+            return false;
+        }
+        for ( i in 0...n) {
+            if ( back.get(i) != (i & 0xFF)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static function Run(server : Bool) : Void
     {
         try {
@@ -87,6 +134,13 @@ class StreamTest extends tests.TestBase {
             tests.TestBase.Expect( read.byte_thing == written.byte_thing, "byte data");
             tests.TestBase.Expect( read.i32_thing == written.i32_thing, "i32 data");
             tests.TestBase.Expect( Int64.compare( read.i64_thing, written.i64_thing) == 0, "i64 data");
+
+            var mem = WriteReadViaMemory();
+            tests.TestBase.Expect( mem.read.string_thing == mem.written.string_thing, "memory: string data");
+            tests.TestBase.Expect( mem.read.byte_thing == mem.written.byte_thing, "memory: byte data");
+            tests.TestBase.Expect( mem.read.i32_thing == mem.written.i32_thing, "memory: i32 data");
+            tests.TestBase.Expect( Int64.compare( mem.read.i64_thing, mem.written.i64_thing) == 0, "memory: i64 data");
+            tests.TestBase.Expect( MemoryStreamGrows(), "memory: grows across many writes");
 
         } catch(e:Dynamic) {
             FileSystem.deleteFile(tmpfile);


### PR DESCRIPTION
## THRIFT-6065: Use TMemoryStream in the Haxe recursion-depth test

Follow-up to #3579. Now that `TMemoryStream` grows on write, the recursion-depth round-trip test no longer needs a temporary file: a single in-memory stream is written, rewound (`Position = 0`) and read back.

Removes from `RecursionLimitTest`:
- the `TFileStream` usage and the `recursion.tmp` temp file;
- `closeQuietly()` (added so a read/write that threw `DEPTH_LIMIT` didn't leave a file handle open and break the next case on **Windows**);
- the surrounding `try/finally` file cleanup.

The nine checks (struct/union/exception × round-trip / over-write / over-read) are unchanged in intent and were re-verified.

> **Depends on #3579** (the `TMemoryStream` fix). This branch is stacked on it, so until #3579 merges the diff/commits here include that fix as well; once #3579 lands this narrows to just the test change. The test would fail against current `master` (where `TMemoryStream` can't be written), which is exactly the bug #3579 fixes.

Validated locally on neko (Haxe lib unit tests have no CI job): the full Normal-mode suite passes — `StreamTest` (incl. the new in-memory cases) and all nine `RecursionLimitTest` checks — with no temp file created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)