### PR TITLE
THRIFT-6077: improve CHANGES.md generator section assignment

### DIFF
--- a/build/generate-changes.py
+++ b/build/generate-changes.py
@@ -199,6 +199,12 @@ GITHUB_LABEL_MAP = {
     "ruby": "Ruby",
     "rust": "Rust",
     "typescript": "nodets",
+    "doc": "Documentation",
+    # dependabot and workflow-file PRs carry these labels; they have no Client:
+    # trailer we could use instead, so route them to the build/CI section.
+    "github_actions": "Build Process",
+    "dependencies": "Build Process",
+    "testsuite": "Build Process",
     "releng": "Build Process",
 }
 
@@ -447,6 +453,19 @@ def fetch_jira_by_fixversion(fix_version):
 # GitHub helpers
 # ---------------------------------------------------------------------------
 
+def labels_to_sections(label_names):
+    """Map GitHub label names to a deduplicated, order-preserving list of
+    canonical CHANGES.md section headings.  Labels with no mapping are ignored."""
+    sections = []
+    seen = set()
+    for name in label_names:
+        section = GITHUB_LABEL_MAP.get(name.lower())
+        if section and section not in seen:
+            seen.add(section)
+            sections.append(section)
+    return sections
+
+
 def fetch_pr_labels(pr_numbers, repo, github_token=None):
     """Return a dict mapping PR number (int) → list of canonical section names.
 
@@ -475,14 +494,9 @@ def fetch_pr_labels(pr_numbers, repo, github_token=None):
             req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=30) as resp:
                 data = json.loads(resp.read())
-            sections: list = []
-            seen: set = set()
-            for label in data.get("labels", []):
-                section = GITHUB_LABEL_MAP.get(label["name"].lower())
-                if section and section not in seen:
-                    seen.add(section)
-                    sections.append(section)
-            result[pr_num] = sections
+            result[pr_num] = labels_to_sections(
+                label["name"] for label in data.get("labels", [])
+            )
         except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as exc:
             print(f"Warning: GitHub PR #{pr_num} label fetch failed: {exc}", file=sys.stderr)
 
@@ -553,6 +567,60 @@ def version_from_configure(repo_root):
 def section_sort_key(name):
     """Alphabetical, but LATE_SECTIONS sort last."""
     return (1 if name in LATE_SECTIONS else 0, name.lower())
+
+
+# ---------------------------------------------------------------------------
+# Section assignment helpers
+# ---------------------------------------------------------------------------
+
+def build_ticket_trailer_sections(commit_meta):
+    """Map ticket id (uppercase) -> ordered, deduplicated list of sections
+    derived from the Client: trailer(s) of commits that reference the ticket.
+
+    Used as a fallback for JIRA tickets that have no usable component."""
+    result: dict = defaultdict(list)
+    for c in commit_meta:
+        for ticket in c["tickets"]:
+            key = ticket.upper()
+            for section in c["sections"]:
+                if section not in result[key]:
+                    result[key].append(section)
+    return result
+
+
+def resolve_ticket_sections(ticket_id, jira_sections, trailer_sections):
+    """Return the section list a JIRA-backed ticket should be filed under.
+
+    JIRA components win when present; when JIRA has no component (the
+    "(No Section)" sentinel) fall back to the commit Client: trailer."""
+    if jira_sections == ["(No Section)"]:
+        fallback = trailer_sections.get(ticket_id.upper())
+        if fallback:
+            return fallback
+    return jira_sections
+
+
+def pr_label_fetch_candidates(commit_meta, jira_data):
+    """Return commits whose section should be resolved from GitHub PR labels:
+    a PR number is known, the commit has no Client: trailer section, and none
+    of its tickets is already covered by JIRA."""
+    return [
+        c
+        for c in commit_meta
+        if c["pr_num"] is not None
+        and not c["sections"]
+        and not any(t.upper() in jira_data for t in c["tickets"])
+    ]
+
+
+def apply_pr_label_sections(candidates, pr_label_data):
+    """Assign fetched PR-label sections to every candidate commit sharing a PR
+    number.  Rebase-merged PRs land several commits under one PR, so a single
+    PR's labels must propagate to all of its section-less commits."""
+    for c in candidates:
+        sections = pr_label_data.get(c["pr_num"])
+        if sections:
+            c["sections"] = list(sections)
 
 
 # ---------------------------------------------------------------------------
