### PR TITLE
fix off-by-ten header bounds check in readHeaderFormat

### DIFF
--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
@@ -222,7 +222,10 @@ void THeaderTransport::readHeaderFormat(uint16_t headerSize, uint32_t sz) {
   }
   headerSize *= 4;
   const uint8_t* const headerBoundary = ptr + headerSize;
-  if (headerSize > sz) {
+  // ptr already skips the 10-byte common header, so the header section has to
+  // fit in the remaining sz - 10 bytes; comparing against sz alone let the
+  // boundary sit up to 10 bytes past the receive buffer.
+  if (headerSize > sz - 10) {
     throw TTransportException(TTransportException::CORRUPTED_DATA,
                               "Header size is larger than frame");
   }

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -96,6 +96,9 @@ set(UnitTest_SOURCES
 add_executable(UnitTests ${UnitTest_SOURCES})
 target_link_libraries(UnitTests testgencpp ${Boost_LIBRARIES})
 target_link_libraries(UnitTests thrift)
+if(WITH_ZLIB)
+    target_link_libraries(UnitTests thriftz)
+endif()
 add_test(NAME UnitTests COMMAND UnitTests)
 if(MSVC)
     # Disable C4503: decorated name length exceeded, name was truncated

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -146,6 +146,7 @@ UnitTests_SOURCES = \
 
 UnitTests_LDADD = \
   libtestgencpp.la \
+  $(top_builddir)/lib/cpp/libthriftz.la \
   $(BOOST_TEST_LDADD) \
   $(BOOST_SYSTEM_LDADD) \
   $(BOOST_THREAD_LDADD)

--- a/lib/cpp/test/ThrifttReadCheckTests.cpp
+++ b/lib/cpp/test/ThrifttReadCheckTests.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <thrift/transport/TTransportUtils.h>
 #include <thrift/transport/TBufferTransports.h>
+#include <thrift/transport/THeaderTransport.h>
 #include <thrift/transport/TSimpleFileTransport.h>
 #include <thrift/transport/TFileTransport.h>
 #include <thrift/protocol/TEnum.h>
@@ -315,6 +316,28 @@ BOOST_AUTO_TEST_CASE(test_tthriftjsonprotocol_read_check_exception) {
   protocol->writeMapEnd();
   BOOST_CHECK_THROW(protocol->readMapBegin(elemType, elemType1, val), TTransportException);
   protocol->readMapEnd();
+}
+
+BOOST_AUTO_TEST_CASE(test_theadertransport_header_size_exceeds_frame) {
+  using apache::thrift::transport::THeaderTransport;
+  // Header-format frame whose declared header size (3 * 4 = 12) leaves fewer
+  // than the 10 common-header bytes inside the 14-byte frame. The trailing
+  // varint bytes are all continuation bytes, so the reader used to run off the
+  // end of the receive buffer.
+  uint8_t frame[] = {
+      0x00, 0x00, 0x00, 0x0E, // frame length = 14
+      0x0F, 0xFF, 0x00, 0x00, // header magic
+      0x00, 0x00, 0x00, 0x00, // seqId
+      0x00, 0x03,             // header size field (3 -> 12 bytes)
+      0x02,                   // protocol id varint
+      0x00,                   // num transforms = 0
+      0x80, 0x80              // info-header varint, all continuation
+  };
+  std::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(frame, sizeof(frame)));
+  std::shared_ptr<THeaderTransport> trans(new THeaderTransport(buffer));
+
+  uint8_t out[1];
+  BOOST_CHECK_THROW(trans->read(out, sizeof(out)), TTransportException);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
readHeaderFormat checks the declared header size against the whole frame size, but the parse pointer has already moved past the 10-byte common header before that check, so a header size landing in the last 10 bytes of the frame leaves the header boundary pointing up to 10 bytes beyond the receive buffer. The varint and string readers only stop at that boundary, so a malformed THeader frame makes them read past the end of the buffer. Comparing the header section against the remaining sz - 10 bytes keeps the boundary inside the allocation, and the added test drives the read path with such a frame.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.