### PR TITLE
THRIFT-6148: Enforce complete Ruby Header frame limits

### DIFF
--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -226,16 +226,15 @@ module Thrift
       @write_buffer = StringIO.new(Bytes.empty_byte_buffer)
 
       return if payload.empty?
-      if payload.bytesize > @max_frame_size
-        raise TransportException.new(TransportException::UNKNOWN, "Attempting to send frame that is too large")
-      end
 
       case @client_type
       when HeaderClientType::HEADERS
         flush_header_format(payload)
       when HeaderClientType::FRAMED_BINARY, HeaderClientType::FRAMED_COMPACT
+        validate_frame_size!(payload.bytesize)
         flush_framed(payload)
       when HeaderClientType::UNFRAMED_BINARY, HeaderClientType::UNFRAMED_COMPACT
+        validate_frame_size!(payload.bytesize)
         @transport.write(payload)
         @transport.flush
       else
@@ -497,7 +496,6 @@ module Thrift
           write_varstring(header_buf, key)
           write_varstring(header_buf, value)
         end
-        @write_headers = {}
       end
 
       # Pad header to 4-byte boundary
@@ -508,6 +506,8 @@ module Thrift
       # Calculate total frame size (excludes the 4-byte length field itself)
       # Frame = magic(2) + flags(2) + seqid(4) + header_len(2) + header_data + payload
       frame_size = 2 + 2 + 4 + 2 + header_data.bytesize + payload.bytesize
+      validate_frame_size!(frame_size)
+      @write_headers = {}
 
       # Write complete frame
       frame = Bytes.empty_byte_buffer
@@ -521,6 +521,15 @@ module Thrift
 
       @transport.write(frame)
       @transport.flush
+    end
+
+    def validate_frame_size!(frame_size)
+      return if frame_size <= @max_frame_size
+
+      raise TransportException.new(
+        TransportException::UNKNOWN,
+        "Frame size #{frame_size} exceeds maximum #{@max_frame_size}"
+      )
     end
 
     # Flushes data in simple framed format (for legacy compatibility)

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -191,10 +191,98 @@ describe 'HeaderTransport' do
     end
 
     describe "frame size limits" do
-      it "should reject payloads larger than max frame size" do
+      it "should enforce the limit against the complete Header frame" do
+        {
+          5 => 19,
+          6 => 20
+        }.each do |payload_size, declared_size|
+          underlying = Thrift::MemoryBufferTransport.new
+          trans = Thrift::HeaderTransport.new(underlying)
+          trans.set_max_frame_size(20)
+          trans.write("x" * payload_size)
+          trans.flush
+
+          frame = underlying.read(underlying.available)
+          expect(frame.unpack1('N')).to eq(declared_size)
+
+          reader = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame))
+          reader.set_max_frame_size(20)
+          expect(reader.read(payload_size)).to eq("x" * payload_size)
+        end
+
+        @trans.set_max_frame_size(20)
+        @trans.write("x" * 7)
+        expect { @trans.flush }.to raise_error(
+          Thrift::TransportException,
+          "Frame size 21 exceeds maximum 20"
+        )
+        expect(@underlying.available).to eq(0)
+      end
+
+      it "should include metadata and padding in the emitted frame limit" do
+        headers = {"a" => "one", "longer-key" => "two"}
+        reference_buffer = Thrift::MemoryBufferTransport.new
+        reference = Thrift::HeaderTransport.new(reference_buffer)
+        headers.each { |key, value| reference.set_header(key, value) }
+        reference.write("payload")
+        reference.flush
+        frame = reference_buffer.read(reference_buffer.available)
+        declared_size = frame.unpack1('N')
+
+        accepted_buffer = Thrift::MemoryBufferTransport.new
+        accepted = Thrift::HeaderTransport.new(accepted_buffer)
+        accepted.set_max_frame_size(declared_size)
+        headers.each { |key, value| accepted.set_header(key, value) }
+        accepted.write("payload")
+        expect { accepted.flush }.not_to raise_error
+
+        rejected_buffer = Thrift::MemoryBufferTransport.new
+        rejected = Thrift::HeaderTransport.new(rejected_buffer)
+        rejected.set_max_frame_size(declared_size - 1)
+        headers.each { |key, value| rejected.set_header(key, value) }
+        rejected.write("payload")
+        expect { rejected.flush }.to raise_error(
+          Thrift::TransportException,
+          "Frame size #{declared_size} exceeds maximum #{declared_size - 1}"
+        )
+
+        rejected.set_max_frame_size(declared_size)
+        rejected.write("payload")
+        rejected.flush
+        retry_frame = rejected_buffer.read(rejected_buffer.available)
+        reader = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(retry_frame))
+        expect(reader.read(7)).to eq("payload")
+        expect(reader.get_headers).to eq(headers)
+      end
+
+      it "should enforce the limit after applying transforms" do
+        payload = "a" * 1_000
+        reference_buffer = Thrift::MemoryBufferTransport.new
+        reference = Thrift::HeaderTransport.new(reference_buffer)
+        reference.add_transform(Thrift::HeaderTransformID::ZLIB)
+        reference.write(payload)
+        reference.flush
+        frame = reference_buffer.read(reference_buffer.available)
+        declared_size = frame.unpack1('N')
+        expect(declared_size).to be < payload.bytesize
+
+        accepted_buffer = Thrift::MemoryBufferTransport.new
+        accepted = Thrift::HeaderTransport.new(accepted_buffer)
+        accepted.add_transform(Thrift::HeaderTransformID::ZLIB)
+        accepted.set_max_frame_size(declared_size)
+        accepted.write(payload)
+        expect { accepted.flush }.not_to raise_error
+
+        accepted_frame = accepted_buffer.read(accepted_buffer.available)
+        reader = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(accepted_frame))
+        reader.set_max_frame_size(declared_size)
+        expect(reader.read(payload.bytesize)).to eq(payload)
+      end
+
+      it "should reject Header frames larger than max frame size" do
         @trans.set_max_frame_size(4)
         @trans.write("12345")
