### PR TITLE
THRIFT-6113: Fix test_keyword_escape.py silently skipping in CI and local builds

### DIFF
--- a/lib/py/Makefile.am
+++ b/lib/py/Makefile.am
@@ -62,7 +62,7 @@ check-local: all py3-test
 	$(PYTHON) test/thrift_TCompactProtocol.py
 	$(PYTHON) test/thrift_TNonblockingServer.py
 	$(PYTHON) test/thrift_TSerializer.py
-	$(PYTHON) test/test_compiler/test_keyword_escape.py
+	THRIFT=${THRIFT} $(PYTHON) test/test_compiler/test_keyword_escape.py
 	$(PYTHON) test/test_recursion_depth.py
 
 

--- a/lib/py/test/test_compiler/test_keyword_escape.py
+++ b/lib/py/test/test_compiler/test_keyword_escape.py
@@ -46,14 +46,14 @@ def find_thrift():
 
     # Check if we're in the source tree with built compiler
     possible_build_thrift = os.path.join(
-        os.path.dirname(__file__), '..', '..', '..',
+        os.path.dirname(__file__), '..', '..', '..', '..',
         'build', 'compiler', 'cpp', 'bin', 'thrift')
     if os.path.exists(possible_build_thrift):
         return possible_build_thrift
 
     # Check for cpp compiler location
     possible_cpp_thrift = os.path.join(
-        os.path.dirname(__file__), '..', '..', '..',
+        os.path.dirname(__file__), '..', '..', '..', '..',
         'compiler', 'cpp', 'thrift')
     if os.path.exists(possible_cpp_thrift):
         return possible_cpp_thrift


### PR DESCRIPTION
## Summary

The `test_keyword_escape.py` regression test added in THRIFT-5927 has never actually exercised the compiler in CI, and can pick up the wrong compiler locally. Confirmed the THRIFT-5927 generator fix itself is correct on master (built the compiler fresh and ran it against `Thrift5927.thrift` directly) — this PR only fixes the test/build-infrastructure gap that was masking it.

Root causes:
- `lib/py/Makefile.am`'s `check-local` recipe invoked the test as plain `$(PYTHON) test/test_compiler/test_keyword_escape.py`, without passing the `THRIFT` make variable through as an environment variable, unlike other Makefile.am files in the tree that need the compiler at test time.
- `find_thrift()`'s relative-path fallback was off by one directory level (3x `../` instead of 4, from `lib/py/test/test_compiler/`), so it could never resolve to `compiler/cpp/thrift` or `build/compiler/cpp/bin/thrift` either.

With neither path working and no system-wide `thrift` on PATH, `find_thrift()` returns `None` and the test prints "thrift compiler not found, skipping test" and returns success — a false green on every CI run since THRIFT-5927 merged (`lib-python` job in `.github/workflows/build.yml` downloads the compiler artifact to exactly `compiler/cpp/thrift`, which the broken fallback failed to reach).

## Fix

- Pass `THRIFT=${THRIFT}` through explicitly on the `check-local` recipe line.
- Correct the off-by-one in the relative-path fallback so standalone invocations (without `make`) still work.

## Test plan

Reproduced and verified against a real autotools build (bootstrap → configure → compiler artifact placed at `compiler/cpp/thrift`, mirroring the CI job exactly):
- [x] Before the fix: `make -C lib/py check-local` silently skips the test (`WARNING: thrift compiler not found, skipping test`) even though the compiler is present and working.
- [x] After the fix: `make -C lib/py check-local` runs the test for real (`OK: All 5 generated Python files compile successfully`).
- [x] Standalone run with no `THRIFT` env and no PATH `thrift`: corrected fallback path finds the compiler and passes.
- [x] Standalone run with genuinely no compiler available anywhere: graceful skip behavior is preserved (no regression there).

---
This PR includes AI-assisted changes (Claude Code); see commit trailer.