### PR TITLE
THRIFT-6098: Preserve caller-supplied Ruby SSL contexts

### DIFF
--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -157,11 +157,13 @@ Its EventMachine dependency also does not build on new Ruby development
 versions. Creating a Thin server now prints a warning. Move to
 `Thrift::RackApplication` with a supported Rack server such as Puma or Falcon.
 
-`Thrift::SSLSocket` now verifies peers by default, including when given a
-blank SSL context. It preserves configured certificate authorities and uses
-the system certificate store when no trust source is configured. Applications
-that intentionally connect without peer identity checks must pass
-`verify_peer: false` explicitly.
+`Thrift::SSLSocket` now verifies peers by default when no SSL context is
+provided. It creates a context that uses the system certificate store. A
+supplied SSL context is not reconfigured by Thrift, so the application is
+responsible for its verification mode and trust sources. A newly constructed
+`OpenSSL::SSL::SSLContext` defaults to `OpenSSL::SSL::VERIFY_NONE`; configuring
+a trust source alone does not enable certificate chain verification. The server
+certificate must still match the connection hostname.
 
 ### 0.24.0
 
@@ -266,8 +268,10 @@ best-effort, not guaranteed.
 ## Migration Notes
 
 - If you upgrade to `0.25.0`, note that `Thrift::SSLSocket` now verifies peers
-  by default. Applications that intentionally connect without peer identity
-  checks must pass `verify_peer: false` explicitly.
+  by default when it creates the SSL context. Supplied contexts are used
+  unchanged and must configure their own verification mode and trust sources.
+  A blank supplied context defaults to `OpenSSL::SSL::VERIFY_NONE`. Hostname
+  checking is performed for both supplied and default contexts.
 - If you upgrade to `0.24.0`, treat `timeout` on `Thrift::Socket` and
   `Thrift::SSLSocket` as one budget for the whole open path. For
   `Thrift::SSLSocket`, that includes both the TCP connect and the TLS
@@ -307,8 +311,17 @@ best-effort, not guaranteed.
   switch to SSL, HTTP, header transport, compact protocol, or namespaced
   generated code, update both ends together.
 - HTTPS client transport and `Thrift::SSLSocket` verify peers by default.
-  `Thrift::SSLSocket` preserves trust sources configured on a supplied SSL
-  context and otherwise uses the system certificate store. It also checks the
-  certificate against `server_hostname` (or the connection host by default).
-  Pass `verify_peer: false` only when peer identity checks are intentionally
-  disabled.
+  When no SSL context is provided, `Thrift::SSLSocket` creates one with peer
+  verification and the system certificate store. Thrift passes a supplied
+  context to OpenSSL without reconfiguring it. `Thrift::SSLSocket` always
+  checks the certificate against `server_hostname` (or the connection host by
+  default). `OpenSSL::SSL::SSLContext.new` defaults to
+  `OpenSSL::SSL::VERIFY_NONE`, and setting `ca_file`, `ca_path`, or `cert_store`
+  does not enable verification by itself. Set `verify_mode` explicitly when
+  supplying a context. For example, to disable certificate chain verification:
+
+  ```ruby
+  context = OpenSSL::SSL::SSLContext.new
+  context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  socket = Thrift::SSLSocket.new(host, port, nil, context)
+  ```

--- a/lib/rb/lib/thrift/transport/ssl_socket.rb
+++ b/lib/rb/lib/thrift/transport/ssl_socket.rb
@@ -23,23 +23,22 @@ require 'ipaddr'
 
 module Thrift
   class SSLSocket < Socket
-    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil, server_hostname: host, verify_peer: true)
+    def initialize(host = 'localhost', port = 9090, timeout = nil, ssl_context = nil, server_hostname: host)
       super(host, port, timeout)
       @ssl_context = ssl_context
       @server_hostname = server_hostname
-      @verify_peer = verify_peer
     end
 
     attr_accessor :ssl_context
     attr_accessor :server_hostname
-    attr_reader :verify_peer
 
     def open
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
       socket = connect_socket(deadline)
 
       begin
-        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, configured_ssl_context)
+        ssl_context = configured_ssl_context
+        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
         ssl_socket.hostname = @server_hostname if send_server_hostname?
         ssl_socket.sync_close = true
         @handle = ssl_socket
@@ -69,7 +68,7 @@ module Thrift
           @handle.connect
         end
 
-        @handle.post_connection_check(server_hostname_for_verification) if @verify_peer
+        @handle.post_connection_check(server_hostname_for_verification)
         @handle
       rescue TransportException
         close_socket(@handle)
@@ -89,23 +88,10 @@ module Thrift
     private
 
     def configured_ssl_context
-      @ssl_context ||= OpenSSL::SSL::SSLContext.new
-
-      if @verify_peer
-        verify_mode = @ssl_context.verify_mode || OpenSSL::SSL::VERIFY_NONE
-        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER if verify_mode == OpenSSL::SSL::VERIFY_NONE
-        configure_default_cert_store
-      elsif @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
-        @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      @ssl_context ||= OpenSSL::SSL::SSLContext.new.tap do |context|
+        context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        context.cert_store = OpenSSL::X509::Store.new.tap(&:set_default_paths)
       end
