### PR TITLE
c_glib: link thrift_memory_buffer into testbinaryprotocol (fixes autotools build)

### DIFF
--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -133,6 +133,7 @@ testbinaryprotocol_LDADD = \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_socket.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_transport.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_server_socket.o \
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/transport/libthrift_c_glib_la-thrift_memory_buffer.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift_configuration.o 
 
 testcompactprotocol_SOURCES = testcompactprotocol.c


### PR DESCRIPTION
`testbinaryprotocol.c`'s recursion-depth skip tests (`test_skip_recursion_depth` / `test_skip_within_limit`, added in c097d239f) use `THRIFT_TYPE_MEMORY_BUFFER`, but `testbinaryprotocol_LDADD` in `lib/c_glib/test/Makefile.am` does not link `thrift_memory_buffer`.

As a result `testbinaryprotocol` fails to build under the **autotools** build:

```
undefined reference to `thrift_memory_buffer_get_type'
```

The **cmake** build links the whole `libthrift_c_glib` library, so it is unaffected — which is why this stayed green in CI. This adds the missing object to the link line, matching the other tests that use the memory buffer (`testbufferedtransport`, `testframedtransport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
