### PR TITLE
enforce stringLengthLimit in TCompactProtocol.readBinary

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
+++ b/lib/java/src/main/java/org/apache/thrift/protocol/TCompactProtocol.java
@@ -680,7 +680,7 @@ public class TCompactProtocol extends TProtocol {
     if (length == 0) {
       return EMPTY_BUFFER;
     }
-    getTransport().checkReadBytesAvailable(length);
+    checkStringReadLength(length);
     if (trans_.getBytesRemainingInBuffer() >= length) {
       ByteBuffer bb = ByteBuffer.wrap(trans_.getBuffer(), trans_.getBufferPosition(), length);
       trans_.consumeBuffer(length);

--- a/lib/java/src/test/java/org/apache/thrift/protocol/TestMessageSizeLimits.java
+++ b/lib/java/src/test/java/org/apache/thrift/protocol/TestMessageSizeLimits.java
@@ -106,6 +106,20 @@ public class TestMessageSizeLimits {
   }
 
   @Test
+  public void testCompactProtocol_stringLengthLimitEnforcedForBinary() throws Exception {
+    // binary uses the same varint-length encoding as a string on the wire
+    byte[] buf = encodeCompactString(repeat('A', 100));
+    TMemoryInputTransport transport = new TMemoryInputTransport(buf);
+
+    TCompactProtocol proto = new TCompactProtocol(transport, 10L, -1L);
+
+    assertThrows(
+        TProtocolException.class,
+        proto::readBinary,
+        "TCompactProtocol stringLengthLimit must also gate readBinary, not just readString");
+  }
+
+  @Test
   public void testConsumeBuffer_decrementsRemainingMessageSize() throws Exception {
     // 20-byte transport; updateKnownMessageSize sets remainingMessageSize = 20
     byte[] buf = new byte[20];


### PR DESCRIPTION
TCompactProtocol.readBinary only checks the binary length against the remaining message budget, so the per-string limit (stringLengthLimit) that readString applies through checkStringReadLength is never enforced for binary fields. a peer that has configured a string length limit therefore has it quietly bypassed for any binary value, which can then be sized up to the whole message. routing readBinary through checkStringReadLength applies the same limit and keeps the existing remaining-bytes check, matching how TBinaryProtocol.readBinary already behaves. added a regression test alongside the existing compact string-limit test.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.