### PR TITLE
THRIFT-6072: Rescue connection errors during accept in ThreadedServer and SimpleServer

### DIFF
--- a/lib/rb/lib/thrift/server/simple_server.rb
+++ b/lib/rb/lib/thrift/server/simple_server.rb
@@ -24,7 +24,14 @@ module Thrift
       begin
         @server_transport.listen
         loop do
-          client = @server_transport.accept
+          begin
+            client = @server_transport.accept
+          rescue Errno::ECONNRESET, Errno::EPIPE
+            next
+          rescue => e
+            next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
+            raise
+          end
           trans = @transport_factory.get_transport(client)
           prot = @protocol_factory.get_protocol(trans)
           begin

--- a/lib/rb/lib/thrift/server/threaded_server.rb
+++ b/lib/rb/lib/thrift/server/threaded_server.rb
@@ -26,7 +26,14 @@ module Thrift
       begin
         @server_transport.listen
         loop do
-          client = @server_transport.accept
+          begin
+            client = @server_transport.accept
+          rescue Errno::ECONNRESET, Errno::EPIPE
+            next
+          rescue => e
+            next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
+            raise
+          end
           trans = @transport_factory.get_transport(client)
           prot = @protocol_factory.get_protocol(trans)
           Thread.new(prot, trans) do |p, t|

--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -18,6 +18,7 @@
 # under the License.
 #
 require 'spec_helper'
+require 'openssl'
 
 describe 'Server' do
   describe Thrift::BaseServer do
@@ -81,6 +82,30 @@ describe 'Server' do
       expect(@serverTrans).to receive(:close).ordered
       expect { @server.serve }.to throw_symbol(:stop)
     end
+
+    it "should continue serving after accept raises Errno::ECONNRESET" do
+      expect(@serverTrans).to receive(:listen).ordered
+      expect(@serverTrans).to receive(:accept).ordered.and_raise(Errno::ECONNRESET)
+      expect(@serverTrans).to receive(:accept).ordered.and_return(@client)
+      expect(@trans).to receive(:get_transport).once.with(@client).and_return(@trans)
+      expect(@prot).to receive(:get_protocol).once.with(@trans).and_return(@prot)
+      expect(@processor).to receive(:process).once.with(@prot, @prot) { throw :stop }
+      expect(@trans).to receive(:close).once
+      expect(@serverTrans).to receive(:close).ordered
+      expect { @server.serve }.to throw_symbol(:stop)
+    end
+
+    it "should continue serving after accept raises OpenSSL::SSL::SSLError" do
+      expect(@serverTrans).to receive(:listen).ordered
+      expect(@serverTrans).to receive(:accept).ordered.and_raise(OpenSSL::SSL::SSLError)
+      expect(@serverTrans).to receive(:accept).ordered.and_return(@client)
+      expect(@trans).to receive(:get_transport).once.with(@client).and_return(@trans)
+      expect(@prot).to receive(:get_protocol).once.with(@trans).and_return(@prot)
+      expect(@processor).to receive(:process).once.with(@prot, @prot) { throw :stop }
+      expect(@trans).to receive(:close).once
+      expect(@serverTrans).to receive(:close).ordered
+      expect { @server.serve }.to throw_symbol(:stop)
+    end
   end
 
   describe Thrift::ThreadedServer do
@@ -115,6 +140,32 @@ describe 'Server' do
         end
       end
       expect(@trans).to receive(:close).exactly(3).times
