### PR TITLE
Enable additional RuboCop rules for Ruby

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -30,7 +30,13 @@ Layout/LeadingEmptyLines:
 Layout/SpaceAfterComma:
   Enabled: true
 
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
 Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
   Enabled: true
 
 Layout/SpaceInsideBlockBraces:
@@ -45,8 +51,68 @@ Layout/TrailingWhitespace:
 Lint/OrderedMagicComments:
   Enabled: true
 
+Lint/UnreachableCode:
+  Enabled: true
+
+Performance/BindCall:
+  Enabled: true
+
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+
+Performance/CompareWithBlock:
+  Enabled: true
+
+Performance/Count:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/DoubleStartEndWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FixedSize:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: true
+
+Performance/RegexpMatch:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/Size:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Performance/StringReplacement:
+  Enabled: true
+
+Performance/TimesMap:
+  Enabled: true
+
 Performance/UnfreezeString:
   Enabled: true
 
+Performance/UriDefaultParser:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/MethodDefParentheses:
   Enabled: true

--- a/lib/rb/Rakefile
+++ b/lib/rb/Rakefile
@@ -84,7 +84,7 @@ end
 
 desc "Build the native library"
 task :build_ext => :'gen-rb' do
-   next if defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
+   next if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
    next if ENV['SKIP_BUILD_EXT'] == '1'
    Dir::chdir(File::dirname('ext/extconf.rb')) do
       unless sh "ruby #{File::basename('ext/extconf.rb')}"

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -196,7 +196,6 @@ class BenchmarkManager
     @report[:longest_call] = longest_call
     @report[:longest_client] = longest_client
     @report[:total_benchmark_time] = @benchmark_end - @benchmark_start
-    @report[:fastthread] = $".include?('fastthread.bundle')
   end
 
   def report_output
@@ -210,8 +209,7 @@ class BenchmarkManager
              [["Socket class", "%s"], socket_class],
              ["Number of processes", @num_processes],
              ["Clients per process", @clients_per_process],
-             ["Calls per client", @calls_per_client],
-             [["Using fastthread", "%s"], @report[:fastthread] ? "yes" : "no"]
+             ["Calls per client", @calls_per_client]
     puts
     failures = (@report[:connection_failures] > 0)
     tabulate fmt,

--- a/lib/rb/ext/extconf.rb
+++ b/lib/rb/ext/extconf.rb
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-if defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
   File.open('Makefile', 'w'){ |f| f.puts "all:\n\ninstall:\n" }
 else
   require 'mkmf'

--- a/lib/rb/lib/thrift/server/nonblocking_server.rb
+++ b/lib/rb/lib/thrift/server/nonblocking_server.rb
@@ -181,7 +181,7 @@ module Thrift
 
       def read_connection(fd)
         @buffers[fd] << fd.read(DEFAULT_BUFFER)
-        while(frame = slice_frame!(@buffers[fd]))
+        while (frame = slice_frame!(@buffers[fd]))
           @logger.debug "#{self} is processing a frame"
           @worker_queue.push [:frame, fd, frame]
         end

--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -53,7 +53,7 @@ module Thrift
         end
       end
 
-      yield self if block_given?
+      yield self if block
     end
 
     def fields_with_default_values
@@ -235,7 +235,7 @@ module Thrift
         # this will set our field default values
         method(:struct_initialize).call()
         # now give it to the exception
-        self.class.send(:class_variable_get, :'@@__thrift_struct_real_initialize').bind(self).call(*args, &block) if args.size > 0
+        self.class.send(:class_variable_get, :'@@__thrift_struct_real_initialize').bind_call(self, *args, &block) if args.size > 0
         # self.class.instance_method(:initialize).bind(self).call(*args, &block)
       end
     end

--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -58,7 +58,7 @@ module Thrift
       end
       resp = http.post(@url.request_uri, @outbuf, @headers)
       response_code = resp.code.to_i
-      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{to_s}, HTTP status code #{response_code}") unless (200..299).include?(response_code)
+      raise TransportException.new(TransportException::UNKNOWN, "#{self.class.name} Could not connect to #{to_s}, HTTP status code #{response_code}") unless (200..299).cover?(response_code)
 
       @response_code = response_code
       data = Bytes.force_binary_encoding(resp.body || Bytes.empty_byte_buffer)

