### PR TITLE
THRIFT-6106: Decode fixed-width values without undefined shifts

### DIFF
--- a/lib/rb/ext/binary_protocol_accelerated.c
+++ b/lib/rb/ext/binary_protocol_accelerated.c
@@ -331,33 +331,62 @@ static char read_byte_direct(VALUE self) {
   return (char)(FIX2INT(byte));
 }
 
+static int16_t uint16_to_int16(uint16_t value) {
+  if (value <= INT16_MAX) {
+    return (int16_t)value;
+  }
+  return (int16_t)((int32_t)value - ((int32_t)UINT16_MAX + 1));
+}
+
+static int32_t uint32_to_int32(uint32_t value) {
+  if (value <= INT32_MAX) {
+    return (int32_t)value;
+  }
+  return (int32_t)((int64_t)value - (INT64_C(1) << 32));
+}
+
+static int64_t uint64_to_int64(uint64_t value) {
+  if (value <= INT64_MAX) {
+    return (int64_t)value;
+  }
+  return -(int64_t)(~value) - INT64_C(1);
+}
+
 static int16_t read_i16_direct(VALUE self) {
   VALUE rbuf = rb_ivar_get(self, rbuf_ivar_id);
   rb_funcall(GET_TRANSPORT(self), read_into_buffer_method_id, 2, rbuf, INT2FIX(2));
-  return (int16_t)(((uint8_t)(RSTRING_PTR(rbuf)[1])) | ((uint16_t)((RSTRING_PTR(rbuf)[0]) << 8)));
+  const uint8_t* bytes = (const uint8_t*)RSTRING_PTR(rbuf);
+  uint16_t value = ((uint16_t)bytes[0] << 8) | (uint16_t)bytes[1];
+  return uint16_to_int16(value);
 }
 
 static int32_t read_i32_direct(VALUE self) {
   VALUE rbuf = rb_ivar_get(self, rbuf_ivar_id);
   rb_funcall(GET_TRANSPORT(self), read_into_buffer_method_id, 2, rbuf, INT2FIX(4));
-  return ((uint8_t)(RSTRING_PTR(rbuf)[3])) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[2])) << 8) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[1])) << 16) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[0])) << 24);
+  const uint8_t* bytes = (const uint8_t*)RSTRING_PTR(rbuf);
+  uint32_t value = ((uint32_t)bytes[0] << 24) |
+    ((uint32_t)bytes[1] << 16) |
+    ((uint32_t)bytes[2] << 8) |
+    (uint32_t)bytes[3];
+  return uint32_to_int32(value);
+}
+
+static uint64_t read_u64_direct(VALUE self) {
+  VALUE rbuf = rb_ivar_get(self, rbuf_ivar_id);
+  rb_funcall(GET_TRANSPORT(self), read_into_buffer_method_id, 2, rbuf, INT2FIX(8));
+  const uint8_t* bytes = (const uint8_t*)RSTRING_PTR(rbuf);
+  return ((uint64_t)bytes[0] << 56) |
+    ((uint64_t)bytes[1] << 48) |
+    ((uint64_t)bytes[2] << 40) |
+    ((uint64_t)bytes[3] << 32) |
+    ((uint64_t)bytes[4] << 24) |
+    ((uint64_t)bytes[5] << 16) |
+    ((uint64_t)bytes[6] << 8) |
+    (uint64_t)bytes[7];
 }
 
 static int64_t read_i64_direct(VALUE self) {
-  VALUE rbuf = rb_ivar_get(self, rbuf_ivar_id);
-  rb_funcall(GET_TRANSPORT(self), read_into_buffer_method_id, 2, rbuf, INT2FIX(8));
-  uint64_t hi = ((uint8_t)(RSTRING_PTR(rbuf)[3])) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[2])) << 8) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[1])) << 16) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[0])) << 24);
-  uint32_t lo = ((uint8_t)(RSTRING_PTR(rbuf)[7])) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[6])) << 8) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[5])) << 16) |
-    (((uint8_t)(RSTRING_PTR(rbuf)[4])) << 24);
-  return (hi << 32) | lo;
+  return uint64_to_int64(read_u64_direct(self));
 }
 
 VALUE rb_thrift_binary_proto_read_message_end(VALUE self) {
@@ -472,9 +501,9 @@ VALUE rb_thrift_binary_proto_read_i64(VALUE self) {
 VALUE rb_thrift_binary_proto_read_double(VALUE self) {
   union {
     double f;
-    int64_t t;
+    uint64_t t;
   } transfer;
-  transfer.t = read_i64_direct(self);
+  transfer.t = read_u64_direct(self);
   return rb_float_new(transfer.f);
 }
 

--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -608,19 +608,19 @@ VALUE rb_thrift_compact_proto_read_i64(VALUE self) {
 VALUE rb_thrift_compact_proto_read_double(VALUE self) {
   union {
     double f;
-    int64_t l;
+    uint64_t l;
   } transfer;
   VALUE rbuf = rb_ivar_get(self, rbuf_ivar_id);
   rb_funcall(GET_TRANSPORT(self), read_into_buffer_method_id, 2, rbuf, INT2FIX(8));
-  uint32_t lo = ((uint8_t)(RSTRING_PTR(rbuf)[0]))
-    | (((uint8_t)(RSTRING_PTR(rbuf)[1])) << 8)
-    | (((uint8_t)(RSTRING_PTR(rbuf)[2])) << 16)
-    | (((uint8_t)(RSTRING_PTR(rbuf)[3])) << 24);
-  uint64_t hi = (((uint8_t)(RSTRING_PTR(rbuf)[4])))
-    | (((uint8_t)(RSTRING_PTR(rbuf)[5])) << 8)
-    | (((uint8_t)(RSTRING_PTR(rbuf)[6])) << 16)
-    | (((uint8_t)(RSTRING_PTR(rbuf)[7])) << 24);
-  transfer.l = (hi << 32) | lo;
+  const uint8_t* bytes = (const uint8_t*)RSTRING_PTR(rbuf);
+  transfer.l = (uint64_t)bytes[0]
+    | ((uint64_t)bytes[1] << 8)
+    | ((uint64_t)bytes[2] << 16)
+    | ((uint64_t)bytes[3] << 24)
+    | ((uint64_t)bytes[4] << 32)
+    | ((uint64_t)bytes[5] << 40)
+    | ((uint64_t)bytes[6] << 48)
+    | ((uint64_t)bytes[7] << 56);
 
   return rb_float_new(transfer.f);
 }

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -394,6 +394,28 @@ shared_examples_for 'a binary protocol' do
     end
   end
 
+  it "should decode fixed-width signed edge byte patterns" do
+    {
+      :read_i16 => {
+        [0x80, 0x00] => -(2**15),
+        [0xff, 0xff] => -1
+      },
+      :read_i32 => {
+        [0x80, 0x00, 0x00, 0x00] => -(2**31),
+        [0xff, 0xff, 0xff, 0xff] => -1
+      },
+      :read_i64 => {
+        [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] => -(2**63),
+        [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] => -1
+      }
+    }.each do |reader, cases|
+      cases.each do |bytes, expected|
+        @trans.write(bytes.pack("C*"))
+        expect(@prot.public_send(reader)).to eq(expected)
+      end
+    end
+  end
+
   it "should read a double" do
     # try a random scattering of values, including min/max
     [Float::MIN, -231231.12351, -323.233513, 0, 123.2351235, 2351235.12351235, Float::MAX].each do |f|

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -120,6 +120,18 @@ describe Thrift::CompactProtocol do
     expect(proto.read_i64).to eq(INTEGER_BOUNDARY_TESTS[:i64].first)
   end
 
+  it "should preserve fixed-width double edge byte patterns" do
+    [
+      [0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00],
+      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80]
+    ].each do |bytes|
+      trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
+      proto = Thrift::CompactProtocol.new(trans)
+
+      expect([proto.read_double].pack("G").reverse.bytes).to eq(bytes)
+    end
+  end
+
   it "should read binary values with multi-byte varint32 lengths" do
     payload = "x" * 128
     trans = Thrift::MemoryBufferTransport.new


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Native Ruby protocol readers previously assembled fixed-width values through shifts on promoted signed integers. On common builds, those reads can appear to return the expected values, but UBSan exposes the undefined operation for high-bit byte patterns.

Before this change, building and running the focused examples from `lib/rb` with:

```sh
make -C ext clean all CFLAGS='-fPIC -O1 -g -fsanitize=undefined -fno-sanitize-recover=undefined' DLDFLAGS='-fsanitize=undefined'
UBSAN_OPTIONS='halt_on_error=1:print_stacktrace=1' bundle exec rspec spec/binary_protocol_spec.rb spec/compact_protocol_spec.rb --example fixed-width
```

reports:

```text
compact_protocol.c:618:42: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
```

This change builds the binary and compact protocol values with correctly sized unsigned intermediates, then converts to signed values only after assembly. It also preserves double bit patterns when the high bit is set.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6106](https://issues.apache.org/jira/browse/THRIFT-6106)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->