-        expect { @trans.flush }.to raise_error(Thrift::TransportException, /frame that is too large/)
+        expect { @trans.flush }.to raise_error(Thrift::TransportException, "Frame size 19 exceeds maximum 4")
       end
 
       {


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby `HeaderTransport` currently applies `max_frame_size` to the payload before constructing the Header frame. The reader applies the same limit to the complete size declared on the wire, which also includes the fixed Header envelope, transformed payload, metadata, and padding. A writer can therefore emit a frame that a reader configured with the identical limit rejects.

This change validates the completed declared Header frame after transforms and header construction, before writing any bytes. The four-byte length prefix remains excluded, matching the read-side contract; each Header field and payload byte is counted exactly once. Framed and unframed Binary/Compact compatibility modes keep their existing accounting. Pending one-shot headers also remain available when this local validation rejects a frame before delivery.

## Benchmarks

The repository Header write benchmark ran 10,000 small-structure writes per scenario for six trials, with the first trial discarded as warm-up:

```text
ruby /thrift/src/test/rb/benchmarks/protocol_benchmark.rb \
  --scenarios hdr-bin-write-small,hdr-cmp-write-small,hdr-zlib-write-small \
  --small-runs 10000 \
  --json
```

Pure-Ruby controls used the identical command with `THRIFT_BENCHMARK_SKIP_NATIVE=1`. Current master and the proposed change used the same Ruby container and rebuilt native extension. Times are median seconds, with the measured five-trial range in parentheses.

| Mode | Scenario | Master | Proposed | Delta |
|---|---|---:|---:|---:|
| Native | Header Binary | 0.153373 (0.150825–0.159381) | 0.154013 (0.151142–0.155030) | +0.42% |
| Native | Header Compact | 0.128464 (0.121187–0.132505) | 0.128461 (0.125729–0.132922) | 0.00% |
| Native | Header ZLIB | 0.206152 (0.204393–0.210734) | 0.205150 (0.201781–0.207064) | -0.49% |
| Pure Ruby | Header Binary | 0.200360 (0.197171–0.210889) | 0.198534 (0.192370–0.205776) | -0.91% |
| Pure Ruby | Header Compact | 0.204374 (0.202167–0.207060) | 0.204823 (0.200498–0.211956) | +0.22% |
| Pure Ruby | Header ZLIB | 0.251476 (0.248048–0.254244) | 0.250412 (0.248805–0.261224) | -0.42% |

All before-and-after ranges overlap; the results show no meaningful performance change.
  
<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6148](https://issues.apache.org/jira/browse/THRIFT-6148)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
