### PR TITLE
THRIFT-6146: Validate Ruby processor message types

### DIFF
--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -34,6 +34,17 @@ module Thrift
 
     def process(iprot, oprot)
       name, type, seqid = iprot.read_message_begin
+      unless type == MessageTypes::CALL || type == MessageTypes::ONEWAY
+        iprot.skip(Types::STRUCT)
+        iprot.read_message_end
+        x = ApplicationException.new(
+          ApplicationException::INVALID_MESSAGE_TYPE,
+          "Invalid message type #{type} for function #{name}"
+        )
+        write_error(x, oprot, name, seqid)
+        return false
+      end
+
       if respond_to?("process_#{name}")
         begin
           send("process_#{name}", seqid, iprot, oprot)

--- a/lib/rb/spec/processor_spec.rb
+++ b/lib/rb/spec/processor_spec.rb
@@ -23,6 +23,14 @@ require 'spec_helper'
 describe 'Processor' do
   class ProcessorSpec
     include Thrift::Processor
+
+    attr_reader :processed
+
+    def process_work(seqid, iprot, _oprot)
+      iprot.skip(Thrift::Types::STRUCT)
+      iprot.read_message_end
+      @processed = seqid
+    end
   end
 
   describe Thrift::Processor do
@@ -39,10 +47,91 @@ describe 'Processor' do
       end
     end
 
+    def input_protocol(name, type, seqid, args = nil)
+      transport = Thrift::MemoryBufferTransport.new
+      protocol = Thrift::BinaryProtocol.new(transport)
+      protocol.write_message_begin(name, type, seqid)
+      if args
+        args.write(protocol)
+      else
+        protocol.write_struct_begin("args")
+        protocol.write_field_stop
+        protocol.write_struct_end
+      end
+      protocol.write_message_end
+      Thrift::BinaryProtocol.new(transport)
+    end
+
+    def output_protocol
+      transport = Thrift::MemoryBufferTransport.new
+      [transport, Thrift::BinaryProtocol.new(transport)]
+    end
+
     it "should call process_<message> when it receives that message" do
       expect(@prot).to receive(:read_message_begin).ordered.and_return ['testMessage', Thrift::MessageTypes::CALL, 17]
       expect(@processor).to receive(:process_testMessage).with(17, @prot, @prot).ordered
       expect(@processor.process(@prot, @prot)).to eq(true)
+    end
+
+    [Thrift::MessageTypes::REPLY, Thrift::MessageTypes::EXCEPTION].each do |message_type|
+      it "rejects message type #{message_type} before dispatching" do
+        input = input_protocol("work", message_type, 11)
+        output_transport, output = output_protocol
+
+        expect(@processor.process(input, output)).to be false
+        expect(@processor.processed).to be_nil
+
+        response = Thrift::BinaryProtocol.new(output_transport)
+        name, type, seqid = response.read_message_begin
+        exception = Thrift::ApplicationException.new
+        exception.read(response)
+        response.read_message_end
+
+        expect(name).to eq("work")
+        expect(type).to eq(Thrift::MessageTypes::EXCEPTION)
+        expect(seqid).to eq(11)
+        expect(exception.type).to eq(Thrift::ApplicationException::INVALID_MESSAGE_TYPE)
+        expect(exception.message).to eq("Invalid message type #{message_type} for function work")
+      end
+    end
+
+    [Thrift::MessageTypes::CALL, Thrift::MessageTypes::ONEWAY].each do |message_type|
+      it "dispatches valid message type #{message_type}" do
+        input = input_protocol("work", message_type, 12)
+        output_transport, output = output_protocol
+
+        expect(@processor.process(input, output)).to be true
+        expect(@processor.processed).to eq(12)
+        expect(output_transport.available).to eq(0)
+      end
+    end
+
+    it "keeps generated oneway behavior when its envelope is CALL" do
+      handler = double("Handler")
+      expect(handler).to receive(:unblock).with(9)
+      processor = SpecNamespace::NonblockingService::Processor.new(handler)
+      args = SpecNamespace::NonblockingService::Unblock_args.new(:n => 9)
+      input = input_protocol("unblock", Thrift::MessageTypes::CALL, 13, args)
+      output_transport, output = output_protocol
+
+      expect(processor.process(input, output)).to be true
+      expect(output_transport.available).to eq(0)
+    end
+
+    it "keeps generated reply behavior when a normal method envelope is ONEWAY" do
+      handler = double("Handler")
+      expect(handler).to receive(:sleep).with(3.0)
+      processor = SpecNamespace::NonblockingService::Processor.new(handler)
+      args = SpecNamespace::NonblockingService::Sleep_args.new(:seconds => 3.0)
+      input = input_protocol("sleep", Thrift::MessageTypes::ONEWAY, 14, args)
+      output_transport, output = output_protocol
+
+      expect(processor.process(input, output)).to be true
+
+      response = Thrift::BinaryProtocol.new(output_transport)
+      expect(response.read_message_begin).to eq(["sleep", Thrift::MessageTypes::REPLY, 14])
+      response.skip(Thrift::Types::STRUCT)
+      response.read_message_end
     end
 
     it "should raise an ApplicationException when the received message cannot be processed" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The Ruby base processor previously dispatched incoming messages solely by function name. A message carrying a `REPLY` or `EXCEPTION` envelope could therefore reach generated request parsing and invoke a server handler instead of being rejected.

This change limits base processor dispatch to `CALL` and `ONEWAY` envelopes, matching the validation already performed by the Ruby multiplexed processor. For another envelope type, the processor consumes the message body and returns an `INVALID_MESSAGE_TYPE` application exception while preserving the original function name and sequence ID. Valid `CALL` and `ONEWAY` dispatch semantics remain unchanged.

## Benchmarks

The server benchmark was run five times for current master and the proposed change using:

```sh
THRIFT_SERVER=Thrift::ThreadPoolServer THRIFT_PROTOCOL=binary THRIFT_NUM_PROCESSES=4 THRIFT_NUM_CLIENTS=5 THRIFT_NUM_CALLS=100 THRIFT_TLS=false ruby benchmark/benchmark.rb
```

Current master had a median wall time of 0.3663 seconds, with a range of 0.3458–0.3856 seconds. The proposed change had a median of 0.3570 seconds, with a range of 0.3478–0.3701 seconds, a nominal decrease of 2.5%. The runs are short enough that this difference should be treated as noise; they show no measurable regression from validating the message type on the dispatch path.

`ThreadedServer` could not be used because the existing benchmark harness passes five constructor arguments to a server accepting two to four, so this comparison uses `ThreadPoolServer`.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6146](https://issues.apache.org/jira/browse/THRIFT-6146)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
