### PR TITLE
THRIFT-6137: Reject incomplete Ruby HeaderTransport frames

### DIFF
--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -268,7 +268,11 @@ module Thrift
       @read_headers = {}
 
       # Read first 4 bytes - could be frame length or protocol magic
-      first_word = @transport.read_all(4)
+      begin
+        first_word = @transport.read_all(4)
+      rescue EOFError
+        raise TransportException.new(TransportException::END_OF_FILE, "Unexpected EOF reading frame size")
+      end
       frame_size = first_word.unpack('N').first
 
       # Check for unframed binary protocol
@@ -292,9 +296,16 @@ module Thrift
       if frame_size > @max_frame_size
         raise TransportException.new(TransportException::UNKNOWN, "Frame size #{frame_size} exceeds maximum #{@max_frame_size}")
       end
+      if frame_size < 4
+        raise TransportException.new(TransportException::UNKNOWN, "Frame size #{frame_size} is too small")
+      end
 
       # Read the complete frame
-      frame_data = @transport.read_all(frame_size)
+      begin
+        frame_data = @transport.read_all(frame_size)
+      rescue EOFError
+        raise TransportException.new(TransportException::END_OF_FILE, "Unexpected EOF reading frame")
+      end
       frame_buf = StringIO.new(frame_data)
 
       # Check the second word for protocol type

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -393,6 +393,54 @@ describe 'HeaderTransport' do
     end
 
     describe "header parsing protections" do
+      it "rejects frame sizes shorter than a protocol signature" do
+        (0..3).each do |frame_size|
+          frame = [frame_size].pack('N') + ("\x00" * frame_size)
+          read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame))
+
+          expect { read_trans.read(1) }.to raise_error(
+            Thrift::TransportException,
+            "Frame size #{frame_size} is too small"
+          ) do |error|
+            expect(error.type).to eq(Thrift::TransportException::UNKNOWN)
+          end
+        end
+      end
+
+      it "reports EOF when the frame size is fragmented" do
+        (0..3).each do |available_size|
+          read_trans = Thrift::HeaderTransport.new(
+            Thrift::MemoryBufferTransport.new("\x00" * available_size)
+          )
+
+          expect { read_trans.read(1) }.to raise_error(
+            Thrift::TransportException,
+            "Unexpected EOF reading frame size"
+          ) do |error|
+            expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+          end
+        end
+      end
+
+      it "reports EOF when the declared frame is fragmented" do
+        frame = [4].pack('N') + "\x80\x01\x00".b
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame))
+
+        expect { read_trans.read(1) }.to raise_error(
+          Thrift::TransportException,
+          "Unexpected EOF reading frame"
+        ) do |error|
+          expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+        end
+      end
+
+      it "accepts a four-byte framed binary protocol signature" do
+        payload = [Thrift::BinaryProtocol::VERSION_1 | Thrift::MessageTypes::CALL].pack('N')
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new([payload.bytesize].pack('N') + payload))
+
+        expect(read_trans.read(payload.bytesize)).to eq(payload)
+      end
+
       it "should reject unreasonable header sizes" do
         frame = build_header_frame("", Thrift::Bytes.empty_byte_buffer, header_words: 16_384)
         read_transport = Thrift::MemoryBufferTransport.new(frame)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby HeaderTransport requires a four-byte protocol signature to distinguish framed Binary, Compact, and Header clients. A frame declaring a shorter payload could reach fixed-width decoding without enough data, producing a raw Ruby exception instead of a typed Thrift transport failure. Premature EOF while reading an in-memory frame could similarly leak the underlying EOF exception.

This change rejects undersized declared frames before decoding and distinguishes them from genuinely truncated input. Complete short frames now receive a typed malformed-frame error, while incomplete frame-size prefixes and payloads are reported as typed end-of-file transport errors. Valid four-byte protocol signatures and larger frames retain their existing behavior.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6137](https://issues.apache.org/jira/browse/THRIFT-6137)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
