### PR TITLE
Fix wildcard dev-dependency version for uuid in Rust crate

### DIFF
--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -25,4 +25,4 @@ default = ["server"]
 server = ["threadpool", "log"]
 
 [dev-dependencies]
-uuid = { version = "*", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary

- Replaces `uuid = { version = "*", ... }` with `uuid = { version = "1", ... }` in `[dev-dependencies]`
- crates.io rejects wildcard (`*`) version constraints on publish — this blocked publishing `thrift v0.23.0`

## Test plan

- [x] No functional change; dev-dependencies only affect test builds, not crate consumers
- [x] Verify `cargo package` succeeds without errors on the Rust library

🤖 Generated with [Claude Code](https://claude.com/claude-code)