### PR TITLE
THRIFT-6098: Verify Ruby SSL peers by default

### DIFF
--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -157,6 +157,12 @@ Its EventMachine dependency also does not build on new Ruby development
 versions. Creating a Thin server now prints a warning. Move to
 `Thrift::RackApplication` with a supported Rack server such as Puma or Falcon.
 
+`Thrift::SSLSocket` now verifies peers by default, including when given a
+blank SSL context. It preserves configured certificate authorities and uses
+the system certificate store when no trust source is configured. Applications
+that intentionally connect without peer identity checks must pass
+`verify_peer: false` explicitly.
+
 ### 0.24.0
 
 Connect timeout handling changed for both `Thrift::Socket` and
@@ -259,6 +265,9 @@ best-effort, not guaranteed.
 
 ## Migration Notes
 
+- If you upgrade to `0.25.0`, note that `Thrift::SSLSocket` now verifies peers
+  by default. Applications that intentionally connect without peer identity
+  checks must pass `verify_peer: false` explicitly.
 - If you upgrade to `0.24.0`, treat `timeout` on `Thrift::Socket` and
   `Thrift::SSLSocket` as one budget for the whole open path. For
   `Thrift::SSLSocket`, that includes both the TCP connect and the TLS
@@ -297,5 +306,9 @@ best-effort, not guaranteed.
 - Client and server must agree on transport and protocol choices. If you
   switch to SSL, HTTP, header transport, compact protocol, or namespaced
   generated code, update both ends together.
-- HTTPS client transport verifies peers by default, and `Thrift::SSLSocket`
-  performs a hostname check against the host you pass in.
+- HTTPS client transport and `Thrift::SSLSocket` verify peers by default.
+  `Thrift::SSLSocket` preserves trust sources configured on a supplied SSL
+  context and otherwise uses the system certificate store. It also checks the
+  certificate against `server_hostname` (or the connection host by default).
+  Pass `verify_peer: false` only when peer identity checks are intentionally
+  disabled.

--- a/lib/rb/lib/thrift/transport/ssl_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_socket.rb
@@ -23,21 +23,23 @@ require 'ipaddr'
 
 module Thrift
   class SSLSocket < Socket
-    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil, server_hostname: host)
+    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil, server_hostname: host, verify_peer: true)
       super(host, port, timeout)
       @ssl_context = ssl_context
       @server_hostname = server_hostname
+      @verify_peer = verify_peer
     end
 
     attr_accessor :ssl_context
     attr_accessor :server_hostname
+    attr_reader :verify_peer
 
     def open
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
       socket = connect_socket(deadline)
 
       begin
-        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, configured_ssl_context)
         ssl_socket.hostname = @server_hostname if send_server_hostname?
         ssl_socket.sync_close = true
         @handle = ssl_socket
@@ -67,7 +69,7 @@ module Thrift
           @handle.connect
         end
 
-        @handle.post_connection_check(server_hostname_for_verification)
+        @handle.post_connection_check(server_hostname_for_verification) if @verify_peer
         @handle
       rescue TransportException
         close_socket(@handle)
@@ -85,6 +87,26 @@ module Thrift
     end
 
     private
+
+    def configured_ssl_context
+      @ssl_context ||= OpenSSL::SSL::SSLContext.new
+
+      if @verify_peer
+        verify_mode = @ssl_context.verify_mode || OpenSSL::SSL::VERIFY_NONE
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER if verify_mode == OpenSSL::SSL::VERIFY_NONE
+        configure_default_cert_store
+      elsif @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
+
+      @ssl_context
+    end
+
+    def configure_default_cert_store
+      return if @ssl_context.ca_file || @ssl_context.ca_path || @ssl_context.cert_store
+
+      @ssl_context.cert_store = OpenSSL::X509::Store.new.tap(&:set_default_paths)
+    end
 
     def send_server_hostname?
       return false if @server_hostname.nil? || @server_hostname.empty?

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -60,12 +60,14 @@ describe 'SSLSocket' do
 
     it "should open a ::Socket with default args" do
       expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
-      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_return(@handle)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, kind_of(OpenSSL::SSL::SSLContext)).and_return(@handle)
       expect(@handle).to receive(:hostname=).with('localhost')
       expect(@handle).to receive(:sync_close=).with(true)
       expect(@handle).to receive(:connect).and_return(true)
       expect(@handle).to receive(:post_connection_check).with('localhost')
       @socket.open
