### PR TITLE
THRIFT-6111: Make Ruby struct equality symmetric

### DIFF
--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -115,7 +115,7 @@ module Thrift
     end
 
     def ==(other)
-      return false if other.nil?
+      return false unless other.instance_of?(self.class)
       each_field do |fid, field_info|
         name = field_info[:name]
         return false unless other.respond_to?(name) && self.send(name) == other.send(name)

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -20,6 +20,33 @@
 
 require 'spec_helper'
 
+module StructEqualityFixtures
+  class Narrow
+    include Thrift::Struct, Thrift::Struct_Union
+
+    FIELDS = {1 => {type: Thrift::Types::STRING, name: 'shared'}}
+
+    def struct_fields; FIELDS; end
+    def validate; end
+
+    Thrift::Struct.generate_accessors self
+  end
+
+  class Wide
+    include Thrift::Struct, Thrift::Struct_Union
+
+    FIELDS = {
+      1 => {type: Thrift::Types::STRING, name: 'shared'},
+      2 => {type: Thrift::Types::STRING, name: 'extra'}
+    }
+
+    def struct_fields; FIELDS; end
+    def validate; end
+
+    Thrift::Struct.generate_accessors self
+  end
+end
+
 describe 'Struct' do
   describe Thrift::Struct do
     it "should iterate over all fields properly" do
@@ -67,6 +94,21 @@ describe 'Struct' do
       expect(SpecNamespace::Foo.new).not_to eq(SpecNamespace::Hello.new)
       expect(SpecNamespace::Foo.new).to eq(SpecNamespace::Foo.new)
       expect(SpecNamespace::Foo.new(:simple => 52)).not_to eq(SpecNamespace::Foo.new)
+    end
+
+    it 'compares only structs of the same generated class' do
+      narrow = StructEqualityFixtures::Narrow.new(shared: 'value')
+      wide = StructEqualityFixtures::Wide.new(shared: 'value', extra: 'different')
+      same_narrow = StructEqualityFixtures::Narrow.new(shared: 'value')
+
+      expect(narrow == wide).to be(false)
+      expect(wide == narrow).to be(false)
+      expect(narrow).to eq(same_narrow)
+      expect(narrow).to eql(same_narrow)
+      expect(narrow.hash).to eq(same_narrow.hash)
+
+      expect({narrow => :value}[wide]).to be_nil
+      expect(Set.new([narrow])).not_to include(wide)
     end
 
     it "should print enum value names in inspect" do


### PR DESCRIPTION
Require two Ruby Thrift struct values to have the same generated class before comparing their fields.

This prevents a narrower struct from comparing equal to a different wider struct in only one operand order, and brings `==` in line with the class-aware `eql?` and `hash` behavior.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6111](https://issues.apache.org/jira/browse/THRIFT-6111)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.
