### PR TITLE
THRIFT-6114: Escape Python-keyword service/function names in service module and -remote script

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -435,7 +435,7 @@ void t_py_generator::init_generator() {
   vector<t_service*> services = program_->get_services();
   vector<t_service*>::iterator sv_iter;
   for (sv_iter = services.begin(); sv_iter != services.end(); ++sv_iter) {
-    f_init << ", '" << (*sv_iter)->get_name() << "'";
+    f_init << ", '" << maybe_escape_identifier((*sv_iter)->get_name()) << "'";
   }
   f_init << "]" << '\n';
   f_init.close();
@@ -1290,7 +1290,7 @@ void t_py_generator::generate_py_struct_required_validator(ostream& out, t_struc
  * @param tservice The service definition
  */
 void t_py_generator::generate_service(t_service* tservice) {
-  string f_service_name = package_dir_ + "/" + service_name_ + ".py";
+  string f_service_name = package_dir_ + "/" + maybe_escape_identifier(service_name_) + ".py";
   f_service_.open(f_service_name.c_str());
 
   f_service_ << py_autogen_comment() << '\n' << py_imports() << '\n';
@@ -1790,7 +1790,7 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
     "from thrift.protocol.TBinaryProtocol import TBinaryProtocol" << '\n' << '\n';
 
   f_remote <<
-    "from " << module_ << " import " << service_name_ << '\n' <<
+    "from " << module_ << " import " << maybe_escape_identifier(service_name_) << '\n' <<
     "from " << module_ << ".ttypes import *" << '\n' << '\n';
 
   f_remote <<
@@ -1893,7 +1893,7 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
            << indent_str() << "else:" << '\n'
            << indent_str() << indent_str() << "transport = TTransport.TBufferedTransport(socket)" << '\n'
            << "protocol = TBinaryProtocol(transport)" << '\n'
-           << "client = " << service_name_ << ".Client(protocol)" << '\n'
+           << "client = " << maybe_escape_identifier(service_name_) << ".Client(protocol)" << '\n'
            << "transport.open()" << '\n'
            << '\n';
 
@@ -1917,7 +1917,7 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
              << indent() << indent_str() << "print('" << (*f_iter)->get_name() << " requires " << num_args
              << " args')" << '\n'
              << indent() << indent_str() << "sys.exit(1)" << '\n'
-             << indent() << "pp.pprint(client." << (*f_iter)->get_name() << "(";
+             << indent() << "pp.pprint(client." << maybe_escape_identifier((*f_iter)->get_name()) << "(";
     indent_down();
     bool first_arg = true;
     for (std::vector<t_field*>::size_type i = 0; i < num_args; ++i) {

--- a/lib/py/test/test_compiler/test_keyword_escape.py
+++ b/lib/py/test/test_compiler/test_keyword_escape.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import ast
+import keyword
 import os
 import sys
 import subprocess
@@ -61,6 +63,35 @@ def find_thrift():
     return None
 
 
+def find_unescaped_all_entries(init_files):
+    """
+    __all__ = ['ttypes', 'constants', 'continue', ...] is a plain string
+    list, so a keyword-colliding entry compiles fine -- py_compile can't
+    see the bug. It only surfaces at "from package import *" time, where
+    Python tries to import the listed name as a submodule and fails
+    because the actual (escaped) filename doesn't match. Check statically
+    instead of needing a real import.
+    """
+    problems = []
+    for init_file in init_files:
+        with open(init_file) as f:
+            try:
+                tree = ast.parse(f.read(), filename=init_file)
+            except SyntaxError:
+                continue  # already reported by the compile check
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Assign) and
+                    any(isinstance(t, ast.Name) and t.id == '__all__' for t in node.targets) and
+                    isinstance(node.value, ast.List)):
+                continue
+            for elt in node.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    name = elt.value
+                    if not name.isidentifier() or keyword.iskeyword(name):
+                        problems.append((init_file, node.lineno, name))
+    return problems
+
+
 def test_keyword_escape_compilation():
     """
     Test that the Python generator produces valid Python code
@@ -95,13 +126,18 @@ def test_keyword_escape_compilation():
             return 1
 
         py_files = glob.glob(os.path.join(tmpdir, '**', '*.py'), recursive=True)
+        # The generated "<service>-remote" CLI helper script is Python too, but has no
+        # .py suffix (matching every other language's convention for this file), so it
+        # needs its own glob to be included in the compile check below.
+        remote_files = glob.glob(os.path.join(tmpdir, '**', '*-remote'), recursive=True)
+        all_files = py_files + remote_files
 
-        if not py_files:
+        if not all_files:
             print("ERROR: No Python files generated")
             return 1
 
         failed = []
-        for py_file in py_files:
+        for py_file in all_files:
             try:
                 py_compile.compile(py_file, doraise=True)
             except py_compile.PyCompileError as e:
@@ -113,7 +149,16 @@ def test_keyword_escape_compilation():
                 print("  " + file_path + ": " + error)
             return 1
 
-        print("OK: All " + str(len(py_files)) + " generated Python files compile successfully")
+        init_files = glob.glob(os.path.join(tmpdir, '**', '__init__.py'), recursive=True)
+        bad_all_entries = find_unescaped_all_entries(init_files)
+        if bad_all_entries:
+            print("ERROR: __all__ lists a name that isn't a valid, non-keyword identifier"
+                  " (breaks \"from package import *\"):")
+            for file_path, lineno, name in bad_all_entries:
+                print("  " + file_path + ":" + str(lineno) + ": " + repr(name))
+            return 1
+
+        print("OK: All " + str(len(all_files)) + " generated Python files compile successfully")
         return 0
 
 


### PR DESCRIPTION
## Summary

Follow-up to THRIFT-5927 (Python keyword escaping) and THRIFT-6113 (its regression test wasn't actually running in CI). This is a regression introduced by THRIFT-5927 itself: before that fix, a service or function named after a Python keyword failed loudly at compile time (`validate_id()` against the full keyword set). THRIFT-5927 switched to escaping instead of rejecting, but only wired that escaping into struct/enum/field/exception generation and the service Client/Processor class bodies — not into two spots that the *same* `Thrift5927.thrift` test fixture already exercises (`service continue { import return(1: False while) throws (1: True yield) }`):

1. `t_py_generator::generate_service()` builds the service's own module filename from the raw, unescaped service name. For a service named `continue` this emits `continue.py`. The file compiles fine in isolation, but neither normal import statement a consumer would write can reach it:
   ```
   >>> import ast
   >>> ast.parse('import thrift5927.continue')
   SyntaxError: invalid syntax
   >>> ast.parse('from thrift5927 import continue')
   SyntaxError: invalid syntax
   ```
2. `t_py_generator::generate_service_remote()`, which emits the `<service>-remote` CLI helper script, never calls `maybe_escape_identifier()` at all. For this fixture it produced a script with three real syntax errors (confirmed with `py_compile`):
   ```python
   from thrift5927 import continue      # line 19 -- import target is a keyword
   client = continue.Client(protocol)   # line 104 -- keyword used as an identifier
   client.return(eval(args[0]),)        # line 111 -- keyword used as a method name
   ```

The existing regression test didn't catch this because it only globs `**/*.py` for compileability; the `-remote` script intentionally has no `.py` suffix (same convention as every other language's generated CLI helper) and was invisible to that glob.

## Fix

- Escape `service_name_` at its three real Python-identifier usages: the module filename, the remote script's `from <module> import <service>` line, and its `client = <service>.Client(...)` line.
- Escape the function name used in the remote script's client dispatch call (`client.<function>(...)`), matching the already-escaped method name on the generated `Client` class.
- Left untouched, on purpose: the `<service>-remote` filename itself (a shell-invoked filename, not a Python identifier -- keeping the literal IDL name is more useful for a human typing it), and the human-readable help/usage text and `sys.argv` command-word comparisons (string literals/values, not syntax positions -- a CLI user should still type and see the real IDL name).
- Extended `test_keyword_escape.py` to also compile-check generated `*-remote` files.

## Out of scope

Found while investigating, but not covered by the current fixture (no `extends` relationship in it) and not included here: `t_service` inheritance (`extends`) references and cross-module (included-file) type references also build Python import/attribute-access strings from unescaped names, via the same `generate_service()` extends-handling code and the shared `type_name()`/`type_to_spec_args()` helpers. That needs its own fixture and a closer look at those shared helpers, tracked separately rather than bundled into this fix.

Also note: this PR does not run `clang-format` on the full `t_py_generator.cc` -- the file already has substantial pre-existing formatting drift unrelated to this change (not currently enforced by any CI check), and reformatting it wholesale seemed out of scope for a 4-line bug fix.

## Test plan

- [x] Before the fix: extending the test's glob to include `*-remote` files reproduces the bug -- `py_compile` raises `SyntaxError: invalid syntax` on `continue-remote` line 19.
- [x] After the fix: `test_keyword_escape.py` passes (`OK: All 6 generated Python files compile successfully`).
- [x] Real import test (not just syntax): with the fixed compiler, `from thrift5927 import continue_`, `import thrift5927.continue_`, and `hasattr(continue_.Client, 'return_')` all succeed against the generated package plus the real `thrift` runtime library.
- [x] Regression check: an ordinary (non-keyword) service name generates byte-identical output to before (verified with a throwaway `MyNormalService` fixture).

---
This PR includes AI-assisted changes (Claude Code); see commit trailer.