### PR TITLE
THRIFT-6123: Reset Ruby serializer after write failures

### DIFF
--- a/lib/rb/lib/thrift/serializer/serializer.rb
+++ b/lib/rb/lib/thrift/serializer/serializer.rb
@@ -21,14 +21,19 @@
 module Thrift
   class Serializer
     def initialize(protocol_factory = BinaryProtocolFactory.new)
+      @protocol_factory = protocol_factory
       @transport = MemoryBufferTransport.new
       @protocol = protocol_factory.get_protocol(@transport)
     end
 
     def serialize(base)
       @transport.reset_buffer
+      @protocol ||= @protocol_factory.get_protocol(@transport)
       base.write(@protocol)
       @transport.read(@transport.available)
+    rescue
+      @protocol = nil
+      raise
     end
   end
 end

--- a/lib/rb/spec/serializer_spec.rb
+++ b/lib/rb/spec/serializer_spec.rb
@@ -20,6 +20,42 @@
 
 require 'spec_helper'
 
+module SerializerFailureFixtures
+  class Value
+    def initialize(stage, error)
+      @stage = stage
+      @error = error
+    end
+
+    def write(protocol)
+      case @stage
+      when :message
+        protocol.write_message_begin("broken", Thrift::MessageTypes::CALL, 1)
+      when :struct
+        protocol.write_struct_begin("Broken")
+      when :field
+        protocol.write_struct_begin("Broken")
+        protocol.write_field_begin("value", Thrift::Types::STRING, 1)
+      when :list
+        protocol.write_struct_begin("Broken")
+        protocol.write_field_begin("value", Thrift::Types::LIST, 1)
+        protocol.write_list_begin(Thrift::Types::STRING, 1)
+      when :set
+        protocol.write_struct_begin("Broken")
+        protocol.write_field_begin("value", Thrift::Types::SET, 1)
+        protocol.write_set_begin(Thrift::Types::STRING, 1)
+      when :nested_map
+        protocol.write_struct_begin("Broken")
+        protocol.write_field_begin("value", Thrift::Types::MAP, 1)
+        protocol.write_map_begin(Thrift::Types::STRING, Thrift::Types::LIST, 1)
+        protocol.write_string("key")
+        protocol.write_list_begin(Thrift::Types::STRING, 1)
+      end
+      raise @error
+    end
+  end
+end
+
 describe 'Serializer' do
   describe Thrift::Serializer do
     it "should serialize structs to binary by default" do
@@ -40,6 +76,46 @@ describe 'Serializer' do
       allow(protocol_factory).to receive(:get_protocol).and_return(protocol)
       serializer = Thrift::Serializer.new(protocol_factory)
       serializer.serialize(SpecNamespace::Hello.new(:greeting => "Good day"))
+    end
+
+    [:message, :struct, :field, :list, :set, :nested_map].each do |stage|
+      it "isolates JSON protocol state after a #{stage} write failure" do
+        serializer = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new)
+        value = SpecNamespace::Hello.new(:greeting => "Good day")
+        expected = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value)
+        error = RuntimeError.new("failed at #{stage}")
+
+        expect {
+          serializer.serialize(SerializerFailureFixtures::Value.new(stage, error))
+        }.to raise_error { |raised| expect(raised).to equal(error) }
+
+        2.times do
+          data = serializer.serialize(value)
+          expect(data).to eq(expected)
+          expect(
+            Thrift::Deserializer.new(Thrift::JsonProtocolFactory.new).deserialize(
+              SpecNamespace::Hello.new,
+              data
+            )
+          ).to eq(value)
+        end
+      end
+    end
+
+    it "recovers after repeated JSON serialization failures" do
+      serializer = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new)
+      value = SpecNamespace::Hello.new(:greeting => "recovered")
+
+      [:field, :nested_map].each do |stage|
+        error = RuntimeError.new("failed at #{stage}")
+        expect {
+          serializer.serialize(SerializerFailureFixtures::Value.new(stage, error))
+        }.to raise_error { |raised| expect(raised).to equal(error) }
+      end
+
+      expect(serializer.serialize(value)).to eq(
+        Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value)
+      )
     end
   end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The Ruby serializer clears its memory buffer between calls but reuses the same protocol object. JSON protocols also retain nested-container and separator state, so an exception during an object's `write` method can leave the serializer positioned inside the failed value. Later serializations may then begin with a stale comma or colon and produce malformed JSON.

This change retains normal protocol reuse for successful calls. If serialization raises, it discards the protocol while preserving the original exception; the next call lazily creates a clean protocol from the configured factory. Subsequent output therefore matches a fresh serializer without adding protocol allocations to the successful hot path.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6123](https://issues.apache.org/jira/browse/THRIFT-6123)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
