### PR TITLE
THRIFT-6078: Send SNI from Ruby SSL clients

### DIFF
--- a/lib/rb/lib/thrift/transport/ssl_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_socket.rb
@@ -19,15 +19,18 @@
 # under the License.
 
 require 'io/wait'
+require 'ipaddr'
 
 module Thrift
   class SSLSocket < Socket
-    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil)
+    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil, server_hostname: host)
       super(host, port, timeout)
       @ssl_context = ssl_context
+      @server_hostname = server_hostname
     end
 
     attr_accessor :ssl_context
+    attr_accessor :server_hostname
 
     def open
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
@@ -35,6 +38,7 @@ module Thrift
 
       begin
         ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+        ssl_socket.hostname = @server_hostname if send_server_hostname?
         ssl_socket.sync_close = true
         @handle = ssl_socket
 
@@ -63,7 +67,7 @@ module Thrift
           @handle.connect
         end
 
-        @handle.post_connection_check(@host)
+        @handle.post_connection_check(server_hostname_for_verification)
         @handle
       rescue TransportException
         close_socket(@handle)
@@ -78,6 +82,21 @@ module Thrift
 
     def to_s
       "ssl(#{super.to_s})"
+    end
+
+    private
+
+    def send_server_hostname?
+      return false if @server_hostname.nil? || @server_hostname.empty?
+
+      IPAddr.new(@server_hostname)
+      false
+    rescue IPAddr::InvalidAddressError
+      true
+    end
+
+    def server_hostname_for_verification
+      @server_hostname.nil? || @server_hostname.empty? ? @host : @server_hostname
     end
   end
 end

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -37,6 +37,7 @@ describe 'SSLSocket' do
       allow(@handle).to receive(:connect).and_return(true)
       allow(@handle).to receive(:connect_nonblock).and_return(@handle)
       allow(@handle).to receive(:close)
+      allow(@handle).to receive(:hostname=)
       allow(@handle).to receive(:post_connection_check)
       allow(@handle).to receive(:sync_close=)
       allow(@handle).to receive(:to_io).and_return(@simple_socket_handle)
@@ -60,6 +61,7 @@ describe 'SSLSocket' do
     it "should open a ::Socket with default args" do
       expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_return(@handle)
+      expect(@handle).to receive(:hostname=).with('localhost')
       expect(@handle).to receive(:sync_close=).with(true)
       expect(@handle).to receive(:connect).and_return(true)
       expect(@handle).to receive(:post_connection_check).with('localhost')
@@ -74,6 +76,7 @@ describe 'SSLSocket' do
       expect(Addrinfo).to receive(:foreach).with("my.domain", 1234, nil, :STREAM).and_yield(@addrinfo)
       expect(@addrinfo).to receive(:connect).with(timeout: 6000).and_return(handle)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(handle, nil).and_return(@handle)
+      expect(@handle).to receive(:hostname=).with('my.domain')
       expect(@handle).to receive(:sync_close=).with(true)
       expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(@handle)
       expect(@handle).to receive(:post_connection_check).with('my.domain')
@@ -86,6 +89,41 @@ describe 'SSLSocket' do
 
     it "should accept an optional context" do
       expect(Thrift::SSLSocket.new('localhost', 8080, 5, @context).ssl_context).to eq(@context)
+    end
+
+    it "should accept an optional server hostname" do
+      socket = Thrift::SSLSocket.new('127.0.0.1', 8080, 5, @context, server_hostname: 'service.example.com')
+      expect(socket.server_hostname).to eq('service.example.com')
+    end
+
+    it "should use the server hostname for SNI and certificate verification" do
+      expect(Addrinfo).to receive(:foreach).with("127.0.0.1", 9090, nil, :STREAM).and_yield(@addrinfo)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).to receive(:hostname=).with('service.example.com')
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).to receive(:post_connection_check).with('service.example.com')
+
+      Thrift::SSLSocket.new('127.0.0.1', 9090, nil, nil, server_hostname: 'service.example.com').open
+    end
+
+    it "should not send SNI for an IP literal hostname" do
+      expect(Addrinfo).to receive(:foreach).with("127.0.0.1", 9090, nil, :STREAM).and_yield(@addrinfo)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).not_to receive(:hostname=)
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).to receive(:post_connection_check).with('127.0.0.1')
+
+      Thrift::SSLSocket.new('127.0.0.1').open
+    end
+
+    it "should allow SNI to be disabled while still checking the connection host" do
+      expect(Addrinfo).to receive(:foreach).with("my.domain", 9090, nil, :STREAM).and_yield(@addrinfo)
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(@handle).not_to receive(:hostname=)
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).to receive(:post_connection_check).with('my.domain')
+
+      Thrift::SSLSocket.new('my.domain', 9090, nil, nil, server_hostname: nil).open
     end
 
     it "should treat zero timeout as blocking for open and handshake" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Some TLS terminators, proxies, and load balancers require SNI in the `ClientHello` to route the connection or select the correct certificate. Ruby clients previously performed post-handshake hostname verification, but did not send a server hostname during the handshake.
  
Ruby `Thrift::SSLSocket` now sets the OpenSSL server hostname before starting the TLS handshake, allowing clients to send SNI for hostname-based SSL connections.

It also adds an optional `server_hostname:` override for cases where the client connects to one address but needs to indicate and verify a different DNS name.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? THRIFT-6078
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
