### PR TITLE
THRIFT-6105: Preserve partial MemoryBufferTransport read progress

### DIFF
--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -131,21 +131,30 @@ VALUE rb_thrift_memory_buffer_read_into_buffer(VALUE self, VALUE buffer_value, V
   int index;
   VALUE buf = GET_BUF(self);
 
+  index = FIX2INT(rb_ivar_get(self, index_ivar_id));
   if (size > 0) {
-    Check_Type(buffer_value, T_STRING);
+    if (index >= RSTRING_LEN(buf)) {
+      rb_ivar_set(self, index_ivar_id, INT2FIX(index));
+      rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
+    }
+    StringValue(buffer_value);
+    if (RSTRING_LEN(buffer_value) == 0) {
+      rb_ivar_set(self, index_ivar_id, INT2FIX(index));
+      rb_raise(rb_eIndexError, "index 0 out of string");
+    }
     rb_str_modify(buffer_value);
   }
 
-  index = FIX2INT(rb_ivar_get(self, index_ivar_id));
   while (i < size) {
     if (index >= RSTRING_LEN(buf)) {
+      rb_ivar_set(self, index_ivar_id, INT2FIX(index));
       rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
     }
-    char byte = RSTRING_PTR(buf)[index++];
-
     if (i >= RSTRING_LEN(buffer_value)) {
+      rb_ivar_set(self, index_ivar_id, INT2FIX(index));
       rb_raise(rb_eIndexError, "index %d out of string", i);
     }
+    char byte = RSTRING_PTR(buf)[index++];
     ((char*)RSTRING_PTR(buffer_value))[i] = byte;
     i++;
   }

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -398,6 +398,24 @@ describe 'BaseTransport' do
       expect(@buffer.available).to eq(0)
     end
 
+    it "should consume bytes copied before the destination is exhausted" do
+      destination = +"x"
+      @buffer.reset_buffer("ab")
+
+      expect { @buffer.read_into_buffer(destination, 2) }.to raise_error(IndexError, "index 1 out of string")
+      expect(destination).to eq("a")
+      expect(@buffer.available).to eq(1)
+    end
+
+    it "should consume bytes copied before input is exhausted" do
+      destination = +"xx"
+      @buffer.reset_buffer("a")
+
+      expect { @buffer.read_into_buffer(destination, 2) }.to raise_error(EOFError)
+      expect(destination).to eq("ax")
+      expect(@buffer.available).to eq(0)
+    end
+
     it "should not mutate or consume input when reading into a frozen buffer" do
       ["xy".freeze, ("x" * 100).freeze].each do |destination|
         @buffer.reset_buffer("ab")
@@ -415,6 +433,24 @@ describe 'BaseTransport' do
       expect(@buffer.read_into_buffer(destination, 0)).to eq(0)
       expect(destination).to eq("x")
       expect(@buffer.available).to eq(1)
+    end
+
+    it "should report EOF before modifying a frozen destination" do
+      destination = "xx".freeze
+      @buffer.reset_buffer("")
+
+      expect { @buffer.read_into_buffer(destination, 1) }.to raise_error(EOFError)
+      expect(destination).to eq("xx")
+    end
+
+    it "should not mutate strings sharing the destination storage" do
+      original = "x" * 256
+      destination = original.byteslice(1, 128)
+      @buffer.reset_buffer("ab")
+
+      expect(@buffer.read_into_buffer(destination, 2)).to eq(2)
+      expect(destination).to eq("ab" + ("x" * 126))
+      expect(original).to eq("x" * 256)
     end
 
     it "should reject negative read_all sizes" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native `MemoryBufferTransport#read_into_buffer` implementation delayed recording its transport position until the whole request completed. If input or destination capacity ran out after bytes had been copied, the destination contained those bytes while the transport still treated them as unread.

This change preserves the progress of successfully copied bytes before raising, so native retry and recovery behavior matches the pure-Ruby implementation.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6105](https://issues.apache.org/jira/browse/THRIFT-6105)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
--> 