### PR TITLE
widen container size precheck to 64-bit in go protocols

### DIFF
--- a/lib/go/thrift/binary_protocol.go
+++ b/lib/go/thrift/binary_protocol.go
@@ -356,8 +356,7 @@ func (p *TBinaryProtocol) ReadMapBegin(ctx context.Context) (kType, vType TType,
 		return
 	}
 	minElemSize := p.getMinSerializedSize(kType) + p.getMinSerializedSize(vType)
-	totalMinSize := size32 * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(int64(size32), minElemSize, p.cfg)
 	if err != nil {
 		return
 	}
@@ -382,8 +381,7 @@ func (p *TBinaryProtocol) ReadListBegin(ctx context.Context) (elemType TType, si
 		return
 	}
 	minElemSize := p.getMinSerializedSize(elemType)
-	totalMinSize := size32 * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(int64(size32), minElemSize, p.cfg)
 	if err != nil {
 		return
 	}
@@ -409,8 +407,7 @@ func (p *TBinaryProtocol) ReadSetBegin(ctx context.Context) (elemType TType, siz
 		return
 	}
 	minElemSize := p.getMinSerializedSize(elemType)
-	totalMinSize := size32 * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(int64(size32), minElemSize, p.cfg)
 	if err != nil {
 		return
 	}

--- a/lib/go/thrift/compact_protocol.go
+++ b/lib/go/thrift/compact_protocol.go
@@ -499,8 +499,7 @@ func (p *TCompactProtocol) ReadMapBegin(ctx context.Context) (keyType TType, val
 	valueType, _ = p.getTType(tCompactType(keyAndValueType & 0xf))
 
 	minElemSize := p.getMinSerializedSize(keyType) + p.getMinSerializedSize(valueType)
-	totalMinSize := size32 * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(int64(size32), minElemSize, p.cfg)
 	if err != nil {
 		return
 	}
@@ -534,8 +533,7 @@ func (p *TCompactProtocol) ReadListBegin(ctx context.Context) (elemType TType, s
 	}
 
 	minElemSize := p.getMinSerializedSize(elemType)
-	totalMinSize := int32(size) * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(int64(size), minElemSize, p.cfg)
 	if err != nil {
 		return
 	}

--- a/lib/go/thrift/configuration.go
+++ b/lib/go/thrift/configuration.go
@@ -345,6 +345,12 @@ func checkContainerSizeForProtocol(size int64, minElemSize int32, cfg *TConfigur
 			fmt.Errorf("negative size: %d", size),
 		)
 	}
