### PR TITLE
THRIFT-6071: Validate container size fits int32 range before narrowing conversion in TSimpleJSONProtocol

### DIFF
--- a/lib/go/thrift/simple_json_protocol.go
+++ b/lib/go/thrift/simple_json_protocol.go
@@ -1117,6 +1117,12 @@ func (p *TSimpleJSONProtocol) ParseElemListBegin() (elemType TType, size int, e 
 	if err != nil {
 		return elemType, 0, err
 	}
+	if nSize > math.MaxInt32 {
+		return elemType, 0, NewTProtocolExceptionWithType(
+			SIZE_LIMIT,
+			fmt.Errorf("size exceeded max allowed: %d", nSize),
+		)
+	}
 	err = checkSizeForProtocol(int32(nSize), p.cfg)
 	if err != nil {
 		return elemType, 0, err

--- a/lib/go/thrift/simple_json_protocol_test.go
+++ b/lib/go/thrift/simple_json_protocol_test.go
@@ -832,3 +832,32 @@ func TestReadSimpleJSONProtocolMapBeginSizeOverflow(t *testing.T) {
 		t.Errorf("expected SIZE_LIMIT, got %d: %v", tpe.TypeId(), err)
 	}
 }
+
+func TestReadSimpleJSONProtocolListBeginSizeOverflow(t *testing.T) {
+	// nSize = 1<<32 + 1; int32 narrowing wraps it to 1, which would pass checkSizeForProtocol.
+	// The list header is written directly as raw JSON to avoid int-width issues on 32-bit platforms.
+	overflowSize := int64(math.MaxInt32)*2 + 3 // = 4294967297 = 1<<32 + 1
+	for _, name := range []string{"list", "set"} {
+		t.Run(name, func(t *testing.T) {
+			buf := NewTMemoryBuffer()
+			buf.WriteString(fmt.Sprintf("[%d,%d]", I32, overflowSize))
+			proto := NewTSimpleJSONProtocolConf(buf, &TConfiguration{MaxMessageSize: 1024})
+			var err error
+			if name == "list" {
+				_, _, err = proto.ReadListBegin(context.Background())
+			} else {
+				_, _, err = proto.ReadSetBegin(context.Background())
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			tpe, ok := err.(TProtocolException)
+			if !ok {
+				t.Fatalf("expected TProtocolException, got %T: %v", err, err)
+			}
+			if tpe.TypeId() != SIZE_LIMIT {
+				t.Errorf("expected SIZE_LIMIT, got %d: %v", tpe.TypeId(), err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ParseElemListBegin` reads the list/set element count from the wire as `int64` via `ParseI64`, but passes `int32(nSize)` to `checkSizeForProtocol`. Values larger than `math.MaxInt32` are silently narrowed before the check; the truncated value may pass while the full `int64` is stored in `size` and returned to callers.

The fix adds an explicit range check (`nSize > math.MaxInt32`) before the narrowing cast, returning `SIZE_LIMIT` immediately. The existing `checkSizeForProtocol` call is retained for the normal range.

`ReadListBegin` and `ReadSetBegin` both delegate to `ParseElemListBegin` and are covered by this change. `binary_protocol`, `compact_protocol`, and `json_protocol` read container sizes as `int32` directly and are not affected.

Related: PR #3599 addresses an analogous issue in `ReadMapBegin`; the same guard should be added there once that fix lands.

## Test plan

- [ ] `TestReadSimpleJSONProtocolListBeginSizeOverflow` — new test covering list and set; verifies `SIZE_LIMIT` is returned for a declared size of `1<<32 + 1` (which `int32` truncation would reduce to `1`)
- [ ] Full Go library test suite: `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)