### PR TITLE
THRIFT-6102: Align malformed CompactProtocol header errors

### DIFF
--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -507,18 +507,16 @@ VALUE rb_thrift_compact_proto_read_message_begin(VALUE self) {
   int8_t protocol_id = read_byte_direct(self);
   if (protocol_id != PROTOCOL_ID) {
     char buf[100];
-    int len = sprintf(buf, "Expected protocol id %d but got %d", PROTOCOL_ID, protocol_id);
-    buf[len] = 0;
-    rb_exc_raise(get_protocol_exception(INT2FIX(-1), rb_str_new2(buf)));
+    snprintf(buf, sizeof(buf), "Expected protocol id %d but got %d", PROTOCOL_ID, protocol_id);
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_BAD_VERSION), rb_str_new2(buf)));
   }
 
   int8_t version_and_type = read_byte_direct(self);
   int8_t version = version_and_type & VERSION_MASK;
   if (version != VERSION) {
     char buf[100];
-    int len = sprintf(buf, "Expected version id %d but got %d", version, VERSION);
-    buf[len] = 0;
-    rb_exc_raise(get_protocol_exception(INT2FIX(-1), rb_str_new2(buf)));
+    snprintf(buf, sizeof(buf), "Expected version %d but got %d", VERSION, version);
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_BAD_VERSION), rb_str_new2(buf)));
   }
 
   int8_t type = (version_and_type >> TYPE_SHIFT_AMOUNT) & TYPE_BITS;

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -235,13 +235,19 @@ module Thrift
     def read_message_begin
       protocol_id = read_byte()
       if protocol_id != PROTOCOL_ID
-        raise ProtocolException.new("Expected protocol id #{PROTOCOL_ID} but got #{protocol_id}")
+        raise ProtocolException.new(
+          ProtocolException::BAD_VERSION,
+          "Expected protocol id #{PROTOCOL_ID} but got #{protocol_id}"
+        )
       end
 
       version_and_type = read_byte()
       version = version_and_type & VERSION_MASK
       if (version != VERSION)
-        raise ProtocolException.new("Expected version #{VERSION} but got #{version}");
+        raise ProtocolException.new(
+          ProtocolException::BAD_VERSION,
+          "Expected version #{VERSION} but got #{version}"
+        )
       end
 
       type = (version_and_type >> TYPE_SHIFT_AMOUNT) & TYPE_BITS

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -122,6 +122,20 @@ describe Thrift::CompactProtocol do
     end
   end
 
+  it "should report malformed message headers consistently" do
+    {
+      [0x00] => "Expected protocol id -126 but got 0",
+      [0x82, 0x00] => "Expected version 1 but got 0"
+    }.each do |bytes, expected_message|
+      trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
+      proto = Thrift::CompactProtocol.new(trans)
+
+      expect { proto.read_message_begin }.to raise_error(Thrift::ProtocolException, expected_message) do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::BAD_VERSION)
+      end
+    end
+  end
+
   it "should decode i32 minima from direct canonical zigzag bytes" do
     trans = Thrift::MemoryBufferTransport.new
     trans.write(INTEGER_MINIMUM_ENCODINGS[:i32].pack("C*"))


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native and pure-Ruby CompactProtocol readers attached malformed-header details to different `ProtocolException` fields. Native mode used a non-standard type with a message, while pure-Ruby mode stored the message text as the exception type and left the message empty.

Both implementations now construct `BAD_VERSION` exceptions with the same descriptive protocol-identifier and version messages, so callers receive consistent error metadata regardless of extension availability.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6102](https://issues.apache.org/jira/browse/THRIFT-6102)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->