### PR TITLE
THRIFT-6118: Forward Ruby protocol decorator message arguments

### DIFF
--- a/lib/rb/lib/thrift/protocol/protocol_decorator.rb
+++ b/lib/rb/lib/thrift/protocol/protocol_decorator.rb
@@ -29,7 +29,7 @@ module Thrift
     end
 
     def write_message_begin(name, type, seqid)
-      @protocol.write_message_begin
+      @protocol.write_message_begin(name, type, seqid)
     end
 
     def write_message_end

--- a/lib/rb/spec/protocol_decorator_spec.rb
+++ b/lib/rb/spec/protocol_decorator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe Thrift::ProtocolDecorator do
+  it 'forwards message begin values to the decorated protocol' do
+    decorator_class = Class.new(Thrift::BaseProtocol) do
+      include Thrift::ProtocolDecorator
+    end
+    protocol = double('Protocol')
+    decorator = decorator_class.new(protocol)
+
+    expect(protocol).to receive(:write_message_begin).with('method', Thrift::MessageTypes::CALL, 42)
+    decorator.write_message_begin('method', Thrift::MessageTypes::CALL, 42)
+  end
+end


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
`Thrift::ProtocolDecorator#write_message_begin` accepted the message name, type, and sequence ID but invoked the decorated protocol without them. A decorator relying on this shared implementation therefore raised `ArgumentError` before it could serialize an outbound message.

This change forwards all three values unchanged, restoring the decorator contract and allowing the wrapped protocol to begin the message normally.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6118](https://issues.apache.org/jira/browse/THRIFT-6118)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