-
-      @ssl_context
-    end
-
-    def configure_default_cert_store
-      return if @ssl_context.ca_file || @ssl_context.ca_path || @ssl_context.cert_store
-
-      @ssl_context.cert_store = OpenSSL::X509::Store.new.tap(&:set_default_paths)
     end
 
     def send_server_hostname?

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -98,29 +98,34 @@ describe 'SSLSocket' do
       expect(socket.server_hostname).to eq('service.example.com')
     end
 
-    it "should accept an optional peer verification setting" do
-      socket = Thrift::SSLSocket.new('localhost', 8080, 5, @context, verify_peer: false)
-      expect(socket.verify_peer).to be(false)
-    end
+    it "should pass a supplied SSL context through unchanged" do
+      verify_mode = @context.verify_mode
+      cert_store = @context.cert_store
 
-    it "should enable peer verification when a blank context reports no verify mode" do
-      allow(@context).to receive(:verify_mode).and_return(nil)
-      expect(@context).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
-
-      Thrift::SSLSocket.new('localhost', 9090, nil, @context).open
-    end
-
-    it "should disable peer identity checks only when explicitly requested" do
-      @context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, @context).and_return(@handle)
       expect(@handle).to receive(:sync_close=).with(true)
       expect(@handle).to receive(:connect).and_return(true)
-      expect(@handle).not_to receive(:post_connection_check)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
 
-      socket = Thrift::SSLSocket.new('localhost', 9090, nil, @context, verify_peer: false)
+      socket = Thrift::SSLSocket.new('localhost', 9090, nil, @context)
       expect(socket.open).to eq(@handle)
-      expect(@context.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+      expect(@context.verify_mode).to eq(verify_mode)
+      expect(@context.cert_store).to equal(cert_store)
+    end
+
+    it "should check the hostname when the supplied context verifies peers" do
+      @context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      cert_store = @context.cert_store
+
+      expect(@simple_socket_handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(@simple_socket_handle, @context).and_return(@handle)
+      expect(@handle).to receive(:sync_close=).with(true)
+      expect(@handle).to receive(:connect).and_return(true)
+      expect(@handle).to receive(:post_connection_check).with('localhost')
+
+      expect(Thrift::SSLSocket.new('localhost', 9090, nil, @context).open).to eq(@handle)
+      expect(@context.cert_store).to equal(cert_store)
     end
 
     it "should use the server hostname for SNI and certificate verification" do
@@ -331,8 +336,8 @@ describe 'SSLSocket' do
       @server_thread.join
     end
 
-    it "should validate the server certificate with a blank client context" do
-      @client = build_client(OpenSSL::SSL::SSLContext.new)
+    it "should validate the server certificate with the default client context" do
+      @client = build_client
 
       expect { @client.open }.to raise_error(Thrift::TransportException) do |error|
         expect(error.type).to eq(Thrift::TransportException::NOT_OPEN)
@@ -342,26 +347,29 @@ describe 'SSLSocket' do
 
     it "should use a configured certificate authority" do
       context = OpenSSL::SSL::SSLContext.new
+      context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       context.ca_file = File.join(ssl_keys_dir, 'server.crt')
       @client = build_client(context)
 
       expect(@client.open).to be_a(OpenSSL::SSL::SSLSocket)
     end
 
-    it "should allow peer certificate verification to be disabled explicitly" do
-      @client = build_client(OpenSSL::SSL::SSLContext.new, verify_peer: false)
+    it "should leave peer verification disabled on a blank supplied context" do
+      context = OpenSSL::SSL::SSLContext.new
+      verify_mode = context.verify_mode
+      @client = build_client(context)
 
       expect(@client.open).to be_a(OpenSSL::SSL::SSLSocket)
+      expect(context.verify_mode).to eq(verify_mode)
     end
 
-    def build_client(context, verify_peer: true)
+    def build_client(context = nil)
       Thrift::SSLSocket.new(
         '127.0.0.1',
         @tcp_server.local_address.ip_port,
         1,
         context,
-        server_hostname: 'localhost',
-        verify_peer: verify_peer
+        server_hostname: 'localhost'
       )
     end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

`Thrift::SSLSocket` reconfigured a caller-supplied `OpenSSL::SSL::SSLContext` in place to apply its separate peer-verification setting. This changed the caller’s verification mode and could install a certificate store on an object the application expected to configure and reuse itself. Ruby OpenSSL also freezes a context after it is used by a socket, making later attempts to apply a different setting fail.

This change gives the context a single owner. When no context is supplied, Thrift creates one with peer verification enabled and the system certificate store. When an application supplies a context, Thrift passes it to OpenSSL without reconfiguring it; the context’s `verify_mode` and trust sources control certificate-chain verification. Thrift continues to check the server certificate against `server_hostname`, preserving hostname-mismatch detection.

The Ruby README now documents both ownership modes and shows how to supply a context configured with `OpenSSL::SSL::VERIFY_NONE` when certificate-chain verification is intentionally disabled.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6098](https://issues.apache.org/jira/browse/THRIFT-6098)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
