### PR TITLE
THRIFT-6068: Auto-publish Rust crate on GitHub Release

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -64,9 +64,11 @@ jobs:
           persist-credentials: false
 
       - name: Verify crate version matches release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           CRATE_VERSION=$(awk -F'"' '/^version/{print $2; exit}' lib/rs/Cargo.toml)
-          TAG_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          TAG_VERSION=$(echo "$RELEASE_TAG" | sed 's/^v//')
           if [ "$CRATE_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: Cargo.toml=$CRATE_VERSION, tag=$TAG_VERSION"
             exit 1

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -20,9 +20,8 @@
 name: Release Rust Packages
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
   pull_request:
     branches:
       - master
@@ -33,7 +32,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: false   # currently broken and no maintainers around -> see THRIFT-5917        
+    environment: release
     permissions:
       contents: read
       id-token: write
@@ -41,20 +40,26 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Dryrun
+
+      - name: Dry run
         working-directory: lib/rs
+        # Use stable toolchain: the repo-pinned 1.83 predates edition2024 support
+        # required by transitive dependencies (getrandom >= 0.4).
         run: cargo publish --dry-run
+        env:
+          RUSTUP_TOOLCHAIN: stable
 
       - name: Authenticate to crates.io
-        # Only publish if it's a tag and the tag is not a pre-release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
+        # Only publish on a non-prerelease GitHub Release event
+        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish
+        # Only publish on a non-prerelease GitHub Release event
+        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         working-directory: lib/rs
-        # Only publish if it's a tag and the tag is not a pre-release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
         run: cargo publish
         env:
+          RUSTUP_TOOLCHAIN: stable
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -30,8 +30,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust 1.85
+        # The repo-pinned toolchain (rust-toolchain: 1.83) predates edition2024 support
+        # required by transitive dependencies (getrandom >= 0.4); 1.85 is the minimum
+        # that passes. Pin explicitly for reproducibility.
+        run: rustup toolchain install 1.85 --profile minimal
+
+      - name: Dry run
+        working-directory: lib/rs
+        run: cargo publish --dry-run
+        env:
+          RUSTUP_TOOLCHAIN: "1.85"
+
   publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     environment: release
     permissions:
       contents: read
@@ -41,25 +63,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Dry run
-        working-directory: lib/rs
-        # Use stable toolchain: the repo-pinned 1.83 predates edition2024 support
-        # required by transitive dependencies (getrandom >= 0.4).
-        run: cargo publish --dry-run
-        env:
-          RUSTUP_TOOLCHAIN: stable
+      - name: Verify crate version matches release tag
+        run: |
+          CRATE_VERSION=$(awk -F'"' '/^version/{print $2; exit}' lib/rs/Cargo.toml)
+          TAG_VERSION=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          if [ "$CRATE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: Cargo.toml=$CRATE_VERSION, tag=$TAG_VERSION"
+            exit 1
+          fi
+          echo "Version check passed: $CRATE_VERSION"
+
+      - name: Install Rust 1.85
+        run: rustup toolchain install 1.85 --profile minimal
 
       - name: Authenticate to crates.io
-        # Only publish on a non-prerelease GitHub Release event
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish
-        # Only publish on a non-prerelease GitHub Release event
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         working-directory: lib/rs
         run: cargo publish
         env:
-          RUSTUP_TOOLCHAIN: stable
+          RUSTUP_TOOLCHAIN: "1.85"
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -25,4 +25,4 @@ default = ["server"]
 server = ["threadpool", "log"]
 
 [dev-dependencies]
-uuid = { version = "*", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Summary

Fixes the `release_rust.yml` workflow so the Rust crate is automatically published to crates.io whenever a GitHub Release is published. Also supersedes #3587.

Changes:
- **Remove `if: false`** gate that disabled the entire job (added in lieu of THRIFT-5917)
- **Switch trigger** from `push: tags:` to `release: types: [published]` — consistent with `pypi.yml` and `release_ruby.yml`, and prevents publishing before the PMC vote passes
- **Add `environment: release`** — required for OIDC trusted publishing (same as pypi/ruby)
- **Set `RUSTUP_TOOLCHAIN: stable`** on cargo steps — the repo-pinned `rust-toolchain` (1.83) predates `edition2024` support required by transitive dependencies (`getrandom >= 0.4`); stable Rust is pre-installed on ubuntu-latest runners
- **Fix publish condition** to `github.event_name == 'release' && !github.event.release.prerelease` — dry-run runs on every trigger, actual publish only on non-prerelease GitHub Releases
- **Fix `Cargo.toml` wildcard dev-dependency** `uuid = "*"` → `uuid = "1"` — crates.io rejects wildcard version constraints (this blocked the 0.23.0 publish; fixed separately in #3587 which this supersedes)

## Prerequisites (one-time manual step — cannot be done in CI)

**Trusted publishing on crates.io must be configured** before the publish step can authenticate:

1. Go to https://crates.io/crates/thrift → Settings → Trusted Publishing
2. Add a trusted publisher:
   - Owner: `apache`
   - Repository: `thrift`
   - Workflow: `release_rust.yml`
   - Environment: `release`

This is the same OIDC mechanism already used for the existing workflow structure.

## Limitations

The OIDC publish path cannot be end-to-end tested without merging and cutting a real release. The `--dry-run` step validates packaging; auth and upload can only be confirmed on first use.

## Test plan

- [ ] Dry-run step passes on this PR (validates packaging and toolchain)
- [ ] Trusted publisher registered on crates.io (prerequisite, see above)
- [ ] Verify publish fires on next GitHub Release (non-prerelease)

🤖 Generated with [Claude Code](https://claude.com/claude-code)