+	if size > math.MaxInt32 {
+		return NewTProtocolExceptionWithType(
+			SIZE_LIMIT,
+			fmt.Errorf("size exceeded max allowed: %d", size),
+		)
+	}
 	totalMinSize := size * int64(minElemSize)
 	if totalMinSize > math.MaxInt32 {
 		return NewTProtocolExceptionWithType(

--- a/lib/go/thrift/configuration.go
+++ b/lib/go/thrift/configuration.go
@@ -22,6 +22,7 @@ package thrift
 import (
 	"crypto/tls"
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -330,6 +331,28 @@ func checkSizeForProtocol(size int32, cfg *TConfiguration) error {
 		)
 	}
 	return nil
+}
+
+// checkContainerSizeForProtocol validates the minimum on-wire size of a
+// container with the given wire-supplied element count, where each element
+// occupies at least minElemSize bytes. The count is range-checked and the
+// product is computed in 64-bit arithmetic, so the value handed to
+// checkSizeForProtocol always stays within int32 range.
+func checkContainerSizeForProtocol(size int64, minElemSize int32, cfg *TConfiguration) error {
+	if size < 0 {
+		return NewTProtocolExceptionWithType(
+			NEGATIVE_SIZE,
+			fmt.Errorf("negative size: %d", size),
+		)
+	}
+	totalMinSize := size * int64(minElemSize)
+	if totalMinSize > math.MaxInt32 {
+		return NewTProtocolExceptionWithType(
+			SIZE_LIMIT,
+			fmt.Errorf("size exceeded max allowed: %d", totalMinSize),
+		)
+	}
+	return checkSizeForProtocol(int32(totalMinSize), cfg)
 }
 
 type tTransportFactoryConf struct {

--- a/lib/go/thrift/json_protocol.go
+++ b/lib/go/thrift/json_protocol.go
@@ -317,8 +317,7 @@ func (p *TJSONProtocol) ReadMapBegin(ctx context.Context) (keyType TType, valueT
 	size = int(iSize)
 
 	minElemSize := p.getMinSerializedSize(keyType) + p.getMinSerializedSize(valueType)
-	totalMinSize := int32(iSize) * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(iSize, minElemSize, p.cfg)
 	if err != nil {
 		return keyType, valueType, 0, err
 	}
@@ -498,8 +497,7 @@ func (p *TJSONProtocol) ParseElemListBegin() (elemType TType, size int, e error)
 	size = int(nSize)
 
 	minElemSize := p.getMinSerializedSize(elemType)
-	totalMinSize := int32(nSize) * minElemSize
-	err = checkSizeForProtocol(totalMinSize, p.cfg)
+	err = checkContainerSizeForProtocol(nSize, minElemSize, p.cfg)
 	if err != nil {
 		return elemType, 0, err
 	}

--- a/lib/go/thrift/protocol_test.go
+++ b/lib/go/thrift/protocol_test.go
@@ -709,6 +709,43 @@ func TestReadContainerSizeOverflow(t *testing.T) {
 			})
 		})
 	}
