### PR TITLE
THRIFT-6128: Exclude development files from the Ruby gem

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -19,11 +19,10 @@ Gem::Specification.new do |s|
 
   dir = File.expand_path(File.dirname(__FILE__))
 
-  s.files = Dir.glob("{lib,spec}/**/*")
-  s.test_files = Dir.glob("{test,spec,benchmark}/**/*")
+  s.files = Dir.glob("{lib,ext}/**/*.{c,h,rb}")
   s.executables = Dir.glob("{bin}/**/*")
 
-  s.extra_rdoc_files = %w[README.md] + Dir.glob("{ext,lib}/**/*.{c,h,rb}")
+  s.extra_rdoc_files = %w[README.md]
 
   s.require_paths = %w[lib ext]
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

The Ruby gem previously packaged `spec/` directly and added `test/`, `spec/`, and `benchmark/` through the obsolete `test_files` attribute. This change explicitly includes the Ruby runtime and native-extension sources, while retaining the README as RDoc input.

See https://github.com/rubygems/guides/issues/90 for more information.

## File list difference

I built gems from the pre-change and current gemspecs, then compared their `data.tar.gz` file lists:

```sh
diff -u \
  <(tar -xOf thrift-before.gem data.tar.gz | tar -tzf -) \
  <(tar -xOf thrift-after.gem data.tar.gz | tar -tzf -)
```

```diff
--- before
+++ after
@@ -1,9 +1,4 @@
 README.md
-benchmark/Benchmark.thrift
-benchmark/benchmark.rb
-benchmark/client.rb
-benchmark/server.rb
-benchmark/thin_server.rb
 ext/binary_protocol_accelerated.c
 ext/binary_protocol_accelerated.h
 ext/bytes.c
@@ -65,67 +60,3 @@
 lib/thrift/types.rb
 lib/thrift/union.rb
 lib/thrift/uuid.rb
-spec/BaseService.thrift
-spec/ExtendedService.thrift
-spec/Referenced.thrift
-spec/ThriftNamespacedSpec.thrift
-spec/ThriftSpec.thrift
-spec/base_protocol_spec.rb
-spec/base_transport_spec.rb
-spec/binary_protocol_accelerated_spec.rb
-spec/binary_protocol_spec.rb
-spec/binary_protocol_spec_shared.rb
-spec/bytes_spec.rb
-spec/client_spec.rb
-spec/compact_protocol_spec.rb
-spec/constants_demo_spec.rb
-spec/exception_spec.rb
-spec/flat_spec.rb
-spec/header_protocol_spec.rb
-spec/header_transport_spec.rb
-spec/http_client_spec.rb
-spec/json_protocol_spec.rb
-spec/multiplexed_processor_spec.rb
-spec/multiplexed_protocol_spec.rb
-spec/namespaced_spec.rb
-spec/nonblocking_server_spec.rb
-spec/processor_spec.rb
-spec/protocol_decorator_spec.rb
-spec/rack_application_spec.rb
-spec/recursion_depth_spec.rb
-spec/serializer_spec.rb
-spec/server_socket_spec.rb
-spec/server_spec.rb
-spec/socket_spec.rb
-spec/socket_spec_shared.rb
-spec/spec_helper.rb
-spec/ssl_server_socket_spec.rb
-spec/ssl_socket_spec.rb
-spec/struct_nested_containers_spec.rb
-spec/struct_spec.rb
-spec/support/header_protocol_helper.rb
-spec/thin_http_server_spec.rb
-spec/types_spec.rb
-spec/union_spec.rb
-spec/unix_socket_spec.rb
-spec/uuid_validation_spec.rb
-test/fuzz/Makefile.am
-test/fuzz/README.md
-test/fuzz/fuzz_common.rb
-test/fuzz/fuzz_parse_binary_protocol.rb
-test/fuzz/fuzz_parse_binary_protocol_accelerated.rb
-test/fuzz/fuzz_parse_binary_protocol_accelerated_harness.rb
-test/fuzz/fuzz_parse_binary_protocol_harness.rb
-test/fuzz/fuzz_parse_compact_protocol.rb
-test/fuzz/fuzz_parse_compact_protocol_harness.rb
-test/fuzz/fuzz_parse_json_protocol.rb
-test/fuzz/fuzz_parse_json_protocol_harness.rb
-test/fuzz/fuzz_roundtrip_binary_protocol.rb
-test/fuzz/fuzz_roundtrip_binary_protocol_harness.rb
-test/fuzz/fuzz_roundtrip_json_protocol.rb
-test/fuzz/fuzz_roundtrip_json_protocol_harness.rb
-test/fuzz/fuzz_tracer.rb
```

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([THRIFT-6128](https://issues.apache.org/jira/browse/THRIFT-6128))
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] This change involves code, so `[skip ci]` does not apply.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
