### PR TITLE
THRIFT-6145: Validate Ruby Compact decoder bounds

### DIFF
--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -484,6 +484,7 @@ static int32_t zig_zag_to_int(uint32_t n) {
 }
 
 #define MAX_VARINT32_BYTES 5  /* ceil(32/7); matches protobuf wire format */
+#define MAX_VARINT32_LAST_BYTE 0x0f
 #define MAX_VARINT64_BYTES 10 /* ceil(64/7); matches protobuf wire format */
 
 static uint64_t read_varint64(VALUE self) {
@@ -504,7 +505,7 @@ static uint64_t read_varint64(VALUE self) {
 static uint32_t read_varint32(VALUE self) {
   int i, shift = 0;
   uint32_t result = 0;
-  for (i = 0; i < MAX_VARINT32_BYTES; i++) {
+  for (i = 0; i < MAX_VARINT32_BYTES - 1; i++) {
     int8_t b = read_byte_direct(self);
     result |= ((uint32_t)(b & 0x7f) << shift);
     if ((b & 0x80) != 0x80) {
@@ -512,8 +513,15 @@ static uint32_t read_varint32(VALUE self) {
     }
     shift += 7;
   }
-  rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_INVALID_DATA), rb_str_new2("Variable-length int over 5 bytes.")));
-  return 0; /* unreachable */
+
+  int8_t b = read_byte_direct(self);
+  if (RB_UNLIKELY((b & 0x80) != 0)) {
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_INVALID_DATA), rb_str_new2("Variable-length int over 5 bytes.")));
+  }
+  if (RB_UNLIKELY((b & ~MAX_VARINT32_LAST_BYTE) != 0)) {
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_INVALID_DATA), rb_str_new2("Variable-length int overflows uint32.")));
+  }
+  return result | ((uint32_t)b << shift);
 }
 
 static int16_t read_i16(VALUE self) {
@@ -683,6 +691,9 @@ VALUE rb_thrift_compact_proto_read_string(VALUE self) {
 
 VALUE rb_thrift_compact_proto_read_binary(VALUE self) {
   uint32_t size = read_varint32(self);
+  if (RB_UNLIKELY(size > INT32_MAX)) {
+    rb_exc_raise(get_protocol_exception(INT2FIX(PROTOERR_SIZE_LIMIT), rb_str_new2("Binary size limit exceeded")));
+  }
   return rb_funcall(GET_TRANSPORT(self), read_all_method_id, 1, UINT2NUM(size));
 }
 

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -28,6 +28,8 @@ module Thrift
     TYPE_BITS = 0x07
     TYPE_SHIFT_AMOUNT = 5
     MAX_VARINT32_BYTES = 5  # ceil(32/7); matches protobuf wire format
+    VARINT32_PREFIX_BYTES = MAX_VARINT32_BYTES - 1
+    MAX_VARINT32_LAST_BYTE = 0x0f
     MAX_VARINT_BYTES = 10   # ceil(64/7); matches protobuf wire format
     BYTE_MIN = -(2**7)
     BYTE_MAX = (2**7) - 1
@@ -420,6 +422,9 @@ module Thrift
 
     def read_binary
       size = read_varint32()
+      if size > I32_MAX
+        raise ProtocolException.new(ProtocolException::SIZE_LIMIT, 'Binary size limit exceeded')
+      end
       trans.read_all(size)
     end
 
@@ -488,13 +493,22 @@ module Thrift
     def read_varint32()
       shift = 0
       result = 0
-      MAX_VARINT32_BYTES.times do
+      VARINT32_PREFIX_BYTES.times do
         b = read_byte()
         result |= (b & 0x7f) << shift
         return result if (b & 0x80) != 0x80
         shift += 7
       end
-      raise ProtocolException.new(ProtocolException::INVALID_DATA, 'Variable-length int over 5 bytes.')
+
+      b = read_byte()
+      if (b & 0x80) != 0
+        raise ProtocolException.new(ProtocolException::INVALID_DATA, 'Variable-length int over 5 bytes.')
+      end
+      if (b & ~MAX_VARINT32_LAST_BYTE) != 0
+        raise ProtocolException.new(ProtocolException::INVALID_DATA, 'Variable-length int overflows uint32.')
+      end
+
+      result | (b << shift)
     end
 
     def read_varint64()

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -34,7 +34,7 @@ describe Thrift::CompactProtocol do
     :i64 => [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]
   }
 
-  CONTAINER_SIZE_ENCODINGS = {
+  VARINT32_SIZE_ENCODINGS = {
     (2**31) - 1 => [0xff, 0xff, 0xff, 0xff, 0x07],
     2**31 => [0x80, 0x80, 0x80, 0x80, 0x08],
     (2**32) - 1 => [0xff, 0xff, 0xff, 0xff, 0x0f]
@@ -282,7 +282,7 @@ describe Thrift::CompactProtocol do
   end
 
   it "should accept container sizes within the signed 32-bit range" do
-    bytes = [0xf5, *CONTAINER_SIZE_ENCODINGS.fetch((2**31) - 1)]
+    bytes = [0xf5, *VARINT32_SIZE_ENCODINGS.fetch((2**31) - 1)]
     trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
     proto = Thrift::CompactProtocol.new(trans)
 
@@ -297,9 +297,9 @@ describe Thrift::CompactProtocol do
     }.each do |reader_method, container_header|
       [2**31, (2**32) - 1].each do |size|
         bytes = if reader_method == :read_map_begin
-                  [*CONTAINER_SIZE_ENCODINGS.fetch(size), *container_header]
+                  [*VARINT32_SIZE_ENCODINGS.fetch(size), *container_header]
                 else
-                  [*container_header, *CONTAINER_SIZE_ENCODINGS.fetch(size)]
+                  [*container_header, *VARINT32_SIZE_ENCODINGS.fetch(size)]
                 end
         trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
         proto = Thrift::CompactProtocol.new(trans)
@@ -362,6 +362,26 @@ describe Thrift::CompactProtocol do
 
     proto = Thrift::CompactProtocol.new(trans)
     expect(proto.read_binary).to eq(payload)
+  end
+
+  it "should accept binary sizes through the signed 32-bit range" do
+    trans = Thrift::MemoryBufferTransport.new(VARINT32_SIZE_ENCODINGS.fetch((2**31) - 1).pack("C*"))
+    proto = Thrift::CompactProtocol.new(trans)
+    expect(trans).to receive(:read_all).with((2**31) - 1).and_return("payload")
+
+    expect(proto.read_binary).to eq("payload")
+  end
+
+  it "should reject binary sizes above the signed 32-bit range before reading the payload" do
+    [2**31, (2**32) - 1].each do |size|
+      trans = Thrift::MemoryBufferTransport.new(VARINT32_SIZE_ENCODINGS.fetch(size).pack("C*"))
+      proto = Thrift::CompactProtocol.new(trans)
+      expect(trans).not_to receive(:read_all)
+
+      expect { proto.read_binary }.to raise_error(Thrift::ProtocolException, "Binary size limit exceeded") do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::SIZE_LIMIT)
+      end
+    end
   end
 
   it "should write a uuid" do
@@ -510,6 +530,17 @@ describe Thrift::CompactProtocol do
     trans = Thrift::MemoryBufferTransport.new((([0x80] * 4) + [0x0f]).pack("C*"))
     proto = Thrift::CompactProtocol.new(trans)
     expect { proto.read_i32 }.not_to raise_error
+  end
+
+  it "should reject 32-bit varints with overflowing fifth-byte payload bits" do
+    [0x10, 0x7f].each do |terminal_byte|
+      trans = Thrift::MemoryBufferTransport.new((([0x80] * 4) + [terminal_byte]).pack("C*"))
+      proto = Thrift::CompactProtocol.new(trans)
+
+      expect { proto.read_i32 }.to raise_error(Thrift::ProtocolException, "Variable-length int overflows uint32.") do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+      end
+    end
   end
 
   class JankyHandler


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby’s pure and native CompactProtocol readers accept fifth-byte varint payload bits outside the uint32 range, and they produce different values for the same input. Binary length prefixes above the signed int32 size domain are also passed to the transport instead of being rejected by the protocol.

This change gives both readers the same boundary behavior. Invalid fifth-byte payload bits now raise `ProtocolException::INVALID_DATA`, while binary lengths above `INT32_MAX` raise `ProtocolException::SIZE_LIMIT` before `read_all` is called. Valid uint32 varints, signed i32 values, binary sizes through `INT32_MAX`, and ordinary Compact messages remain supported.

## Benchmarks

I ran the repository’s small Compact read benchmark against current master (`c2def39207a73394420088da9b4b105571dd9036`) and this change in the same Ruby container:

```console
ruby test/rb/benchmarks/protocol_benchmark.rb --json --small-runs 10000 --scenarios rb-cmp-read-small
THRIFT_BENCHMARK_SKIP_NATIVE=1 ruby test/rb/benchmarks/protocol_benchmark.rb --json --small-runs 10000 --scenarios rb-cmp-read-small
```

Each result is the median of 11 independent warmed runs.

| Mode | Master median (range) | Proposed median (range) | Delta |
| --- | ---: | ---: | ---: |
| Native extension | 0.051075 s (0.049545–0.053581) | 0.052138 s (0.050545–0.054560) | +2.08% |
| Pure Ruby | 0.180099 s (0.173008–0.235398) | 0.177465 s (0.174482–0.180574) | -1.46% |

The ranges overlap. This focused small-structure read workload does not show a clear performance change.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/browse/THRIFT-6145) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [x] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
