### PR TITLE
THRIFT-6069: python: use a flat fastbinary encode buffer

### DIFF
--- a/lib/py/src/ext/protocol.tcc
+++ b/lib/py/src/ext/protocol.tcc
@@ -29,6 +29,7 @@
 #include <cStringIO.h>
 #else
 #include <algorithm>
+#include <cstring>
 #endif
 
 namespace apache {
@@ -120,8 +121,10 @@ inline bool input_check(PyObject* input) {
 
 inline EncodeBuffer* new_encode_buffer(size_t size) {
   EncodeBuffer* buffer = new EncodeBuffer;
-  buffer->buf.reserve(size);
-  buffer->pos = 0;
+  if (!buffer->init(size)) {
+    delete buffer;
+    return nullptr;
+  }
   return buffer;
 }
 
@@ -165,21 +168,18 @@ inline bool ProtocolBase<Impl>::isUtf8(PyObject* typeargs) {
 
 template <typename Impl>
 PyObject* ProtocolBase<Impl>::getEncodedValue() {
-  return PyBytes_FromStringAndSize(output_->buf.data(), output_->buf.size());
+  return PyBytes_FromStringAndSize(output_->data, output_->size);
 }
 
 template <typename Impl>
 inline bool ProtocolBase<Impl>::writeBuffer(char* data, size_t size) {
-  size_t need = size + output_->pos;
-  if (output_->buf.capacity() < need) {
-    try {
-      output_->buf.reserve(need);
-    } catch (std::bad_alloc&) {
-      PyErr_SetString(PyExc_MemoryError, "Failed to allocate write buffer");
-      return false;
-    }
+  if (!output_->ensure(size)) {
+    PyErr_SetString(PyExc_MemoryError, "Failed to allocate write buffer");
+    return false;
   }
-  std::copy(data, data + size, std::back_inserter(output_->buf));
+
+  memcpy(output_->data + output_->size, data, size);
+  output_->size += size;
   return true;
 }
 

--- a/lib/py/src/ext/types.h
+++ b/lib/py/src/ext/types.h
@@ -31,6 +31,8 @@
 #if PY_MAJOR_VERSION >= 3
 
 #include <vector>
+#include <limits>
+#include <stdlib.h>
 
 // TODO: better macros
 #define PyInt_AsLong(v) PyLong_AsLong(v)
@@ -131,8 +133,65 @@ typedef PyObject EncodeBuffer;
 #else
 extern const char* refill_signature;
 struct EncodeBuffer {
-  std::vector<char> buf;
-  size_t pos;
+  char* data;
+  size_t size;
+  size_t capacity;
+
+  EncodeBuffer() : data(nullptr), size(0), capacity(0) {}
+  EncodeBuffer(const EncodeBuffer&) = delete;
+  EncodeBuffer& operator=(const EncodeBuffer&) = delete;
+
+  ~EncodeBuffer() {
+    if (data) {
+      free(data);
+    }
+  }
+
+  bool init(size_t initial_capacity) {
+    if (initial_capacity == 0) {
+      data = nullptr;
+      size = 0;
+      capacity = 0;
+      return true;
+    }
+
+    data = static_cast<char*>(malloc(initial_capacity));
+    if (!data) {
+      return false;
+    }
+    size = 0;
+    capacity = initial_capacity;
+    return true;
+  }
+
+  bool ensure(size_t additional) {
+    if (additional > (std::numeric_limits<size_t>::max)() - size) {
+      return false;
+    }
+
+    size_t needed = size + additional;
+    if (needed <= capacity) {
+      return true;
+    }
+
+    size_t new_capacity = capacity == 0 ? needed : capacity;
+    while (new_capacity < needed) {
+      if (new_capacity > (std::numeric_limits<size_t>::max)() / 2) {
+        new_capacity = needed;
+        break;
+      }
+      new_capacity *= 2;
+    }
+
+    char* new_data = static_cast<char*>(realloc(data, new_capacity));
+    if (!new_data) {
+      return false;
+    }
+
+    data = new_data;
+    capacity = new_capacity;
+    return true;
+  }
 };
 #endif
 

--- a/lib/py/test/thrift_TBinaryProtocol.py
+++ b/lib/py/test/thrift_TBinaryProtocol.py
@@ -22,7 +22,9 @@ import unittest
 import uuid
 
 import _import_local_thrift  # noqa
+from thrift.Thrift import TApplicationException
 from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAcceleratedFactory
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.transport import TTransport
 
@@ -167,6 +169,13 @@ def testField(type, data):
     protocol.readStructEnd()
 
 
+APPLICATION_EXCEPTION_THRIFT_SPEC = (
+    None,
+    (1, 11, "message", "UTF8", None),
+    (2, 8, "type", None, None),
+)
+
+
 def testMessage(data, strict=True):
     message = {}
     message['name'] = data[0]
@@ -195,6 +204,13 @@ def testMessage(data, strict=True):
 
 
 class TestTBinaryProtocol(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            from thrift.protocol import fastbinary  # noqa: F401
+            self._has_fastbinary = True
+        except ImportError:
+            self._has_fastbinary = False
 
     def test_TBinaryProtocol_write_read(self):
         try:
@@ -279,6 +295,33 @@ class TestTBinaryProtocol(unittest.TestCase):
         except Exception as e:
             print("Assertion fail")
             raise e
+
+    def test_accelerated_large_message_roundtrip(self):
+        if not self._has_fastbinary:
+            self.skipTest("C extension not available")
+
+        original = TApplicationException(
+            type=TApplicationException.INTERNAL_ERROR,
+            message="x" * 8192,
+        )
+
+        otrans = TTransport.TMemoryBuffer()
+        oproto = TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(otrans)
+        oproto.trans.write(oproto._fast_encode(
+            original,
+            [TApplicationException, APPLICATION_EXCEPTION_THRIFT_SPEC],
+        ))
+
+        itrans = TTransport.TMemoryBuffer(otrans.getvalue())
+        iproto = TBinaryProtocolAcceleratedFactory(fallback=False).getProtocol(itrans)
+        decoded = iproto._fast_decode(
+            None,
+            iproto,
+            [TApplicationException, APPLICATION_EXCEPTION_THRIFT_SPEC],
+        )
+
+        self.assertEqual(decoded.message, original.message)
+        self.assertEqual(decoded.type, original.type)
 
     def test_TBinaryProtocol_no_strict_write_read(self):
         TMessageType = {"T_CALL": 1, "T_REPLY": 2, "T_EXCEPTION": 3, "T_ONEWAY": 4}


### PR DESCRIPTION
Hi - I figured I'd share a few perf optimizations we are using internally. We are still on an older thrift version (😢 ), so I did use some agent magic to port these to the head of this repo. My testing was primarily on my branch, so buyer beware on that front!

This one is 1 of 3 PRs

⚠️ I did use AI tools to investigate and address feedback, but I am a real human ready to collaborate 😄 

---

Replace std::vector back_inserter writes in the fastbinary encoder with a malloc/realloc buffer so encoded bytes can be copied in bulk while preserving the existing growth behavior.

Performance (50k iterations, warmed)

| Message size | apache/master | branch | speedup |
|--------------|---------------|--------|---------|
| 8 KiB | 12.19 us | 1.11 us | 11.0x |
| 64 KiB | 101.58 us | 5.48 us | 18.5x |
| 256 KiB | 564.34 us | 25.22 us | 22.4x |
| 1 MiB | 2188.97 us | 136.22 us | 16.1x |

Decode performance is unchanged because this only affects the encode path.

