### PR TITLE
Fix Python process-pool test server lifecycle

### DIFF
--- a/test/py/RunClientServer.py
+++ b/test/py/RunClientServer.py
@@ -47,7 +47,6 @@ SCRIPTS = [
 FRAMED = ["TNonblockingServer"]
 SKIP_ZLIB = ['TNonblockingServer', 'THttpServer']
 SKIP_SSL = ['THttpServer']
-EXTRA_DELAY = dict(TProcessPoolServer=5.5)
 
 PROTOS = [
     'accel',
@@ -76,6 +75,49 @@ def default_servers():
 
 def relfile(fname):
     return os.path.join(SCRIPT_DIR, fname)
+
+
+def terminate_process_group(process, timeout=5):
+    """Terminate a test server, killing it if graceful shutdown times out."""
+    if platform.system() == 'Windows':
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        return
+
+    process_group = process.pid
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        process.wait()
+        return
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        process.poll()
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            process.wait()
+            return
+        except PermissionError:
+            # macOS can report EPERM briefly while group members are exiting.
+            pass
+        time.sleep(0.01)
+
+    try:
+        os.killpg(process_group, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        if process.poll() is None:
+            process.kill()
+    process.wait()
 
 
 def setup_pypath(libdir, gendir):
@@ -182,22 +224,7 @@ def runServiceTest(libdir, genbase, genpydir, server_class, proto, port, use_zli
                 ensureServerAlive()
             except Exception as exc:
                 cleanup_exc = exc
-            extra_sleep = EXTRA_DELAY.get(server_class, 0)
-            if extra_sleep > 0 and verbose > 0:
-                print('Giving %s (proto=%s,zlib=%s,ssl=%s) an extra %d seconds for child'
-                      'processes to terminate via alarm'
-                      % (server_class, proto, use_zlib, use_ssl, extra_sleep))
-                time.sleep(extra_sleep)
-            sig = signal.SIGKILL if platform.system() != 'Windows' else signal.SIGABRT
-            try:
-                if platform.system() == 'Windows':
-                    os.kill(serverproc.pid, sig)
-                else:
-                    # POSIX: kill the whole process group to reap forked children.
-                    os.killpg(serverproc.pid, sig)
-            except OSError:
-                pass
-            serverproc.wait()
+            terminate_process_group(serverproc)
         try:
             os.unlink(port_file)
         except OSError:

--- a/test/py/TestServer.py
+++ b/test/py/TestServer.py
@@ -413,28 +413,14 @@ def main(options):
     if server_type == "TNonblockingServer":
         server = TNonblockingServer.TNonblockingServer(processor, transport, inputProtocolFactory=pfactory)
     elif server_type == "TProcessPoolServer":
-        import signal
         from thrift.server import TProcessPoolServer
         server = TProcessPoolServer.TProcessPoolServer(processor, transport, tfactory, pfactory)
         server.setNumWorkers(5)
 
-        def set_alarm():
-            def clean_shutdown(signum, frame):
-                for worker in server.workers:
-                    if options.verbose > 0:
-                        logging.info('Terminating worker: %s' % worker)
-                    worker.terminate()
-                if options.verbose > 0:
-                    logging.info('Shutting down server')
-                # server.stop() would deadlock here: it calls Condition.notify()
-                # reentrantly on the same thread that's blocked in serve()'s
-                # Condition.wait(), which can never post the wake ack notify()
-                # is waiting for (THRIFT-6082). Workers are already terminated,
-                # so just exit directly.
-                os._exit(0)
-            signal.signal(signal.SIGALRM, clean_shutdown)
-            signal.alarm(4)
-        set_alarm()
+        def stop_process_pool(signum, frame):
+            raise SystemExit
+
+        signal.signal(signal.SIGTERM, stop_process_pool)
     else:
         # look up server class dynamically to instantiate server
         ServerClass = getattr(TServer, server_type)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Python process-pool tests currently stop the server through a four-second alarm and `os._exit(0)`. The abrupt exit bypasses normal multiprocessing cleanup, can report leaked semaphore objects, and forces every process-pool test to wait for the alarm.

Observed macOS failures from this lifecycle include:

- [macOS 15 Intel with Python 3.14](https://github.com/apache/thrift/actions/runs/29772369990/job/88454190096), where the alarm shut down `TProcessPoolServer` while the client was still running and emitted leaked-semaphore warnings.
- [macOS 15 Intel with Python 3.12](https://github.com/apache/thrift/actions/runs/29755655340/job/88397891601), where the server exited with return code 0 before the harness completed.
- [macOS 15 with Python 3.13](https://github.com/apache/thrift/actions/runs/28817226680/job/85471806532), where the earlier process-pool shutdown path deadlocked until GitHub Actions cancelled it at the six-hour limit.

This change replaces the alarm with a `SIGTERM` handler that unwinds `TProcessPoolServer.serve()` through its existing `SystemExit` handling. The client/server harness waits for the complete POSIX process group to exit and falls back to `SIGKILL` only when graceful shutdown times out. Windows retains equivalent terminate-and-kill fallback behavior for its supported server types.

This is a focused test-harness lifecycle fix, so Jira was intentionally skipped.
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
