### PR TITLE
THRIFT-6144: Report EOF when Ruby transport reads make no progress

### DIFF
--- a/lib/rb/lib/thrift/transport/base_transport.rb
+++ b/lib/rb/lib/thrift/transport/base_transport.rb
@@ -90,10 +90,23 @@ module Thrift
     def read_all(size)
       raise TransportException.new(TransportException::NEGATIVE_SIZE, 'Negative size') unless size >= 0
       return Bytes.empty_byte_buffer if size == 0
-      buf = Bytes.force_binary_encoding(read(size))
+
+      buf = read(size)
+      if buf.nil? || buf.empty?
+        raise TransportException.new(TransportException::END_OF_FILE, 'No more data available')
+      end
+
+      buf = Bytes.force_binary_encoding(buf)
+      return buf if buf.length >= size
+
+      buf = buf.dup if buf.frozen?
       while (buf.length < size)
         chunk = read(size - buf.length)
-        buf << chunk
+        if chunk.nil? || chunk.empty?
+          raise TransportException.new(TransportException::END_OF_FILE, 'No more data available')
+        end
+
+        buf << Bytes.force_binary_encoding(chunk)
       end
 
       buf

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -48,6 +48,62 @@ describe 'BaseTransport' do
       expect(buf.encoding).to eq(Encoding::BINARY)
     end
 
+    it "treats an empty initial read as end of file without retrying" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).to receive(:read).with(3).once.and_return(+'')
+
+      expect { transport.read_all(3) }.to raise_error(Thrift::TransportException, "No more data available") do |error|
+        expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+      end
+    end
+
+    it "treats an empty read after partial progress as end of file without retrying" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).to receive(:read).with(4).ordered.and_return(+'ab')
+      expect(transport).to receive(:read).with(2).ordered.once.and_return(+'')
+
+      expect { transport.read_all(4) }.to raise_error(Thrift::TransportException, "No more data available") do |error|
+        expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+      end
+    end
+
+    it "treats a nil read as end of file" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).to receive(:read).with(1).once.and_return(nil)
+
+      expect { transport.read_all(1) }.to raise_error(Thrift::TransportException, "No more data available") do |error|
+        expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+      end
+    end
+
+    it "allows repeated short reads while every read makes progress" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).to receive(:read).with(4).ordered.and_return('a')
+      expect(transport).to receive(:read).with(3).ordered.and_return('b')
+      expect(transport).to receive(:read).with(2).ordered.and_return('c')
+      expect(transport).to receive(:read).with(1).ordered.and_return('d')
+
+      expect(transport.read_all(4)).to eq('abcd')
+    end
+
+    it "allows a frozen binary string as the first short read" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).to receive(:read).with(4).ordered.and_return('ab'.b.freeze)
+      expect(transport).to receive(:read).with(2).ordered.and_return('cd')
+
+      expect(transport.read_all(4)).to eq('abcd')
+    end
+
+    it "returns an empty binary string for a zero-size read without reading" do
+      transport = Thrift::BaseTransport.new
+      expect(transport).not_to receive(:read)
+
+      result = transport.read_all(0)
+
+      expect(result).to eq('')
+      expect(result.encoding).to eq(Encoding::BINARY)
+    end
+
     it "should reject negative read sizes" do
       transport = Thrift::BaseTransport.new
       expect(transport).not_to receive(:read)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby transports may report end of input by returning `nil` or an empty string. `BaseTransport#read_all` currently leaks a Ruby `NoMethodError` for `nil`, while an empty result causes it to retry forever without making progress.

This change treats either result as `TransportException::END_OF_FILE` when bytes are still required. Partial reads continue normally while each call makes progress, and zero-size reads still return an empty binary string without invoking the underlying transport.

The common path returns a complete first chunk directly. A short frozen chunk is copied only when it must become the accumulator for subsequent reads.

## Benchmarks

The common exact-read path was measured in the dedicated Ruby container using Ruby 4.0.6 on aarch64 Linux. A temporary stdlib benchmark used a `BaseTransport` whose `read` method returned a frozen eight-byte binary string, with 1,000,000 warmup calls followed by seven trials of 5,000,000 calls:

`bundle exec ruby -Ilib /tmp/rb-read-all-benchmark.rb`

- Master `c2def39207a73394420088da9b4b105571dd9036`: median 6,406,402 operations/second
- Proposed change: median 5,902,949 operations/second
- Difference: −7.9%

This deliberately removes all underlying I/O and therefore magnifies the cost of the EOF and progress checks. Network, file, and layered transports should spend most of their time in the underlying read. Returning a complete first chunk directly avoids the allocation and copy that an intermediate accumulator would otherwise add.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6144](https://issues.apache.org/jira/browse/THRIFT-6144)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
