### PR TITLE
avoid integer overflow in container size precheck

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_binary_protocol.c
@@ -577,9 +577,9 @@ thrift_binary_protocol_read_map_begin (ThriftProtocol *protocol,
     return -1;
   }
 
-  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT(tp->transport), 
-                                    sizei * thrift_binary_protocol_get_min_serialized_size(protocol, k, error) + 
-                                    sizei * thrift_binary_protocol_get_min_serialized_size(protocol, v, error),
+  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT(tp->transport),
+                                    (gint64) sizei * thrift_binary_protocol_get_min_serialized_size(protocol, k, error) +
+                                    (gint64) sizei * thrift_binary_protocol_get_min_serialized_size(protocol, v, error),
                                     error))
   {
     return -1;
@@ -642,8 +642,8 @@ thrift_binary_protocol_read_list_begin (ThriftProtocol *protocol,
     return -1;
   }
 
-  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT(tp->transport), 
-                                    (sizei * thrift_binary_protocol_get_min_serialized_size(protocol, e, error)),
+  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT(tp->transport),
+                                    ((gint64) sizei * thrift_binary_protocol_get_min_serialized_size(protocol, e, error)),
                                     error))
   {
     return -1;

--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_compact_protocol.c
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_compact_protocol.c
@@ -1108,9 +1108,9 @@ thrift_compact_protocol_read_map_begin (ThriftProtocol *protocol,
     return -1;
   }
 
-  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT (tp->transport), 
-                                    msize * thrift_protocol_get_min_serialized_size (protocol, *key_type, error) + 
-                                    msize * thrift_protocol_get_min_serialized_size (protocol, *value_type, error),
+  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT (tp->transport),
+                                    (gint64) msize * thrift_protocol_get_min_serialized_size (protocol, *key_type, error) +
+                                    (gint64) msize * thrift_protocol_get_min_serialized_size (protocol, *value_type, error),
                                     error))
   {
     return -1;
@@ -1183,8 +1183,8 @@ thrift_compact_protocol_read_list_begin (ThriftProtocol *protocol,
   *element_type = ret;
   *size = (guint32) lsize;
 
-  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT (tp->transport), 
-                                    (lsize * thrift_protocol_get_min_serialized_size (protocol, *element_type, error)),
+  if(!ttc->checkReadBytesAvailable (THRIFT_TRANSPORT (tp->transport),
+                                    ((gint64) lsize * thrift_protocol_get_min_serialized_size (protocol, *element_type, error)),
                                     error))
   {
     return -1;

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.c
@@ -160,7 +160,7 @@ thrift_transport_updateKnownMessageSize(ThriftTransport *transport, glong size, 
 }
 
 gboolean
-thrift_transport_checkReadBytesAvailable(ThriftTransport *transport, glong numBytes, GError **error)
+thrift_transport_checkReadBytesAvailable(ThriftTransport *transport, gint64 numBytes, GError **error)
 {
   gboolean boolean = TRUE;
   ThriftTransport *tt = THRIFT_TRANSPORT (transport);

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_transport.h
@@ -83,7 +83,7 @@ struct _ThriftTransportClass
   gint32 (*read_all) (ThriftTransport *transport, gpointer buf,
                       guint32 len, GError **error);
   gboolean (*updateKnownMessageSize) (ThriftTransport *transport, glong size, GError **error);
-  gboolean (*checkReadBytesAvailable) (ThriftTransport *transport, glong numBytes, GError **error);
+  gboolean (*checkReadBytesAvailable) (ThriftTransport *transport, gint64 numBytes, GError **error);
   gboolean (*resetConsumedMessageSize) (ThriftTransport *transport, glong newSize, GError **error);
   gboolean (*countConsumedMessageBytes) (ThriftTransport *transport, glong numBytes, GError **error);
 };

--- a/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TBinaryProtocol.h
@@ -174,18 +174,18 @@ public:
 
   void checkReadBytesAvailable(TSet& set) override
   {
-      trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(set.size_) * getMinSerializedSize(set.elemType_));
   }
 
   void checkReadBytesAvailable(TList& list) override
   {
-      trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(list.size_) * getMinSerializedSize(list.elemType_));
   }
 
   void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
-      trans_->checkReadBytesAvailable(map.size_ * elmSize);
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(map.size_) * elmSize);
   }
 
 protected:

--- a/lib/cpp/src/thrift/protocol/TCompactProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TCompactProtocol.h
@@ -146,18 +146,18 @@ public:
 
   void checkReadBytesAvailable(TSet& set) override
   {
-      trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(set.size_) * getMinSerializedSize(set.elemType_));
   }
 
   void checkReadBytesAvailable(TList& list) override
   {
-      trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(list.size_) * getMinSerializedSize(list.elemType_));
   }
 
   void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