@@ -661,13 +729,8 @@ def generate_changes(args):
     # Only done when commits are included in output; skips commits already
     # covered by JIRA or that already have sections from the trailer.
     if not args.no_commits:
-        pr_nums_to_fetch = [
-            c["pr_num"]
-            for c in commit_meta
-            if c["pr_num"] is not None
-            and not c["sections"]
-            and not any(t.upper() in jira_data for t in c["tickets"])
-        ]
+        label_candidates = pr_label_fetch_candidates(commit_meta, jira_data)
+        pr_nums_to_fetch = sorted({c["pr_num"] for c in label_candidates})
         if pr_nums_to_fetch:
             print(
                 f"Fetching GitHub labels for {len(pr_nums_to_fetch)} PRs "
@@ -677,16 +740,9 @@ def generate_changes(args):
             pr_label_data = fetch_pr_labels(
                 pr_nums_to_fetch, args.repo, args.github_token
             )
-            # Propagate fetched sections back into commit_meta in-place so the
-            # section-building loop below picks them up transparently.
-            pr_meta_by_num = {
-                c["pr_num"]: c
-                for c in commit_meta
-                if c["pr_num"] is not None
-            }
-            for pr_num, sections in pr_label_data.items():
-                if sections and pr_num in pr_meta_by_num:
-                    pr_meta_by_num[pr_num]["sections"] = sections
+            # Propagate fetched sections to every section-less commit sharing the
+            # PR, so rebase-merged PRs (several commits, one PR) are all covered.
+            apply_pr_label_sections(label_candidates, pr_label_data)
 
     # --- Build per-section entry lists ---
     # sections_jira[section]   = list of (ticket_num, line)
@@ -698,12 +754,18 @@ def generate_changes(args):
     emitted_ticket: dict = defaultdict(set)   # section -> {ticket_id}
     emitted_commit: dict = defaultdict(set)   # section -> {sha}
 
+    # Ticket -> Client: trailer sections, used to file a JIRA ticket that has
+    # no usable component under the section named by its commit(s) instead.
+    trailer_sections = build_ticket_trailer_sections(commit_meta)
+
     # JIRA-backed entries
     for ticket_id, info in jira_data.items():
         ticket_num = int(re.search(r"\d+", ticket_id).group())
         ticket_url = f"{JIRA_BASE}/browse/{ticket_id}"
         line = f"- [{ticket_id}]({ticket_url}) - {info['summary']}"
-        for section in info["sections"]:
+        for section in resolve_ticket_sections(
+            ticket_id, info["sections"], trailer_sections
+        ):
             if ticket_id not in emitted_ticket[section]:
                 emitted_ticket[section].add(ticket_id)
                 sections_jira[section].append((ticket_num, line))

--- a/build/test_generate_changes.py
+++ b/build/test_generate_changes.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""Unit tests for build/generate-changes.py section-assignment logic.
+
+These cover the three cases that previously produced "(No Section)" entries:
+
+  1. dependabot / CI PRs whose only GitHub labels are github_actions /
+     dependencies (label -> section mapping);
+  2. rebase-merged PRs that land several commits under one PR number
+     (PR-label fan-out); and
+  3. JIRA tickets with no usable component, filed under the section named
+     by their commit's Client: trailer instead (JIRA -> trailer fallback).
+
+No network access is required: only the pure mapping/assignment helpers are
+exercised.
+"""
+
+import importlib.util
+import os
+import unittest
+
+# generate-changes.py has a hyphen in its name, so it cannot be imported with a
+# plain ``import``; load it as a module from its path instead.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SPEC = importlib.util.spec_from_file_location(
+    "generate_changes", os.path.join(_HERE, "generate-changes.py")
+)
+gc = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gc)
+
+
+def make_commit(sha="0" * 40, pr_num=None, sections=None, tickets=()):
+    """Build a commit_meta entry like generate_changes() constructs."""
+    return {
+        "sha": sha,
+        "short": sha[:9],
+        "subject": sha,
+        "tickets": set(tickets),
+        "sections": list(sections or []),
+        "pr_num": pr_num,
+    }
+
+
+class LabelMappingTests(unittest.TestCase):
+    """Fix 1: dependabot / CI labels route to the Build Process section."""
+
+    def test_github_actions_maps_to_build_process(self):
+        self.assertEqual(gc.GITHUB_LABEL_MAP["github_actions"], "Build Process")
+
+    def test_dependencies_maps_to_build_process(self):
+        self.assertEqual(gc.GITHUB_LABEL_MAP["dependencies"], "Build Process")
+
+    def test_testsuite_maps_to_build_process(self):
+        self.assertEqual(gc.GITHUB_LABEL_MAP["testsuite"], "Build Process")
+
+    def test_doc_maps_to_documentation(self):
+        self.assertEqual(gc.GITHUB_LABEL_MAP["doc"], "Documentation")
+
+    def test_labels_to_sections_maps_and_dedupes_preserving_order(self):
+        self.assertEqual(
+            gc.labels_to_sections(["golang", "github_actions", "dependencies"]),
+            ["Go", "Build Process"],
+        )
+
+    def test_labels_to_sections_is_case_insensitive(self):
+        self.assertEqual(gc.labels_to_sections(["GitHub_Actions"]), ["Build Process"])
+
+    def test_labels_to_sections_ignores_unknown_labels(self):
+        self.assertEqual(gc.labels_to_sections(["totally-unknown-label"]), [])
+
+    def test_labels_to_sections_accepts_a_generator(self):
+        # fetch_pr_labels() passes a generator expression, not a list.
+        self.assertEqual(
+            gc.labels_to_sections(name for name in ["php"]), ["PHP"]
+        )
+
+
+class PrLabelFanoutTests(unittest.TestCase):
+    """Fix 2: a PR's labels reach every section-less commit of that PR."""
+
+    def test_multiple_commits_one_pr_all_get_labelled(self):
+        # Regression for the dict-collision bug: a rebase-merged PR lands two
+        # section-less commits; both must receive the PR's label section.
+        commits = [
+            make_commit("a" * 40, pr_num=100),
+            make_commit("b" * 40, pr_num=100),
+        ]
+        candidates = gc.pr_label_fetch_candidates(commits, {})
+        self.assertEqual(len(candidates), 2)
+        gc.apply_pr_label_sections(candidates, {100: ["Build Process"]})
+        self.assertEqual(commits[0]["sections"], ["Build Process"])
+        self.assertEqual(commits[1]["sections"], ["Build Process"])
+
+    def test_commit_with_trailer_section_is_not_clobbered(self):
+        # Mirrors PR #3385: one commit carries a Client: js trailer, its sibling
+        # carries none.  Only the section-less sibling is (re)assigned.
+        with_trailer = make_commit("c" * 40, pr_num=3385, sections=["JavaScript"])
+        without = make_commit("d" * 40, pr_num=3385)
+        candidates = gc.pr_label_fetch_candidates([with_trailer, without], {})
+        self.assertEqual(candidates, [without])
+        gc.apply_pr_label_sections(candidates, {3385: ["nodejs"]})
+        self.assertEqual(with_trailer["sections"], ["JavaScript"])
+        self.assertEqual(without["sections"], ["nodejs"])
+
+    def test_fetch_list_is_deduplicated(self):
+        commits = [
+            make_commit("a" * 40, pr_num=100),
+            make_commit("b" * 40, pr_num=100),
+        ]
+        candidates = gc.pr_label_fetch_candidates(commits, {})
+        self.assertEqual(sorted({c["pr_num"] for c in candidates}), [100])
+
+    def test_commit_covered_by_jira_is_not_a_candidate(self):
+        commits = [make_commit("e" * 40, pr_num=200, tickets=["THRIFT-1"])]
+        self.assertEqual(
+            gc.pr_label_fetch_candidates(commits, {"THRIFT-1": {}}), []
+        )
+
+    def test_commit_without_pr_number_is_not_a_candidate(self):
+        self.assertEqual(
+            gc.pr_label_fetch_candidates([make_commit("f" * 40, pr_num=None)], {}), []
+        )
+
+    def test_apply_copies_sections_and_does_not_alias(self):
+        commit = make_commit("a" * 40, pr_num=100)
+        shared = ["Build Process"]
+        gc.apply_pr_label_sections([commit], {100: shared})
+        self.assertEqual(commit["sections"], ["Build Process"])
+        self.assertIsNot(commit["sections"], shared)
+
+
+class JiraTrailerFallbackTests(unittest.TestCase):
+    """Fix 3: a componentless JIRA ticket falls back to its Client: trailer."""
+
+    def test_build_ticket_trailer_sections(self):
+        commits = [
+            make_commit(tickets=["THRIFT-6068"], sections=["Rust"]),
+            make_commit(tickets=["THRIFT-6069"], sections=["Python"]),
+        ]
+        mapping = gc.build_ticket_trailer_sections(commits)
+        self.assertEqual(mapping["THRIFT-6068"], ["Rust"])
+        self.assertEqual(mapping["THRIFT-6069"], ["Python"])
+
+    def test_build_ticket_trailer_sections_dedupes(self):
+        commits = [
+            make_commit("a" * 40, tickets=["THRIFT-1"], sections=["Go"]),
+            make_commit("b" * 40, tickets=["THRIFT-1"], sections=["Go"]),
+        ]
+        self.assertEqual(
+            gc.build_ticket_trailer_sections(commits)["THRIFT-1"], ["Go"]
+        )
+
+    def test_fallback_used_when_jira_has_no_component(self):
+        trailer = {"THRIFT-6068": ["Rust"]}
+        self.assertEqual(
+            gc.resolve_ticket_sections("THRIFT-6068", ["(No Section)"], trailer),
+            ["Rust"],
+        )
+
+    def test_jira_component_wins_over_trailer(self):
+        trailer = {"THRIFT-6069": ["Rust"]}
+        self.assertEqual(
+            gc.resolve_ticket_sections("THRIFT-6069", ["Python"], trailer),
+            ["Python"],
+        )
+
+    def test_no_section_kept_when_no_trailer_available(self):
+        self.assertEqual(
+            gc.resolve_ticket_sections("THRIFT-9999", ["(No Section)"], {}),
+            ["(No Section)"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## [THRIFT-6077](https://issues.apache.org/jira/browse/THRIFT-6077)

`build/generate-changes.py` filed several classes of entries under **(No Section)** in the generated `CHANGES.md` draft despite a usable signal being available. This routes them correctly:

1. **CI / dependabot PRs** — `github_actions`, `dependencies` and `testsuite` labels now map to *Build Process*, and `doc` to *Documentation*. dependabot cannot add a `Client:` trailer, so the GitHub label map is the right seam for these.
2. **Rebase-merged PRs** — such PRs land several commits under one PR number. The old PR→label write-back keyed a dict by PR number, so only one commit of the PR received its label while the rest fell through to (No Section) — and a sibling commit's `Client:` trailer section could be overwritten. Labels now propagate to every section-less commit of the PR, without clobbering trailer-derived sections.
3. **Componentless JIRA tickets** — a ticket referenced by an in-range commit but with no JIRA component now falls back to the section named by the commit's `Client:` trailer.

On the current `master` draft, items 1 and 2 reduce (No Section) from **28 → 3**; the three that remain carry no label and no `Client:` trailer (e.g. CODEOWNERS edits), which genuinely need human/JIRA classification. **Item 3 does not change today's output** — every referenced ticket currently has a JIRA component — it is a robustness fix that keeps componentless tickets (as seen in earlier drafts) out of (No Section).

A PR that carries both a CI label and a language label is listed under both sections (deduplicated).

Adds `build/test_generate_changes.py` — 19 unit tests for the section-assignment helpers, no network required. Note: `flake8` excludes `build/` and Thrift's Python test suite lives under `lib/py`, so no CI job currently collects this module; run it directly with `python3 -m unittest build.test_generate_changes`.

This only changes the release-notes draft generator (the `generate-changes` workflow artifact); no library or generated code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
