### PR TITLE
THRIFT-6147: Finalize buffered Ruby serializer transports

### DIFF
--- a/lib/rb/lib/thrift/serializer/serializer.rb
+++ b/lib/rb/lib/thrift/serializer/serializer.rb
@@ -30,6 +30,7 @@ module Thrift
       @transport.reset_buffer
       @protocol ||= @protocol_factory.get_protocol(@transport)
       base.write(@protocol)
+      @protocol.trans.flush
       @transport.read(@transport.available)
     rescue
       @protocol = nil

--- a/lib/rb/spec/serializer_spec.rb
+++ b/lib/rb/spec/serializer_spec.rb
@@ -111,6 +111,29 @@ module DeserializerResetFixtures
   end
 end
 
+module SerializerFixtures
+  class HeaderMessage
+    def initialize(value, sequence_id)
+      @value = value
+      @sequence_id = sequence_id
+    end
+
+    def write(protocol)
+      protocol.set_header("request-id", "abc")
+      protocol.add_transform(Thrift::HeaderTransformID::ZLIB)
+      protocol.write_message_begin("serialize", Thrift::MessageTypes::CALL, @sequence_id)
+      @value.write(protocol)
+      protocol.write_message_end
+    end
+  end
+
+  class FramedBinaryProtocolFactory
+    def get_protocol(transport)
+      Thrift::BinaryProtocol.new(Thrift::FramedTransport.new(transport))
+    end
+  end
+end
+
 describe 'Serializer' do
   describe Thrift::Serializer do
     it "should serialize structs to binary by default" do
@@ -120,13 +143,15 @@ describe 'Serializer' do
     end
 
     it "should serialize structs to the given protocol" do
-      protocol = Thrift::BaseProtocol.new(double("transport"))
+      transport = double("transport")
+      protocol = Thrift::BaseProtocol.new(transport)
       expect(protocol).to receive(:write_struct_begin).with("SpecNamespace::Hello")
       expect(protocol).to receive(:write_field_begin).with("greeting", Thrift::Types::STRING, 1)
       expect(protocol).to receive(:write_string).with("Good day")
       expect(protocol).to receive(:write_field_end)
       expect(protocol).to receive(:write_field_stop)
       expect(protocol).to receive(:write_struct_end)
+      expect(transport).to receive(:flush)
       protocol_factory = double("ProtocolFactory")
       allow(protocol_factory).to receive(:get_protocol).and_return(protocol)
       serializer = Thrift::Serializer.new(protocol_factory)
@@ -171,6 +196,53 @@ describe 'Serializer' do
       expect(serializer.serialize(value)).to eq(
         Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value)
       )
+    end
+
+    it "keeps ordinary protocol output byte-for-byte stable" do
+      value = SpecNamespace::Hello.new(:greeting => "Good day")
+      expected = {
+        Thrift::BinaryProtocolFactory => "\v\x00\x01\x00\x00\x00\bGood day\x00".b,
+        Thrift::CompactProtocolFactory => "\x18\bGood day\x00".b,
+        Thrift::JsonProtocolFactory => "{\"1\":{\"str\":\"Good day\"}}"
+      }
+
+      expected.each do |factory_class, bytes|
+        expect(Thrift::Serializer.new(factory_class.new).serialize(value)).to eq(bytes)
+      end
+    end
+
+    it "finalizes and round-trips framed transport output" do
+      value = SpecNamespace::Hello.new(:greeting => "Good day")
+      factory = SerializerFixtures::FramedBinaryProtocolFactory.new
+
+      data = Thrift::Serializer.new(factory).serialize(value)
+
+      expect(data.unpack1('N')).to eq(data.bytesize - 4)
+      decoded = SpecNamespace::Hello.new
+      decoded.read(factory.get_protocol(Thrift::MemoryBufferTransport.new(data)))
+      expect(decoded).to eq(value)
+    end
+
+    [
+      Thrift::HeaderSubprotocolID::BINARY,
+      Thrift::HeaderSubprotocolID::COMPACT
+    ].each do |protocol_id|
+      it "finalizes and round-trips Header protocol #{protocol_id}" do
+        value = SpecNamespace::NonblockingService::Shutdown_args.new
+        message = SerializerFixtures::HeaderMessage.new(value, 42)
+        factory = Thrift::HeaderProtocolFactory.new(nil, protocol_id)
+
+        data = Thrift::Serializer.new(factory).serialize(message)
+
+        expect(data).not_to be_empty
+        reader = factory.get_protocol(Thrift::MemoryBufferTransport.new(data))
+        expect(reader.read_message_begin).to eq(["serialize", Thrift::MessageTypes::CALL, 42])
+        expect(reader.get_headers).to eq("request-id" => "abc")
+        decoded = SpecNamespace::NonblockingService::Shutdown_args.new
+        decoded.read(reader)
+        reader.read_message_end
+        expect(decoded).to eq(value)
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby `Serializer` reads its backing memory buffer immediately after writing a value through the selected protocol. That produces the expected bytes for protocols writing directly to `MemoryBufferTransport`, but transports such as Header and Framed retain their output until they are flushed. In those configurations, serialization succeeds while returning an empty string.

This change finalizes the transport exposed by the selected protocol before reading the serializer buffer. It relies on the existing transport contract: flushing a memory buffer remains a no-op, while buffering and framing transports complete their wire representation. The behavior therefore remains generic instead of coupling `Serializer` to specific protocol or transport classes.

## Benchmarks

A targeted benchmark ran 50,000 ordinary serializer calls per protocol for five trials with:

```text
bundle exec ruby -Ilib /tmp/serializer_benchmark.rb
```

The benchmark compared current master with this change under the same Ruby container and workload. Medians in seconds were:

| Mode | Protocol | Master | Proposed | Delta |
|---|---|---:|---:|---:|
| Native | Binary | 0.095683 | 0.095480 | -0.2% |
| Native | Compact | 0.068843 | 0.067851 | -1.4% |
| Native | JSON | 0.393388 | 0.392847 | -0.1% |
| Pure Ruby | Binary | 0.130590 | 0.130288 | -0.2% |
| Pure Ruby | Compact | 0.127151 | 0.128482 | +1.0% |
| Pure Ruby | JSON | 0.470556 | 0.472781 | +0.5% |

The small differences are within run-to-run noise. This benchmark targets the existing direct-memory paths, where the new call resolves to a no-op flush. It does not compare Header or Framed throughput because master returns no serialized bytes for those configurations.
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6147](https://issues.apache.org/jira/browse/THRIFT-6147)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