-      trans_->checkReadBytesAvailable(map.size_ * elmSize);
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(map.size_) * elmSize);
   }
 
   /**

--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.h
@@ -253,18 +253,18 @@ public:
 
   void checkReadBytesAvailable(TSet& set) override
   {
-      trans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(set.size_) * getMinSerializedSize(set.elemType_));
   }
 
   void checkReadBytesAvailable(TList& list) override
   {
-      trans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(list.size_) * getMinSerializedSize(list.elemType_));
   }
 
   void checkReadBytesAvailable(TMap& map) override
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
-      trans_->checkReadBytesAvailable(map.size_ * elmSize);
+      trans_->checkReadBytesAvailable(static_cast<int64_t>(map.size_) * elmSize);
   }
 
   class LookaheadReader {

--- a/lib/cpp/src/thrift/protocol/TProtocol.h
+++ b/lib/cpp/src/thrift/protocol/TProtocol.h
@@ -604,18 +604,18 @@ protected:
 
   virtual void checkReadBytesAvailable(TSet& set)
   {
-      ptrans_->checkReadBytesAvailable(set.size_ * getMinSerializedSize(set.elemType_));
+      ptrans_->checkReadBytesAvailable(static_cast<int64_t>(set.size_) * getMinSerializedSize(set.elemType_));
   }
 
   virtual void checkReadBytesAvailable(TList& list)
   {
-      ptrans_->checkReadBytesAvailable(list.size_ * getMinSerializedSize(list.elemType_));
+      ptrans_->checkReadBytesAvailable(static_cast<int64_t>(list.size_) * getMinSerializedSize(list.elemType_));
   }
 
   virtual void checkReadBytesAvailable(TMap& map)
   {
       int elmSize = getMinSerializedSize(map.keyType_) + getMinSerializedSize(map.valueType_);
-      ptrans_->checkReadBytesAvailable(map.size_ * elmSize);
+      ptrans_->checkReadBytesAvailable(static_cast<int64_t>(map.size_) * elmSize);
   }
 
   std::shared_ptr<TTransport> ptrans_;

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -23,6 +23,7 @@
 #include <thrift/Thrift.h>
 #include <thrift/TConfiguration.h>
 #include <thrift/transport/TTransportException.h>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -282,7 +283,7 @@ public:
    *
    * @param numBytes  numBytes bytes of data
    */
-  void checkReadBytesAvailable(long int numBytes)
+  void checkReadBytesAvailable(int64_t numBytes)
   {
     if (remainingMessageSize_ < numBytes || numBytes < 0)
       throw TTransportException(TTransportException::END_OF_FILE, "MaxMessageSize reached");

--- a/lib/cpp/test/ThrifttReadCheckTests.cpp
+++ b/lib/cpp/test/ThrifttReadCheckTests.cpp
@@ -242,6 +242,54 @@ BOOST_AUTO_TEST_CASE(test_tthriftcompactprotocol_read_check_pass) {
   BOOST_CHECK_NO_THROW(protocol->readString(eleven));
 }
 
+BOOST_AUTO_TEST_CASE(test_tthriftbinaryprotocol_container_size_overflow) {
+  std::shared_ptr<TConfiguration> config (new TConfiguration(1024));
+  std::shared_ptr<TMemoryBuffer> transport(new TMemoryBuffer(config));
+  std::shared_ptr<TBinaryProtocol> protocol(new TBinaryProtocol(transport));
+
+  uint32_t val = 0;
+  TType elemType = apache::thrift::protocol::T_STOP;
+  // 0x40000000 elements of min size 4 require 4 GiB; the product wraps to 0 in
+  // 32-bit math and used to slip past the MaxMessageSize check.
+  TList list(T_I32, 0x40000000);
+  protocol->writeListBegin(list.elemType_, list.size_);
+  protocol->writeListEnd();
+  BOOST_CHECK_THROW(protocol->readListBegin(elemType, val), TTransportException);
+  protocol->readListEnd();
+}
+
+BOOST_AUTO_TEST_CASE(test_tthriftcompactprotocol_container_size_overflow) {
+  std::shared_ptr<TConfiguration> config (new TConfiguration(1024));
+  std::shared_ptr<TMemoryBuffer> transport(new TMemoryBuffer(config));
+  std::shared_ptr<TCompactProtocol> protocol(new TCompactProtocol(transport));
+
+  uint32_t val = 0;
+  TType elemType = apache::thrift::protocol::T_STOP;
+  // 0x10000000 elements of min size 16 (UUID) require 4 GiB; the product wraps
+  // to 0 in 32-bit math and used to slip past the MaxMessageSize check.
+  TList list(T_UUID, 0x10000000);
+  protocol->writeListBegin(list.elemType_, list.size_);
+  protocol->writeListEnd();
+  BOOST_CHECK_THROW(protocol->readListBegin(elemType, val), TTransportException);
+  protocol->readListEnd();
+}
+
+BOOST_AUTO_TEST_CASE(test_tthriftjsonprotocol_container_size_overflow) {
+  std::shared_ptr<TConfiguration> config (new TConfiguration(1024));
+  std::shared_ptr<TMemoryBuffer> transport(new TMemoryBuffer(config));
+  std::shared_ptr<TJSONProtocol> protocol(new TJSONProtocol(transport));
+
+  uint32_t val = 0;
+  TType elemType = apache::thrift::protocol::T_STOP;
+  // 0x10000000 elements of min size 16 (UUID) require 4 GiB; the product wraps
+  // to 0 in 32-bit math and used to slip past the MaxMessageSize check.
+  TList list(T_UUID, 0x10000000);
+  protocol->writeListBegin(list.elemType_, list.size_);
+  protocol->writeListEnd();
+  BOOST_CHECK_THROW(protocol->readListBegin(elemType, val), TTransportException);
+  protocol->readListEnd();
+}
+
 BOOST_AUTO_TEST_CASE(test_tthriftjsonprotocol_read_check_exception) {
   std::shared_ptr<TConfiguration> config (new TConfiguration(MAX_MESSAGE_SIZE));
   std::shared_ptr<TMemoryBuffer> transport(new TMemoryBuffer(config));


### PR DESCRIPTION
the container size precheck multiplies a wire-controlled element count by the per-element minimum size in 32-bit int, so a crafted list, set or map header can wrap the product down to a small or zero value and slip past the maxMessageSize guard, letting an oversized container through before any allocation is bounded. the same shape sits in the binary, compact and json protocols and the protocol base, plus the c_glib binary and compact readers. widen the multiplication to the long type checkReadBytesAvailable already takes so the count can no longer overflow, and add a regression test for the three c++ protocols.