### PR TITLE
THRIFT-6131: Bound Ruby HeaderTransport varint32 parsing

### DIFF
--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -89,6 +89,9 @@ module Thrift
     COMPACT_VERSION_MASK = 0x1f
     COMPACT_VERSION = 0x01
 
+    MAX_VARINT32_BYTES = 5
+    MAX_VARINT32_LAST_BYTE = 0x0f
+
     attr_reader :protocol_id, :sequence_id, :flags
 
     # Creates a new HeaderTransport wrapping the given transport.
@@ -500,11 +503,20 @@ module Thrift
         end
         byte = io.getbyte
         raise TransportException.new(TransportException::END_OF_FILE, "Unexpected EOF reading varint") if byte.nil?
+
+        if shift == (MAX_VARINT32_BYTES - 1) * 7
+          if (byte & 0x80) != 0
+            raise TransportException.new(TransportException::UNKNOWN, "Variable-length int over 5 bytes.")
+          end
+          if (byte & ~MAX_VARINT32_LAST_BYTE) != 0
+            raise TransportException.new(TransportException::UNKNOWN, "Variable-length int overflows uint32.")
+          end
+        end
+
         result |= (byte & 0x7f) << shift
-        break if (byte & 0x80) == 0
+        return result if (byte & 0x80) == 0
         shift += 7
       end
-      result
     end
 
     # Writes a varint32 to the given IO

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -320,6 +320,34 @@ describe 'HeaderTransport' do
         expect { read_trans.read(1) }.to raise_error(Thrift::TransportException, /header boundary/)
       end
 
+      it "should reject varints longer than uint32" do
+        header_data = "\x80".b * 65_532
+        frame = build_header_frame(header_data)
+        read_transport = Thrift::MemoryBufferTransport.new(frame)
+        read_trans = Thrift::HeaderTransport.new(read_transport)
+
+        expect { read_trans.read(1) }.to raise_error(Thrift::TransportException, /over 5 bytes/)
+      end
+
+      it "should reject uint32 varints with an overflowing fifth byte" do
+        header_data = ([0x80] * 4 + [0x10]).pack('C*')
+        frame = build_header_frame(header_data)
+        read_transport = Thrift::MemoryBufferTransport.new(frame)
+        read_trans = Thrift::HeaderTransport.new(read_transport)
+
+        expect { read_trans.read(1) }.to raise_error(Thrift::TransportException, /overflows uint32/)
+      end
+
+      it "should accept uint32 varints with a valid fifth byte" do
+        header_data = ([0x80] * 4 + [0x0f, 0]).pack('C*')
+        frame = build_header_frame(header_data)
+        read_transport = Thrift::MemoryBufferTransport.new(frame)
+        read_trans = Thrift::HeaderTransport.new(read_transport)
+
+        expect(read_trans.read(1)).to eq(Thrift::Bytes.empty_byte_buffer)
+        expect(read_trans.protocol_id).to eq(0xf0000000)
+      end
+
       it "should reject strings that exceed header boundary" do
         header_data = +""
         header_data << varint32(Thrift::HeaderSubprotocolID::BINARY)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby HeaderTransport previously continued parsing malformed variable-length uint32s until the Header boundary. It now limits the reader to five bytes, rejects fifth-byte overflow, and retains valid five-byte values. The regression coverage includes the boundary-sized continuation header, a fifth-byte overflow, and a valid fifth byte.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? ([THRIFT-6131](https://issues.apache.org/jira/browse/THRIFT-6131), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit? (not required, but preferred)
- [x] Did you do your best to avoid breaking changes? If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
