### PR TITLE
limit recursion depth in c_glib thrift_protocol_skip

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol.c
@@ -433,9 +433,26 @@ thrift_protocol_get_min_serialized_size (ThriftProtocol *protocol, ThriftType ty
     (_RES) += _x; \
   }
 
-gint32
-thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
+static gint32
+thrift_protocol_skip_impl (ThriftProtocol *protocol, ThriftType type,
+                           gint32 recursion_depth, GError **error)
 {
+  gint32 recursion_limit = DEFAULT_RECURSION_DEPTH;
+
+  if (protocol->transport != NULL &&
+      protocol->transport->configuration != NULL)
+  {
+    recursion_limit = protocol->transport->configuration->recursionLimit_;
+  }
+
+  if (recursion_depth > recursion_limit)
+  {
+    g_set_error (error, THRIFT_PROTOCOL_ERROR,
+                 THRIFT_PROTOCOL_ERROR_DEPTH_LIMIT,
+                 "Maximum skip depth exceeded");
+    return -1;
+  }
+
   switch (type)
   {
     case T_BOOL:
@@ -497,7 +514,8 @@ thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
             break;
           }
           THRIFT_SKIP_RESULT_OR_RETURN(result,
-            thrift_protocol_skip (protocol, ftype, error))
+            thrift_protocol_skip_impl (protocol, ftype, recursion_depth + 1,
+                                       error))
           THRIFT_SKIP_RESULT_OR_RETURN(result,
             thrift_protocol_read_field_end (protocol, error))
         }
@@ -516,7 +534,8 @@ thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
         for (i = 0; i < size; i++)
         {
           THRIFT_SKIP_RESULT_OR_RETURN(result,
-            thrift_protocol_skip (protocol, elem_type, error))
+            thrift_protocol_skip_impl (protocol, elem_type, recursion_depth + 1,
+                                       error))
         }
         THRIFT_SKIP_RESULT_OR_RETURN(result,
           thrift_protocol_read_set_end (protocol, error))
@@ -534,9 +553,11 @@ thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
         for (i = 0; i < size; i++)
         {
           THRIFT_SKIP_RESULT_OR_RETURN(result,
-            thrift_protocol_skip (protocol, key_type, error))
+            thrift_protocol_skip_impl (protocol, key_type, recursion_depth + 1,
+                                       error))
           THRIFT_SKIP_RESULT_OR_RETURN(result,
-            thrift_protocol_skip (protocol, elem_type, error))
+            thrift_protocol_skip_impl (protocol, elem_type, recursion_depth + 1,
+                                       error))
         }
         THRIFT_SKIP_RESULT_OR_RETURN(result,
           thrift_protocol_read_map_end (protocol, error))
@@ -553,7 +574,8 @@ thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
         for (i = 0; i < size; i++)
         {
           THRIFT_SKIP_RESULT_OR_RETURN(result,
-          thrift_protocol_skip (protocol, elem_type, error))
+          thrift_protocol_skip_impl (protocol, elem_type, recursion_depth + 1,
+                                     error))
         }
         THRIFT_SKIP_RESULT_OR_RETURN(result,
           thrift_protocol_read_list_end (protocol, error))
@@ -567,6 +589,12 @@ thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
                THRIFT_PROTOCOL_ERROR_INVALID_DATA,
                "unrecognized type");
   return -1;
+}
+
+gint32
+thrift_protocol_skip (ThriftProtocol *protocol, ThriftType type, GError **error)
+{
+  return thrift_protocol_skip_impl (protocol, type, 0, error);
 }
 
 /* define the GError domain for Thrift protocols */

--- a/lib/c_glib/test/testbinaryprotocol.c
+++ b/lib/c_glib/test/testbinaryprotocol.c
@@ -36,6 +36,8 @@
 #include <thrift/c_glib/transport/thrift_socket.h>
 #include <thrift/c_glib/transport/thrift_server_socket.h>
 #include <thrift/c_glib/transport/thrift_framed_transport.h>
+#include <thrift/c_glib/transport/thrift_memory_buffer.h>
+#include <thrift/c_glib/thrift_configuration.h>
 
 #define TEST_BOOL TRUE
 #define TEST_BYTE 123
@@ -839,6 +841,90 @@ thrift_server_many_frames (const int port)
   g_object_unref (tsocket);
 }
 
