### PR TITLE
Skip Thin HTTP server bundle on Ruby head

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -907,6 +907,7 @@ jobs:
     env:
       SKIP_BUILD_EXT: ${{ matrix.skip-build-ext && '1' || '' }}
       BUNDLER_VERSION: ${{ case(matrix.ruby-version == 'head', '0', '2.2.34') }} # Bundler version is managed via setup-ruby action, not Bundler itself
+      BUNDLE_WITHOUT: ${{ case(matrix.ruby-version == 'head', 'thin_http_server', '') }} # thin pulls in eventmachine, which does not compile on Ruby 4.1+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/lib/rb/Gemfile
+++ b/lib/rb/Gemfile
@@ -7,4 +7,8 @@ gemspec
 gem 'cgi'
 gem 'ostruct'
 
+group :thin_http_server do
+  gem 'thin', '~> 1.7'
+end
+
 eval_gemfile "Gemfile.linters"

--- a/lib/rb/Gemfile.lock
+++ b/lib/rb/Gemfile.lock
@@ -64,8 +64,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
-    srv (1.0.0)
-      rack (>= 1.3.0)
     thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -92,7 +90,6 @@ DEPENDENCIES
   rubocop (~> 1.82.0)
   rubocop-performance (~> 1.26.1)
   rubocop-rspec (~> 3.8.0)
-  srv (~> 1.0)
   thin (~> 1.7)
   thrift!
 

--- a/lib/rb/spec/thin_http_server_spec.rb
+++ b/lib/rb/spec/thin_http_server_spec.rb
@@ -20,9 +20,16 @@
 
 require 'spec_helper'
 require 'rack/test'
-require 'thrift/server/thin_http_server'
 
-describe Thrift::ThinHTTPServer do
+begin
+  require 'thrift/server/thin_http_server'
+rescue LoadError
+  # The thin gem is optional and may be excluded on unsupported Ruby versions.
+end
+
+thin_dependency = defined?(Thin) ? {} : { :skip => "thin not available" }
+
+describe 'Thrift::ThinHTTPServer', thin_dependency do
   let(:processor) { double('processor') }
 
   describe "#initialize" do
@@ -76,7 +83,7 @@ describe Thrift::ThinHTTPServer do
   end
 end
 
-describe Thrift::ThinHTTPServer::RackApplication do
+describe 'Thrift::ThinHTTPServer::RackApplication', thin_dependency do
   include Rack::Test::Methods
 
   let(:processor) { double('processor') }

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -34,8 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test',          '~> 0.8.3'
   s.add_development_dependency 'rake',               '~> 13.3'
   s.add_development_dependency 'rspec',              '~> 3.7'
-  s.add_development_dependency 'srv',                '~> 1.0'
-  s.add_development_dependency 'thin',               '~> 1.7'
 
   s.metadata = {
     'bug_tracker_uri' => 'https://issues.apache.org/jira/browse/THRIFT',

--- a/test/rb/Gemfile
+++ b/test/rb/Gemfile
@@ -5,7 +5,10 @@ source "https://rubygems.org"
 gem 'thrift', path: '../../lib/rb'
 
 gem 'rack', '~> 2.2', '>= 2.2.23'
-gem 'thin', '~> 1.7', '>= 1.7.2'
 gem 'test-unit', '~> 3.2', '>= 3.2.7'
+
+group :thin_http_server do
+  gem 'thin', '~> 1.7', '>= 1.7.2'
+end
 
 eval_gemfile "../../lib/rb/Gemfile.linters"


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
This change disables tests Ruby HTTP server powered by Thin on Ruby 4.1 (head). [Eventmachine](https://github.com/eventmachine/eventmachine), the library that powers Thin, has not been updated for 8 years, and probably never will. At this point we might as well consider Ruby HTTP server implementation non-functional, and start looking for a replacement.

https://github.com/apache/thrift/actions/runs/28798532945/job/85395896533?pr=3626

Also removed "srv" dependency,— it is not used in the project, and I don't see how it would have ever been used.

A follow-up ticket to rewrite HTTP server using server-agnostic Rack application: THRIFT-6079

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
