### PR TITLE
THRIFT-6133: Handle oversized Ruby memory-buffer reads

### DIFF
--- a/lib/rb/ext/memory_buffer.c
+++ b/lib/rb/ext/memory_buffer.c
@@ -48,28 +48,28 @@ VALUE rb_thrift_memory_buffer_write(VALUE self, VALUE str) {
 }
 
 VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value) {
-  int length = FIX2INT(length_value);
+  long long length = NUM2LL(length_value);
 
   if (RB_UNLIKELY(length < 0)) {
     rb_exc_raise(rb_funcall(transport_exception_class, new_method_id, 2, transport_negative_size, rb_str_new2("Negative size")));
   }
 
   VALUE index_value = rb_ivar_get(self, index_ivar_id);
-  int index = FIX2INT(index_value);
+  long index = NUM2LONG(index_value);
 
   VALUE buf = GET_BUF(self);
   VALUE data = rb_funcall(buf, slice_method_id, 2, index_value, length_value);
 
   if (length > RSTRING_LEN(buf) - index) {
-    index = (int)RSTRING_LEN(buf);
+    index = RSTRING_LEN(buf);
   } else {
-    index += length;
+    index += (long)length;
   }
   if (index >= GARBAGE_BUFFER_SIZE) {
-    rb_ivar_set(self, buf_ivar_id, rb_funcall(buf, slice_method_id, 2, INT2FIX(index), INT2FIX(RSTRING_LEN(buf) - 1)));
+    rb_ivar_set(self, buf_ivar_id, rb_funcall(buf, slice_method_id, 2, LONG2NUM(index), LONG2NUM(RSTRING_LEN(buf) - 1)));
     index = 0;
   }
-  rb_ivar_set(self, index_ivar_id, INT2FIX(index));
+  rb_ivar_set(self, index_ivar_id, LONG2NUM(index));
 
   if (RSTRING_LEN(data) < length) {
     rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
@@ -79,28 +79,28 @@ VALUE rb_thrift_memory_buffer_read(VALUE self, VALUE length_value) {
 }
 
 VALUE rb_thrift_memory_buffer_read_all(VALUE self, VALUE length_value) {
-  int length = FIX2INT(length_value);
+  long long length = NUM2LL(length_value);
 
   if (RB_UNLIKELY(length < 0)) {
     rb_exc_raise(rb_funcall(transport_exception_class, new_method_id, 2, transport_negative_size, rb_str_new2("Negative size")));
   }
 
   VALUE index_value = rb_ivar_get(self, index_ivar_id);
-  int index = FIX2INT(index_value);
+  long index = NUM2LONG(index_value);
   VALUE buf = GET_BUF(self);
 
   if (RB_UNLIKELY(length > RSTRING_LEN(buf) - index)) {
     rb_raise(rb_eEOFError, "Not enough bytes remain in memory buffer");
   }
 
-  VALUE data = rb_str_subseq(buf, index, length);
+  VALUE data = rb_str_subseq(buf, index, (long)length);
 
-  index += length;
+  index += (long)length;
   if (index >= GARBAGE_BUFFER_SIZE) {
     rb_ivar_set(self, buf_ivar_id, rb_str_subseq(buf, index, RSTRING_LEN(buf) - index));
     index = 0;
   }
-  rb_ivar_set(self, index_ivar_id, INT2FIX(index));
+  rb_ivar_set(self, index_ivar_id, LONG2NUM(index));
 
   return data;
 }

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -394,7 +394,7 @@ describe 'BaseTransport' do
       @buffer.reset_buffer("abcd")
 
       expect(@buffer.read(1)).to eq("a")
-      expect { @buffer.read((2**31) - 1) }.to raise_error(EOFError)
+      expect { @buffer.read(2**31) }.to raise_error(EOFError)
       expect(@buffer.available).to eq(0)
     end
 
@@ -464,6 +464,12 @@ describe 'BaseTransport' do
       expect { @buffer.read_all(-1) }.to raise_error(Thrift::TransportException, "Negative size") do |e|
         expect(e.type).to eq(Thrift::TransportException::NEGATIVE_SIZE)
       end
+    end
+
+    it "should handle oversized read_all sizes without overflowing" do
+      @buffer.reset_buffer("x")
+
+      expect { @buffer.read_all(3_397_380_576) }.to raise_error(EOFError)
     end
   end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Native `MemoryBufferTransport` converted read sizes to a signed C integer before checking the bytes available. Positive Compact lengths above `INT_MAX` therefore raised `RangeError` instead of reporting truncated input.

The native implementation now preserves the requested Compact length through the availability check and returns `EOFError` for truncated oversized `read` and `read_all` calls, matching pure Ruby behavior.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([THRIFT-6133](https://issues.apache.org/jira/browse/THRIFT-6133))
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
