### PR TITLE
THRIFT-6073: Allow injecting external SSL_CTX into C++ SSLContext

### DIFF
--- a/lib/cpp/README.md
+++ b/lib/cpp/README.md
@@ -138,7 +138,11 @@ TSSLSocket are always created from TSSLSocketFactory.
 The default TSSLSocketFactory context uses OpenSSL's version-flexible TLS
 method and sets TLS 1.2 as the minimum negotiated protocol version. Applications
 that need a different protocol range can provide a custom SSLContext factory and
-adjust the OpenSSL context options before creating sockets.
+adjust the OpenSSL context options before creating sockets. Applications that
+link against an OpenSSL-compatible TLS library can also create and configure an
+SSL_CTX externally, wrap it with `SSLContext`, and pass it through the factory
+(for example, protocol-specific or dual-certificate setups that the default
+factory methods cannot express).
 
 ## How to use SSL APIs
 

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -213,6 +213,12 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
   }
 }
 
+SSLContext::SSLContext(SSL_CTX* ctx) : ctx_(ctx) {
+  if (ctx_ == nullptr) {
+    throw TSSLException("SSLContext: ctx must not be null");
+  }
+}
+
 SSLContext::~SSLContext() {
   if (ctx_ != nullptr) {
     SSL_CTX_free(ctx_);

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -365,6 +365,21 @@ public:
 class SSLContext {
 public:
   SSLContext(const SSLProtocol& protocol = SSLTLS);
+  /**
+   * Wrap an existing OpenSSL SSL_CTX.
+   *
+   * Takes ownership of @a ctx; the caller must not call SSL_CTX_free on it.
+   * The context must remain valid for the lifetime of this SSLContext and any
+   * TSSLSocket instances created from it (see TSSLSocketFactory lifetime notes).
+   *
+   * Unlike SSLContext(SSLProtocol) with the default SSLTLS protocol, this
+   * constructor does not apply a minimum TLS version (no SSL_OP_NO_TLSv1*).
+   * Configure protocol options on @a ctx before wrapping if a version floor
+   * is required.
+   *
+   * @param ctx  OpenSSL context to wrap (ownership transferred)
+   */
+  explicit SSLContext(SSL_CTX* ctx);
   virtual ~SSLContext();
   SSL* createSSL();
   SSL_CTX* get() { return ctx_; }

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -34,6 +34,7 @@
 #endif
 
 using apache::thrift::transport::TSSLServerSocket;
+using apache::thrift::transport::SSLContext;
 using apache::thrift::transport::SSLContextFactory;
 using apache::thrift::transport::TSSLException;
 using apache::thrift::transport::TServerTransport;
@@ -272,6 +273,34 @@ BOOST_AUTO_TEST_CASE(custom_ssl_context_options)
         BOOST_CHECK((options & SSL_OP_NO_TLSv1_1) == 0);
     }
     context.reset();
+}
+
+BOOST_AUTO_TEST_CASE(wrapped_ssl_context)
+{
+    SSL_CTX* raw = SSL_CTX_new(TLS_method());
+    BOOST_REQUIRE(raw != nullptr);
+    SSL_CTX_set_mode(raw, SSL_MODE_AUTO_RETRY);
+
+    std::shared_ptr<SSLContext> context;
+    TSSLSocketFactory factory([&context, raw]() {
+        context = std::make_shared<SSLContext>(raw);
+        return context;
+    });
+    BOOST_CHECK(context->get() == raw);
+    context.reset();
+}
+
+BOOST_AUTO_TEST_CASE(wrapped_ssl_context_null)
+{
+    try
+    {
+        std::make_shared<SSLContext>(nullptr);
+        BOOST_FAIL("Expected null SSL_CTX to throw");
+    }
+    catch (const TSSLException& ex)
+    {
+        BOOST_CHECK_EQUAL("SSLContext: ctx must not be null", std::string(ex.what()));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(custom_ssl_context_factory_validation)


### PR DESCRIPTION
## Summary

Add a backend-neutral extension point to the C++ `TSSLSocket` stack: applications can inject a pre-configured OpenSSL `SSL_CTX` through the existing `SSLContextFactory` / `TSSLSocketFactory` hook.

This makes it easier for applications to supply a fully configured TLS context—protocol options, cipher suites, certificate loading, and other OpenSSL settings—in application code, without patching libthrift or replacing the transport layer.

## Background

Thrift C++ already provides SSL/TLS through `TSSLSocket` / `TSSLSocketFactory`, backed by OpenSSL. The default factory covers the common case: a single certificate/key pair via `loadCertificate()` / `loadPrivateKey()`, and protocol selection via `SSLProtocol`.

`TSSLSocketFactory` already accepts a custom `SSLContextFactory`, but `SSLContext` could previously only be created from `SSLProtocol`. Applications that need a context configured outside Thrift's helpers—multi-step cert setup, non-default methods, or options not exposed by `TSSLSocketFactory`—had to patch Thrift locally.

This PR adds a small wrapper constructor on `SSLContext` while keeping the default OpenSSL build unchanged.

## What changed

- **`SSLContext`**: `explicit SSLContext(SSL_CTX* ctx)` — wrap an application-configured `SSL_CTX`; ownership is transferred and the context is freed on destruction. Doxygen documents caller responsibilities for TLS protocol configuration (the default `SSLTLS` minimum-version options are not applied automatically).
- **`lib/cpp/README.md`**: document the injection pattern.
- **`SecurityTest`**: wrapped-context and null-validation coverage.

Threat-model cross-check against `doc/thrift-threat-model.md` is recorded in JIRA THRIFT-6073 (per AGENTS.md §6).

## Usage

**Standard TLS (unchanged):**

```cpp
TSSLSocketFactory factory;  // default SSLTLS
factory.loadCertificate("server.crt");
factory.loadPrivateKey("server.key");
```

**Injected `SSL_CTX` (application configures OpenSSL, then transfers ownership):**

```cpp
#include <thrift/transport/TSSLSocket.h>

auto factory = std::make_shared<TSSLSocketFactory>([]() {
  SSL_CTX* ctx = SSL_CTX_new(TLS_method());
  SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
  // Configure ctx before wrapping: protocol floor, ciphers, certificates, etc.
  return std::make_shared<apache::thrift::transport::SSLContext>(ctx);
});
factory->loadTrustedCertificates("ca-bundle.crt");
factory->authenticate(true);
factory->server(true);
auto socket = factory->createSocket("127.0.0.1", port);
```

Link your application against whichever OpenSSL-compatible TLS library you choose; libthrift continues to default to system OpenSSL at build time.

## Licensing

Thrift introduces **no new build-time dependency**. Nothing is vendored; no `LICENSE` / `NOTICE` update is required.

## Test plan

- [x] Standard OpenSSL build: `ctest -R SecurityTest` (`wrapped_ssl_context`, `wrapped_ssl_context_null`)