### PR TITLE
Add make dist CI job and fix stale EXTRA_DIST references

### DIFF
--- a/.github/workflows/make-dist.yml
+++ b/.github/workflows/make-dist.yml
@@ -1,0 +1,47 @@
+name: "make dist"
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+env:
+  BUILD_DEPS: automake bison flex git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config
+
+permissions:
+  contents: read
+
+jobs:
+  make-dist:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -y --no-install-recommends g++ $BUILD_DEPS
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      # Assemble the source distribution tarball only.  --disable-libs keeps the
+      # job fast and toolchain-independent; make dist still recurses every
+      # language directory via DIST_SUBDIRS, so all EXTRA_DIST lists are
+      # validated regardless of which bindings are enabled.
+      - name: Run configure
+        run: ./configure --disable-debug --disable-tests --disable-libs
+
+      - name: Run make dist
+        run: make dist
+
+      - name: Verify distribution tarball
+        run: |
+          set -e
+          ls -l thrift-*.tar.gz
+          entries=$(tar tzf thrift-*.tar.gz | wc -l)
+          echo "Distribution tarball contains $entries entries."
+          test "$entries" -gt 1000

--- a/Makefile.am
+++ b/Makefile.am
@@ -178,5 +178,4 @@ EXTRA_DIST = \
 	phpcs.xml.dist \
 	README.md \
 	rust-toolchain \
-	sonar-project.properties \
-	Thrift.podspec
+	sonar-project.properties

--- a/lib/netstd/Makefile.am
+++ b/lib/netstd/Makefile.am
@@ -100,7 +100,7 @@ EXTRA_DIST = \
 	Thrift/Transport \
 	Thrift/*.snk \
 	Thrift.AspNetCore/.editorconfig \
-	Thrift.AspNetCore/THttpServerTransport.cs \
+	Thrift.AspNetCore/Transport \
 	Thrift.AspNetCore/Thrift.AspNetCore.csproj \
 	Thrift.slnx \
 	build.cmd \


### PR DESCRIPTION
## Summary

Adds a `make dist` job to CI so stale `EXTRA_DIST` references are caught at merge time instead of only when cutting a release.

**Why now:** preparing the 0.24.0 release surfaced `make dist` breakages that had sat for months — a removed `Thrift.podspec` (Swift binding removal) and a moved netstd `THttpServerTransport.cs` — because no GitHub Actions workflow runs `make dist` (only the legacy `.travis.yml` referenced it). Both breakages are present on `master` today.

## Changes

1. **Fix the two stale `EXTRA_DIST` references** currently on `master` (`Makefile.am`, `lib/netstd/Makefile.am`) — a prerequisite for the new job to be green:
   - `Thrift.podspec` was removed with the Swift binding but left in the top-level `EXTRA_DIST`.
   - netstd `THttpServerTransport.cs` was moved into `Thrift.AspNetCore/Transport/Server/`; `EXTRA_DIST` now points at the `Transport` directory, matching the existing `Thrift/Transport` entry.
2. **Add `.github/workflows/make-dist.yml`** — runs `bootstrap` → `configure --disable-libs` → `make dist` on `ubuntu-24.04` for every push/PR, then verifies the tarball is produced.

`--disable-libs` keeps the job fast and toolchain-independent; `make dist` still recurses every language directory via `DIST_SUBDIRS`, so all `EXTRA_DIST` lists are validated regardless of which bindings are enabled.

## Verification

Ran the exact job recipe on a clean `ubuntu:24.04` container with only the listed `apt` dependencies:
`./bootstrap.sh && ./configure --disable-debug --disable-tests --disable-libs && make dist` completes and produces a valid `thrift-0.24.0.tar.gz` (3487 entries). Confirmed `make dist` still recurses and packages `lib/netstd` even with libs disabled (so a stale ref there would fail the job).

## Notes

- Companion PR for `release/0.24.0`: #3623. That branch additionally fixes a separate `configure` Go/Rust version-detection bug. `master` has that bug too, but this job does not trip it (`--disable-libs` skips the version probes). Happy to send the `configure` fix for `master` as a follow-up if wanted.
- No JIRA ID in the commit titles yet — add `THRIFT-NNNN:` if you want JIRA linking.

---

🤖 AI-assisted with Claude Code (Claude Opus 4.8). The human author has reviewed and tested all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
