### PR TITLE
THRIFT-6110: Reject empty successful Ruby HTTP responses

### DIFF
--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -37,7 +37,12 @@ module Thrift
     end
 
     def open?; true end
-    def read(sz); @inbuf.read sz end
+    def read(sz)
+      data = @inbuf.read sz
+      return data unless data.nil?
+
+      raise TransportException.new(TransportException::END_OF_FILE, "#{self.class.name} reached EOF reading response from #{to_s}, HTTP status code #{@response_code}")
+    end
     def write(buf); @outbuf << Bytes.force_binary_encoding(buf) end
 
     def add_headers(headers)
@@ -52,10 +57,11 @@ module Thrift
         http.ca_file = @ssl_ca_file if @ssl_ca_file
       end
       resp = http.post(@url.request_uri, @outbuf, @headers)
-      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{to_s}, HTTP status code #{resp.code.to_i}") unless (200..299).include?(resp.code.to_i)
+      response_code = resp.code.to_i
+      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{to_s}, HTTP status code #{response_code}") unless (200..299).include?(response_code)
 
-      data = resp.body
-      data = Bytes.force_binary_encoding(data)
+      @response_code = response_code
+      data = Bytes.force_binary_encoding(resp.body || Bytes.empty_byte_buffer)
       @inbuf = StringIO.new data
     ensure
       @outbuf = Bytes.empty_byte_buffer

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -73,6 +73,57 @@ describe 'Thrift::HTTPClientTransport' do
       expect(@client.read(10)).to eq("data")
     end
 
+    it "should report successful HTTP responses without a Thrift payload when read" do
+      {'204' => nil, '200' => ''}.each do |status, body|
+        client = Thrift::HTTPClientTransport.new("http://my.domain.com/service")
+        client.write("request")
+        http = instance_double(Net::HTTP)
+        response = instance_double(Net::HTTPResponse, :code => status, :body => body)
+
+        expect(Net::HTTP).to receive(:new).with("my.domain.com", 80).and_return(http)
+        expect(http).to receive(:use_ssl=).with(false)
+        expect(http).to receive(:post).with("/service", "request", {"Content-Type" => "application/x-thrift"}).and_return(response)
+
+        expect { client.flush }.not_to raise_error
+        expect { client.read_all(1) }.to raise_error(Thrift::TransportException) do |error|
+          expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+          expect(error.message).to eq("Thrift::HTTPClientTransport reached EOF reading response from http(my.domain.com:80/service), HTTP status code #{status}")
+        end
+      end
+    end
+
+    it "should allow oneway calls with successful empty HTTP responses" do
+      {'200' => '', '204' => nil}.each do |status, body|
+        transport = Thrift::HTTPClientTransport.new("http://my.domain.com/service")
+        client = SpecNamespace::NonblockingService::Client.new(Thrift::BinaryProtocol.new(transport))
+        http = instance_double(Net::HTTP)
+        response = instance_double(Net::HTTPResponse, :code => status, :body => body)
+
+        expect(Net::HTTP).to receive(:new).with("my.domain.com", 80).and_return(http)
+        expect(http).to receive(:use_ssl=).with(false)
+        expect(http).to receive(:post).with("/service", kind_of(String), {"Content-Type" => "application/x-thrift"}).and_return(response)
+
+        expect { client.shutdown }.not_to raise_error
+      end
+    end
+
+    it "should include a safe endpoint and status in empty response errors" do
+      client = Thrift::HTTPClientTransport.new("https://user:secret@my.domain.com/service?token=secret")
+      client.write("request")
+      http = instance_double(Net::HTTP)
+      response = instance_double(Net::HTTPNoContent, :code => "204", :body => nil)
+
+      expect(Net::HTTP).to receive(:new).with("my.domain.com", 443).and_return(http)
+      expect(http).to receive(:use_ssl=).with(true)
+      expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+      expect(http).to receive(:post).with("/service?token=secret", "request", {"Content-Type" => "application/x-thrift"}).and_return(response)
+
+      expect { client.flush }.not_to raise_error
+      expect { client.read_all(1) }.to raise_error(Thrift::TransportException) do |error|
+        expect(error.message).to eq("Thrift::HTTPClientTransport reached EOF reading response from https(my.domain.com:443/service), HTTP status code 204")
+      end
+    end
+
     it "should send custom headers if defined" do
       @client.write "test"
       custom_headers = {"Cookie" => "Foo"}


### PR DESCRIPTION
Return a typed transport error when `Thrift::HTTPClientTransport` receives a successful HTTP response without a Thrift payload.

This handles both 204 responses with no body and 200 responses with an empty body, so callers no longer receive an unrelated `NoMethodError` while normal responses and existing HTTP-status handling remain unchanged.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6110](https://issues.apache.org/jira/browse/THRIFT-6110)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
