### PR TITLE
THRIFT-6109: Format Ruby HTTP transport endpoint labels

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -52,7 +52,7 @@ module Thrift
         http.ca_file = @ssl_ca_file if @ssl_ca_file
       end
       resp = http.post(@url.request_uri, @outbuf, @headers)
-      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{@url}, HTTP status code #{resp.code.to_i}") unless (200..299).include?(resp.code.to_i)
+      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{to_s}, HTTP status code #{resp.code.to_i}") unless (200..299).include?(resp.code.to_i)
 
       data = resp.body
       data = Bytes.force_binary_encoding(data)
@@ -62,7 +62,9 @@ module Thrift
     end
 
     def to_s
-      "@{self.url}"
+      path = @url.path.to_s
+      path = '/' if path.empty?
+      "#{@url.scheme}(#{@url.host}:#{@url.port}#{path})"
     end
   end
 end

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -27,7 +27,26 @@ describe 'Thrift::HTTPClientTransport' do
     end
 
     it "should provide a reasonable to_s" do
-      @client.to_s == "http://my.domain.com/path/to/service?param=value"
+      expect(@client.to_s).to eq("http(my.domain.com:80/path/to/service)")
+    end
+
+    it "should include the root path in its endpoint label" do
+      client = Thrift::HTTPClientTransport.new("http://my.domain.com")
+
+      expect(client.to_s).to eq("http(my.domain.com:80/)")
+    end
+
+    it "should distinguish an IPv6 host from its port" do
+      client = Thrift::HTTPClientTransport.new("https://[2001:db8::1]:8443/path/to/service")
+
+      expect(client.to_s).to eq("https([2001:db8::1]:8443/path/to/service)")
+    end
+
+    it "should not include userinfo in its endpoint label" do
+      client = Thrift::HTTPClientTransport.new("https://user:secret@my.domain.com/path/to/service?token=secret")
+
+      expect(client.to_s).to eq("https(my.domain.com:443/path/to/service)")
+      expect(client.to_s).not_to include("user", "secret", "token")
     end
 
     it "should always be open" do
@@ -104,6 +123,23 @@ describe 'Thrift::HTTPClientTransport' do
       end
 
       expect { @client.flush }.to raise_error(Thrift::TransportException)
+    end
+
+    it 'should omit URL secrets from HTTP failure messages' do
+      client = Thrift::HTTPClientTransport.new("https://user:secret@my.domain.com/path/to/service?token=secret")
+      client.write "test"
+      http = double("Net::HTTP")
+      response = double("HTTP response", :code => "503")
+
+      expect(Net::HTTP).to receive(:new).with("my.domain.com", 443).and_return(http)
+      expect(http).to receive(:use_ssl=).with(true)
+      expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      expect(http).to receive(:post).with("/path/to/service?token=secret", "test", {"Content-Type" => "application/x-thrift"}).and_return(response)
+
+      expect { client.flush }.to raise_error(Thrift::TransportException) do |error|
+        expect(error.message).to include("https(my.domain.com:443/path/to/service)")
+        expect(error.message).not_to include("user", "secret", "token")
+      end
     end
   end
 


### PR DESCRIPTION
Replace the malformed diagnostic label returned by `Thrift::HTTPClientTransport#to_s` with an endpoint description that includes the scheme, host, port, and path.

The label distinguishes HTTP from HTTPS while leaving URL userinfo and query parameters out of logs and exception output.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6109](https://issues.apache.org/jira/browse/THRIFT-6109)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
