### PR TITLE
Fix Python socket timeout test units

### DIFF
--- a/lib/py/test/test_socket.py
+++ b/lib/py/test/test_socket.py
@@ -63,12 +63,12 @@ class TSocketTest(unittest.TestCase):
         # https://docs.python.org/3/library/socket.html#notes-on-socket-timeouts
         # https://docs.python.org/3/library/socket.html#socket.socket.settimeout
         timeouts = [
-            None,  # blocking mode
-            0,  # non-blocking mode
-            1.0,  # timeout mode
+            (None, None),  # blocking mode
+            (0, 0.0),  # non-blocking mode
+            (1000, 1.0),  # timeout mode: Thrift milliseconds, socket seconds
         ]
 
-        for timeout in timeouts:
+        for timeout, expected_socket_timeout in timeouts:
             acc = ServerAcceptor(TServerSocket(port=0))
             acc.start()
 
@@ -76,6 +76,7 @@ class TSocketTest(unittest.TestCase):
             self.assertFalse(sock.isOpen())
             sock.open()
             sock.setTimeout(timeout)
+            self.assertEqual(sock.handle.gettimeout(), expected_socket_timeout)
 
             # the socket shows as open immediately after connecting
             self.assertTrue(sock.isOpen())


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
`TSocket.setTimeout` accepts milliseconds, but the socket readability test passed `1.0`, producing a one-millisecond socket timeout. That made the immediate readability check unnecessarily timing-sensitive, particularly on macOS.

Use `1000` milliseconds for timeout mode and assert that the underlying Python socket receives the expected one-second timeout. The blocking and non-blocking cases are also asserted explicitly.

Related failures: [May 23, 2026](https://github.com/apache/thrift/actions/runs/26346040200/job/77556134153), [June 30, 2026](https://github.com/apache/thrift/actions/runs/28478127892/job/84408347327), and [July 13, 2026](https://github.com/apache/thrift/actions/runs/29291970170/job/86957960913). Each was a `macos-15-intel` / Python 3.13 job that failed in `test_isOpen_checks_for_readability` with a read timeout.
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes) — Not required for this minor test-only fix.
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"? — No ticket exists.
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources. — Not applicable; this changes a test.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
