### PR TITLE
THRIFT-6138: Give Ruby memory buffers private ownership

### DIFF
--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -23,13 +23,9 @@ module Thrift
   class MemoryBufferTransport < BaseTransport
     GARBAGE_BUFFER_SIZE = 4*(2**10) # 4kB
 
-    # If you pass a string to this, you should #dup that string
-    # unless you want it to be modified by #read and #write
-    #--
-    # this behavior is no longer required. If you wish to change it
-    # go ahead, just make sure the specs pass
+    # The transport copies the input buffer and keeps its own mutable storage.
     def initialize(buffer = nil)
-      @buf = buffer ? Bytes.force_binary_encoding(buffer) : Bytes.empty_byte_buffer
+      @buf = buffer ? Bytes.force_binary_encoding(buffer.dup) : Bytes.empty_byte_buffer
       @index = 0
     end
 

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -305,12 +305,26 @@ describe 'BaseTransport' do
       expect(@buffer.to_s).to eq("memory")
     end
 
-    it "should accept a buffer on input and use it directly" do
-      s = +"this is a test"
-      @buffer = Thrift::MemoryBufferTransport.new(s)
-      expect(@buffer.read(4)).to eq("this")
-      s.slice!(-4..-1)
-      expect(@buffer.read(@buffer.available)).to eq(" is a ")
+    it "should privately own a buffer passed on input" do
+      source = +"this is a test"
+      @buffer = Thrift::MemoryBufferTransport.new(source)
+
+      expect(source.encoding).to eq(Encoding::UTF_8)
+      source.replace("caller changed")
+      @buffer.write("!")
+
+      expect(source).to eq("caller changed")
+      expect(@buffer.read(@buffer.available)).to eq("this is a test!".b)
+    end
+
+    it "should allow writes and resets after receiving a frozen buffer" do
+      @buffer = Thrift::MemoryBufferTransport.new("abc".b.freeze)
+
+      @buffer.write("d")
+      expect(@buffer.read(4)).to eq("abcd")
+
+      @buffer.reset_buffer("xy")
+      expect(@buffer.read(2)).to eq("xy")
     end
 
     it "should always remain open" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby `MemoryBufferTransport` currently retains a caller-supplied string as its internal storage. Mutating either object can therefore unexpectedly alter the other, frozen input can fail during later writes or resets, and construction can change the caller's string encoding.

This change duplicates constructor input before normalizing it to binary encoding. The transport consequently owns a private mutable buffer: caller mutations no longer change unread bytes, transport operations no longer modify the caller's string, and frozen input remains usable.

This deliberately removes the historical shared-buffer behavior. Callers that intentionally treated the original string as a live view of the transport will instead need to read from the transport.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6138](https://issues.apache.org/jira/browse/THRIFT-6138)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
