### PR TITLE
THRIFT-6142: Enforce Ruby unframed HeaderTransport limits

### DIFF
--- a/lib/rb/ext/binary_protocol_accelerated.c
+++ b/lib/rb/ext/binary_protocol_accelerated.c
@@ -422,6 +422,10 @@ VALUE rb_thrift_binary_proto_read_message_begin(VALUE self) {
   VALUE name, seqid;
   int type;
 
+  if (RTEST(rb_ivar_get(self, reset_message_size_ivar_id))) {
+    rb_funcall(GET_TRANSPORT(self), reset_message_size_method_id, 0);
+  }
+
   int version = read_i32_direct(self);
 
   if (version < 0) {

--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -515,6 +515,10 @@ VALUE rb_thrift_compact_proto_read_set_end(VALUE self) {
 }
 
 VALUE rb_thrift_compact_proto_read_message_begin(VALUE self) {
+  if (RTEST(rb_ivar_get(self, reset_message_size_ivar_id))) {
+    rb_funcall(GET_TRANSPORT(self), reset_message_size_method_id, 0);
+  }
+
   int8_t protocol_id = read_byte_direct(self);
   if (protocol_id != PROTOCOL_ID) {
     char buf[100];

--- a/lib/rb/ext/constants.h
+++ b/lib/rb/ext/constants.h
@@ -77,12 +77,14 @@ extern ID skip_method_id;
 extern ID write_method_id;
 extern ID read_all_method_id;
 extern ID read_into_buffer_method_id;
+extern ID reset_message_size_method_id;
 extern ID force_binary_encoding_id;
 extern ID convert_to_utf8_byte_buffer_id;
 extern ID convert_to_string_id;
 
 extern ID fields_const_id;
 extern ID transport_ivar_id;
+extern ID reset_message_size_ivar_id;
 extern ID strict_read_ivar_id;
 extern ID strict_write_ivar_id;
 

--- a/lib/rb/ext/thrift_native.c
+++ b/lib/rb/ext/thrift_native.c
@@ -92,6 +92,7 @@ ID skip_method_id;
 ID write_method_id;
 ID read_all_method_id;
 ID read_into_buffer_method_id;
+ID reset_message_size_method_id;
 ID force_binary_encoding_id;
 ID convert_to_utf8_byte_buffer_id;
 ID convert_to_string_id;
@@ -99,6 +100,7 @@ ID convert_to_string_id;
 // constant ids
 ID fields_const_id;
 ID transport_ivar_id;
+ID reset_message_size_ivar_id;
 ID strict_read_ivar_id;
 ID strict_write_ivar_id;
 
@@ -200,6 +202,7 @@ RUBY_FUNC_EXPORTED void Init_thrift_native(void) {
   write_method_id = rb_intern("write");
   read_all_method_id = rb_intern("read_all");
   read_into_buffer_method_id = rb_intern("read_into_buffer");
+  reset_message_size_method_id = rb_intern("reset_message_size");
   force_binary_encoding_id = rb_intern("force_binary_encoding");
   convert_to_utf8_byte_buffer_id = rb_intern("convert_to_utf8_byte_buffer");
   convert_to_string_id = rb_intern("convert_to_string");
@@ -207,6 +210,7 @@ RUBY_FUNC_EXPORTED void Init_thrift_native(void) {
   // constant ids
   fields_const_id = rb_intern("FIELDS");
   transport_ivar_id = rb_intern("@trans");
+  reset_message_size_ivar_id = rb_intern("@reset_message_size");
   strict_read_ivar_id = rb_intern("@strict_read");
   strict_write_ivar_id = rb_intern("@strict_write");
 

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -36,6 +36,7 @@ module Thrift
 
     def initialize(trans, strict_read = true, strict_write = true)
       super(trans)
+      @reset_message_size = trans.message_boundaries?
       @strict_read = strict_read
       @strict_write = strict_write
 
@@ -142,6 +143,8 @@ module Thrift
     end
 
     def read_message_begin
+      trans.reset_message_size if @reset_message_size
+
       version = read_i32
       if version < 0
         if (version & VERSION_MASK != VERSION_1)

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -110,6 +110,7 @@ module Thrift
 
     def initialize(transport)
       super(transport)
+      @reset_message_size = transport.message_boundaries?
 
       @last_field = [0]
       @boolean_value = nil
@@ -241,6 +242,8 @@ module Thrift
     end
 
     def read_message_begin
+      trans.reset_message_size if @reset_message_size
+
       protocol_id = read_byte()
       if protocol_id != PROTOCOL_ID
         raise ProtocolException.new(

--- a/lib/rb/lib/thrift/transport/base_transport.rb
+++ b/lib/rb/lib/thrift/transport/base_transport.rb
@@ -56,6 +56,11 @@ module Thrift
 
     def close; end
 
+    # Returns true when the transport needs protocol message boundary notifications.
+    def message_boundaries?
+      false
+    end
+
     # Reads a number of bytes from the transports. The String returned will have a BINARY (aka ASCII-8BIT) encoding.
     #
     # sz - The number of bytes to read from the transport.

--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -120,6 +120,7 @@ module Thrift
       @flags = 0
       @max_frame_size = MAX_FRAME_SIZE
       @max_decompressed_size = DEFAULT_MAX_DECOMPRESSED_SIZE
+      @unframed_bytes_read = 0
     end
 
     def sequence_id=(sequence_id)
@@ -207,7 +208,7 @@ module Thrift
       # Handle unframed passthrough - read directly from underlying transport
       if @client_type == HeaderClientType::UNFRAMED_BINARY ||
          @client_type == HeaderClientType::UNFRAMED_COMPACT
-        return data + @transport.read(bytes_left)
+        return data + read_unframed(bytes_left)
       end
 
       # Need to read the next frame
@@ -253,6 +254,17 @@ module Thrift
       read_frame(0)
     end
 
+    def message_boundaries?
+      true
+    end
+
+    # Starts a new protocol message without forcing client-type detection.
+    def reset_message_size
+      return unless @read_buffer.nil? || @read_buffer.eof?
+
+      @unframed_bytes_read = 0
+    end
+
     private
 
     # Sets the client type after validation
@@ -266,6 +278,7 @@ module Thrift
     # Reads the next frame, detecting client type on first read
     def read_frame(req_sz)
       @read_headers = {}
+      @unframed_bytes_read = 0
 
       # Read first 4 bytes - could be frame length or protocol magic
       begin
@@ -336,13 +349,32 @@ module Thrift
 
     # Handles unframed protocol - puts first_word back in buffer
     def handle_unframed(first_word, req_sz)
+      @unframed_bytes_read = first_word.bytesize
+      raise_unframed_size_limit if @unframed_bytes_read > @max_frame_size
+
       bytes_left = req_sz - 4
-      if bytes_left > 0
-        rest = @transport.read(bytes_left)
+      if bytes_left > 0 && @unframed_bytes_read < @max_frame_size
+        rest = read_unframed(bytes_left)
         @read_buffer = StringIO.new(first_word + rest)
       else
         @read_buffer = StringIO.new(first_word)
       end
+    end
+
+    def read_unframed(size)
+      remaining = @max_frame_size - @unframed_bytes_read
+      raise_unframed_size_limit if remaining <= 0
+
+      data = @transport.read([size, remaining].min)
+      @unframed_bytes_read += data.bytesize
+      data
+    end
+
+    def raise_unframed_size_limit
+      raise TransportException.new(
+        TransportException::SIZE_LIMIT,
+        "Unframed message size exceeds maximum #{@max_frame_size}"
+      )
     end
 
     # Parses a Header format frame

--- a/lib/rb/spec/binary_protocol_accelerated_spec.rb
+++ b/lib/rb/spec/binary_protocol_accelerated_spec.rb
@@ -34,7 +34,8 @@ if defined? Thrift::BinaryProtocolAccelerated
 
     describe Thrift::BinaryProtocolAcceleratedFactory do
       it "should create a BinaryProtocolAccelerated" do
-        expect(Thrift::BinaryProtocolAcceleratedFactory.new.get_protocol(double("MockTransport"))).to be_instance_of(Thrift::BinaryProtocolAccelerated)
+        transport = Thrift::MemoryBufferTransport.new
+        expect(Thrift::BinaryProtocolAcceleratedFactory.new.get_protocol(transport)).to be_instance_of(Thrift::BinaryProtocolAccelerated)
       end
 
       it "should provide a reasonable to_s" do

--- a/lib/rb/spec/binary_protocol_spec.rb
+++ b/lib/rb/spec/binary_protocol_spec.rb
@@ -63,7 +63,8 @@ describe 'BinaryProtocol' do
 
   describe Thrift::BinaryProtocolFactory do
     it "should create a BinaryProtocol" do
-      expect(Thrift::BinaryProtocolFactory.new.get_protocol(double("MockTransport"))).to be_instance_of(Thrift::BinaryProtocol)
+      transport = Thrift::MemoryBufferTransport.new
+      expect(Thrift::BinaryProtocolFactory.new.get_protocol(transport)).to be_instance_of(Thrift::BinaryProtocol)
     end
 
     it "should provide a reasonable to_s" do

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -395,7 +395,8 @@ end
 
 describe Thrift::CompactProtocolFactory do
   it "should create a CompactProtocol" do
-    expect(Thrift::CompactProtocolFactory.new.get_protocol(double("MockTransport"))).to be_instance_of(Thrift::CompactProtocol)
+    transport = Thrift::MemoryBufferTransport.new
+    expect(Thrift::CompactProtocolFactory.new.get_protocol(transport)).to be_instance_of(Thrift::CompactProtocol)
   end
 
   it "should provide a reasonable to_s" do

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -69,6 +69,24 @@ describe 'HeaderTransport' do
       [message.bytesize].pack('N') + message
     end
 
+    def unframed_message(protocol_class, name = "legacy_unframed")
+      buffer = Thrift::MemoryBufferTransport.new
+      protocol = protocol_class.new(buffer)
+      protocol.write_message_begin(name, Thrift::MessageTypes::CALL, 1)
+      protocol.write_struct_begin("Args")
+      protocol.write_field_stop
+      protocol.write_struct_end
+      protocol.write_message_end
+      buffer.read(buffer.available)
+    end
+
+    def read_unframed_message(protocol)
+      name = protocol.read_message_begin.first
+      protocol.skip(Thrift::Types::STRUCT)
+      protocol.read_message_end
+      name
+    end
+
     before(:each) do
       @underlying = Thrift::MemoryBufferTransport.new
       @trans = Thrift::HeaderTransport.new(@underlying)
@@ -177,6 +195,117 @@ describe 'HeaderTransport' do
         @trans.set_max_frame_size(4)
         @trans.write("12345")
         expect { @trans.flush }.to raise_error(Thrift::TransportException, /frame that is too large/)
+      end
+
+      {
+        "binary" => Thrift::BinaryProtocol,
+        "compact" => Thrift::CompactProtocol
+      }.each do |protocol_name, protocol_class|
+        it "enforces max frame size for unframed #{protocol_name} messages" do
+          payload = unframed_message(protocol_class)
+
+          exact_limit = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(payload))
+          exact_limit.set_max_frame_size(payload.bytesize)
+          expect(read_unframed_message(Thrift::HeaderProtocol.new(exact_limit))).to eq("legacy_unframed")
+
+          over_limit = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(payload))
+          over_limit.set_max_frame_size(payload.bytesize - 1)
+          protocol = Thrift::HeaderProtocol.new(over_limit)
+          expect { read_unframed_message(protocol) }.to raise_error(
+            Thrift::TransportException,
+            "Unframed message size exceeds maximum #{payload.bytesize - 1}"
+          ) do |error|
+            expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
+          end
+        end
+      end
+
+      it "rejects an unframed protocol signature larger than the configured limit" do
+        payload = unframed_message(Thrift::BinaryProtocol)
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(payload))
+        read_trans.set_max_frame_size(3)
+
+        expect { read_trans.read(1) }.to raise_error(
+          Thrift::TransportException,
+          "Unframed message size exceeds maximum 3"
+        ) do |error|
+          expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
+        end
+      end
+
+      it "counts bytes actually returned by partial unframed reads" do
+        payload = unframed_message(Thrift::BinaryProtocol)
+        chunked_transport = Class.new(Thrift::BaseTransport) do
+          def initialize(data)
+            @data = data.dup
+          end
+
+          def read(size)
+            @data.slice!(0, [size, 2].min)
+          end
+        end
+        read_trans = Thrift::HeaderTransport.new(chunked_transport.new(payload))
+        read_trans.set_max_frame_size(payload.bytesize)
+
+        expect(read_unframed_message(Thrift::HeaderProtocol.new(read_trans))).to eq("legacy_unframed")
+      end
+
+      it "returns partial unframed data up to the configured limit" do
+        payload = unframed_message(Thrift::BinaryProtocol)
+        chunked_transport = Class.new(Thrift::BaseTransport) do
+          def initialize(data)
+            @data = data.dup
+          end
+
+          def read(size)
+            @data.slice!(0, [size, 1].min)
+          end
+        end
+        read_trans = Thrift::HeaderTransport.new(chunked_transport.new(payload))
+        read_trans.set_max_frame_size(5)
+
+        expect(read_trans.read(payload.bytesize)).to eq(payload.byteslice(0, 5))
+        expect { read_trans.read(1) }.to raise_error(Thrift::TransportException) do |error|
+          expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
+        end
+      end
+
+      it "returns the unframed protocol signature at the configured limit" do
+        payload = unframed_message(Thrift::BinaryProtocol)
+        read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(payload))
+        read_trans.set_max_frame_size(4)
+
+        expect(read_trans.read(payload.bytesize)).to eq(payload.byteslice(0, 4))
+        expect { read_trans.read(1) }.to raise_error(Thrift::TransportException) do |error|
+          expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
+        end
+      end
+
+      protocol_pairs = {
+        "binary" => [Thrift::BinaryProtocol, Thrift::BinaryProtocol],
+        "compact" => [Thrift::CompactProtocol, Thrift::CompactProtocol]
+      }
+      if defined?(Thrift::BinaryProtocolAccelerated)
+        protocol_pairs["accelerated binary"] = [
+          Thrift::BinaryProtocol,
+          Thrift::BinaryProtocolAccelerated
+        ]
+      end
+
+      protocol_pairs.each do |protocol_name, (writer_class, reader_class)|
+        it "resets the unframed size budget between #{protocol_name} messages" do
+          first = unframed_message(writer_class, "first")
+          second = unframed_message(writer_class, "second")
+          read_trans = Thrift::HeaderTransport.new(
+            Thrift::MemoryBufferTransport.new(first + second)
+          )
+          read_trans.set_max_frame_size([first.bytesize, second.bytesize].max)
+          expect(read_trans).to receive(:message_boundaries?).once.and_return(true)
+          protocol = reader_class.new(read_trans)
+
+          expect(read_unframed_message(protocol)).to eq("first")
+          expect(read_unframed_message(protocol)).to eq("second")
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
Ruby HeaderTransport enforced `max_frame_size` for Header and framed clients but passed unframed Binary and Compact reads directly to the underlying transport without applying the configured limit.

This change counts bytes consumed by each unframed protocol message, including the initial protocol signature. Reads are capped at the remaining budget, so partial reads and exact-limit messages remain supported; a later read after the budget is exhausted raises `TransportException::SIZE_LIMIT`.

Binary and Compact protocols query `BaseTransport#message_boundaries?` once during construction and cache the result. The base transport returns `false`, while HeaderTransport returns `true`, so pure-Ruby and native readers notify HeaderTransport when sequential messages need independent budgets. The normal read path performs one cached boolean check without repeated method lookup, runtime class changes, or per-instance extensions; native readers resolve the transport only inside the enabled branch.

## Benchmarks

I compared the commit before this PR (`a9663bc`) with the current commit (`1fff4ca`) on Ruby 4.0.6 for aarch64 Linux. The benchmark reads 100,000 minimal message envelopes; each result is the median of 21 warmed trials, with payload construction outside the timed section.

| Mode | Reader | Before | After | Change |
| --- | --- | ---: | ---: | ---: |
| Native extension loaded | Binary (Ruby reader) | 984 ns/message | 986 ns/message | +0.3% |
| Native extension loaded | Compact | 645 ns/message | 675 ns/message | +4.7% |
| Native extension loaded | Accelerated Binary | 531 ns/message | 548 ns/message | +3.2% |
| Native extension loaded | Header / Binary | 6,395 ns/message | 6,512 ns/message | +1.8% |
| Native extension loaded | Header / Compact | 5,954 ns/message | 6,113 ns/message | +2.7% |
| Pure Ruby | Binary | 2,574 ns/message | 2,561 ns/message | -0.5% |
| Pure Ruby | Compact | 1,983 ns/message | 1,978 ns/message | -0.2% |
| Pure Ruby | Header / Binary | 6,729 ns/message | 6,765 ns/message | +0.5% |
| Pure Ruby | Header / Compact | 6,959 ns/message | 7,062 ns/message | +1.5% |

On this deliberately small workload, the measurable direct-protocol cost is about 17 ns per message for accelerated Binary and 30 ns per message for native Compact. The pure-Ruby direct readers were within run-to-run noise. Normal RPCs also perform field decoding, transport I/O, and application work, so this benchmark emphasizes the fixed per-message cost.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/browse/THRIFT-6142) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