--- a/lib/rb/lib/thrift/uuid.rb
+++ b/lib/rb/lib/thrift/uuid.rb
@@ -29,7 +29,7 @@ module Thrift
         raise ProtocolException.new(ProtocolException::INVALID_DATA, 'UUID must be a string')
       end
 
-      unless uuid =~ UUID_REGEX
+      unless UUID_REGEX.match?(uuid)
         raise ProtocolException.new(ProtocolException::INVALID_DATA, 'Invalid UUID format')
       end
     end

--- a/lib/rb/spec/spec_helper.rb
+++ b/lib/rb/spec/spec_helper.rb
@@ -24,21 +24,7 @@ require 'rspec'
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. ext])
 
-# pretend we already loaded fastthread, otherwise the nonblocking_server_spec
-# will get screwed up
-# $" << 'fastthread.bundle'
-
 require 'thrift'
-
-unless Object.method_defined? :tap
-  # if Object#tap isn't defined, then add it; this should only happen in Ruby < 1.8.7
-  class Object
-    def tap(&block)
-      block.call(self)
-      self
-    end
-  end
-end
 
 RSpec.configure do |configuration|
   configuration.before(:each) do

--- a/lib/rb/spec/uuid_validation_spec.rb
+++ b/lib/rb/spec/uuid_validation_spec.rb
@@ -137,14 +137,14 @@ describe 'UUID Validation' do
 
       context 'multiple UUIDs in sequence' do
         it 'should handle 10 UUIDs in sequence' do
-          uuids = 10.times.map { |i| sprintf('%08x-0000-0000-0000-000000000000', i) }
+          uuids = Array.new(10) { |i| sprintf('%08x-0000-0000-0000-000000000000', i) }
 
           @trans = Thrift::MemoryBufferTransport.new
           @prot = protocol_class.new(@trans)
 
           uuids.each { |uuid| @prot.write_uuid(uuid) }
 
-          results = 10.times.map { @prot.read_uuid }
+          results = Array.new(10) { @prot.read_uuid }
           expect(results).to eq(uuids)
         end
 

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -35,7 +35,7 @@ $protocolType = "binary"
 $ssl = false
 $transport = "buffered"
 
-ARGV.each do|a|
+ARGV.each do |a|
   if a == "--help"
     puts "Allowed options:"
     puts "\t -h [ --help ] \t produce help message"


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This expands Ruby RuboCop coverage with compatible layout, lint, style, and performance cops. Existing offenses are corrected with semantics-preserving forms, including exact JRuby engine comparisons, `Regexp#match?`, `Range#cover?`, `Array.new`, explicit block checks, and `UnboundMethod#bind_call`.

The change also removes the obsolete pre-Ruby-1.8.7 `Object#tap` compatibility shim and stale fastthread benchmark reporting. Apache Thrift's Ruby minimum is 2.7.

## Benchmarks

A dependency-free microbenchmark compared the exact old and proposed struct dispatch operations. Each result is the median of seven trials after 100,000 warmup operations, with 1,000,000 measured operations per trial.

Command and configuration:

```console
ITERATIONS=1000000 WARMUP_ITERATIONS=100000 TRIALS=7 ruby struct_dispatch_benchmark.rb
```

| Ruby | Operation | Master median | Proposed median | Delta |
|---|---|---:|---:|---:|
| 2.7.8, aarch64-linux | Explicit struct block dispatch | 0.154338 s | 0.144482 s | -6.39% |
| 2.7.8, aarch64-linux | Exception initializer dispatch | 0.277553 s | 0.206366 s | -25.65% |
| 4.0.6, aarch64-linux | Explicit struct block dispatch | 0.187137 s | 0.168729 s | -9.84% |
| 4.0.6, aarch64-linux | Exception initializer dispatch | 0.276757 s | 0.188756 s | -31.80% |

The harness isolates `block_given?` versus an explicit block check and `bind(...).call` versus `bind_call`; it does not estimate whole-application performance.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
