### PR TITLE
THRIFT-6116: Escape Python-keyword names in consts, enum-value defaults, required-field checks, and type_hints/twisted/enum modes

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -592,7 +592,7 @@ void t_py_generator::generate_enum(t_enum* tenum) {
  */
 void t_py_generator::generate_const(t_const* tconst) {
   t_type* type = tconst->get_type();
-  string name = tconst->get_name();
+  string name = maybe_escape_identifier(tconst->get_name());
   t_const_value* value = tconst->get_value();
 
   indent(f_consts_) << name << " = " << render_const_value(type, value);
@@ -644,7 +644,7 @@ string t_py_generator::render_const_value(t_type* type, t_const_value* value) {
     int64_t int_val = value->get_integer();
     if (gen_enum_) {
       t_enum_value* enum_val = ((t_enum*)type)->get_constant_by_value(int_val);
-      out << type_name(type) << "." << enum_val->get_name();
+      out << type_name(type) << "." << maybe_escape_identifier(enum_val->get_name());
     } else {
       out << int_val;
     }
@@ -852,7 +852,7 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
   if (gen_type_hints_ && is_immutable(tstruct) && members.size() > 0) {
     out << '\n';
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-      indent(out) << (*m_iter)->get_name()
+      indent(out) << maybe_escape_identifier((*m_iter)->get_name())
                   << member_hint((*m_iter)->get_type(), (*m_iter)->get_req()) << '\n';
     }
   }
@@ -922,7 +922,7 @@ void t_py_generator::generate_py_struct_definition(ostream& out,
           indent(out) << "super(" << maybe_escape_identifier(tstruct->get_name()) << ", self).__setattr__('"
                       << (*m_iter)->get_name() << "', " << maybe_escape_identifier((*m_iter)->get_name())
                       << " if hasattr(" << maybe_escape_identifier((*m_iter)->get_name()) << ", 'value') else "
-                      << type_name(type) << ".__members__.get(" << (*m_iter)->get_name() << "))" << '\n';
+                      << type_name(type) << ".__members__.get(" << maybe_escape_identifier((*m_iter)->get_name()) << "))" << '\n';
         } else if (gen_newstyle_ || gen_dynamic_) {
           indent(out) << "super(" << maybe_escape_identifier(tstruct->get_name()) << ", self).__setattr__('"
                       << (*m_iter)->get_name() << "', " << maybe_escape_identifier((*m_iter)->get_name()) << ")" << '\n';
@@ -1273,7 +1273,7 @@ void t_py_generator::generate_py_struct_required_validator(ostream& out, t_struc
     for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
       t_field* field = (*f_iter);
       if (field->get_req() == t_field::T_REQUIRED) {
-        indent(out) << "if self." << field->get_name() << " is None:" << '\n';
+        indent(out) << "if self." << maybe_escape_identifier(field->get_name()) << " is None:" << '\n';
         indent(out) << indent_str() << "raise TProtocolException(message='Required field "
                     << field->get_name() << " is unset!')" << '\n';
       }
@@ -2177,10 +2177,10 @@ void t_py_generator::generate_process_function(t_service* tservice, t_function* 
     if (!tfunction->is_oneway()) {
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
         const string& xname = (*x_iter)->get_name();
-        f_service_ << indent() << "except " << type_name((*x_iter)->get_type()) << " as " << xname
+        f_service_ << indent() << "except " << type_name((*x_iter)->get_type()) << " as " << maybe_escape_identifier(xname)
                    << ":" << '\n';
         indent_up();
-        f_service_ << indent() << "result." << xname << " = " << xname << '\n';
+        f_service_ << indent() << "result." << maybe_escape_identifier(xname) << " = " << maybe_escape_identifier(xname) << '\n';
         indent_down();
       }
     }

--- a/lib/py/test/test_compiler/Thrift5927.thrift
+++ b/lib/py/test/test_compiler/Thrift5927.thrift
@@ -58,3 +58,26 @@ service AlsoDerived extends continue {
 service Derived extends thrift5927include.class {
 }
 
+# Exercises a plain top-level const whose own name is a keyword.
+const i32 break = 42
+
+# Exercises render_const_value()'s enum branch (an unescaped enum *value*
+# reference, e.g. "Lambda.None"), reached both from a top-level const like
+# this one and from any field's default value (they share the same
+# rendering code), together with a keyword-named const.
+const Lambda del = Lambda.None
+
+# Exercises the required-field self-check ("if self.<field> is None:").
+struct RequiredKw {
+	1: required i32 pass
+}
+
+# Exercises two gen_type_hints_/is_immutable-gated code paths at once: the
+# class-level type-hint annotation (-gen py:type_hints,enum) and the
+# __setattr__ override's "EnumType.__members__.get(<field>)" call
+# (-gen py:enum), both keyed on the same keyword-named, enum-typed,
+# default-valued field.
+struct ImmutableEnumField {
+	1: Lambda with = Lambda.None
+} (python.immutable = "")
+

--- a/lib/py/test/test_compiler/test_keyword_escape.py
+++ b/lib/py/test/test_compiler/test_keyword_escape.py
@@ -113,6 +113,53 @@ def find_keyword_literal_except_types(py_files):
     return problems
 
 
+# Several of the bugs this test catches only fire under non-default generator
+# options (gen_enum_/gen_type_hints_/gen_twisted_ gate specific codegen
+# branches), so a single default "-gen py" run isn't enough coverage.
+GENERATION_MODES = ['py', 'py:type_hints,enum', 'py:twisted']
+
+
+def check_generated_output(tmpdir):
+    """
+    Run every static check against one directory of generated output.
+    Returns (error_message_or_None, files_checked_count).
+    """
+    py_files = glob.glob(os.path.join(tmpdir, '**', '*.py'), recursive=True)
+    # The generated "<service>-remote" CLI helper script is Python too, but has no
+    # .py suffix (matching every other language's convention for this file), so it
+    # needs its own glob to be included in the compile check below.
+    remote_files = glob.glob(os.path.join(tmpdir, '**', '*-remote'), recursive=True)
+    all_files = py_files + remote_files
+
+    if not all_files:
+        return "no Python files generated", 0
+
+    failed = []
+    for py_file in all_files:
+        try:
+            py_compile.compile(py_file, doraise=True)
+        except py_compile.PyCompileError as e:
+            failed.append("  " + py_file + ": " + str(e))
+    if failed:
+        return "generated Python files have syntax errors:\n" + "\n".join(failed), 0
+
+    init_files = glob.glob(os.path.join(tmpdir, '**', '__init__.py'), recursive=True)
+    bad_all_entries = find_unescaped_all_entries(init_files)
+    if bad_all_entries:
+        lines = ["  " + f + ":" + str(lineno) + ": " + repr(n) for f, lineno, n in bad_all_entries]
+        return ("__all__ lists a name that isn't a valid, non-keyword identifier"
+                " (breaks \"from package import *\"):\n" + "\n".join(lines)), 0
+
+    keyword_literal_excepts = find_keyword_literal_except_types(py_files)
+    if keyword_literal_excepts:
+        lines = ["  " + f + ":" + str(lineno) + ": except " + v + " as ..."
+                 for f, lineno, v in keyword_literal_excepts]
+        return ("generated code catches a keyword literal instead of an exception class:\n" +
+                "\n".join(lines)), 0
+
+    return None, len(all_files)
+
+
 def test_keyword_escape_compilation():
     """
     Test that the Python generator produces valid Python code
@@ -133,61 +180,30 @@ def test_keyword_escape_compilation():
         print("(In CI, thrift should be available via THRIFT env var)")
         return 0  # Skip gracefully rather than fail
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        result = subprocess.run(
-            [thrift_bin, '-r', '-gen', 'py', '-out', tmpdir, thrift_file],
-            capture_output=True,
-            text=True
-        )
+    total_checked = 0
+    for mode in GENERATION_MODES:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = subprocess.run(
+                [thrift_bin, '-r', '-gen', mode, '-out', tmpdir, thrift_file],
+                capture_output=True,
+                text=True
+            )
 
-        if result.returncode != 0:
-            print("ERROR: thrift compiler failed")
-            print("stdout: " + result.stdout)
-            print("stderr: " + result.stderr)
-            return 1
+            if result.returncode != 0:
+                print("ERROR: thrift compiler failed for -gen " + mode)
+                print("stdout: " + result.stdout)
+                print("stderr: " + result.stderr)
+                return 1
 
-        py_files = glob.glob(os.path.join(tmpdir, '**', '*.py'), recursive=True)
-        # The generated "<service>-remote" CLI helper script is Python too, but has no
-        # .py suffix (matching every other language's convention for this file), so it
-        # needs its own glob to be included in the compile check below.
-        remote_files = glob.glob(os.path.join(tmpdir, '**', '*-remote'), recursive=True)
-        all_files = py_files + remote_files
+            error, checked = check_generated_output(tmpdir)
+            if error:
+                print("ERROR (-gen " + mode + "): " + error)
+                return 1
+            total_checked += checked
 
-        if not all_files:
-            print("ERROR: No Python files generated")
-            return 1
-
-        failed = []
-        for py_file in all_files:
-            try:
-                py_compile.compile(py_file, doraise=True)
-            except py_compile.PyCompileError as e:
-                failed.append((py_file, str(e)))
-
-        if failed:
-            print("ERROR: Generated Python files have syntax errors:")
-            for file_path, error in failed:
-                print("  " + file_path + ": " + error)
-            return 1
-
-        init_files = glob.glob(os.path.join(tmpdir, '**', '__init__.py'), recursive=True)
-        bad_all_entries = find_unescaped_all_entries(init_files)
-        if bad_all_entries:
-            print("ERROR: __all__ lists a name that isn't a valid, non-keyword identifier"
-                  " (breaks \"from package import *\"):")
-            for file_path, lineno, name in bad_all_entries:
-                print("  " + file_path + ":" + str(lineno) + ": " + repr(name))
-            return 1
-
-        keyword_literal_excepts = find_keyword_literal_except_types(py_files)
-        if keyword_literal_excepts:
-            print("ERROR: Generated code catches a keyword literal instead of an exception class:")
-            for file_path, lineno, value in keyword_literal_excepts:
-                print("  " + file_path + ":" + str(lineno) + ": except " + value + " as ...")
-            return 1
-
-        print("OK: All " + str(len(all_files)) + " generated Python files compile successfully")
-        return 0
+    print("OK: All " + str(total_checked) + " generated Python files (across " +
+          str(len(GENERATION_MODES)) + " generation modes) compile successfully")
+    return 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

**Depends on #3660 (THRIFT-6115), which depends on #3659 (THRIFT-6114).** Branched from `THRIFT-6115`, not `master` -- the twisted `except` fix here (item 5 below) is layered on top of THRIFT-6115's `type_name()` fix (the exception-type half of that same generated line). Diff will narrow to this PR's own commit once #3660 and #3659 land and this rebases.

Fifth in the THRIFT-5927 follow-up chain (THRIFT-6113: regression test wasn't running in CI; THRIFT-6114: service module filename, `__all__`, and `-remote` script; THRIFT-6115: service extends and cross-module type references) -- and, per a full audit of every `get_name()`-family call in `t_py_generator.cc` (105 call sites classified), the last one needed for this class of bug.

Six more spots never got `maybe_escape_identifier()` wired in. Each confirmed with a real `SyntaxError` via `py_compile`/`ast.parse`, not just inferred from reading the code:

1. `t_py_generator.cc:598`, `generate_const()`: a top-level `const i32 break = 42` whose own name is a keyword renders `break = 42` in `constants.py`.
2. `t_py_generator.cc:647`, `render_const_value()`'s enum branch: an unescaped enum *value* reference (e.g. `Lambda.None`). Reached from top-level consts and, via `render_field_default_value()` calling the same function, from every field's default value -- struct `__init__` defaults, `thrift_spec` entries, and type-hint parameter defaults all share this one line. One fix covers all four manifestations (verified by regenerating a probe fixture under every relevant mode post-fix).
3. `t_py_generator.cc:925` (`-gen py:enum` + a `(python.immutable = "")` struct): the `__setattr__` override's `EnumType.__members__.get(<field>)` call uses the raw field name, inconsistent with two escaped uses of the same identifier earlier in the same statement.
4. `t_py_generator.cc:1276`, `generate_py_struct_required_validator()`: `if self.<field> is None:` for a required field uses the raw field name.
5. `t_py_generator.cc:2179-2183` (`-gen py:twisted`): the `except <Type> as <name>:` clause and its two subsequent uses use the raw exception field name, unescaped -- inconsistent with the tornado-style and default-style equivalents a few lines away, which already call `maybe_escape_identifier`. The exception *type* half of this line was already fixed by THRIFT-6115; only the `as` binding itself was not.
6. `t_py_generator.cc:855` (`-gen py:type_hints,enum` + immutable struct): the class-level type-hint annotation (`<field>: typing.Optional[...]`) uses the raw field name.

## Why the test didn't catch these already

Four of the six only surface under non-default generator options (`gen_enum_`/`gen_type_hints_`/`gen_twisted_`), and `test_keyword_escape.py` only ever ran a single default `-gen py`. Same blind-spot shape as THRIFT-6113 (a check that only exercises the default path). Fixed by extending the test to loop the compiler over three modes (`py`, `py:type_hints,enum`, `py:twisted`) and running every existing static check (compile, `__all__`, keyword-literal-except) against each mode's output.

## Fixture additions

`Thrift5927.thrift` gets: a keyword-named plain const, a keyword-named const of enum type (reusing the existing `Lambda` enum's `None` value), a struct with a required keyword-named field, and a struct with a keyword-named, enum-typed, default-valued field marked `(python.immutable = "")`.

## Const-reference note

Consts referencing other consts (`const i32 B = A;`) are resolved to their literal value by the compiler at parse time (`B = 5`, not `B = A`), so there's no separate const-reference call site needing escaping beyond the definition itself -- checked directly, not assumed.

## Out of scope (different bug category)

`get_real_py_module()`'s fallback to `program->get_name()` when no `namespace py ...` is declared -- if a `.thrift` file's own base name collides with a Python keyword, the generated top-level *package* name would too. That's a package/namespace-naming concern, not an identifier-escaping one, and the project already has an established workaround for exactly this (see the `namespace d share` comment in `tutorial/shared.thrift` -- pick a different namespace name rather than auto-escape).

## Test plan

- [x] Before the fix: extending the fixture + multi-mode test reproduced all six as real `SyntaxError`s (`break = 42`, `Lambda.None` in four different contexts, `.get(with)`, `self.pass is None`, `except True_ as yield:`, `with: typing.Optional[Lambda]`) -- verified via a stash/rebuild/unstash cycle (fixtures+test in place, generator fix stashed out, confirmed failure; fix restored, confirmed pass).
- [x] After the fix: `test_keyword_escape.py` passes (`OK: All 45 generated Python files (across 3 generation modes) compile successfully`).
- [x] Regression: `make -C lib/py check` (full suite) passes; regenerated the full `ThriftTest.thrift`/`DebugProtoTest.thrift`/etc. suite under `py` and `py:type_hints,enum` and all output still compiles cleanly.

---
This PR includes AI-assisted changes (Claude Code); see commit trailer.