### PR TITLE
Run the Haxe library unit tests (neko) in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -545,6 +545,29 @@ jobs:
         run: |
           lib/haxe/codegen/run-Haxe-Codegen-Tests.ps1
 
+      # The autotools `make check` path for the Haxe library is disabled
+      # (--without-haxe) because it drives the cpp/php hxml targets; run the
+      # library unit tests directly on the lightweight neko target instead,
+      # reusing the toolchain (Haxe+neko, uuid, thrift compiler) set up above.
+      # The harness throws and Sys.exit(1)s on a failed assertion, so a failing
+      # test fails this step.
+      #
+      # Only the standalone "Normal" mode (StreamTest + RecursionLimitTest) is
+      # run. Multiplex needs a client+server; "constants" (ConstantsTest) is
+      # omitted for now because it constructs a TMemoryStream, which currently
+      # fails on the neko target -- run it here once that is fixed.
+      - name: Run Haxe library unit tests (neko)
+        run: |
+          cd lib/haxe/test
+          rm -rf gen-haxe bin
+          thrift --gen haxe -r ../../../test/ThriftTest.thrift
+          thrift --gen haxe -r ../../../contrib/async-test/aggr.thrift
+          thrift --gen haxe -r ../../../lib/rb/benchmark/Benchmark.thrift
+          thrift --gen haxe -r ../../../test/Recursive.thrift
+          thrift --gen haxe -r ../../../test/ConstantsDemo.thrift
+          haxe --cwd . neko.hxml
+          neko bin/Test.n
+
   lib-swift:
     needs: compiler
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Run the Haxe library unit tests (neko) in CI

Until now the Haxe **library unit tests** never ran in CI — only the codegen tests (`lib-haxe-codegen`), and the autotools `make check` path is disabled everywhere (`--without-haxe` in `build.yml` and `sca.yml`).

This adds a step to the existing `lib-haxe-codegen` job that builds the test harness for the lightweight **neko** target and runs the standalone `StreamTest` and `RecursionLimitTest` (Main's *Normal* mode). It reuses the toolchain that job already provisions — Haxe + neko, the `uuid` haxelib, and the `thrift` compiler artifact on `PATH` — so it's a small, self-contained addition rather than reviving the heavier cpp/php `make check`. A failed assertion throws and `Sys.exit(1)`s, so a regression fails the job (verified: a deliberately failing mode exits non-zero).

Validated locally on neko (ubuntu, same as the runner): the Normal-mode run is green on current `master`.

### Not run (yet)
- **multiplex** — needs a client + server.
- **constants** (`ConstantsTest`) — it constructs a `TMemoryStream`, whose write path is currently broken on the neko target (uninitialized `Position` → `"Invalid operation (+)"`); `ConstantsTest` therefore fails on neko today. That's fixed by #3579 (THRIFT-6065); once it lands, running `neko bin/Test.n constants` here is a one-line follow-up.

Independent of #3579/#3580 — but note that as those merge, the Normal-mode run here automatically starts exercising the in-memory `TMemoryStream` versions of the stream/recursion tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)