### PR TITLE
THRIFT-6104: Accept Ruby Set subclasses in native struct writing

### DIFF
--- a/lib/rb/ext/struct.c
+++ b/lib/rb/ext/struct.c
@@ -315,7 +315,7 @@ static void write_container(int ttype, VALUE field_info, VALUE value, VALUE prot
     if (TYPE(value) == T_ARRAY) {
       items = value;
     } else {
-      if (rb_cSet == CLASS_OF(value)) {
+      if (rb_obj_is_kind_of(value, rb_cSet)) {
         items = rb_funcall(value, entries_method_id, 0);
       } else {
         Check_Type(value, T_HASH);

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -246,6 +246,15 @@ describe 'Struct' do
       struct.write(prot)
     end
 
+    it "should serialize subclasses of Set like Set" do
+      set_subclass = Class.new(Set)
+      regular = SpecNamespace::Foo.new(:shorts => Set.new([5, 17, 239]))
+      subclassed = SpecNamespace::Foo.new(:shorts => set_subclass.new([5, 17, 239]))
+      serializer = Thrift::Serializer.new(Thrift::BinaryProtocolFactory.new)
+
+      expect(serializer.serialize(subclassed)).to eq(serializer.serialize(regular))
+    end
+
     it "should raise an exception if presented with an unknown container" do
       # yeah this is silly, but I'm going for code coverage here
       struct = SpecNamespace::Foo.new


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native struct writer checked for the exact `Set` class when serializing Thrift `set` fields. A `Set` subclass was therefore routed to Hash handling and rejected, while the pure-Ruby writer accepted and serialized the same value.

The native writer now honors the public `Set` contract, allowing subclasses to serialize the same elements as an equivalent `Set`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6104](https://issues.apache.org/jira/browse/THRIFT-6104)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->