### PR TITLE
THRIFT-6149: Avoid decoding skipped Ruby strings

### DIFF
--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -231,6 +231,10 @@ module Thrift
       raise NotImplementedError
     end
 
+    def skip_string
+      read_string
+    end
+
     # Writes a field based on the field information, field ID and value.
     #
     # field_info - A Hash containing the definition of the field:
@@ -359,7 +363,7 @@ module Thrift
       when Types::DOUBLE
         read_double
       when Types::STRING
-        read_string
+        skip_string
       when Types::UUID
         read_uuid
       when Types::STRUCT

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -262,6 +262,10 @@ module Thrift
       end
     end
 
+    def skip_string
+      read_binary
+    end
+
     def read_uuid
       UUID.uuid_from_bytes(trans.read_all(16))
     end

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -428,6 +428,10 @@ module Thrift
       trans.read_all(size)
     end
 
+    def skip_string
+      read_binary
+    end
+
     def read_uuid
       UUID.uuid_from_bytes(trans.read_all(16))
     end

--- a/lib/rb/lib/thrift/protocol/header_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/header_protocol.rb
@@ -265,6 +265,10 @@ module Thrift
       @protocol.read_binary
     end
 
+    def skip_string
+      @protocol.skip_string
+    end
+
     def read_uuid
       @protocol.read_uuid
     end

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -772,6 +772,10 @@ module Thrift
       read_json_base64
     end
 
+    def skip_string
+      read_string
+    end
+
     def read_uuid
       uuid = read_json_string
       UUID.validate_uuid!(uuid)

--- a/lib/rb/lib/thrift/protocol/protocol_decorator.rb
+++ b/lib/rb/lib/thrift/protocol/protocol_decorator.rb
@@ -196,6 +196,10 @@ module Thrift
       @protocol.read_binary
     end
 
+    def skip_string
+      @protocol.skip_string
+    end
+
     def read_uuid
       @protocol.read_uuid
     end

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -255,6 +255,16 @@ shared_examples_for 'a binary protocol' do
     expect(a.unpack('C*')).to eq([0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x02, 0x03])
   end
 
+  it 'should skip strings as binary values' do
+    @prot.write_binary('value')
+    expect(@prot).to receive(:read_binary).and_call_original
+    expect(@prot).not_to receive(:read_string)
+
+    @prot.skip(Thrift::Types::STRING)
+
+    expect(@trans.available).to eq(0)
+  end
+
   it 'should write a frozen non-binary string without mutating the input' do
     buffer = "abc \u20AC".encode('UTF-8').freeze
     @prot.write_binary(buffer)

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -66,6 +66,18 @@ describe Thrift::CompactProtocol do
     end
   end
 
+  it "should skip strings as binary values" do
+    trans = Thrift::MemoryBufferTransport.new
+    proto = Thrift::CompactProtocol.new(trans)
+    proto.write_binary("value")
+    expect(proto).to receive(:read_binary).and_call_original
+    expect(proto).not_to receive(:read_string)
+
+    proto.skip(Thrift::Types::STRING)
+
+    expect(trans.available).to eq(0)
+  end
+
   it "should encode and decode primitives in fields correctly" do
     TESTS.each_pair do |primitive_type, test_values|
       final_primitive_type = primitive_type == :binary ? :string : primitive_type

--- a/lib/rb/spec/header_protocol_spec.rb
+++ b/lib/rb/spec/header_protocol_spec.rb
@@ -44,6 +44,13 @@ describe 'HeaderProtocol' do
       expect(protocol.trans).to equal(header_trans)
     end
 
+    it "should delegate skipped strings to the selected protocol" do
+      selected_protocol = @protocol.instance_variable_get(:@protocol)
+      expect(selected_protocol).to receive(:skip_string)
+
+      @protocol.skip(Thrift::Types::STRING)
+    end
+
     describe "header management delegation" do
       it "should delegate get_headers" do
         # Write with headers and read back to populate read headers

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -583,6 +583,27 @@ describe 'JsonProtocol' do
       expect(@prot.read_set_end).to eq(nil)
     end
 
