### PR TITLE
THRIFT-5917: Remove Rust deprecation warning

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rs_generator.cc
@@ -71,9 +71,6 @@ public:
         throw "unknown option rs:" + iter->first;
       }
     }
-
-    fprintf(stderr, "We are sorry, but for the lack of active maintainers, the RUST compiler target is being deprecated and may be removed in the next version. Feel free to contact the dev mailing list (dev@thrift.apache.org) for further details.\n");
-
   }
 
   /**


### PR DESCRIPTION
## Summary

Remove the Rust compiler target deprecation warning now that Rust maintenance has resumed. Dedicated CI, cross-tests, and crate publishing have been restored, and the Rust binding has received ongoing maintenance.

This follows the latest discussion in [THRIFT-5917](https://issues.apache.org/jira/browse/THRIFT-5917).

## User impact

Running the compiler with `--gen rs` no longer emits an outdated deprecation warning on stderr. Generated Rust code is unchanged.

## Validation

- Built `thrift-compiler` from the current source with CMake.
- Generated Rust code from `compiler/cpp/test/compiler/Single.thrift`; stderr was empty.
- Compared generated output before and after the change; the SHA-256 hashes were identical.
- `git diff --check` passed.
- The changed region passed `clang-format` 17.
- `make style` could not complete on macOS because the target uses GNU `find -printf`, which BSD `find` does not support.

Generated-by: OpenAI Codex (GPT-5)

<!-- Explain the changes in the pull request below: -->
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit? (not required, but preferred)
- [x] Did you do your best to avoid breaking changes? If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!-- The Contributing Guide at: https://github.com/apache/thrift/blob/master/CONTRIBUTING.md has more details and tips for committing properly. -->