### PR TITLE
Fix make dist and Go/Rust version detection on release/0.24.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -178,5 +178,4 @@ EXTRA_DIST = \
 	phpcs.xml.dist \
 	README.md \
 	rust-toolchain \
-	sonar-project.properties \
-	Thrift.podspec
+	sonar-project.properties

--- a/configure.ac
+++ b/configure.ac
@@ -388,7 +388,7 @@ if test "$with_go" = "yes";  then
       ax_go118_version="1.18"
 
       AC_MSG_CHECKING([for Go version])
-      golang_version=`$GO version 2>&1 | $SED -e 's/\(go \)\(version \)\(go\)\(@<:@0-9@:>@.@<:@0-9@:>@.@<:@0-9@:>@\)\(@<:@\*@:>@*\).*/\4/'`
+      golang_version=`$GO version 2>&1 | $SED -n -e 's/^go version go\(@<:@0-9@:>@@<:@0-9.@:>@*\).*/\1/p'`
       AC_MSG_RESULT($golang_version)
       AC_SUBST([golang_version],[$golang_version])
       AX_COMPARE_VERSION([$ax_go_version],[le],[$golang_version],[
@@ -431,7 +431,7 @@ if test "$with_rs" = "yes";  then
       min_rustc_version="1.13"
 
       AC_MSG_CHECKING([for rustc version])
-      rustc_version=`$RUSTC --version 2>&1 | $SED -e 's/\(rustc \)\([0-9]\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\2.\3/'`
+      rustc_version=`$RUSTC --version 2>&1 | $SED -n -e 's/^rustc \(@<:@0-9@:>@@<:@0-9.@:>@*\).*/\1/p'`
       AC_MSG_RESULT($rustc_version)
       AC_SUBST([rustc_version],[$rustc_version])
 

--- a/lib/netstd/Makefile.am
+++ b/lib/netstd/Makefile.am
@@ -100,7 +100,7 @@ EXTRA_DIST = \
 	Thrift/Transport \
 	Thrift/*.snk \
 	Thrift.AspNetCore/.editorconfig \
-	Thrift.AspNetCore/THttpServerTransport.cs \
+	Thrift.AspNetCore/Transport \
 	Thrift.AspNetCore/Thrift.AspNetCore.csproj \
 	Thrift.slnx \
 	build.cmd \


### PR DESCRIPTION
## Summary

Fixes two independent problems that break the build on `release/0.24.0`, one commit per issue.

### 1. Go/Rust version detection for multi-digit versions (`configure.ac`) — `Client: go,rs`

The version-parsing `sed` in `configure` only matched single-digit version components (`[0-9].[0-9].[0-9]`), so modern toolchains such as `go1.25.0` did not match. The raw, unparsed output — a multi-line string containing `/` (from `linux/amd64` and the `go: downloading …` toolchain line triggered by the root `go.mod`'s `go 1.25`) — was stored verbatim in `golang_version` / `rustc_version`. That broke `AX_COMPARE_VERSION`'s internal `sed` (`unterminated 's' command`) and corrupted `config.status`, so `configure` failed while *bootstrapping the dependency-tracking makefile fragments* and produced a malformed `Makefile`.

Fix: anchor both expressions to the reported version line and accept multi-digit, multi-component versions → clean `1.25.0` / `1.85.1`.

### 2. Stale `EXTRA_DIST` references breaking `make dist` (`Makefile.am`, `lib/netstd/Makefile.am`) — `Client: netstd`

`make dist` aborted with `No rule to make target …, needed by 'distdir-am'`:

- `Thrift.podspec` was removed together with the Swift binding but left behind in the top-level `EXTRA_DIST`.
- The netstd `THttpServerTransport.cs` was moved into `Thrift.AspNetCore/Transport/Server/`; `EXTRA_DIST` now points at the `Transport` directory, matching the existing `Thrift/Transport` entry.

## Verification

`./bootstrap.sh && ./configure && make dist` now completes and produces a valid `thrift-0.24.0.tar.gz`, verified end-to-end on a clean tree (`Thrift.podspec` correctly absent, the netstd source present at its new path).

## Notes

- No JIRA ID is in the commit titles yet — add `THRIFT-NNNN:` if you want JIRA linking.
- These `make dist` breakages were not caught by CI because no GitHub Actions workflow runs `make dist` (only the legacy `.travis.yml` references it). A separate PR against `master` adds a `make dist` job to prevent recurrence.

---

🤖 AI-assisted with Claude Code (Claude Opus 4.8). The human author has reviewed and tested all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