+/* skip should stop recursing once it has descended past the configured
+   recursion limit, rather than running off the stack on a deeply nested
+   message. */
+static void
+test_skip_recursion_depth (void)
+{
+  ThriftConfiguration *configuration = NULL;
+  ThriftMemoryBuffer *tbuffer = NULL;
+  ThriftBinaryProtocol *tb = NULL;
+  ThriftProtocol *protocol = NULL;
+  GError *error = NULL;
+  gint i;
+  const gint recursion_limit = 8;
+
+  /* a memory buffer carrying a small recursion limit */
+  configuration = g_object_new (THRIFT_TYPE_CONFIGURATION,
+                                "recursion_limit", recursion_limit, NULL);
+  tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                          "buf_size", 1024,
+                          "configuration", configuration, NULL);
+  tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport", tbuffer, NULL);
+  protocol = THRIFT_PROTOCOL (tb);
+
+  /* nest struct field headers a good way past the limit */
+  for (i = 0; i < recursion_limit + 10; i++)
+  {
+    g_assert (thrift_binary_protocol_write_field_begin (protocol, NULL,
+                                                        T_STRUCT, 1, NULL) > 0);
+  }
+
+  /* skipping the outermost struct must bail out with a depth-limit error
+     instead of recursing without bound */
+  g_assert (thrift_protocol_skip (protocol, T_STRUCT, &error) == -1);
+  g_assert (error != NULL);
+  g_assert (error->domain == THRIFT_PROTOCOL_ERROR);
+  g_assert (error->code == THRIFT_PROTOCOL_ERROR_DEPTH_LIMIT);
+  g_error_free (error);
+  error = NULL;
+
+  g_object_unref (tb);
+  g_object_unref (tbuffer);
+  g_object_unref (configuration);
+}
+
+/* a struct nested within the limit should still skip cleanly */
+static void
+test_skip_within_limit (void)
+{
+  ThriftConfiguration *configuration = NULL;
+  ThriftMemoryBuffer *tbuffer = NULL;
+  ThriftBinaryProtocol *tb = NULL;
+  ThriftProtocol *protocol = NULL;
+  GError *error = NULL;
+  gint i;
+  const gint depth = 3;
+
+  configuration = g_object_new (THRIFT_TYPE_CONFIGURATION,
+                                "recursion_limit", 8, NULL);
+  tbuffer = g_object_new (THRIFT_TYPE_MEMORY_BUFFER,
+                          "buf_size", 1024,
+                          "configuration", configuration, NULL);
+  tb = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport", tbuffer, NULL);
+  protocol = THRIFT_PROTOCOL (tb);
+
+  /* depth struct fields, each closed off with a stop, plus the innermost
+     empty struct's stop */
+  for (i = 0; i < depth; i++)
+  {
+    g_assert (thrift_binary_protocol_write_field_begin (protocol, NULL,
+                                                        T_STRUCT, 1, NULL) > 0);
+  }
+  for (i = 0; i < depth + 1; i++)
+  {
+    g_assert (thrift_binary_protocol_write_field_stop (protocol, NULL) > 0);
+  }
+
+  g_assert (thrift_protocol_skip (protocol, T_STRUCT, &error) > 0);
+  g_assert (error == NULL);
+
+  g_object_unref (tb);
+  g_object_unref (tbuffer);
+  g_object_unref (configuration);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -854,6 +940,10 @@ main(int argc, char *argv[])
   g_test_add_func ("/testbinaryprotocol/ReadAndWriteComplexTypes", test_read_and_write_complex_types);
   g_test_add_func ("/testbinaryprotocol/ReadAndWriteManyFrames",
                    test_read_and_write_many_frames);
+  g_test_add_func ("/testbinaryprotocol/SkipRecursionDepth",
+                   test_skip_recursion_depth);
+  g_test_add_func ("/testbinaryprotocol/SkipWithinLimit",
+                   test_skip_within_limit);
 
   return g_test_run ();
 }


### PR DESCRIPTION
thrift_protocol_skip recurses through nested structs, lists, sets and maps with no depth guard, so a server skipping an unknown field (the dispatch processor calls it on every unrecognised method) can be driven into unbounded recursion by a deeply nested message and overflow the stack. The configuration already carries recursionLimit_ with a default of 64 but nothing reads it. I noticed this reading the c_glib skip next to the C++ one, which guards the same path with TInputRecursionTracker. This routes skip through an internal helper that tracks depth and stops at the configured limit.