### PR TITLE
THRIFT-6099: Reject invalid Ruby MemoryBufferTransport read lengths

### DIFF
--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -50,15 +50,20 @@ VALUE rb_thrift_memory_buffer_write(VALUE self, VALUE str) {
 VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value) {
   int length = FIX2INT(length_value);
 
+  if (RB_UNLIKELY(length < 0)) {
+    rb_exc_raise(rb_funcall(transport_exception_class, new_method_id, 2, transport_negative_size, rb_str_new2("Negative size")));
+  }
+
   VALUE index_value = rb_ivar_get(self, index_ivar_id);
   int index = FIX2INT(index_value);
 
   VALUE buf = GET_BUF(self);
   VALUE data = rb_funcall(buf, slice_method_id, 2, index_value, length_value);
 
-  index += length;
-  if (index > RSTRING_LEN(buf)) {
+  if (length > RSTRING_LEN(buf) - index) {
     index = (int)RSTRING_LEN(buf);
+  } else {
+    index += length;
   }
   if (index >= GARBAGE_BUFFER_SIZE) {
     rb_ivar_set(self, buf_ivar_id, rb_funcall(buf, slice_method_id, 2, INT2FIX(index), INT2FIX(RSTRING_LEN(buf) - 1)));

--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -58,6 +58,8 @@ module Thrift
     end
 
     def read(len)
+      raise TransportException.new(TransportException::NEGATIVE_SIZE, 'Negative size') unless len >= 0
+
       data = @buf.slice(@index, len)
       @index += len
       @index = @buf.size if @index > @buf.size

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -381,6 +381,23 @@ describe 'BaseTransport' do
       expect{ @buffer.read(5) }.to raise_error(EOFError)
     end
 
+    it "should reject negative read sizes without consuming input" do
+      @buffer.reset_buffer("abc")
+
+      expect { @buffer.read(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |error|
+        expect(error.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)
+      end
+      expect(@buffer.available).to eq(3)
+    end
+
+    it "should handle maximum read sizes without overflowing" do
+      @buffer.reset_buffer("abcd")
+
+      expect(@buffer.read(1)).to eq("a")
+      expect { @buffer.read((2**31) - 1) }.to raise_error(EOFError)
+      expect(@buffer.available).to eq(0)
+    end
+
     it "should reject negative read_all sizes" do
       expect { @buffer.read_all(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |e|
         expect(e.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby’s `MemoryBufferTransport#read` did not reject negative lengths consistently. With the native extension loaded, a negative length could terminate the Ruby process. The pure-Ruby implementation instead raised an unrelated exception after changing the transport’s read position.

This change rejects negative lengths with `TransportException::NEGATIVE_SIZE` before touching the buffer. It also avoids overflowing the native read index when an oversized read follows an earlier read, while preserving the existing behavior for valid and out-of-range lengths.
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6099](https://issues.apache.org/jira/browse/THRIFT-6099)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->