### PR TITLE
THRIFT-6112: Reject duplicate Ruby socket opens

### DIFF
--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -165,6 +165,10 @@ responsible for its verification mode and trust sources. A newly constructed
 a trust source alone does not enable certificate chain verification. The server
 certificate must still match the connection hostname.
 
+`Thrift::Socket#open` now raises
+`Thrift::TransportException::ALREADY_OPEN` when the TCP transport is already
+open. Close the transport before opening it again.
+
 ### 0.24.0
 
 Connect timeout handling changed for both `Thrift::Socket` and
@@ -272,6 +276,9 @@ best-effort, not guaranteed.
   unchanged and must configure their own verification mode and trust sources.
   A blank supplied context defaults to `OpenSSL::SSL::VERIFY_NONE`. Hostname
   checking is performed for both supplied and default contexts.
+- If you upgrade to `0.25.0`, close a `Thrift::Socket` before calling `open`
+  again. A duplicate open now raises
+  `Thrift::TransportException::ALREADY_OPEN`.
 - If you upgrade to `0.24.0`, treat `timeout` on `Thrift::Socket` and
   `Thrift::SSLSocket` as one budget for the whole open path. For
   `Thrift::SSLSocket`, that includes both the TCP connect and the TLS

--- a/lib/rb/lib/thrift/transport/socket.rb
+++ b/lib/rb/lib/thrift/transport/socket.rb
@@ -34,6 +34,8 @@ module Thrift
     attr_accessor :handle, :timeout
 
     def open
+      raise TransportException.new(TransportException::ALREADY_OPEN, "Socket already open") if open?
+
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout unless @timeout.nil? || @timeout == 0
       @handle = connect_socket(deadline)
     end

--- a/lib/rb/spec/socket_spec.rb
+++ b/lib/rb/spec/socket_spec.rb
@@ -52,6 +52,30 @@ describe 'Socket' do
       @socket.open
     end
 
+    it "should reject a second open without orphaning the live connection" do
+      allow(Addrinfo).to receive(:foreach).and_call_original
+      server = TCPServer.new('127.0.0.1', 0)
+      socket = Thrift::Socket.new('127.0.0.1', server.addr[1])
+      peer = nil
+
+      socket.open
+      peer = server.accept
+      first_handle = socket.handle
+
+      expect { socket.open }.to raise_error(Thrift::TransportException, /already open/) do |error|
+        expect(error.type).to eq(Thrift::TransportException::ALREADY_OPEN)
+      end
+      expect(socket.handle).to equal(first_handle)
+
+      socket.close
+      expect(peer.read).to eq('')
+    ensure
+      socket&.close
+      first_handle&.close unless first_handle&.closed?
+      peer&.close
+      server&.close
+    end
+
     it "should accept host/port options" do
       handle = double("Handle", :closed? => false)
       allow(handle).to receive(:close)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The Ruby TCP transport currently replaces its live socket when `open` is called a second time. The original connection remains open but is no longer reachable through the transport, so a later `close` only closes the replacement connection.

This change rejects a duplicate open with `TransportException::ALREADY_OPEN` while preserving the existing live connection. Callers can continue using or explicitly close the original transport without leaving an orphaned TCP session.

The change is intentionally scoped to `Thrift::Socket`; transports that provide their own `open` implementation are not altered.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6112](https://issues.apache.org/jira/browse/THRIFT-6112)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