+    it "should skip unknown string fields without base64 decoding" do
+      prot = Thrift::JsonProtocol.new(Thrift::MemoryBufferTransport.new('{"2":{"str":"%"}}'))
+      hello = SpecNamespace::Hello.new
+
+      expect {
+        hello.read(prot)
+      }.not_to raise_error
+      expect(hello.greeting).to eq("hello world")
+    end
+
+    it "should skip unknown string fields through protocol decorators" do
+      trans = Thrift::MemoryBufferTransport.new('{"2":{"str":"%"}}')
+      prot = Thrift::MultiplexedProtocol.new(Thrift::JsonProtocol.new(trans), "service")
+      hello = SpecNamespace::Hello.new
+
+      expect {
+        hello.read(prot)
+      }.not_to raise_error
+      expect(hello.greeting).to eq("hello world")
+    end
+
     it "should read bool" do
       @trans.write("0\"\"")
       expect(@prot.read_bool).to eq(false)

--- a/lib/rb/spec/protocol_decorator_spec.rb
+++ b/lib/rb/spec/protocol_decorator_spec.rb
@@ -30,4 +30,15 @@ describe Thrift::ProtocolDecorator do
     expect(protocol).to receive(:write_message_begin).with('method', Thrift::MessageTypes::CALL, 42)
     decorator.write_message_begin('method', Thrift::MessageTypes::CALL, 42)
   end
+
+  it 'forwards skipped strings to the decorated protocol' do
+    decorator_class = Class.new(Thrift::BaseProtocol) do
+      include Thrift::ProtocolDecorator
+    end
+    protocol = double('Protocol')
+    decorator = decorator_class.new(protocol)
+
+    expect(protocol).to receive(:skip_string)
+    decorator.skip(Thrift::Types::STRING)
+  end
 end


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby clients and servers skip fields they do not recognize when communicating across schema versions. The shared Ruby protocol path currently handles skipped `STRING` values through `read_string`. Binary and Compact protocols therefore construct a UTF-8 string from the raw bytes even though the value is immediately discarded.

This change gives protocols control over how skipped strings are consumed. Binary and Compact use their binary readers, while the base protocol preserves the existing string behavior for custom protocols. JSON continues reading skipped values as strings because JSON strings and binary values have different wire representations. Header and decorated protocols forward the operation to their selected or wrapped protocol.

The wire bytes consumed are unchanged. The change only avoids unnecessary representation work when Binary or Compact string values are skipped.

## Benchmarks

The benchmark used Ruby 4.0.6 on aarch64 Linux and skipped 100,000 strings of 128 bytes each. Each result is the median of five measured trials after one warm-up trial. The same temporary harness and configuration were run against master commit `9b10484ca7687af6cc67567df9d457d0f031748e` and the proposed change:

```bash
bundle exec ruby /tmp/rb_skip_string_benchmark.rb
THRIFT_BENCHMARK_SKIP_NATIVE=1 bundle exec ruby /tmp/rb_skip_string_benchmark.rb
```

| Mode and protocol | Master median | Proposed median | Runtime delta | Allocated objects |
| --- | ---: | ---: | ---: | ---: |
| Native Binary | 70.250 ms | 56.999 ms | -18.86% | 303,181 → 203,181 (-32.98%) |
| Native Compact | 59.493 ms | 52.577 ms | -11.63% | 203,132 → 103,132 (-49.23%) |
| Native Binary accelerated | 55.630 ms | 44.984 ms | -19.14% | 203,180 → 103,180 (-49.22%) |
| Pure Ruby Binary | 130.605 ms | 120.119 ms | -8.03% | 306,355 → 206,355 (-32.64%) |
| Pure Ruby Compact | 122.418 ms | 108.034 ms | -11.75% | 306,258 → 206,258 (-32.65%) |

JSON must retain its string-reading path. A separate alternating paired benchmark of 20,000 skipped JSON strings measured the forwarding overhead at +0.53% in native mode and +0.06% in pure Ruby, with unchanged allocations.

These are synthetic skip-only workloads on one Ruby version and architecture. The temporary harness is not included in the change.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6149](https://issues.apache.org/jira/browse/THRIFT-6149)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
