### PR TITLE
enforce max_string_size on non-strict binary message name

### DIFF
--- a/lib/rs/src/protocol/binary.rs
+++ b/lib/rs/src/protocol/binary.rs
@@ -137,6 +137,17 @@ where
                 // is the message name. strings (byte arrays) are length-prefixed,
                 // so we've just read the length in the first 4 bytes
                 let name_size = BigEndian::read_i32(&first_bytes) as usize;
+                if let Some(max_size) = self.config.max_string_size() {
+                    if name_size > max_size {
+                        return Err(crate::Error::Protocol(ProtocolError::new(
+                            ProtocolErrorKind::SizeLimit,
+                            format!(
+                                "Message name size {} exceeds maximum allowed size of {}",
+                                name_size, max_size
+                            ),
+                        )));
+                    }
+                }
                 let mut name_buf: Vec<u8> = vec![0; name_size];
                 self.transport.read_exact(&mut name_buf)?;
                 let name = String::from_utf8(name_buf)?;
@@ -1263,6 +1274,56 @@ mod tests {
             }
             _ => panic!("Expected protocol error with SizeLimit"),
         }
+    }
+
+    #[test]
+    fn must_enforce_string_size_limit_on_non_strict_message_name() {
+        let mem = TBufferChannel::with_capacity(100, 100);
+        let (r_mem, mut w_mem) = mem.split().unwrap();
+
+        let config = TConfiguration::builder()
+            .max_string_size(Some(1000))
+            .build()
+            .unwrap();
+        // non-strict: the first 4 bytes are the (positive) message-name length
+        let mut i_prot = TBinaryInputProtocol::with_config(r_mem, false, config);
+
+        w_mem.set_readable_bytes(&[0x00, 0x00, 0x07, 0xD0]);
+
+        let result = i_prot.read_message_begin();
+        assert!(result.is_err());
+        match result {
+            Err(crate::Error::Protocol(e)) => {
+                assert_eq!(e.kind, ProtocolErrorKind::SizeLimit);
+                assert!(e
+                    .message
+                    .contains("Message name size 2000 exceeds maximum allowed size of 1000"));
+            }
+            _ => panic!("Expected protocol error with SizeLimit"),
+        }
+    }
+
+    #[test]
+    fn must_allow_non_strict_message_name_at_limit() {
+        let mem = TBufferChannel::with_capacity(100, 100);
+        let (r_mem, mut w_mem) = mem.split().unwrap();
+
+        let config = TConfiguration::builder()
+            .max_string_size(Some(5))
+            .build()
+            .unwrap();
+        // non-strict: the first 4 bytes are the (positive) message-name length
+        let mut i_prot = TBinaryInputProtocol::with_config(r_mem, false, config);
+
+        // name length 5 (== limit), name "hello", message type Call, sequence 0
+        w_mem.set_readable_bytes(&[
+            0x00, 0x00, 0x00, 0x05, b'h', b'e', b'l', b'l', b'o', 0x01, 0x00, 0x00, 0x00, 0x00,
+        ]);
+
+        let ident = i_prot.read_message_begin().unwrap();
+        assert_eq!(ident.name, "hello");
+        assert_eq!(ident.message_type, TMessageType::Call);
+        assert_eq!(ident.sequence_number, 0);
     }
 
     #[test]


### PR DESCRIPTION
the rust binary protocol reader routes every length-prefixed value through the configured `max_string_size`, except one. in the non-strict `read_message_begin` path (the legacy mode kept for senders that don't write the protocol-version header) the leading four bytes are taken as the message-name length and the name buffer is allocated straight from that wire value, without the check that `read_bytes` and `read_string` both apply. this change runs the name length through the same `max_string_size` check before allocating and returns a `SizeLimit` error when it is exceeded. the compact reader is unaffected because its `read_message_begin` goes through `read_string`, which is already bounded.

kept the change inside `read_message_begin` so the rest of the path is unchanged. tests: a non-strict name over the limit is now rejected with `SizeLimit`, and a name of exactly the configured limit is still accepted so the boundary is `>` and not `>=`.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
