### PR TITLE
fix info-header string bound check in THeaderTransport::readString

### DIFF
--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
@@ -199,13 +199,17 @@ void THeaderTransport::readString(uint8_t*& ptr,
   int32_t strLen;
 
   uint32_t bytes = readVarint32(ptr, &strLen, headerBoundary);
-  if (strLen > headerBoundary - ptr) {
+  // Bound the string against the header bytes that remain once the length varint
+  // itself is accounted for, and reject a negative length so the size_t
+  // conversion in assign() below stays within the buffer. ptr is only advanced
+  // once these checks pass, keeping the "advances on success" contract above.
+  uint8_t* strStart = ptr + bytes;
+  if (strLen < 0 || strLen > headerBoundary - strStart) {
     throw TTransportException(TTransportException::CORRUPTED_DATA,
                               "Info header length exceeds header size");
   }
-  ptr += bytes;
-  str.assign(reinterpret_cast<const char*>(ptr), strLen);
-  ptr += strLen;
+  str.assign(reinterpret_cast<const char*>(strStart), strLen);
+  ptr = strStart + strLen;
 }
 
 void THeaderTransport::readHeaderFormat(uint16_t headerSize, uint32_t sz) {

--- a/lib/cpp/test/ThrifttReadCheckTests.cpp
+++ b/lib/cpp/test/ThrifttReadCheckTests.cpp
@@ -340,6 +340,58 @@ BOOST_AUTO_TEST_CASE(test_theadertransport_header_size_exceeds_frame) {
   BOOST_CHECK_THROW(trans->read(out, sizeof(out)), TTransportException);
 }
 
+BOOST_AUTO_TEST_CASE(test_theadertransport_info_header_string_overrun) {
+  using apache::thrift::transport::THeaderTransport;
+  // Header-format frame whose info-header key length (4) does not fit within the
+  // header bytes that remain once the length varint itself is accounted for. The
+  // header section (8 bytes) exactly fills the frame, so the boundary sits at the
+  // buffer end; the key length has to be bounded against the remaining bytes and
+  // rejected.
+  uint8_t frame[] = {
+      0x00, 0x00, 0x00, 0x12, // frame length = 18
+      0x0F, 0xFF, 0x00, 0x00, // header magic
+      0x00, 0x00, 0x00, 0x00, // seqId
+      0x00, 0x02,             // header size field (2 -> 8 bytes)
+      0x02,                   // protocol id varint
+      0x00,                   // num transforms = 0
+      0x01,                   // info id = key/value
+      0x01,                   // one key/value pair
+      0x04,                   // key length = 4 (only 3 bytes remain)
+      0xAA, 0xBB, 0xCC        // key bytes
+  };
+  std::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(frame, sizeof(frame)));
+  std::shared_ptr<THeaderTransport> trans(new THeaderTransport(buffer));
+
+  uint8_t out[1];
+  BOOST_CHECK_THROW(trans->read(out, sizeof(out)), TTransportException);
+}
+
+BOOST_AUTO_TEST_CASE(test_theadertransport_info_header_string_negative_length) {
+  using apache::thrift::transport::THeaderTransport;
+  // Header-format frame whose info-header key length varint decodes to a
+  // negative int32 (top bit set). The length has to be treated as out of range
+  // rather than converted to a size_t, so the read is rejected instead of
+  // reaching the string assignment. The three trailing bytes only pad the
+  // header section out to its declared size and are never reached.
+  uint8_t frame[] = {
+      0x00, 0x00, 0x00, 0x16,             // frame length = 22
+      0x0F, 0xFF, 0x00, 0x00,             // header magic
+      0x00, 0x00, 0x00, 0x00,             // seqId
+      0x00, 0x03,                         // header size field (3 -> 12 bytes)
+      0x02,                               // protocol id varint
+      0x00,                               // num transforms = 0
+      0x01,                               // info id = key/value
+      0x01,                               // one key/value pair
+      0x80, 0x80, 0x80, 0x80, 0x08,       // key length varint = INT32_MIN
+      0x00, 0x00, 0x00                    // padding to fill the header section
+  };
+  std::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(frame, sizeof(frame)));
+  std::shared_ptr<THeaderTransport> trans(new THeaderTransport(buffer));
+
+  uint8_t out[1];
+  BOOST_CHECK_THROW(trans->read(out, sizeof(out)), TTransportException);
+}
+
 BOOST_AUTO_TEST_CASE(test_theadertransport_zlib_roundtrip) {
   using apache::thrift::transport::THeaderTransport;
   // A run of identical bytes compresses to far fewer bytes than it occupies

--- a/lib/cpp/test/ThrifttReadCheckTests.cpp
+++ b/lib/cpp/test/ThrifttReadCheckTests.cpp
@@ -374,16 +374,16 @@ BOOST_AUTO_TEST_CASE(test_theadertransport_info_header_string_negative_length) {
   // reaching the string assignment. The three trailing bytes only pad the
   // header section out to its declared size and are never reached.
   uint8_t frame[] = {
-      0x00, 0x00, 0x00, 0x16,             // frame length = 22
-      0x0F, 0xFF, 0x00, 0x00,             // header magic
-      0x00, 0x00, 0x00, 0x00,             // seqId
-      0x00, 0x03,                         // header size field (3 -> 12 bytes)
-      0x02,                               // protocol id varint
-      0x00,                               // num transforms = 0
-      0x01,                               // info id = key/value
-      0x01,                               // one key/value pair
-      0x80, 0x80, 0x80, 0x80, 0x08,       // key length varint = INT32_MIN
-      0x00, 0x00, 0x00                    // padding to fill the header section
+      0x00, 0x00, 0x00, 0x16,       // frame length = 22
+      0x0F, 0xFF, 0x00, 0x00,       // header magic
+      0x00, 0x00, 0x00, 0x00,       // seqId
+      0x00, 0x03,                   // header size field (3 -> 12 bytes)
+      0x02,                         // protocol id varint
+      0x00,                         // num transforms = 0
+      0x01,                         // info id = key/value
+      0x01,                         // one key/value pair
+      0x80, 0x80, 0x80, 0x80, 0x08, // key length varint = INT32_MIN
+      0x00, 0x00, 0x00              // padding to fill the header section
   };
   std::shared_ptr<TMemoryBuffer> buffer(new TMemoryBuffer(frame, sizeof(frame)));
   std::shared_ptr<THeaderTransport> trans(new THeaderTransport(buffer));


### PR DESCRIPTION
The info-header string length is bounded against the header section before `ptr` moves past the length varint, so the remaining count is overstated by the varint width and a negative length is never rejected. A regression test is added to `ThrifttReadCheckTests`.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.