### PR TITLE
Silence Ruby native capability queries

### DIFF
--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -49,7 +49,6 @@ module Thrift
     end
 
     def native?
-      puts "wrong method is being called!"
       false
     end
 

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -38,6 +38,18 @@ describe 'BaseProtocol' do
       expect(@prot.trans).to eql(@trans)
     end
 
+    it "should report native capability without writing to stdout or stderr" do
+      binary = Thrift::BinaryProtocol.new(Thrift::MemoryBufferTransport.new)
+      compact = Thrift::CompactProtocol.new(Thrift::MemoryBufferTransport.new)
+      expected_compact_native = defined?(Thrift::BinaryProtocolAccelerated) ? true : false
+
+      expect do
+        expect(@prot.native?).to be(false)
+        expect(binary.native?).to be(false)
+        expect(compact.native?).to eq(expected_compact_native)
+      end.to output("").to_stdout.and output("").to_stderr
+    end
+
     it 'should write out a field nicely (deprecated write_field signature)' do
       expect(@prot).to receive(:write_field_begin).with('field', 'type', 'fid').ordered
       expect(@prot).to receive(:write_type).with({:name => 'field', :type => 'type'}, 'value').ordered


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Calling `BaseProtocol#native?` currently writes `wrong method is being called!` to standard output, even though this is a normal capability query. This makes protocol introspection unexpectedly noisy and can contaminate application output.

Remove the diagnostic output while preserving the existing capability result for pure-Ruby protocols and the native overrides.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
