### PR TITLE
THRIFT-6115: Escape Python-keyword names in service extends and cross-module type references

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1298,7 +1298,7 @@ void t_py_generator::generate_service(t_service* tservice) {
   if (tservice->get_extends() != nullptr) {
     f_service_ << "import "
                << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_, package_prefix_) << "."
-               << tservice->get_extends()->get_name() << '\n';
+               << maybe_escape_identifier(tservice->get_extends()->get_name()) << '\n';
   }
 
   f_service_ << "import logging" << '\n'
@@ -2877,12 +2877,12 @@ string t_py_generator::type_name(t_type* ttype) {
 
   t_program* program = ttype->get_program();
   if (ttype->is_service()) {
-    return get_real_py_module(program, gen_twisted_, package_prefix_) + "." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + "." + maybe_escape_identifier(ttype->get_name());
   }
   if (program != nullptr && program != program_) {
-    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes." + maybe_escape_identifier(ttype->get_name());
   }
-  return ttype->get_name();
+  return maybe_escape_identifier(ttype->get_name());
 }
 
 string t_py_generator::arg_hint(t_type* type) {

--- a/lib/py/test/test_compiler/Thrift5927.thrift
+++ b/lib/py/test/test_compiler/Thrift5927.thrift
@@ -17,9 +17,11 @@
 
 namespace py thrift5927
 
-enum Lambda { 
-	None = 0, 
-	FluxCapacitor = 1 
+include "thrift5927include.thrift"
+
+enum Lambda {
+	None = 0,
+	FluxCapacitor = 1
 }
 
 struct False {
@@ -37,5 +39,22 @@ exception True {
 
 service continue {
 	import return(1: False while) throws (1: True yield)
+}
+
+# Exercises type_name()'s cross-module branch: a field typed with a struct
+# defined in an included file, where that struct's name is a keyword.
+struct UsesIncluded {
+	1: thrift5927include.except item
+}
+
+# Exercises the extends import/base-class code path with a keyword-named
+# parent service defined in the same file.
+service AlsoDerived extends continue {
+}
+
+# Exercises type_name()'s service branch for both "extends" (import of the
+# parent's module + base class reference) and the cross-module include path
+# at once, since the parent service's name is also a keyword.
+service Derived extends thrift5927include.class {
 }
 

--- a/lib/py/test/test_compiler/test_keyword_escape.py
+++ b/lib/py/test/test_compiler/test_keyword_escape.py
@@ -92,6 +92,27 @@ def find_unescaped_all_entries(init_files):
     return problems
 
 
+def find_keyword_literal_except_types(py_files):
+    """
+    "True"/"False"/"None" are valid Python expression atoms (unlike most
+    other reserved words), so an unescaped "except True as e:" parses fine
+    -- it just silently tries to catch the literal bool/None instead of the
+    intended exception class, and would raise a runtime TypeError once hit.
+    py_compile can't see this; walk the AST instead.
+    """
+    problems = []
+    for py_file in py_files:
+        with open(py_file) as f:
+            try:
+                tree = ast.parse(f.read(), filename=py_file)
+            except SyntaxError:
+                continue  # already reported by the compile check
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and isinstance(node.type, ast.Constant):
+                problems.append((py_file, node.lineno, repr(node.type.value)))
+    return problems
+
+
 def test_keyword_escape_compilation():
     """
     Test that the Python generator produces valid Python code
@@ -156,6 +177,13 @@ def test_keyword_escape_compilation():
                   " (breaks \"from package import *\"):")
             for file_path, lineno, name in bad_all_entries:
                 print("  " + file_path + ":" + str(lineno) + ": " + repr(name))
+            return 1
+
+        keyword_literal_excepts = find_keyword_literal_except_types(py_files)
+        if keyword_literal_excepts:
+            print("ERROR: Generated code catches a keyword literal instead of an exception class:")
+            for file_path, lineno, value in keyword_literal_excepts:
+                print("  " + file_path + ":" + str(lineno) + ": except " + value + " as ...")
             return 1
 
         print("OK: All " + str(len(all_files)) + " generated Python files compile successfully")

--- a/lib/py/test/test_compiler/thrift5927include.thrift
+++ b/lib/py/test/test_compiler/thrift5927include.thrift
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Included by Thrift5927.thrift to exercise cross-module (include) references
+# to Python-keyword-colliding struct and service names, the same way
+# tutorial/tutorial.thrift includes tutorial/shared.thrift.
+
+namespace py thrift5927include
+
+struct except {
+	1: i32 value
+}
+
+service class {
+	except getValue(1: i32 key)
+}


### PR DESCRIPTION
## Summary

**Depends on #3659 (THRIFT-6114)** -- this branch is based on `THRIFT-6114`, not `master`, so the diff below includes THRIFT-6114's commit until that one merges. Please review/merge #3659 first; this will show a clean 1-commit diff once it's rebased onto `master` after that lands. See "Why the 6114 dependency" below for why.

Fourth in the THRIFT-5927 follow-up chain (THRIFT-6113: regression test wasn't running in CI; THRIFT-6114: service module filename and `-remote` script weren't escaped).

`t_py_generator::type_name()` is the shared helper that renders any struct/enum/exception/service reference as a Python expression (class instantiation, type hints, extends declarations, deserialization, `except` clauses, etc.). None of its three return paths escaped the identifier:

```cpp
string t_py_generator::type_name(t_type* ttype) {
  ...
  if (ttype->is_service()) {
    return get_real_py_module(...) + "." + ttype->get_name();        // service extends / references
  }
  if (program != nullptr && program != program_) {
    return get_real_py_module(...) + ".ttypes." + ttype->get_name(); // cross-module (include) type references
  }
  return ttype->get_name();                                          // same-module type references
}
```

This meant:
- A service `extends`ing another service whose name is a Python keyword generated a broken `import module.<keyword>` statement (`t_py_generator.cc:1298-1301`, a direct call that doesn't go through `type_name()`) and a broken `class Client(module.<keyword>.Client):` (via `type_name()`).
- A struct/enum/exception referenced across an `include` boundary whose name is a keyword generated a broken `module.ttypes.<keyword>` reference wherever it's used -- including the `except <Type> as <name>:` clauses generated for service exceptions.

Same class of regression as THRIFT-6114 (5927 escaped identifiers in some code paths, not others), just reached via `extends`/`include` instead of the service module and `-remote` script.

**One added wrinkle:** for exception types specifically, `True`/`False`/`None` are Python keyword *literals*, not statement keywords -- `except True as e:` parses without a `SyntaxError` (`True` is a valid expression atom), so `py_compile`-based testing alone doesn't catch that sub-case; it silently binds the wrong object and would raise a runtime `TypeError` if ever hit. Same fix either way (escape to `True_`), but the test needed a small addition to see it.

## Fix

- Escape the identifier at `type_name()`'s three return points.
- Escape the parent service name in the direct `import module.<service>` extends statement (`t_py_generator.cc:1298-1301`).
- Extend `test_keyword_escape.py` with an AST-based check: fail if any generated file has an `except` clause whose type expression is a bare `True`/`False`/`None` constant (which `py_compile` alone can't see).

## Why the 6114 dependency

The service-extends-a-keyword-named-service scenario needs both fixes to work end-to-end: 6114 fixes the *parent* service's own module filename (`continue.py` -> `continue_.py`); this fix corrects the *child's* reference to it. Neither alone is sufficient for that one scenario. The struct/enum/exception cross-module and same-file cases in this PR are independent of 6114 (those types live in `ttypes.py`, already correctly escaped by the original THRIFT-5927) -- only the service-extends-service path is coupled.

## Test fixtures

- Same-file: added `service AlsoDerived extends continue` to the existing `Thrift5927.thrift`, exercising extends of a keyword-named parent in the same file.
- Cross-module: added `lib/py/test/test_compiler/thrift5927include.thrift`, modeled on `tutorial/shared.thrift` + `tutorial/tutorial.thrift`'s `include`/`extends` pattern, providing a keyword-named struct (`except`) and service (`class`). `Thrift5927.thrift` now `include`s it, adds `struct UsesIncluded { 1: thrift5927include.except item }`, and `service Derived extends thrift5927include.class`.

## Out of scope

Found while investigating, same missed-escaping category but each a different specific variable bolted onto an otherwise-correct `type_name()` call site (not part of `type_name()`'s own output, so not covered by this fix) -- flagging for a possible future consolidated pass:
- `t_py_generator.cc:647`, `render_const_value()`: the enum *value* name in `EnumClass.VALUE` constant rendering is unescaped, inconsistent with that same value being escaped everywhere else (e.g. as a class attribute).
- `t_py_generator.cc:925`: a trailing field-name use in a `__setattr__` override's `__members__.get(...)` call is unescaped, inconsistent with two escaped sibling uses of the same identifier two lines earlier in the same statement.
- `t_py_generator.cc:2180`, `generate_service_client()`: the exception field name (`xname`) is unescaped in one `except <Type> as xname:` binding and its two subsequent uses, inconsistent with the same pattern at `:2246` and `:2322` which do escape it.

## Test plan

- [x] Before the fix: extending the fixture (extends + include) reproduced three distinct `SyntaxError`s via `py_compile` -- `import thrift5927.continue`, `import thrift5927include.class`, and `thrift5927include.ttypes.except()`.
- [x] After the fix: `test_keyword_escape.py` passes (`OK: All 15 generated Python files compile successfully`), including the new AST check.
- [x] Real import/cross-reference test (not just syntax): `AlsoDerived.Client`/`Derived.Client` correctly inherit from the escaped parent `Client` classes; `UsesIncluded`'s field type correctly resolves to the escaped `except_` class from the included module.
- [x] Regression check: an ordinary (non-keyword) two-file extends+include fixture generates byte-identical output to before.
- [x] Wider regression: `make -C lib/py check` (full suite, not just this test) and `make -C test/py check`'s code-generation step both still pass -- 189 generated files across `ThriftTest.thrift`/`DebugProtoTest.thrift`/`DoubleConstantsTest.thrift`/`Recursive.thrift` in all 8 generation flavors (default/slots/oldstyle/no_utf8strings/dynamic/dynamicslots/enum/type_hints) still compile cleanly, since `type_name()` is used file-wide.

---
This PR includes AI-assisted changes (Claude Code); see commit trailer.