### PR TITLE
THRIFT-6132: Reset Ruby Header metadata between frames

### DIFF
--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -268,6 +268,8 @@ module Thrift
 
     # Reads the next frame, detecting client type on first read
     def read_frame(req_sz)
+      @read_headers = {}
+
       # Read first 4 bytes - could be frame length or protocol magic
       first_word = @transport.read_all(4)
       frame_size = first_word.unpack('N').first
@@ -370,7 +372,6 @@ module Thrift
         transforms << transform_id
       end
       # Read info headers
-      @read_headers = {}
       while buf.pos < end_of_headers
         info_type = read_varint32(buf, end_of_headers)
         if info_type == 0

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -48,6 +48,27 @@ describe 'HeaderTransport' do
   end
 
   describe Thrift::HeaderTransport do
+    def header_frame(payload, headers = {})
+      buffer = Thrift::MemoryBufferTransport.new
+      writer = Thrift::HeaderTransport.new(buffer)
+      headers.each { |key, value| writer.set_header(key, value) }
+      writer.write(payload)
+      writer.flush
+      buffer.read(buffer.available)
+    end
+
+    def binary_message
+      [Thrift::BinaryProtocol::VERSION_1 | Thrift::MessageTypes::CALL].pack('N')
+    end
+
+    def compact_message
+      [0x82, 0x21, 0, 0].pack('C*')
+    end
+
+    def framed(message)
+      [message.bytesize].pack('N') + message
+    end
+
     before(:each) do
       @underlying = Thrift::MemoryBufferTransport.new
       @trans = Thrift::HeaderTransport.new(@underlying)
@@ -257,6 +278,63 @@ describe 'HeaderTransport' do
         read_trans.read(7)
         headers = read_trans.get_headers
         expect(headers["request-id"]).to eq("12345")
+      end
+
+      {
+        "framed binary" => [:binary_message, true],
+        "unframed binary" => [:binary_message, false],
+        "framed compact" => [:compact_message, true],
+        "unframed compact" => [:compact_message, false]
+      }.each do |legacy_name, (legacy_message, is_framed)|
+        it "does not carry Header metadata through a #{legacy_name} protocol switch" do
+          legacy_payload = public_send(legacy_message)
+          bytes = header_frame("A", "request-id" => "first")
+          bytes << (is_framed ? framed(legacy_payload) : legacy_payload)
+          bytes << header_frame("B", "request-id" => "second")
+          read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(bytes))
+
+          expect(read_trans.read(1)).to eq("A")
+          expect(read_trans.get_headers).to eq("request-id" => "first")
+
+          read_trans.reset_protocol
+          expect(read_trans.read(4)).to eq(legacy_payload)
+          expect(read_trans.get_headers).to eq({})
+
+          read_trans.reset_protocol
+          expect(read_trans.read(1)).to eq("B")
+          expect(read_trans.get_headers).to eq("request-id" => "second")
+        end
+      end
+
+      it "keeps metadata empty across multiple legacy frames" do
+        bytes = header_frame("A", "request-id" => "first")
+        bytes << framed(binary_message)
+        bytes << framed(binary_message)
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(bytes))
+
+        expect(read_trans.read(1)).to eq("A")
+        expect(read_trans.get_headers).to eq("request-id" => "first")
+
+        2.times do
+          read_trans.reset_protocol
+          expect(read_trans.read(4)).to eq(binary_message)
+          expect(read_trans.get_headers).to eq({})
+        end
+      end
+
+      it "clears metadata before reporting a malformed following frame" do
+        malformed_frame = [4].pack('N') + "nope"
+        bytes = header_frame("A", "request-id" => "first") + malformed_frame
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(bytes))
+
+        expect(read_trans.read(1)).to eq("A")
+        expect(read_trans.get_headers).to eq("request-id" => "first")
+
+        expect { read_trans.reset_protocol }.to raise_error(
+          Thrift::TransportException,
+          "Could not detect client transport type"
+        )
+        expect(read_trans.get_headers).to eq({})
       end
 
       it "should decode signed sequence ids from Header frames" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby `HeaderTransport` currently preserves key-value headers from a Header frame when the same connection switches to a legacy framed or unframed Binary or Compact message. Applications can therefore observe metadata from an earlier request while processing a later message that did not carry it.

Reset read headers at the start of every frame parse, before protocol detection and validation. Legacy protocol switches and malformed following frames now expose an empty header map, while each later valid Header frame exposes only its own metadata.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6132](https://issues.apache.org/jira/browse/THRIFT-6132)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
