### PR TITLE
THRIFT-5655: Fix Swift library build on Swift 6.x and re-enable Swift CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -575,7 +575,6 @@ jobs:
   lib-swift:
     needs: compiler
     runs-on: ubuntu-24.04
-    if: false                     # swift is currently broken and no maintainers around -> see THRIFT-5864
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1007,7 +1006,7 @@ jobs:
     needs:
       - lib-php
       - lib-java-kotlin
-      #- lib-swift                     # currently broken and no maintainers around -> see THRIFT-5864
+      - lib-swift
       - lib-rust
       - lib-go
       - lib-python
@@ -1017,11 +1016,10 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        # swift is currently broken and no maintainers around -> see THRIFT-5864
         # kotlin cross test are failing -> see THRIFT-5879
-        server_lang: ['java', 'go', 'rs', 'cpp', 'py', 'rb', 'php', 'nodejs', 'nodets']
+        server_lang: ['java', 'go', 'rs', 'cpp', 'py', 'rb', 'php', 'nodejs', 'nodets', 'swift']
         # we always use comma join as many client langs as possible, to reduce the number of jobs
-        client_lang: ['java,kotlin', 'go,rs,cpp,py,php,nodejs,nodets,rb']
+        client_lang: ['java,kotlin', 'go,rs,cpp,py,php,nodejs,nodets,rb', 'swift']
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1085,7 +1083,6 @@ jobs:
 
       - name: Download swift precross artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: false   # currently broken and no maintainers around -> see THRIFT-5864
         with:
           name: swift-precross
           path: test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug
@@ -1143,7 +1140,7 @@ jobs:
           chmod a+x lib/java/build/run*
           chmod a+x lib/kotlin/cross-test-client/build/install/TestClient/bin/*
           chmod a+x lib/kotlin/cross-test-server/build/install/TestServer/bin/*
-          # THRIFT-5864  chmod a+x test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug/*
+          chmod a+x test/swift/CrossTests/.build/x86_64-unknown-linux-gnu/debug/*
           chmod a+x test/rs/bin/*
           chmod a+x test/go/bin/*
           chmod a+x test/cpp/*

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -348,7 +348,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/swift/README.md">Swift</a></td>
 <!-- Since -----------------><td>0.12.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td colspan=2>5.7</td>
+<!-- Language Levels -------><td>5.7</td><td>6.1</td>
 <!-- Field types -----------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>

--- a/lib/swift/Sources/TFileTransport.swift
+++ b/lib/swift/Sources/TFileTransport.swift
@@ -30,8 +30,8 @@ import Foundation
 /// Uses C fopen/fread/fwrite,
 /// provided by Glibc in linux and Darwin on OSX/iOS
 public class TFileTransport: TTransport {
-  var fileHandle: UnsafeMutablePointer<FILE>? = nil
-  
+  let fileHandle: UnsafeMutablePointer<FILE>
+
   public init (fileHandle: UnsafeMutablePointer<FILE>) {
     self.fileHandle = fileHandle
   }


### PR DESCRIPTION
## THRIFT-5655: Fix Swift library build on Swift 6.x and re-enable Swift CI

The Swift cross-test CI (`lib-swift`) was disabled in May 2025 (THRIFT-5864) when the `ubuntu-24.04` runner's bundled Swift toolchain moved to 6.x and the library stopped compiling.

### Root cause
`TFileTransport` declared `fileHandle` as an optional `UnsafeMutablePointer<FILE>?` although it is always non-nil after init. Swift 6's `Glibc`/`Darwin` overlays annotate `fclose`/`fread`/`fwrite` as taking a non-optional `FILE*`, so the three call sites failed to compile. (The `CFSocketError` symbol named in the original ticket is **not** an issue on Swift 6.1.3.)

### Changes
- **`TFileTransport`**: make `fileHandle` a non-optional `let` — fixes all three call sites at the root, with no platform conditional (correct on both Darwin and Linux).
- **CI**: re-enable the `lib-swift` job and add `swift` back to the `cross-test` matrix (server + client).
- **`LANGUAGES.md`**: Swift tested level `5.7` → `5.7 / 6.1`.

### Testing
Verified in Docker (Linux):
- `lib/swift` builds clean on **Swift 5.7** (37/37) and **Swift 6.1.3** (39/39).
- Swift cross-test (`precross`) builds `TestServer` + `TestClient` on 6.1.3.
- `ThriftTest` round-trips pass for **binary/compact × buffered/framed × ip/domain** (`client_exit=0`).

Real Apple-platform (macOS/Xcode) coverage is not part of this PR; the fix is platform-agnostic by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
