### PR TITLE
Measure JSON field size against the configured maximum

### DIFF
--- a/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
+++ b/lib/cpp/src/thrift/protocol/TJSONProtocol.cpp
@@ -748,17 +748,22 @@ uint32_t TJSONProtocol::readJSONEscapeChar(uint16_t* out) {
 uint32_t TJSONProtocol::readJSONString(std::string& str, bool skipContext) {
   uint32_t result = (skipContext ? 0 : context_->read(reader_));
   result += readJSONSyntaxChar(kJSONStringDelimiter);
+  // JSON strings are quote-delimited rather than length-prefixed, so there is no
+  // declared size to pre-check the way TBinaryProtocol::readStringBody() does.
+  // Bound the running byte count instead, so a single string cannot grow past
+  // the limit. The count is measured against the configured maximum rather than
+  // the message size still remaining, which a transport that draws the budget
+  // down as it reads has already reduced by these same bytes.
+  const int64_t maxSize = trans_->getConfiguration()->getMaxMessageSize();
   std::vector<uint16_t> codeunits;
   uint8_t ch;
   str.clear();
   while (true) {
     ch = reader_.read();
     ++result;
-    // JSON strings are quote-delimited rather than length-prefixed, so there is
-    // no declared size to pre-check the way TBinaryProtocol::readStringBody()
-    // does. Bound the running byte count against the configured message size
-    // instead, so a single string cannot grow past the limit.
-    trans_->checkReadBytesAvailable(result);
+    if (static_cast<int64_t>(result) > maxSize) {
+      throw TTransportException(TTransportException::END_OF_FILE, "MaxMessageSize reached");
+    }
     if (ch == kJSONStringDelimiter) {
       break;
     }
@@ -840,6 +845,9 @@ uint32_t TJSONProtocol::readJSONBase64(std::string& str) {
 // a valid JSON numeric character.
 uint32_t TJSONProtocol::readJSONNumericChars(std::string& str) {
   uint32_t result = 0;
+  // Numeric literals are also read char-by-char with no declared length; bound
+  // the running count the same way, and for the same reason.
+  const int64_t maxSize = trans_->getConfiguration()->getMaxMessageSize();
   str.clear();
   while (true) {
     uint8_t ch = reader_.peek();
@@ -849,9 +857,9 @@ uint32_t TJSONProtocol::readJSONNumericChars(std::string& str) {
     reader_.read();
     str += ch;
     ++result;
-    // Numeric literals are also read char-by-char with no declared length;
-    // bound the running count against the configured message size as well.
-    trans_->checkReadBytesAvailable(result);
+    if (static_cast<int64_t>(result) > maxSize) {
+      throw TTransportException(TTransportException::END_OF_FILE, "MaxMessageSize reached");
+    }
   }
   return result;
 }

--- a/lib/cpp/test/JSONProtoTest.cpp
+++ b/lib/cpp/test/JSONProtoTest.cpp
@@ -27,6 +27,7 @@
 #include <thrift/TConfiguration.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TTransportException.h>
+#include <thrift/transport/TVirtualTransport.h>
 #include "gen-cpp/DebugProtoTest_types.h"
 
 #define BOOST_TEST_MODULE JSONProtoTest
@@ -460,4 +461,83 @@ BOOST_AUTO_TEST_CASE(test_json_number_respects_max_message_size) {
   auto proto = std::make_shared<TJSONProtocol>(buffer);
   int64_t out = 0;
   BOOST_CHECK_THROW(proto->readI64(out), apache::thrift::transport::TTransportException);
+}
+
+// TMemoryBuffer checks the message size budget but never draws it down, so the
+// tests above cannot tell a bound against the configured maximum apart from one
+// against the size still remaining -- on such a transport the two are the same
+// thing. TZlibTransport::read() does draw the budget down as bytes are consumed;
+// this stand-in reproduces that accounting without adding a zlib dependency to
+// this test.
+class TCountingTransport
+    : public apache::thrift::transport::TVirtualTransport<TCountingTransport> {
+public:
+  TCountingTransport(std::shared_ptr<apache::thrift::transport::TTransport> inner,
+                     std::shared_ptr<TConfiguration> config)
+    : TVirtualTransport(config), inner_(inner) {}
+
+  uint32_t read(uint8_t* buf, uint32_t len) {
+    checkReadBytesAvailable(len);
+    uint32_t got = inner_->read(buf, len);
+    countConsumedMessageBytes(got);
+    return got;
+  }
+
+  void write(const uint8_t* buf, uint32_t len) { inner_->write(buf, len); }
+  bool isOpen() const override { return inner_->isOpen(); }
+  void open() override { inner_->open(); }
+  void close() override { inner_->close(); }
+
+private:
+  std::shared_ptr<apache::thrift::transport::TTransport> inner_;
+};
+
+static std::shared_ptr<TJSONProtocol> countingProtoReading(const std::string& json,
+                                                           std::shared_ptr<TConfiguration> config) {
+  auto buffer = std::make_shared<TMemoryBuffer>(
+      reinterpret_cast<uint8_t*>(const_cast<char*>(json.data())),
+      static_cast<uint32_t>(json.size()), TMemoryBuffer::COPY, config);
+  auto transport = std::make_shared<TCountingTransport>(buffer, config);
+  return std::make_shared<TJSONProtocol>(transport);
+}
+
+// The size of a field must be measured against the configured maximum, not
+// against whatever is left of the message budget: a transport that draws the
+// budget down as it reads has already accounted for those same bytes, and
+// counting them a second time rejects strings well inside the limit.
+BOOST_AUTO_TEST_CASE(test_json_string_size_measured_against_configured_maximum) {
+  const int kMaxMessageSize = 1024;
+  const size_t kStringSize = kMaxMessageSize * 3 / 4; // inside the limit, past half of it
+
+  // Within the limit: must be read, even though the transport has drawn the
+  // remaining budget down by the same bytes as they arrived.
+  {
+    auto config = std::make_shared<TConfiguration>(kMaxMessageSize);
+    auto proto = countingProtoReading("\"" + std::string(kStringSize, 'A') + "\"", config);
+    std::string out;
+    BOOST_CHECK_NO_THROW(proto->readString(out));
+    BOOST_CHECK_EQUAL(out.size(), kStringSize);
+  }
+
+  // Past the limit: still rejected on that same transport.
+  {
+    auto config = std::make_shared<TConfiguration>(kMaxMessageSize);
+    auto proto
+        = countingProtoReading("\"" + std::string(kMaxMessageSize * 2, 'A') + "\"", config);
+    std::string out;
+    BOOST_CHECK_THROW(proto->readString(out), apache::thrift::transport::TTransportException);
+  }
+}
+
+// readJSONNumericChars() counts the same way and needs the same treatment.
+BOOST_AUTO_TEST_CASE(test_json_number_size_measured_against_configured_maximum) {
+  const int kMaxMessageSize = 40;
+  const size_t kDigits = 24; // inside the limit, past half of it
+
+  auto config = std::make_shared<TConfiguration>(kMaxMessageSize);
+  // Terminated by a non-numeric byte so the numeric run ends on the terminator
+  // rather than on buffer exhaustion, isolating the size check itself.
+  auto proto = countingProtoReading(std::string(kDigits, '1') + " ", config);
+  double out = 0;
+  BOOST_CHECK_NO_THROW(proto->readDouble(out));
 }

--- a/lib/cpp/test/ZlibTest.cpp
+++ b/lib/cpp/test/ZlibTest.cpp
@@ -43,12 +43,14 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/version.hpp>
 
+#include <thrift/protocol/TJSONProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TZlibTransport.h>
 #include <thrift/TConfiguration.h>
 
 using namespace apache::thrift::transport;
 using apache::thrift::TConfiguration;
+using apache::thrift::protocol::TJSONProtocol;
 using std::shared_ptr;
 using std::string;
 
@@ -372,6 +374,41 @@ void test_message_size_limit() {
   }
 }
 
+// A JSON string carries no declared length, so TJSONProtocol measures the one it
+// is decoding against the configured maximum. This transport draws the remaining
+// message size down as it reads, so the two must not be confused: a string that
+// fits the configured maximum has to be read in full, however much of the budget
+// the transport has already accounted for.
+void test_json_string_message_size_limit() {
+  const int max_message_size = 1024;
+  const size_t string_size = max_message_size * 3 / 4;
+  const string json = "\"" + string(string_size, 'a') + "\"";
+
+  shared_ptr<TMemoryBuffer> membuf(new TMemoryBuffer());
+  {
+    shared_ptr<TZlibTransport> writer(new TZlibTransport(membuf));
+    writer->write(reinterpret_cast<const uint8_t*>(json.data()),
+                  static_cast<uint32_t>(json.size()));
+    writer->finish();
+  }
+
+  auto config = std::make_shared<TConfiguration>();
+  config->setMaxMessageSize(max_message_size);
+  shared_ptr<TZlibTransport> reader(new TZlibTransport(
+      membuf,
+      TZlibTransport::DEFAULT_URBUF_SIZE,
+      TZlibTransport::DEFAULT_CRBUF_SIZE,
+      TZlibTransport::DEFAULT_UWBUF_SIZE,
+      TZlibTransport::DEFAULT_CWBUF_SIZE,
+      Z_DEFAULT_COMPRESSION,
+      config));
+
+  shared_ptr<TJSONProtocol> protocol(new TJSONProtocol(reader));
+  string str;
+  BOOST_CHECK_NO_THROW(protocol->readString(str));
+  BOOST_CHECK_EQUAL(str.size(), string_size);
+}
+
 /*
  * Initialization
  */
@@ -476,6 +513,7 @@ bool init_unit_test_suite() {
   suite->add(BOOST_TEST_CASE(test_no_write));
   suite->add(BOOST_TEST_CASE(test_get_underlying_transport));
   suite->add(BOOST_TEST_CASE(test_message_size_limit));
+  suite->add(BOOST_TEST_CASE(test_json_string_message_size_limit));
 
   return true;
 }
@@ -504,6 +542,7 @@ boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
   suite->add(BOOST_TEST_CASE(test_no_write));
   suite->add(BOOST_TEST_CASE(test_get_underlying_transport));
   suite->add(BOOST_TEST_CASE(test_message_size_limit));
+  suite->add(BOOST_TEST_CASE(test_json_string_message_size_limit));
 
   return nullptr;
 }


### PR DESCRIPTION
Follow-up to the recent `TJSONProtocol` message-size changes.

`readJSONString()` and `readJSONNumericChars()` passed their running byte count to
`checkReadBytesAvailable()`, which compares against the message size still *remaining*
rather than the configured maximum. On a transport whose `read()` also draws that budget
down, the same bytes are accounted for twice: once as they are consumed, and once as the
running count.

`TZlibTransport::read()` does exactly that, so JSON over zlib rejects a string once it
passes roughly half of whatever was left of the budget when the field started -- and since
nothing resets the budget between fields, the threshold keeps shrinking as the message goes
on. With a 1 KB maximum, a 768-byte string is cut off at 511 bytes.

This measures the running count against the configured maximum instead, which is what the
Java, netstd, Delphi, Go and Python readers already do. Every transport that checks the
budget without drawing it down -- socket, SSL, buffered, framed, memory, HTTP -- behaves
exactly as before, because for those the remaining size never moves off the maximum during
a read.

### Tests

- `JSONProtoTest.cpp` covers it transport-agnostically, with a stand-in that draws the
  budget down the way `TZlibTransport::read()` does (no zlib dependency, so no conditional
  build).
- `ZlibTest.cpp` covers the real composition.

Both new cases fail without the change and pass with it. `ZlibTest` (34 cases),
`JSONProtoTest` (17) and `UnitTests` (87) are green, built in `thrift:jammy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)