### PR TITLE
THRIFT-6069: python: avoid utf8 copy during fastbinary string encode

### DIFF
--- a/lib/py/src/ext/binary.h
+++ b/lib/py/src/ext/binary.h
@@ -67,6 +67,11 @@ public:
     writeBuffer(PyBytes_AS_STRING(value), len);
   }
 
+  void writeString(const char* value, int32_t len) {
+    writeI32(len);
+    writeBuffer(value, len);
+  }
+
   bool writeListBegin(PyObject* value, const SetListTypeArgs& parsedargs, int32_t len) {
     writeByte(parsedargs.element_type);
     writeI32(len);
@@ -88,7 +93,7 @@ public:
     return encodeValue(value, parsedspec.type, parsedspec.typeargs);
   }
 
-  void writeUuid(char* value) {
+  void writeUuid(const char* value) {
     writeBuffer(value, 16);
   }
 

--- a/lib/py/src/ext/compact.h
+++ b/lib/py/src/ext/compact.h
@@ -61,6 +61,11 @@ public:
     writeBuffer(PyBytes_AS_STRING(value), len);
   }
 
+  void writeString(const char* value, int32_t len) {
+    writeVarint(len);
+    writeBuffer(value, len);
+  }
+
   bool writeListBegin(PyObject* value, const SetListTypeArgs& args, int32_t len) {
     int ctype = toCompactType(args.element_type);
     if (len <= 14) {
@@ -104,7 +109,7 @@ public:
 
   void writeFieldStop() { writeByte(0); }
 
-  void writeUuid(char* value) {
+  void writeUuid(const char* value) {
     writeBuffer(value, 16);
   }
 

--- a/lib/py/src/ext/protocol.h
+++ b/lib/py/src/ext/protocol.h
@@ -71,7 +71,7 @@ protected:
     return true;
   }
 
-  bool writeBuffer(char* data, size_t len);
+  bool writeBuffer(const char* data, size_t len);
 
   void writeByte(uint8_t val) { writeBuffer(reinterpret_cast<char*>(&val), 1); }
 

--- a/lib/py/src/ext/protocol.tcc
+++ b/lib/py/src/ext/protocol.tcc
@@ -89,7 +89,7 @@ PyObject* ProtocolBase<Impl>::getEncodedValue() {
 }
 
 template <typename Impl>
-inline bool ProtocolBase<Impl>::writeBuffer(char* data, size_t size) {
+inline bool ProtocolBase<Impl>::writeBuffer(const char* data, size_t size) {
   if (!PycStringIO) {
     PycString_IMPORT;
   }
@@ -169,7 +169,7 @@ PyObject* ProtocolBase<Impl>::getEncodedValue() {
 }
 
 template <typename Impl>
-inline bool ProtocolBase<Impl>::writeBuffer(char* data, size_t size) {
+inline bool ProtocolBase<Impl>::writeBuffer(const char* data, size_t size) {
   size_t need = size + output_->pos;
   if (output_->buf.capacity() < need) {
     try {
@@ -456,18 +456,32 @@ bool ProtocolBase<Impl>::encodeValue(PyObject* value, TType type, PyObject* type
 
   case T_STRING: {
     ScopedPyObject nval;
+    Py_ssize_t len;
 
     if (PyUnicode_Check(value)) {
+#if PY_VERSION_HEX >= 0x03030000
+      const char* str = PyUnicode_AsUTF8AndSize(value, &len);
+      if (!str) {
+        return false;
+      }
+      if (!detail::check_ssize_t_32(len)) {
+        return false;
+      }
+
+      impl()->writeString(str, static_cast<int32_t>(len));
+      return true;
+#else
       nval.reset(PyUnicode_AsUTF8String(value));
       if (!nval) {
         return false;
       }
+#endif
     } else {
       Py_INCREF(value);
       nval.reset(value);
     }
 
-    Py_ssize_t len = PyBytes_Size(nval.get());
+    len = PyBytes_Size(nval.get());
     if (!detail::check_ssize_t_32(len)) {
       return false;
     }

--- a/lib/py/test/thrift_TBinaryProtocol.py
+++ b/lib/py/test/thrift_TBinaryProtocol.py
@@ -302,7 +302,7 @@ class TestTBinaryProtocol(unittest.TestCase):
 
         original = TApplicationException(
             type=TApplicationException.PROTOCOL_ERROR,
-            message=("snowman-\u2603-rocket-\U0001F680-" * 32),
+            message=(u"snowman-\u2603-rocket-\U0001F680-" * 32),
         )
 
         typeargs = [TApplicationException, APPLICATION_EXCEPTION_THRIFT_SPEC]

--- a/lib/py/test/thrift_TBinaryProtocol.py
+++ b/lib/py/test/thrift_TBinaryProtocol.py
@@ -22,7 +22,9 @@ import unittest
 import uuid
 
 import _import_local_thrift  # noqa
+from thrift.Thrift import TApplicationException
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAcceleratedFactory
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.transport import TTransport
 
@@ -167,6 +169,13 @@ def testField(type, data):
     protocol.readStructEnd()
 
 
+APPLICATION_EXCEPTION_THRIFT_SPEC = (
+    None,
+    (1, 11, "message", "UTF8", None),
+    (2, 8, "type", None, None),
+)
+
+
 def testMessage(data, strict=True):
     message = {}
     message['name'] = data[0]
@@ -195,6 +204,13 @@ def testMessage(data, strict=True):
 
 
 class TestTBinaryProtocol(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            from thrift.protocol import fastbinary  # noqa: F401
+            self._has_fastbinary = True
+        except ImportError:
+            self._has_fastbinary = False
 
     def test_TBinaryProtocol_write_read(self):
         try:
@@ -279,6 +295,28 @@ class TestTBinaryProtocol(unittest.TestCase):
         except Exception as e:
             print("Assertion fail")
             raise e
+
+    def test_accelerated_utf8_roundtrip_on_application_exception(self):
+        if not self._has_fastbinary:
+            self.skipTest("C extension not available")
+
+        original = TApplicationException(
+            type=TApplicationException.PROTOCOL_ERROR,
+            message=("snowman-\u2603-rocket-\U0001F680-" * 32),
+        )
+
+        typeargs = [TApplicationException, APPLICATION_EXCEPTION_THRIFT_SPEC]
+
+        otrans = TTransport.TMemoryBuffer()
+        oproto = TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(otrans)
+        oproto.trans.write(oproto._fast_encode(original, typeargs))
+
+        itrans = TTransport.TMemoryBuffer(otrans.getvalue())
+        iproto = TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(itrans)
+        decoded = iproto._fast_decode(None, iproto, typeargs)
+
+        self.assertEqual(decoded.message, original.message)
+        self.assertEqual(decoded.type, original.type)
 
     def test_TBinaryProtocol_no_strict_write_read(self):
         TMessageType = {"T_CALL": 1, "T_REPLY": 2, "T_EXCEPTION": 3, "T_ONEWAY": 4}

--- a/lib/py/test/thrift_TSerializer.py
+++ b/lib/py/test/thrift_TSerializer.py
@@ -70,6 +70,17 @@ class TestSerializer(unittest.TestCase):
         factory = TCompactProtocolAcceleratedFactory()
         self.verify(self.compact_serialized, factory)
 
+    def test_TCompactProtocolAccelerated_unicode_matches_python(self):
+        message = Message("é", 42)
+        expected = serialize(message, TCompactProtocolFactory())
+        actual = serialize(message, TCompactProtocolAcceleratedFactory())
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(
+            message.body,
+            deserialize(Message(), actual, TCompactProtocolAcceleratedFactory()).body,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lib/py/test/thrift_TSerializer.py
+++ b/lib/py/test/thrift_TSerializer.py
@@ -71,7 +71,7 @@ class TestSerializer(unittest.TestCase):
         self.verify(self.compact_serialized, factory)
 
     def test_TCompactProtocolAccelerated_unicode_matches_python(self):
-        message = Message("é", 42)
+        message = Message(u"\u00e9", 42)
         expected = serialize(message, TCompactProtocolFactory())
         actual = serialize(message, TCompactProtocolAcceleratedFactory())
 


### PR DESCRIPTION
Hi - I figured I'd share a few perf optimizations we are using internally. We are still on an older thrift version (😢 ), so I did use some agent magic to port these to the head of this repo. My testing was primarily on my branch - in this case, for example, we only care about p3.12+, so i added some compat for when they added PyUnicode_AsUTF8AndSize in py3.3 (impressed the repo still suports py2!)

This one is 1 of 3 PRs

⚠️ I did use AI tools to investigate and address feedback, but I am a real human ready to collaborate 😄 

---

Use PyUnicode_AsUTF8AndSize when available, with a fallback for older Python 3 releases, so UTF-8 strings can be encoded without allocating an intermediate PyBytes object.

Performance (50k iterations, warmed)

| Workload | Baseline | This commit | Speedup |
|----------|----------|-------------|---------|
| encode simple (30B, 1 string) | 0.60 us | 0.55 us | 1.09x | | encode 10-string (182B) | 1.44 us | 1.01 us | 1.43x | | encode complex (395B) | 3.02 us | 2.56 us | 1.18x |

The more string fields a struct has, the larger the gain. Decode is unchanged.
