### PR TITLE
THRIFT-5000: Use per-version Docker build contexts

### DIFF
--- a/docker/0.22.0/Dockerfile
+++ b/docker/0.22.0/Dockerfile
@@ -62,11 +62,11 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/thrift/bin/thrift /usr/local/bin/thrift
-COPY ../docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY ../tests/smoke.thrift /tmp/smoke.thrift
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN set -eux; \
 	thrift --version | grep -F "$THRIFT_VERSION"; \
+	echo 'struct Ping { 1: string message }' > /tmp/smoke.thrift; \
 	mkdir -p /tmp/smoke-out; \
 	thrift --gen json -o /tmp/smoke-out /tmp/smoke.thrift; \
 	find /tmp/smoke-out -type f | grep -q .; \

--- a/docker/0.22.0/Dockerfile.alpine
+++ b/docker/0.22.0/Dockerfile.alpine
@@ -58,11 +58,11 @@ RUN set -eux; \
 	apk add --no-cache libstdc++
 
 COPY --from=builder /opt/thrift/bin/thrift /usr/local/bin/thrift
-COPY ../docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY ../tests/smoke.thrift /tmp/smoke.thrift
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN set -eux; \
 	thrift --version | grep -F "$THRIFT_VERSION"; \
+	echo 'struct Ping { 1: string message }' > /tmp/smoke.thrift; \
 	mkdir -p /tmp/smoke-out; \
 	thrift --gen json -o /tmp/smoke-out /tmp/smoke.thrift; \
 	find /tmp/smoke-out -type f | grep -q .; \

--- a/docker/0.22.0/docker-entrypoint.sh
+++ b/docker/0.22.0/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -eq 0 ]; then
+	set -- thrift
+elif [ "${1#-}" != "$1" ]; then
+	set -- thrift "$@"
+fi
+
+exec "$@"

--- a/docker/0.23.0/Dockerfile
+++ b/docker/0.23.0/Dockerfile
@@ -62,11 +62,11 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/thrift/bin/thrift /usr/local/bin/thrift
-COPY ../docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY ../tests/smoke.thrift /tmp/smoke.thrift
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN set -eux; \
 	thrift --version | grep -F "$THRIFT_VERSION"; \
+	echo 'struct Ping { 1: string message }' > /tmp/smoke.thrift; \
 	mkdir -p /tmp/smoke-out; \
 	thrift --gen json -o /tmp/smoke-out /tmp/smoke.thrift; \
 	find /tmp/smoke-out -type f | grep -q .; \

--- a/docker/0.23.0/Dockerfile.alpine
+++ b/docker/0.23.0/Dockerfile.alpine
@@ -58,11 +58,11 @@ RUN set -eux; \
 	apk add --no-cache libstdc++
 
 COPY --from=builder /opt/thrift/bin/thrift /usr/local/bin/thrift
-COPY ../docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY ../tests/smoke.thrift /tmp/smoke.thrift
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN set -eux; \
 	thrift --version | grep -F "$THRIFT_VERSION"; \
+	echo 'struct Ping { 1: string message }' > /tmp/smoke.thrift; \
 	mkdir -p /tmp/smoke-out; \
 	thrift --gen json -o /tmp/smoke-out /tmp/smoke.thrift; \
 	find /tmp/smoke-out -type f | grep -q .; \

--- a/docker/0.23.0/docker-entrypoint.sh
+++ b/docker/0.23.0/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -eq 0 ]; then
+	set -- thrift
+elif [ "${1#-}" != "$1" ]; then
+	set -- thrift "$@"
+fi
+
+exec "$@"

--- a/docker/generate-stackbrew-library.sh
+++ b/docker/generate-stackbrew-library.sh
@@ -68,8 +68,8 @@ for version, meta in maintained:
     print(f"Tags: {', '.join(debian_tags)}")
     print("Architectures: amd64, arm64v8")
     print(f"GitCommit: {git_commit}")
-    print("Directory: docker")
-    print(f"File: {version}/Dockerfile")
+    print(f"Directory: docker/{version}")
+    print("File: Dockerfile")
     print()
 
     alpine_tags = [f"{version}-alpine{alpine}"]
@@ -86,8 +86,8 @@ for version, meta in maintained:
     print(f"Tags: {', '.join(alpine_tags)}")
     print("Architectures: amd64, arm64v8")
     print(f"GitCommit: {git_commit}")
-    print("Directory: docker")
-    print(f"File: {version}/Dockerfile.alpine")
+    print(f"Directory: docker/{version}")
+    print("File: Dockerfile.alpine")
     if version != maintained[-1][0]:
         print()
 PY

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -110,16 +110,18 @@ for version in $(maintained_versions); do
 		for variant in debian alpine; do
 			case "$variant" in
 				debian)
-					dockerfile="$version/Dockerfile"
+					context="$version"
+					dockerfile="Dockerfile"
 					;;
 				alpine)
-					dockerfile="$version/Dockerfile.alpine"
+					context="$version"
+					dockerfile="Dockerfile.alpine"
 					;;
 			esac
 
 			image="$(image_tag "$version" "$variant" "$platform")"
 			echo "Building $image for $platform"
-			docker buildx build --platform "$platform" --load -t "$image" -f "$dockerfile" .
+			docker buildx build --platform "$platform" --load -t "$image" -f "$context/$dockerfile" "$context"
 			echo "Testing $image for $platform"
 			smoke_image "$image" "$platform" "$version" "$variant"
 		done


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Fixing build error in the docker official images repo: https://github.com/docker-library/official-images/actions/runs/26417245079/job/79192738571?pr=21530

Copied the entrypoint script into each of the version directories, similarly to how [Apache Storm](https://github.com/apache/storm-docker/tree/master/2.6.2) is doing it.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? THRIFT-5000
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
