### PR TITLE
Add job timeout to Python CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -641,6 +641,7 @@ jobs:
   lib-python:
     needs: compiler
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: &python_versions ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -722,6 +723,7 @@ jobs:
         python-version: *python_versions
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- `lib-python` and `lib-python-macos` had no `timeout-minutes`, so a hung job would run until GitHub Actions' default 6-hour ceiling before being cancelled.
- A recent `lib-python-macos` run did exactly this: the test suite passed, but a `TestServer.py` subprocess (`TProcessPoolServer`) never exited, and the job sat cancelled at exactly 360 minutes ([run 28817226680](https://github.com/apache/thrift/actions/runs/28817226680/job/85471806532)).
- Adds `timeout-minutes: 20` to both jobs — comfortably above the ~2-6.5 minute normal duration observed across recent runs, but far below the 6-hour default.

## Test plan
- [x] Validated the workflow YAML parses correctly and both jobs carry `timeout-minutes: 20`
- [ ] CI run on this PR exercises both jobs under the new timeout

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>