### PR TITLE
THRIFT-5955 Require C extension in Python wheels

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -149,6 +149,12 @@ except BuildFailed:
     print()
     print('*' * 80)
     print("An error occurred while trying to compile with the C extension enabled")
+
+    if os.environ.get('CIBUILDWHEEL') == '1':
+        print('Refusing to build a release wheel without the C extension')
+        print('*' * 80)
+        raise
+
     print("Attempting to build without the extension now")
     print('*' * 80)
     print()


### PR DESCRIPTION
## What changed
- Keep cibuildwheel release builds from falling back to a pure-Python wheel when the fastbinary C extension fails to compile.
- Leave the upstream PyPI wheel workflow intact; it already builds manylinux aarch64 wheels after the rebase.

## Why
THRIFT-5955 is about published Linux arm64 wheels. The current upstream workflow now builds those wheels, and this PR adds a safety guard so release wheel jobs fail fast instead of uploading incomplete binary artifacts if the extension build fails.

## Validation
- Parsed `.github/workflows/pypi.yml` with Ruby YAML.
- Ran `python setup.py sdist --dist-dir /tmp/thrift-py-dist`.
- Ran `CIBUILDWHEEL=1 CXX=false python setup.py build_ext --force` and verified it fails with the new guard.
- Ran `git diff --check HEAD^ HEAD`.

---

Not my cup of tea - asked Codex to do it.