### PR TITLE
THRIFT-6122: Normalize Ruby JSON Unicode handling

### DIFF
--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -301,9 +301,10 @@ module Thrift
 
     # Write out the contents of the string str as a JSON string, escaping characters as appropriate.
     def write_json_string(str)
+      str = normalize_json_string(str)
       @context.write(trans)
       trans.write(@@kJSONStringDelimiter)
-      str.split('').each do |ch|
+      str.each_char do |ch|
         write_json_char(ch)
       end
       trans.write(@@kJSONStringDelimiter)
@@ -494,18 +495,25 @@ module Thrift
       JsonProtocol::read_syntax_char(@reader, ch)
     end
 
-    # Decodes the four hex parts of a JSON escaped string character and returns
-    # the character via out.
-    #
-    # Note - this only supports Unicode characters in the BMP (U+0000 to U+FFFF);
-    # characters above the BMP are encoded as two escape sequences (surrogate pairs),
-    # which is not yet implemented
     def read_json_escape_char
-      str = +@reader.read
-      str << @reader.read
-      str << @reader.read
-      str << @reader.read
-      str.hex.chr(Encoding::UTF_8)
+      code_unit = read_unicode_code_unit
+
+      if code_unit.between?(0xD800, 0xDBFF)
+        slash = @reader.read
+        marker = @reader.read
+        invalid_unicode!("Unpaired UTF-16 high surrogate") unless slash == '\\' && marker == 'u'
+
+        low_surrogate = read_unicode_code_unit
+        invalid_unicode!("Unpaired UTF-16 high surrogate") unless low_surrogate.between?(0xDC00, 0xDFFF)
+        codepoint = 0x10000 + ((code_unit - 0xD800) << 10) + (low_surrogate - 0xDC00)
+        [codepoint].pack('U')
+      elsif code_unit.between?(0xDC00, 0xDFFF)
+        invalid_unicode!("Unpaired UTF-16 low surrogate")
+      else
+        [code_unit].pack('U')
+      end
+    rescue EOFError
+      invalid_unicode!("Incomplete Unicode escape")
     end
 
     # Decodes a JSON string, including unescaping, and returns the string via str
@@ -525,7 +533,7 @@ module Thrift
         @context.read(@reader)
       end
       read_json_syntax_char(@@kJSONStringDelimiter)
-      str = +''
+      str = Bytes.empty_byte_buffer
       while (true)
         ch = @reader.read
         if (ch == @@kJSONStringDelimiter)
@@ -543,9 +551,9 @@ module Thrift
             ch = escape_char_vals[pos]
           end
         end
-        str << ch
+        str << Bytes.force_binary_encoding(ch)
       end
-      return str
+      decode_json_string(str)
     end
 
     # Reads a block of base64 characters, decoding it, and returns via str
@@ -788,6 +796,41 @@ module Thrift
 
     def to_s
       "json(#{super.to_s})"
+    end
+
+    private
+
+    def normalize_json_string(str)
+      utf8 = if str.encoding == Encoding::UTF_8
+        str
+      elsif str.encoding == Encoding::BINARY
+        str.ascii_only? ? str : str.dup.force_encoding(Encoding::UTF_8)
+      else
+        str.encode(Encoding::UTF_8)
+      end
+      invalid_unicode!("Invalid UTF-8 string") unless utf8.valid_encoding?
+      utf8
+    rescue EncodingError
+      invalid_unicode!("Invalid UTF-8 string")
+    end
+
+    def decode_json_string(bytes)
+      bytes.force_encoding(Encoding::UTF_8)
+      invalid_unicode!("Invalid UTF-8 string") unless bytes.valid_encoding?
+      bytes
+    end
+
+    def read_unicode_code_unit
+      hex = Bytes.empty_byte_buffer
+      4.times { hex << @reader.read }
+      invalid_unicode!("Invalid Unicode escape") unless hex.match?(/\A[0-9a-fA-F]{4}\z/)
+      hex.to_i(16)
+    rescue EOFError
+      invalid_unicode!("Incomplete Unicode escape")
+    end
+
+    def invalid_unicode!(message)
+      raise ProtocolException.new(ProtocolException::INVALID_DATA, message)
     end
   end
 

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -235,6 +235,38 @@ describe 'JsonProtocol' do
       expect(a.encoding).to eq(Encoding::BINARY)
     end
 
