### PR TITLE
c_glib: fix testbinaryprotocol expectation for non-versioned message headers

### DIFF
--- a/lib/c_glib/test/testbinaryprotocol.c
+++ b/lib/c_glib/test/testbinaryprotocol.c
@@ -345,7 +345,10 @@ test_read_and_write_complex_types (void)
     /* invalid version */
     g_assert (thrift_binary_protocol_write_i32 (protocol, -1, NULL) > 0);
 
-    /* sz > 0 for a message */
+    /* a non-versioned (old-style) message: the leading int32 is the length of
+       the method name, followed by the message type and the sequence id */
+    g_assert (thrift_binary_protocol_write_string (protocol, "test", NULL) > 0);
+    g_assert (thrift_binary_protocol_write_byte (protocol, T_CALL, NULL) > 0);
     g_assert (thrift_binary_protocol_write_i32 (protocol, 1, NULL) > 0);
 
     /* send a valid message */
@@ -717,10 +720,14 @@ thrift_server_complex_types (const int port)
                                                      &message_type, &seqid,
                                                      NULL) == -1);
 
-  /* sz > 0 */
+  /* a non-versioned (old-style) message */
   g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,
                                                      &message_type, &seqid,
                                                      NULL) > 0);
+  g_assert_cmpstr (message_name, ==, "test");
+  g_assert_cmpint (message_type, ==, T_CALL);
+  g_assert_cmpint (seqid, ==, 1);
+  g_free (message_name);
 
   /* read a valid message */
   g_assert (thrift_binary_protocol_read_message_begin (protocol, &message_name,


### PR DESCRIPTION
`testbinaryprotocol` currently fails on master:

```
ERROR:lib/c_glib/test/testbinaryprotocol.c:726:thrift_server_complex_types:
  assertion failed: (thrift_binary_protocol_read_message_begin (...) > 0)
```

`test_read_and_write_complex_types` covers the case where the leading int32 of a
message is non-negative. The client wrote a bare `int32` for it and the server
asserted that `read_message_begin` returned success — which it did, because the
function had no branch for the old-style (non-versioned) header and returned
without consuming a name, message type or sequence id.

Since 280d9778d that branch exists, so the call now reads those three fields.
The four bytes the test wrote are no longer a complete message, the read fails,
and everything after it in the shared socket stream is misaligned, which is why
the failure shows up twice (once in the server child, once in the parent's
`status == 0` assertion).

This sends a complete old-style header for that case — name length + name,
message type, sequence id — and verifies what the server read back, so the case
now exercises the branch it is named after and the stream stays in sync.

Verified with the c_glib suite via cmake in `thrift:jammy`: 20/20 pass, where
master is 19/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)