### PR TITLE
THRIFT-6121: Make Ruby Header protocol errors parseable

### DIFF
--- a/lib/rb/lib/thrift/protocol/header_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/header_protocol.rb
@@ -178,8 +178,9 @@ module Thrift
         @header_transport.reset_protocol
         reset_protocol_if_needed
       rescue ProtocolException => ex
+        use_default_protocol
         app_ex = ApplicationException.new(ApplicationException::INVALID_PROTOCOL, ex.message)
-        write_message_begin("", MessageTypes::EXCEPTION, 0)
+        write_message_begin("", MessageTypes::EXCEPTION, @header_transport.sequence_id)
         app_ex.write(self)
         write_message_end
         @header_transport.flush
@@ -281,6 +282,12 @@ module Thrift
         @protocol = create_protocol(new_protocol_id)
         @current_protocol_id = new_protocol_id
       end
+    end
+
+    def use_default_protocol
+      @protocol = create_protocol(@default_protocol)
+      @current_protocol_id = @default_protocol
+      @header_transport.protocol_id = @default_protocol
     end
 
     # Creates a protocol instance based on protocol ID

--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -130,6 +130,14 @@ module Thrift
       @sequence_id = sequence_id
     end
 
+    def protocol_id=(protocol_id)
+      unless [HeaderSubprotocolID::BINARY, HeaderSubprotocolID::COMPACT].include?(protocol_id)
+        raise ArgumentError, "Unknown protocol ID: #{protocol_id}"
+      end
+
+      @protocol_id = protocol_id
+    end
+
     def open?
       @transport.open?
     end

--- a/lib/rb/spec/header_protocol_spec.rb
+++ b/lib/rb/spec/header_protocol_spec.rb
@@ -262,21 +262,48 @@ describe 'HeaderProtocol' do
     end
 
     describe "unknown protocol handling" do
-      it "should write an exception response on unknown protocol id" do
-        header_data = +""
-        header_data << varint32(0x10)
-        header_data << varint32(0)
-        frame = build_header_frame(header_data)
+      [Thrift::HeaderSubprotocolID::BINARY, Thrift::HeaderSubprotocolID::COMPACT].each do |fallback|
+        it "writes a parseable #{fallback} exception response for an unknown protocol id" do
+          header_data = +""
+          header_data << varint32(0x10)
+          header_data << varint32(0)
+          frame = build_header_frame(header_data, sequence_id: 77)
 
+          buffer = Thrift::MemoryBufferTransport.new(frame)
+          protocol = Thrift::HeaderProtocol.new(buffer, nil, fallback)
+
+          expect { protocol.read_message_begin }.to raise_error(Thrift::ProtocolException) do |error|
+            expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+            expect(error.message).to eq("Unknown protocol ID: 16")
+          end
+
+          response = buffer.read(buffer.available)
+          read_protocol = Thrift::HeaderProtocol.new(Thrift::MemoryBufferTransport.new(response))
+          name, type, seqid = read_protocol.read_message_begin
+          application_exception = Thrift::ApplicationException.new
+          application_exception.read(read_protocol)
+          read_protocol.read_message_end
+
+          expect(name).to eq("")
+          expect(type).to eq(Thrift::MessageTypes::EXCEPTION)
+          expect(seqid).to eq(77)
+          expect(application_exception.type).to eq(Thrift::ApplicationException::INVALID_PROTOCOL)
+          expect(application_exception.message).to eq("Unknown protocol ID: 16")
+          expect(response[8, 4].unpack1('N')).to eq(77)
+        end
+      end
+
+      it "does not recursively write a response for a malformed Header" do
+        header_data = [0x80, 0x80, 0x80, 0x80].pack('C*')
+        frame = build_header_frame(header_data, sequence_id: 77)
         buffer = Thrift::MemoryBufferTransport.new(frame)
         protocol = Thrift::HeaderProtocol.new(buffer)
 
-        expect { protocol.read_message_begin }.to raise_error(Thrift::ProtocolException)
-
-        response = buffer.read(buffer.available)
-        expect(response.bytesize).to be > 0
-        magic = response[4, 2].unpack('n').first
-        expect(magic).to eq(Thrift::HeaderTransport::HEADER_MAGIC)
+        expect { protocol.read_message_begin }.to raise_error(Thrift::TransportException) do |error|
+          expect(error.type).to eq(Thrift::TransportException::UNKNOWN)
+          expect(error.message).to eq("Trying to read past header boundary")
+        end
+        expect(buffer.available).to eq(0)
       end
     end
 

--- a/lib/rb/spec/support/header_protocol_helper.rb
+++ b/lib/rb/spec/support/header_protocol_helper.rb
@@ -33,7 +33,7 @@ module HeaderProtocolHelper
     bytes.pack('C*')
   end
 
-  def build_header_frame(header_data, payload = Thrift::Bytes.empty_byte_buffer, header_words: nil)
+  def build_header_frame(header_data, payload = Thrift::Bytes.empty_byte_buffer, header_words: nil, sequence_id: 0)
     header_data = header_data.b
     if header_words.nil?
       padding = (4 - (header_data.bytesize % 4)) % 4
@@ -46,7 +46,7 @@ module HeaderProtocolHelper
     frame << [frame_size].pack('N')
     frame << [Thrift::HeaderTransport::HEADER_MAGIC].pack('n')
     frame << [0].pack('n')
-    frame << [0].pack('N')
+    frame << [sequence_id].pack('N')
     frame << [header_words].pack('n')
     frame << header_data
     frame << payload


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
`HeaderProtocol` previously attempted to report an unknown Header subprotocol using the same unknown protocol identifier in its response frame. Although the payload contained an application exception, the peer could not select a decoder for it. The response also replaced the Header sequence ID with zero, preventing the peer from reliably associating the error with its request.

This change writes the application exception using the configured default Binary or Compact protocol and preserves the sequence ID parsed from the incoming Header frame. The resulting response can be decoded by a fresh `HeaderProtocol` and correlated with the request. If the Header itself is malformed before a valid error response can be constructed, the original error is raised without attempting to emit another response.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6121](https://issues.apache.org/jira/browse/THRIFT-6121)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
