### PR TITLE
THRIFT-6141: Adapt invalid Ruby Header ZLIB payloads

### DIFF
--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -431,6 +431,8 @@ module Thrift
         inflater.inflate(compressed, &append_chunk)
         inflater.finish(&append_chunk)
         buffer
+      rescue Zlib::DataError, Zlib::BufError
+        raise TransportException.new(TransportException::UNKNOWN, "Invalid ZLIB payload")
       ensure
         inflater.close rescue nil
       end

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -206,6 +206,28 @@ describe 'HeaderTransport' do
         expect(read_trans.read(1_000)).to eq("A" * 1_000)
       end
 
+      {
+        "invalid" => "not-zlib",
+        "truncated" => Zlib::Deflate.deflate("valid payload")[0...-1]
+      }.each do |failure_type, payload|
+        it "adapts #{failure_type} ZLIB payloads to the transport exception boundary" do
+          header_data = [
+            Thrift::HeaderSubprotocolID::BINARY,
+            1,
+            Thrift::HeaderTransformID::ZLIB
+          ].pack('C*')
+          frame = build_header_frame(header_data, payload)
+          read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame))
+
+          expect { read_trans.read(1) }.to raise_error(
+            Thrift::TransportException,
+            "Invalid ZLIB payload"
+          ) do |error|
+            expect(error.type).to eq(Thrift::TransportException::UNKNOWN)
+          end
+        end
+      end
+
       it "should raise SIZE_LIMIT TransportException when decompressed output exceeds the limit" do
         write_buf = Thrift::MemoryBufferTransport.new
         writer = Thrift::HeaderTransport.new(write_buf)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Ruby HeaderTransport exposed `Zlib::DataError` and `Zlib::BufError` when a Header frame contained invalid or truncated ZLIB data. Those implementation-specific errors bypassed the transport exception contract expected by callers.

This change adapts only those decompression failures to `TransportException::UNKNOWN`. Valid compressed frames retain their existing behavior, and decompressed output exceeding the configured limit continues to raise `TransportException::SIZE_LIMIT`.

## Benchmarks

Ruby 4.0.6, pure-Ruby implementation, 64 KiB valid compressed frames, 2,500 reads per trial, seven trials:

```sh
ruby -Ilib -rthrift -rzlib -e 'payload = "A" * 65536; buffer = Thrift::MemoryBufferTransport.new; writer = Thrift::HeaderTransport.new(buffer); writer.add_transform(Thrift::HeaderTransformID::ZLIB); writer.write(payload); writer.flush; frame = buffer.read(buffer.available); iterations = 2500; times = 7.times.map do; GC.start; started = Process.clock_gettime(Process::CLOCK_MONOTONIC); iterations.times do; reader = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame.dup)); raise "mismatch" unless reader.read(payload.bytesize) == payload; end; Process.clock_gettime(Process::CLOCK_MONOTONIC) - started; end; sorted = times.sort; puts sorted[times.length / 2]'
```

| Revision | Median |
| --- | ---: |
| master `a9663bc6661a5dd1d99d629e1f269c1907592a1a` | 0.516872 s |
| this change | 0.500563 s (-3.15%) |

The microbenchmark includes transport allocation and payload comparison, so small deltas should be treated as noise. It shows no regression in valid ZLIB frame reads.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/browse/THRIFT-6141) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
