### PR TITLE
THRIFT-6130: Restore CommonJS UUID compatibility

### DIFF
--- a/lib/nodejs/test/package-lock.json
+++ b/lib/nodejs/test/package-lock.json
@@ -17,7 +17,7 @@
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
-        "uuid": "^13.0.0",
+        "uuid": "^11.1.1",
         "ws": "^5.2.3"
       },
       "devDependencies": {

--- a/lib/nodejs/test/testAll.sh
+++ b/lib/nodejs/test/testAll.sh
@@ -143,6 +143,7 @@ node ${DIR}/int64_bigint.test.js || TESTOK=1
 node ${DIR}/deep-constructor.test.js || TESTOK=1
 node ${DIR}/recursion_depth.test.js || TESTOK=1
 node ${DIR}/transport_receiver.test.js || TESTOK=1
+node ${DIR}/uuid.test.js || TESTOK=1
 node ${DIR}/generated-exceptions.test.js || TESTOK=1
 node ${DIR}/include.test.mjs || TESTOK=1
 node ${DIR}/thrift_4987_xhr_protocol.test.mjs || TESTOK=1

--- a/lib/nodejs/test/uuid.test.js
+++ b/lib/nodejs/test/uuid.test.js
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const test = require("tape");
+const childProcess = require("child_process");
+const path = require("path");
+const TBinaryProtocol = require("../lib/thrift/binary_protocol");
+const TCompactProtocol = require("../lib/thrift/compact_protocol");
+
+const UUID = "00112233-4455-4677-8899-aabbccddeeff";
+const UUID_BYTES = [
+  0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x46, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+  0xdd, 0xee, 0xff,
+];
+
+test("CommonJS runtime loads without require(esm)", function (assert) {
+  const args = [];
+  if (
+    process.allowedNodeEnvironmentFlags &&
+    process.allowedNodeEnvironmentFlags.has("--no-experimental-require-module")
+  ) {
+    args.push("--no-experimental-require-module");
+  }
+  args.push(
+    "-e",
+    [
+      'const thrift = require("./lib/nodejs/lib/thrift");',
+      'const uuid = require("uuid");',
+      'if (!thrift || typeof uuid.v4 !== "function" || typeof uuid.v4() !== "string") process.exit(1);',
+    ].join("\n"),
+  );
+
+  const result = childProcess.spawnSync(process.execPath, args, {
+    cwd: path.resolve(__dirname, "../../.."),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.end();
+});
+
+[
+  ["binary", TBinaryProtocol],
+  ["compact", TCompactProtocol],
+].forEach(function ([name, Protocol]) {
+  test(name + " protocol round-trips UUIDs", function (assert) {
+    let encoded;
+    const writer = new Protocol({
+      write: function (value) {
+        encoded = Buffer.from(value);
+      },
+    });
+    writer.writeUuid(UUID.toUpperCase());
+
+    assert.deepEqual(Array.from(encoded), UUID_BYTES);
+
+    const reader = new Protocol({
+      read: function (length) {
+        assert.equal(length, 16);
+        return encoded;
+      },
+    });
+    assert.equal(reader.readUuid(), UUID);
+    assert.end();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
-        "uuid": "^14.0.0",
+        "uuid": "^11.1.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -3049,16 +3049,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "browser-or-node": "^1.2.1",
     "isomorphic-ws": "^4.0.1",
     "node-int64": "^0.4.0",
-    "uuid": "^14.0.0",
+    "uuid": "^11.1.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- constrain `uuid` to `^11.1.1`, its maintained `legacy-11` floor with both CommonJS and ESM conditional exports
- preserve the existing UUID parse/stringify and generated-code `v4` APIs
- add a behavioral CJS-only subprocess regression plus binary/compact UUID round trips

## Motivation

The Node.js runtime and generated CommonJS code load `uuid` with `require()`, but `uuid` 12 and newer are ESM-only. Consequently, `require("thrift")` fails in CommonJS tooling such as Jest before application tests execute.

The `11.1.1` floor is deliberate: it is the maintained `legacy-11` release, while the caret range remains within v11 and cannot resolve an ESM-only major. It should not be relaxed to an earlier 11.x release.

Downstream reproduction: https://github.com/databricks/databricks-sql-nodejs/issues/461

## Test plan

- `npm run lint-tests`
- `npx prettier --check lib/nodejs/test/uuid.test.js`
- `node lib/nodejs/test/binary.test.js`
- `node lib/nodejs/test/header.test.js`
- `node lib/nodejs/test/uuid.test.js` on Node 16 and Node 24; modern Node runs the load check with `require(esm)` explicitly disabled
- packed-tarball Jest smoke test on Node 20 and Node 24
- packed consumer production audit: 0 vulnerabilities

The broad `npm run lint` command remains red on existing legacy files on `master`; the changed test file and the complete Node.js test directory pass ESLint.

Generated-by: OpenAI Codex (GPT-5)
