### PR TITLE
Update MSVC CI to windows-2025-vs2026 runner and start Docker service explicitly

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
       contents: read
       packages: write
@@ -70,15 +70,17 @@ jobs:
 
       - name: Wait for Docker daemon
         shell: pwsh
-        timeout-minutes: 5
+        timeout-minutes: 8
         run: |
-          # GitHub-hosted Windows runners occasionally have the Docker engine not
-          # yet ready when the job starts (the named pipe
-          # \\.\pipe\docker_engine is not listening). The subsequent docker
-          # pull/run then fails instantly with "failed to connect to the docker
-          # API", which previously surfaced as a confusing "LastTest.log not
-          # found". Poll until the daemon answers (or fail with a clear message).
-          $deadline = (Get-Date).AddMinutes(4)
+          # GitHub-hosted Windows runners (especially windows-2025-vs2026) have
+          # the Docker Engine installed but not always auto-started. Kick it
+          # explicitly, then poll until the daemon answers.
+          $svc = Get-Service -Name Docker -ErrorAction SilentlyContinue
+          if ($svc -and $svc.Status -ne 'Running') {
+            Write-Host "Starting Docker service..."
+            Start-Service -Name Docker -ErrorAction SilentlyContinue
+          }
+          $deadline = (Get-Date).AddMinutes(6)
           while ($true) {
             docker version --format '{{.Server.Version}}' 2>$null | Out-Null
             if ($LASTEXITCODE -eq 0) {


### PR DESCRIPTION
## Summary

- Switch `runs-on` from `windows-2025` to `windows-2025-vs2026` ahead of GitHub's forced migration (deadline 2026-06-15; already active on new jobs per runner notice in CI logs)
- Explicitly start the Docker service (`Start-Service -Name Docker`) at the top of the daemon-wait step — the new runner image has Docker Engine installed but not auto-started, causing the polling loop to exhaust completely
- Extend the poll deadline from 4 → 6 minutes and the step timeout from 5 → 8 minutes as a safety margin

## Context

PR #3578 added a polling loop to handle the case where the daemon was *slow to start*. The `windows-2025-vs2026` runner image goes further: the Docker Engine service is present but **never starts on its own**, so the loop always times out. Starting the service explicitly fixes this.

## Test plan

- [ ] CI passes on this PR with the `windows-2025-vs2026` runner
- [ ] `Wait for Docker daemon` step completes in well under 6 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)