### PR TITLE
THRIFT-6101: Use Ruby truthiness for CompactProtocol booleans

### DIFF
--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -264,7 +264,7 @@ VALUE rb_thrift_compact_proto_write_set_begin(VALUE self, VALUE etype, VALUE siz
 }
 
 VALUE rb_thrift_compact_proto_write_bool(VALUE self, VALUE b) {
-  int8_t type = b == Qtrue ? CTYPE_BOOLEAN_TRUE : CTYPE_BOOLEAN_FALSE;
+  int8_t type = RTEST(b) ? CTYPE_BOOLEAN_TRUE : CTYPE_BOOLEAN_FALSE;
   VALUE boolean_field = rb_ivar_get(self, boolean_field_id);
   if (NIL_P(boolean_field)) {
     // we're not part of a field, so just write the value.

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -185,6 +185,7 @@ module Thrift
     end
 
     def write_bool(bool)
+      # Preserve Ruby truthiness: only false and nil encode as false.
       type = bool ? CompactTypes::BOOLEAN_TRUE : CompactTypes::BOOLEAN_FALSE
       unless @boolean_field.nil?
         # we haven't written the field header yet

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -104,6 +104,24 @@ describe Thrift::CompactProtocol do
     end
   end
 
+  it "should use Ruby truthiness when writing bools" do
+    {
+      true => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
+      false => Thrift::CompactProtocol::CompactTypes::BOOLEAN_FALSE,
+      nil => Thrift::CompactProtocol::CompactTypes::BOOLEAN_FALSE,
+      0 => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
+      1 => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
+      Object.new => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE
+    }.each do |value, expected|
+      trans = Thrift::MemoryBufferTransport.new
+      proto = Thrift::CompactProtocol.new(trans)
+
+      proto.write_bool(value)
+
+      expect(trans.read_byte).to eq(expected)
+    end
+  end
+
   it "should decode i32 minima from direct canonical zigzag bytes" do
     trans = Thrift::MemoryBufferTransport.new
     trans.write(INTEGER_MINIMUM_ENCODINGS[:i32].pack("C*"))


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native `CompactProtocol#write_bool` implementation treated only the literal `true` as true, while the pure-Ruby implementation followed normal Ruby truthiness. Truthy values such as numbers and objects could therefore produce different wire values depending on whether `thrift_native` was loaded.

The native writer now uses Ruby’s truthiness semantics. Both implementations encode only `false` and `nil` as false, while other values encode as true.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6101](https://issues.apache.org/jira/browse/THRIFT-6101)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->