### PR TITLE
THRIFT-6119: Preserve Ruby multiplexed protocol service names

### DIFF
--- a/lib/rb/spec/multiplexed_protocol_spec.rb
+++ b/lib/rb/spec/multiplexed_protocol_spec.rb
@@ -17,29 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'thrift/protocol/protocol_decorator'
+require 'spec_helper'
 
-module Thrift
-  class MultiplexedProtocol < BaseProtocol
+describe Thrift::MultiplexedProtocol do
+  it 'keeps its configured service name when formatted for diagnostics' do
+    transport = Thrift::MemoryBufferTransport.new
+    protocol = Thrift::MultiplexedProtocol.new(Thrift::BinaryProtocol.new(transport), 'Calculator')
 
-    include ProtocolDecorator
+    expect(protocol.to_s).to eq('multiplexed(binary(memory))')
+    expect(protocol.to_s).to eq('multiplexed(binary(memory))')
 
-    def initialize(protocol, service_name)
-      super(protocol)
-      @service_name = service_name
-    end
+    protocol.write_message_begin('add', Thrift::MessageTypes::CALL, 7)
 
-    def write_message_begin(name, type, seqid)
-      case type
-      when MessageTypes::CALL, MessageTypes::ONEWAY
-        @protocol.write_message_begin("#{@service_name}:#{name}", type, seqid)
-      else
-        @protocol.write_message_begin(name, type, seqid)
-      end
-    end
-
-    def to_s
-      "multiplexed(#{@protocol})"
-    end
+    name, type, seqid = Thrift::BinaryProtocol.new(transport).read_message_begin
+    expect([name, type, seqid]).to eq(['Calculator:add', Thrift::MessageTypes::CALL, 7])
   end
 end


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
`Thrift::MultiplexedProtocol#to_s` assigned the wrapped protocol's diagnostic string to `@service_name` while formatting its output. Logging or interpolating the protocol therefore changed the service prefix used by later calls, causing messages configured for a service such as `Calculator` to be written for `binary(memory)` instead.

This change makes diagnostic formatting side-effect-free. It preserves the existing `to_s` output while leaving the configured service name untouched, so subsequent call and oneway messages retain their original multiplexed service prefix.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6119](https://issues.apache.org/jira/browse/THRIFT-6119)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