+
+	// TJSONProtocol reads the element count as a 64-bit value, so the count can
+	// exceed int32 on the wire. WriteMapBegin takes a platform int (too narrow on
+	// 32-bit builds) to carry such a count, so place it on the wire with the
+	// lower-level writers, mirroring WriteMapBegin.
+	t.Run("json/map", func(t *testing.T) {
+		// 0x4000000000000000 * 2 (min size of a map<bool,bool> entry) stays
+		// outside int32 range when kept in 64 bits.
+		const jsonOverflowSize int64 = 0x4000000000000000
+		trans := NewTMemoryBuffer()
+		w := NewTJSONProtocol(trans)
+		if err := w.OutputListBegin(); err != nil {
+			t.Fatal(err)
+		}
+		ks, _ := w.TypeIdToString(BOOL)
+		if err := w.WriteString(ctx, ks); err != nil {
+			t.Fatal(err)
+		}
+		vs, _ := w.TypeIdToString(BOOL)
+		if err := w.WriteString(ctx, vs); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.WriteI64(ctx, jsonOverflowSize); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.OutputObjectBegin(); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+		r := NewTJSONProtocol(trans)
+		r.SetTConfiguration(&TConfiguration{})
+		if _, _, _, err := r.ReadMapBegin(ctx); err == nil {
+			t.Error("expected error reading oversized map header, got nil")
+		}
+	})
 }
 
 func TestCheckContainerSizeForProtocol(t *testing.T) {
@@ -725,6 +762,9 @@ func TestCheckContainerSizeForProtocol(t *testing.T) {
 		// JSON reads the count as int64; a count past int32 must be rejected
 		// rather than reduced to a small product.
 		{"int64-count", 0x100000000, 2, true},
+		// A count near math.MaxInt64/minElem keeps the 64-bit product itself
+		// outside int32 range; it must be rejected by the count range check.
+		{"int64-product", 0x4000000000000000, 2, true},
 	} {
 		t.Run(c.label, func(t *testing.T) {
 			err := checkContainerSizeForProtocol(c.size, c.minElem, &TConfiguration{})

--- a/lib/go/thrift/protocol_test.go
+++ b/lib/go/thrift/protocol_test.go
@@ -660,3 +660,80 @@ func UnmatchedBeginEndProtocolTest(t *testing.T, protocolFactory TProtocolFactor
 	})
 	trans.Close()
 }
+
+// A wire-supplied container element count is multiplied by the per-element
+// minimum serialised size and the result is checked against the configured
+// message size. These tests drive the readers with counts whose minimum-size
+// product, computed in 64 bits, is outside int32 range, and verify the readers
+// reject the header rather than returning it.
+func TestReadContainerSizeOverflow(t *testing.T) {
+	ctx := context.Background()
+	// 0x20000000 * 8 (min size of a DOUBLE element) == 1<<32, i.e. 0 taken as a
+	// signed 32-bit product; the doubled product used for maps is likewise.
+	const overflowSize = 0x20000000
+
+	for _, proto := range []struct {
+		name string
+		make func(TTransport) TProtocol
+	}{
+		{"binary", func(trans TTransport) TProtocol { return NewTBinaryProtocolConf(trans, &TConfiguration{}) }},
+		{"compact", func(trans TTransport) TProtocol { return NewTCompactProtocolConf(trans, &TConfiguration{}) }},
+	} {
+		t.Run(proto.name, func(t *testing.T) {
+			t.Run("map", func(t *testing.T) {
+				p := proto.make(NewTMemoryBuffer())
+				if err := p.WriteMapBegin(ctx, DOUBLE, DOUBLE, overflowSize); err != nil {
+					t.Fatal(err)
+				}
+				if _, _, _, err := p.ReadMapBegin(ctx); err == nil {
+					t.Error("expected error reading oversized map header, got nil")
+				}
+			})
+			t.Run("list", func(t *testing.T) {
+				p := proto.make(NewTMemoryBuffer())
+				if err := p.WriteListBegin(ctx, DOUBLE, overflowSize); err != nil {
+					t.Fatal(err)
+				}
+				if _, _, err := p.ReadListBegin(ctx); err == nil {
+					t.Error("expected error reading oversized list header, got nil")
+				}
+			})
+			t.Run("set", func(t *testing.T) {
+				p := proto.make(NewTMemoryBuffer())
+				if err := p.WriteSetBegin(ctx, DOUBLE, overflowSize); err != nil {
+					t.Fatal(err)
+				}
+				if _, _, err := p.ReadSetBegin(ctx); err == nil {
+					t.Error("expected error reading oversized set header, got nil")
+				}
+			})
+		})
+	}
+}
+
+func TestCheckContainerSizeForProtocol(t *testing.T) {
+	for _, c := range []struct {
+		label     string
+		size      int64
+		minElem   int32
+		wantError bool
+	}{
+		{"small", 10, 8, false},
+		{"negative", -1, 8, true},
+		// 0x20000000 * 8 == 1<<32, i.e. 0 taken as a signed 32-bit product.
+		{"int32-product", 0x20000000, 8, true},
+		// JSON reads the count as int64; a count past int32 must be rejected
+		// rather than reduced to a small product.
+		{"int64-count", 0x100000000, 2, true},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			err := checkContainerSizeForProtocol(c.size, c.minElem, &TConfiguration{})
+			if c.wantError && err == nil {
+				t.Errorf("size=%d minElem=%d: expected error, got nil", c.size, c.minElem)
+			}
+			if !c.wantError && err != nil {
+				t.Errorf("size=%d minElem=%d: unexpected error: %v", c.size, c.minElem, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Go binary, compact and JSON protocol readers computed the container size precheck (`size * minElemSize`) in 32-bit arithmetic. This routes the three readers through a small helper that performs the multiplication in 64-bit and range-checks the element count, so the value compared against `maxMessageSize` always stays within int32 range — matching the 64-bit precheck widening already done for the C++ and C/GLib bindings in #3590. The JSON readers read the element count as `int64`, so the helper also bounds the count before the multiply. Includes regression tests driving each reader (binary, compact, JSON) with counts whose 64-bit product is outside int32 range.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