+    it "transcodes non-UTF-8 strings before writing JSON" do
+      value = +"caf\xE9"
+      value.force_encoding(Encoding::ISO_8859_1)
+
+      @prot.write_string(value)
+      data = @trans.read(@trans.available)
+
+      expect(data).to eq("\"caf\u00E9\"".encode(Encoding::UTF_8).b)
+      expect(data.dup.force_encoding(Encoding::UTF_8)).to be_valid_encoding
+      expect(value.encoding).to eq(Encoding::ISO_8859_1)
+    end
+
+    it "writes valid UTF-8 stored in a binary string" do
+      value = "caf\xC3\xA9".b
+
+      @prot.write_string(value)
+      data = @trans.read(@trans.available)
+
+      expect(data).to eq("\"caf\xC3\xA9\"".b)
+      expect(value.encoding).to eq(Encoding::BINARY)
+    end
+
+    it "rejects invalid UTF-8 before writing any JSON bytes" do
+      value = "\xC3\x28".b.force_encoding(Encoding::UTF_8)
+
+      expect { @prot.write_string(value) }.to raise_error(Thrift::ProtocolException) do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+        expect(error.message).to eq("Invalid UTF-8 string")
+      end
+      expect(@trans.available).to eq(0)
+    end
+
     it "should write binary" do
       @prot.write_binary("this is a base64 string")
       expect(@trans.read(@trans.available)).to eq("\"dGhpcyBpcyBhIGJhc2U2NCBzdHJpbmc=\"")
@@ -315,6 +347,54 @@ describe 'JsonProtocol' do
 
       @trans.write("\"\\t\"")
       expect(@prot.read_json_string(false)).to eq("\t")
+    end
+
+    it "decodes BMP and supplementary Unicode escapes" do
+      {
+        '"\u20AC"' => "\u20AC",
+        '"\uD83D\uDE00"' => "\u{1F600}",
+        '"\ud83d\uDe00"' => "\u{1F600}"
+      }.each do |wire, value|
+        trans = Thrift::MemoryBufferTransport.new(wire.b)
+        protocol = Thrift::JsonProtocol.new(trans)
+
+        expect(protocol.read_json_string).to eq(value)
+      end
+    end
+
+    it "decodes mixed raw UTF-8 and escaped Unicode" do
+      @trans.write("\"raw \u{1F600} and \\u20AC\"".encode(Encoding::UTF_8).b)
+
+      value = @prot.read_json_string
+
+      expect(value).to eq("raw \u{1F600} and \u20AC")
+      expect(value.encoding).to eq(Encoding::UTF_8)
+      expect(value).to be_valid_encoding
+    end
+
+    it "rejects malformed Unicode escapes and unpaired surrogates" do
+      [
+        '"\u12G4"',
+        '"\u123"',
+        '"\uD83D"',
+        '"\uD83D\u0041"',
+        '"\uDE00"'
+      ].each do |wire|
+        protocol = Thrift::JsonProtocol.new(Thrift::MemoryBufferTransport.new(wire.b))
+
+        expect { protocol.read_json_string }.to raise_error(Thrift::ProtocolException) do |error|
+          expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+        end
+      end
+    end
+
+    it "rejects invalid raw UTF-8 in JSON strings" do
+      @trans.write("\"\xC3\x28\"".b)
+
+      expect { @prot.read_json_string }.to raise_error(Thrift::ProtocolException) do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+        expect(error.message).to eq("Invalid UTF-8 string")
+      end
     end
 
     it "should read json string" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The Ruby JSON protocol interprets every `\uXXXX` escape independently, so supplementary Unicode characters represented as UTF-16 surrogate pairs fail before the two code units can be combined. It also writes strings using the caller's declared encoding, which can place non-UTF-8 bytes in a JSON payload.

This change combines valid surrogate pairs into their Unicode scalar value and reports malformed escapes or unpaired surrogates as typed protocol errors. When writing, it preserves valid UTF-8, accepts valid UTF-8 bytes carried by binary Ruby strings, transcodes strings with another declared encoding, and rejects invalid byte sequences before emitting any JSON bytes. The caller's string is left unchanged.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6122](https://issues.apache.org/jira/browse/THRIFT-6122)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