+      expect(@serverTrans).to receive(:close).ordered
+      expect { @server.serve }.to throw_symbol(:stop)
+    end
+
+    it "should continue serving after accept raises Errno::ECONNRESET" do
+      expect(@serverTrans).to receive(:listen).ordered
+      expect(@serverTrans).to receive(:accept).ordered.and_raise(Errno::ECONNRESET)
+      expect(@serverTrans).to receive(:accept).ordered.and_return(@client)
+      expect(@trans).to receive(:get_transport).once.with(@client).and_return(@trans)
+      expect(@prot).to receive(:get_protocol).once.with(@trans).and_return(@prot)
+      expect(Thread).to receive(:new).with(@prot, @trans).once.and_yield(@prot, @trans)
+      expect(@processor).to receive(:process).once.with(@prot, @prot) { throw :stop }
+      expect(@trans).to receive(:close).once
+      expect(@serverTrans).to receive(:close).ordered
+      expect { @server.serve }.to throw_symbol(:stop)
+    end
+
+    it "should continue serving after accept raises OpenSSL::SSL::SSLError" do
+      expect(@serverTrans).to receive(:listen).ordered
+      expect(@serverTrans).to receive(:accept).ordered.and_raise(OpenSSL::SSL::SSLError)
+      expect(@serverTrans).to receive(:accept).ordered.and_return(@client)
+      expect(@trans).to receive(:get_transport).once.with(@client).and_return(@trans)
+      expect(@prot).to receive(:get_protocol).once.with(@trans).and_return(@prot)
+      expect(Thread).to receive(:new).with(@prot, @trans).once.and_yield(@prot, @trans)
+      expect(@processor).to receive(:process).once.with(@prot, @prot) { throw :stop }
+      expect(@trans).to receive(:close).once
       expect(@serverTrans).to receive(:close).ordered
       expect { @server.serve }.to throw_symbol(:stop)
     end


### PR DESCRIPTION
## Summary

- `ThreadedServer` and `SimpleServer` did not rescue errors raised during `@server_transport.accept`.
- When an SSL server socket receives a plain TCP probe connection (e.g. the cross-test runner's `ensure_socket_open` readiness check), the immediately-aborted connection causes an `OpenSSL::SSL::SSLError` from within `accept`, which propagated unhandled and terminated the server process.
- This produces `RESULT_ERROR (64)` in the cross-test runner because the server exits before the client can be started.
- The fix wraps `accept` in a rescue that swallows `Errno::ECONNRESET`, `Errno::EPIPE`, and `OpenSSL::SSL::SSLError` (when OpenSSL is loaded), allowing the server to continue serving after such transient connection failures.
- `ThreadPoolServer` and `NonblockingServer` were already safe; this brings `ThreadedServer` and `SimpleServer` in line.

## How the problem was found

While reviewing CI results on an unrelated PR, the cross-test combination `rb-cpp accel-binary buffered-ip-ssl` occasionally produced `RESULT_ERROR (64)` (meaning the server process exited before the client was ever started).

Root cause trace:
1. `test/crossrunner/run.py` calls `ensure_socket_open()` to confirm the server is ready — it does a plain TCP connect to the bound port and immediately closes it.
2. For an SSL server socket (`SSLServerSocket`), the port is bound via a plain `TCPServer` that is then wrapped by `OpenSSL::SSL::SSLServer`. The port is already visible after `listen`, so the TCP probe succeeds at the transport level.
3. However, `SSLServer#accept` includes the SSL handshake. The probe connection aborts mid-handshake, raising `OpenSSL::SSL::SSLError` inside the `accept` call.
4. `ThreadedServer#serve` and `SimpleServer#serve` had no rescue around `accept`, so the exception propagated out of the `loop`, through the outer `begin…ensure`, triggering `@server_transport.close` and terminating the process — before the real client was launched.

## Test plan

- [ ] New unit tests in `lib/rb/spec/server_spec.rb` verify that both `SimpleServer` and `ThreadedServer` continue serving when `accept` raises `Errno::ECONNRESET` or `OpenSSL::SSL::SSLError`
- [x] Existing server spec tests still pass (normal accept path unchanged)
- [ ] `lib-ruby` CI job passes
- [x] Cross-test `rb-cpp accel-binary buffered-ip-ssl` no longer produces `RESULT_ERROR (64)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
