### PR TITLE
THRIFT-6100: Respect frozen Ruby MemoryBufferTransport destinations

### DIFF
--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -131,6 +131,11 @@ VALUE rb_thrift_memory_buffer_read_into_buffer(VALUE self, VALUE buffer_value, V
   int index;
   VALUE buf = GET_BUF(self);
 
+  if (size > 0) {
+    Check_Type(buffer_value, T_STRING);
+    rb_str_modify(buffer_value);
+  }
+
   index = FIX2INT(rb_ivar_get(self, index_ivar_id));
   while (i < size) {
     if (index >= RSTRING_LEN(buf)) {

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -398,6 +398,25 @@ describe 'BaseTransport' do
       expect(@buffer.available).to eq(0)
     end
 
+    it "should not mutate or consume input when reading into a frozen buffer" do
+      ["xy".freeze, ("x" * 100).freeze].each do |destination|
+        @buffer.reset_buffer("ab")
+
+        expect { @buffer.read_into_buffer(destination, 2) }.to raise_error(FrozenError)
+        expect(destination).to eq(destination.length == 2 ? "xy" : "x" * 100)
+        expect(@buffer.available).to eq(2)
+      end
+    end
+
+    it "should allow a zero-length read into a frozen buffer" do
+      destination = "x".freeze
+      @buffer.reset_buffer("a")
+
+      expect(@buffer.read_into_buffer(destination, 0)).to eq(0)
+      expect(destination).to eq("x")
+      expect(@buffer.available).to eq(1)
+    end
+
     it "should reject negative read_all sizes" do
       expect { @buffer.read_all(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |e|
         expect(e.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native `MemoryBufferTransport#read_into_buffer` implementation bypassed Ruby’s frozen-string checks. A positive-length read could therefore overwrite a frozen destination and consume transport input, while the pure-Ruby implementation raised `FrozenError`.

This change asks Ruby to make positive-length destination strings mutable before reading from the transport. Frozen destinations now raise `FrozenError` before either the destination or transport is modified, while zero-length reads remain no-ops.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6100](https://issues.apache.org/jira/browse/THRIFT-6100)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->