### PR TITLE
THRIFT-6067: [py] Remove sys.exit() from setup.py to fix PEP 517 builds on setuptools < 69

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -144,10 +144,7 @@ def run_setup(with_binary):
 
 
 try:
-    with_binary = True
-    run_setup(with_binary)
-    sys.exit(0)
-
+    run_setup(with_binary=True)
 except BuildFailed:
     print()
     print('*' * 80)
@@ -155,17 +152,6 @@ except BuildFailed:
     print("Attempting to build without the extension now")
     print('*' * 80)
     print()
-
-# Retry but without the binary
-try:
-    run_setup(False)
-    sys.exit(0)
-
-except BuildFailed:
-    print()
-    print('*' * 80)
-    print("An error occurred while trying to compile without the C extension enabled")
-    print("Build failed")
-    print('*' * 80)
-    print()
-    sys.exit(1)
+    # Fall back to the pure-Python build. If this also fails, let the
+    # exception propagate so the build backend reports the real error.
+    run_setup(with_binary=False)


### PR DESCRIPTION
## Problem

thrift ships sdist-only, so every `pip install` builds `lib/py/setup.py` via the PEP 517 in-process backend. `setup.py` calls `sys.exit(0)` on its build success paths. setuptools' `build_meta.run_setup()` runs `setup.py` with `exec()`:

- **setuptools < 69:** the `SystemExit` propagates and terminates the build backend before it writes pip's result file → `OSError: [Errno 2] No such file or directory: '.../output.json'`.
- **setuptools >= 69:** a `try/except SystemExit` swallows exit code 0 (with a deprecation warning), so the bug only manifests on older toolchains.

setuptools itself flags this exact pattern: when it encounters a `sys.exit()` during the build it emits a `SetuptoolsDeprecationWarning` — *"Running `setup.py` directly as CLI tool is deprecated. Please avoid using `sys.exit(0)` or similar statements that don't fit in the paradigm of a configuration file"* (see `setuptools/build_meta.py`, and the reference it links: [Why you shouldn't invoke setup.py directly](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html), Paul Ganssle). Because thrift has no wheels, any environment with setuptools < 69 cannot install thrift 0.23.0 (seen on runtime images bundling setuptools 68).

## Origin

The `sys.exit()` calls were added incidentally in `a715bdff` (PR #3330, "THRIFT-5923: UUID python", Oct 2025) with no rationale in the commit, PR description, or review comments. Before that commit, `setup.py` used plain `try/except` control flow with no `sys.exit()` and built on all setuptools versions.

## Fix

Restore the pre-#3330 control flow: try the C-extension build; on `BuildFailed`, fall back to the pure-Python build; let any remaining failure propagate so the frontend reports the real error. No `sys.exit()` in `setup.py`.

## Testing

Built an sdist from this branch and installed it under the failing configuration (**setuptools 68.0.0 / pip 23.0.1, build isolation off**):

- Install now succeeds; the `thrift.protocol.fastbinary` C extension compiles and imports.
- Pure-Python fallback still triggers when the C compiler is unavailable (install succeeds, `fastbinary` absent) — unchanged behavior.
- Install on setuptools >= 69 and with build isolation on: unchanged (still succeeds).

## Compatibility

No API, runtime, or packaging-layout change. `setup.py` control-flow only.

Related: THRIFT-5915 / #3007 (distutils → setuptools migration).


---

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
