### PR TITLE
Fix Go and Rust version detection for multi-digit version numbers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,7 +388,7 @@ if test "$with_go" = "yes";  then
       ax_go118_version="1.18"
 
       AC_MSG_CHECKING([for Go version])
-      golang_version=`$GO version 2>&1 | $SED -e 's/\(go \)\(version \)\(go\)\(@<:@0-9@:>@.@<:@0-9@:>@.@<:@0-9@:>@\)\(@<:@\*@:>@*\).*/\4/'`
+      golang_version=`$GO version 2>&1 | $SED -n -e 's/^go version go\(@<:@0-9@:>@@<:@0-9.@:>@*\).*/\1/p'`
       AC_MSG_RESULT($golang_version)
       AC_SUBST([golang_version],[$golang_version])
       AX_COMPARE_VERSION([$ax_go_version],[le],[$golang_version],[
@@ -431,7 +431,7 @@ if test "$with_rs" = "yes";  then
       min_rustc_version="1.13"
 
       AC_MSG_CHECKING([for rustc version])
-      rustc_version=`$RUSTC --version 2>&1 | $SED -e 's/\(rustc \)\([0-9]\)\.\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\2.\3/'`
+      rustc_version=`$RUSTC --version 2>&1 | $SED -n -e 's/^rustc \(@<:@0-9@:>@@<:@0-9.@:>@*\).*/\1/p'`
       AC_MSG_RESULT($rustc_version)
       AC_SUBST([rustc_version],[$rustc_version])
 


### PR DESCRIPTION
## Summary

Applies the `configure.ac` Go/Rust version-detection fix to `master` (the same commit as in #3623, which targets `release/0.24.0`; `master` has the identical bug).

`configure`'s version-parsing `sed` only matched single-digit version components (`[0-9].[0-9].[0-9]`), so modern toolchains such as `go1.25.0` did not match. The raw, unparsed output — a multi-line string containing `/` (from `linux/amd64` and the `go: downloading …` toolchain line triggered by the root `go.mod`'s `go 1.25`) — was stored verbatim in `golang_version` / `rustc_version`. That broke `AX_COMPARE_VERSION`'s internal `sed` (`unterminated 's' command`) and corrupted `config.status`, so `configure` failed while *bootstrapping the dependency-tracking makefile fragments* and produced a malformed `Makefile`.

Fix: anchor both expressions to the reported version line and accept multi-digit, multi-component versions → clean `1.25.0` / `1.85.1`.

## Verification

Verified end-to-end on the identical `configure.ac` in #3623: `./bootstrap.sh && ./configure && make dist` completes with `checking for Go version... 1.25.0` / `checking for rustc version... 1.85.1` and no `sed` errors, producing a valid tarball. The change is isolated to `configure.ac`'s Go/Rust version parsing.

## Context

Follow-up to #3624, which added the `make dist` CI job but intentionally uses `--disable-libs` (so it skips the Go/Rust version probes and does not exercise this code path). This PR closes that remaining gap on `master`.

No JIRA ID yet — add `THRIFT-NNNN:` if you want JIRA linking.

---

🤖 AI-assisted with Claude Code (Claude Opus 4.8). The human author has reviewed and tested all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