+      expect(@socket.ssl_context.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
+      expect(@socket.ssl_context.cert_store).to be_a(OpenSSL::X509::Store)
     end
 
     it "should accept host/port options" do
@@ -75,7 +77,7 @@ describe 'SSLSocket' do
       expect(handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       expect(Addrinfo).to receive(:foreach).with("my.domain", 1234, nil, :STREAM).and_yield(@addrinfo)
       expect(@addrinfo).to receive(:connect).with(timeout: 6000).and_return(handle)
-      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(handle, nil).and_return(@handle)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(handle, kind_of(OpenSSL::SSL::SSLContext)).and_return(@handle)
       expect(@handle).to receive(:hostname=).with('my.domain')
       expect(@handle).to receive(:sync_close=).with(true)
       expect(@handle).to receive(:connect_nonblock).with(exception: false).and_return(@handle)
@@ -94,6 +96,31 @@ describe 'SSLSocket' do
     it "should accept an optional server hostname" do
       socket = Thrift::SSLSocket.new('127.0.0.1', 8080, 5, @context, server_hostname: 'service.example.com')
       expect(socket.server_hostname).to eq('service.example.com')
+    end
+
+    it "should accept an optional peer verification setting" do
+      socket = Thrift::SSLSocket.new('localhost', 8080, 5, @context, verify_peer: false)
+      expect(socket.verify_peer).to be(false)
+    end
+
+    it "should enable peer verification when a blank context reports no verify mode" do
+      allow(@context).to receive(:verify_mode).and_return(nil)
+      expect(@context).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+
+      Thrift::SSLSocket.new('localhost', 9090, nil, @context).open
+    end
+
+    it "should disable peer identity checks only when explicitly requested" do
+      @context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, @context).and_return(@handle)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).not_to receive(:post_connection_check)
+
+      socket = Thrift::SSLSocket.new('localhost', 9090, nil, @context, verify_peer: false)
+      expect(socket.open).to eq(@handle)
+      expect(@context.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
     end
 
     it "should use the server hostname for SNI and certificate verification" do
@@ -226,7 +253,7 @@ describe 'SSLSocket' do
       expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 101.0)
       expect(@addrinfo).to receive(:connect).with(timeout: 4.0).and_return(@simple_socket_handle)
       expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
-      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, nil).and_raise(StandardError.new("ssl init failed"))
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, kind_of(OpenSSL::SSL::SSLContext)).and_raise(StandardError.new("ssl init failed"))
       expect(@simple_socket_handle).to receive(:close)
 
       expect { @socket.open }.to raise_error(Thrift::TransportException) do |e|
@@ -281,6 +308,72 @@ describe 'SSLSocket' do
 
     it "should provide a reasonable to_s" do
       expect(Thrift::SSLSocket.new('myhost', 8090).to_s).to eq("ssl(socket(myhost:8090))")
+    end
+  end
+
+  describe "peer certificate verification" do
+    before(:each) do
+      @tcp_server = TCPServer.new('127.0.0.1', 0)
+      ssl_server = OpenSSL::SSL::SSLServer.new(@tcp_server, server_context)
+      @server_thread = Thread.new do
+        ssl_server.accept.close
+      rescue OpenSSL::SSL::SSLError, IOError, Errno::EBADF
+        nil
+      end
+      @server_thread.report_on_exception = false
+    end
+
+    after(:each) do
+      @client&.close
+      @tcp_server.close
+      @server_thread.join(1)
+      @server_thread.kill if @server_thread.alive?
+      @server_thread.join
+    end
+
+    it "should validate the server certificate with a blank client context" do
+      @client = build_client(OpenSSL::SSL::SSLContext.new)
+
+      expect { @client.open }.to raise_error(Thrift::TransportException) do |error|
+        expect(error.type).to eq(Thrift::TransportException::NOT_OPEN)
+        expect(error.cause).to be_a(OpenSSL::SSL::SSLError)
+      end
+    end
+
+    it "should use a configured certificate authority" do
+      context = OpenSSL::SSL::SSLContext.new
+      context.ca_file = File.join(ssl_keys_dir, 'server.crt')
+      @client = build_client(context)
+
+      expect(@client.open).to be_a(OpenSSL::SSL::SSLSocket)
+    end
+
+    it "should allow peer certificate verification to be disabled explicitly" do
+      @client = build_client(OpenSSL::SSL::SSLContext.new, verify_peer: false)
+
+      expect(@client.open).to be_a(OpenSSL::SSL::SSLSocket)
+    end
+
+    def build_client(context, verify_peer: true)
+      Thrift::SSLSocket.new(
+        '127.0.0.1',
+        @tcp_server.local_address.ip_port,
+        1,
+        context,
+        server_hostname: 'localhost',
+        verify_peer: verify_peer
+      )
+    end
+
+    def server_context
+      OpenSSL::SSL::SSLContext.new.tap do |context|
+        context.cert = OpenSSL::X509::Certificate.new(File.read(File.join(ssl_keys_dir, 'server.crt')))
+        context.key = OpenSSL::PKey::RSA.new(File.read(File.join(ssl_keys_dir, 'server.key')))
+      end
+    end
+
+    def ssl_keys_dir
+      File.expand_path('../../../test/keys', __dir__)
     end
   end
 end


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This updates `Thrift::SSLSocket` to verify peers by default when no SSL context is provided or when the caller supplies a blank `OpenSSL::SSL::SSLContext`.

Caller-configured CA files, CA directories, and certificate stores are preserved. When no trust source is configured, the socket uses the system certificate store. Applications that intentionally disable peer identity checks can pass `verify_peer: false` explicitly.

This makes `Thrift::SSLSocket` consistent with `Thrift::HTTPClientTransport`, which already enables HTTPS peer verification by default.

## Compatibility

This is an intentional Ruby behavior change for 0.25.0. Applications currently relying on connections without peer identity checks must opt out explicitly with `verify_peer: false`.

The Ruby README documents the new default and its migration requirements.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? THRIFT-6098
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
