### PR TITLE
THRIFT-6103: Return unsigned values from Ruby MemoryBufferTransport

### DIFF
--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -113,7 +113,7 @@ VALUE rb_thrift_memory_buffer_read_byte(VALUE self) {
   if (index >= RSTRING_LEN(buf)) {
     rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
   }
-  char byte = RSTRING_PTR(buf)[index++];
+  unsigned char byte = (unsigned char)RSTRING_PTR(buf)[index++];
 
   if (index >= GARBAGE_BUFFER_SIZE) {
     rb_ivar_set(self, buf_ivar_id, rb_funcall(buf, slice_method_id, 2, INT2FIX(index), INT2FIX(RSTRING_LEN(buf) - 1)));
@@ -121,8 +121,7 @@ VALUE rb_thrift_memory_buffer_read_byte(VALUE self) {
   }
   rb_ivar_set(self, index_ivar_id, INT2FIX(index));
 
-  int result = (int) byte;
-  return INT2FIX(result);
+  return INT2FIX(byte);
 }
 
 VALUE rb_thrift_memory_buffer_read_into_buffer(VALUE self, VALUE buffer_value, VALUE size_value) {

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -398,6 +398,13 @@ describe 'BaseTransport' do
       expect(@buffer.available).to eq(0)
     end
 
+    it "should return unsigned byte values" do
+      [0x00, 0x7f, 0x80, 0xff].each do |byte|
+        @buffer.reset_buffer([byte].pack("C"))
+        expect(@buffer.read_byte).to eq(byte)
+      end
+    end
+
     it "should consume bytes copied before the destination is exhausted" do
       destination = +"x"
       @buffer.reset_buffer("ab")


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native `MemoryBufferTransport#read_byte` implementation returned signed values for bytes above `0x7f` because it stored the byte in a plain C `char`. The pure-Ruby implementation returns unsigned values, making direct raw-byte consumers depend on extension availability and platform representation.

The native transport now returns the same `0..255` byte values as the pure-Ruby implementation.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6103](https://issues.apache.org/jira/browse/THRIFT-6103)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->