### PR TITLE
Enforce modern Ruby hash syntax

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -752,44 +752,44 @@ void t_rb_generator::generate_field_data(t_rb_ofstream& out,
   field_type = get_true_type(field_type);
 
   // Begin this field's defn
-  out << "{:type => " << type_to_enum(field_type);
+  out << "{type: " << type_to_enum(field_type);
 
   if (!field_name.empty()) {
-    out << ", :name => \"" << field_name << "\"";
+    out << ", name: \"" << field_name << "\"";
   }
 
   if (field_value != nullptr) {
-    out << ", :default => ";
+    out << ", default: ";
     render_const_value(out, field_type, field_value);
   }
 
   if (!field_type->is_base_type()) {
     if (field_type->is_struct() || field_type->is_xception()) {
-      out << ", :class => " << full_type_name((t_struct*)field_type);
+      out << ", class: " << full_type_name((t_struct*)field_type);
     } else if (field_type->is_list()) {
-      out << ", :element => ";
+      out << ", element: ";
       generate_field_data(out, ((t_list*)field_type)->get_elem_type());
     } else if (field_type->is_map()) {
-      out << ", :key => ";
+      out << ", key: ";
       generate_field_data(out, ((t_map*)field_type)->get_key_type());
-      out << ", :value => ";
+      out << ", value: ";
       generate_field_data(out, ((t_map*)field_type)->get_val_type());
     } else if (field_type->is_set()) {
-      out << ", :element => ";
+      out << ", element: ";
       generate_field_data(out, ((t_set*)field_type)->get_elem_type());
     }
   } else {
     if (((t_base_type*)field_type)->is_binary()) {
-      out << ", :binary => true";
+      out << ", binary: true";
     }
   }
 
   if (optional) {
-    out << ", :optional => true";
+    out << ", optional: true";
   }
 
   if (field_type->is_enum()) {
-    out << ", :enum_class => " << full_type_name(field_type);
+    out << ", enum_class: " << full_type_name(field_type);
   }
 
   // End of this field's defn
@@ -960,8 +960,15 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
     f_service_.indent() << messageSendProc << "(\"" << funname << "\", " << argsname;
 
-    for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
-      f_service_ << ", :" << (*fld_iter)->get_name() << " => " << (*fld_iter)->get_name();
+    if (!fields.empty()) {
+      f_service_ << ", {";
+      for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
+        if (fld_iter != fields.begin()) {
+          f_service_ << ", ";
+        }
+        f_service_ << (*fld_iter)->get_name() << ": " << (*fld_iter)->get_name();
+      }
+      f_service_ << "}";
     }
 
     f_service_ << ")" << '\n';

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -90,11 +90,40 @@ TEST_CASE("t_rb_generator uses suffixed field id constants to avoid FIELDS colli
     const string generated_content = read_file("gen-rb/test_field_id_conflict_types.rb");
     REQUIRE(!generated_content.empty());
     REQUIRE(generated_content.find("FIELDS_FIELD_ID = 1") != string::npos);
-    REQUIRE(generated_content.find("FIELDS_FIELD_ID => {:type => ::Thrift::Types::STRING, :name => \"fields\"}")
+    REQUIRE(generated_content.find("FIELDS_FIELD_ID => {type: ::Thrift::Types::STRING, name: \"fields\"}")
             != string::npos);
     REQUIRE(generated_content.find("FIELDS = 1") == string::npos);
-    REQUIRE(generated_content.find("FIELDS => {:type => ::Thrift::Types::STRING, :name => \"fields\"}")
+    REQUIRE(generated_content.find("FIELDS => {type: ::Thrift::Types::STRING, name: \"fields\"}")
             == string::npos);
+
+    std::remove(thrift_path.c_str());
+}
+
+TEST_CASE("t_rb_generator emits service arguments as a positional hash", "[functional]")
+{
+    const string thrift_path = "test_service_arguments.thrift";
+    const string thrift_source =
+        "service PingService {\n"
+        "  oneway void ping(1: i32 n)\n"
+        "}\n";
+
+    {
+        std::ofstream thrift_file(thrift_path, std::ios::binary);
+        REQUIRE(thrift_file.is_open());
+        thrift_file << thrift_source;
+    }
+
+    map<string, string> parsed_options;
+    std::unique_ptr<t_program> program(new t_program(thrift_path, "test_service_arguments"));
+    parse_thrift_for_test(program.get());
+
+    std::unique_ptr<t_generator> gen(
+        t_generator_registry::get_generator(program.get(), "rb", parsed_options, ""));
+    REQUIRE(gen != nullptr);
+    REQUIRE_NOTHROW(gen->generate_program());
+
+    const string service = read_file("gen-rb/ping_service.rb");
+    REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
 
     std::remove(thrift_path.c_str());
 }

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -114,6 +114,10 @@ Performance/UriDefaultParser:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
+Style/HashSyntax:
+  Enabled: true
+  EnforcedShorthandSyntax: either
+
 Style/MethodDefParentheses:
   Enabled: true
 

--- a/lib/rb/Rakefile
+++ b/lib/rb/Rakefile
@@ -26,8 +26,8 @@ require "bundler/gem_tasks"
 
 THRIFT = "../../compiler/cpp/thrift"
 
-task :default => [:gem]
-task :spec => [:'gen-rb', :build_ext, :realspec]
+task default: [:gem]
+task spec: [:'gen-rb', :build_ext, :realspec]
 
 RSpec::Core::RakeTask.new(:realspec) do |t|
   t.rspec_opts = ["--color", "--format d"]
@@ -40,7 +40,7 @@ RSpec::Core::RakeTask.new(:'spec:rcov') do |t|
 end
 
 desc "Compile the .thrift files for the specs"
-task :'gen-rb' => [:'gen-rb:spec', :'gen-rb:namespaced_spec', :'gen-rb:flat_spec', :'gen-rb:benchmark', :'gen-rb:debug_proto', :'gen-rb:constants_demo', :'gen-rb:fuzz']
+task 'gen-rb': [:'gen-rb:spec', :'gen-rb:namespaced_spec', :'gen-rb:flat_spec', :'gen-rb:benchmark', :'gen-rb:debug_proto', :'gen-rb:constants_demo', :'gen-rb:fuzz']
 namespace :'gen-rb' do
   task :'spec' do
     dir = File.dirname(__FILE__) + "/spec"
@@ -83,7 +83,7 @@ namespace :'gen-rb' do
 end
 
 desc "Build the native library"
-task :build_ext => :'gen-rb' do
+task build_ext: :'gen-rb' do
    next if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
    next if ENV["SKIP_BUILD_EXT"] == "1"
    Dir::chdir(File::dirname("ext/extconf.rb")) do
@@ -107,7 +107,7 @@ task :test do
 end
 
 desc "Run benchmarking of NonblockingServer"
-task :benchmark => [:'gen-rb:benchmark'] do
+task benchmark: [:'gen-rb:benchmark'] do
   ruby "benchmark/benchmark.rb"
 end
 
@@ -119,7 +119,7 @@ rescue LoadError
 end
 
 desc "Builds the thrift gem"
-task :gem => [:spec, :build_ext] do
+task gem: [:spec, :build_ext] do
   unless sh "gem", "build", "thrift.gemspec"
     $stderr.puts "Failed to build thrift gem"
     break
@@ -127,7 +127,7 @@ task :gem => [:spec, :build_ext] do
 end
 
 desc "Install the thrift gem"
-task :install => [:gem] do
+task install: [:gem] do
   unless sh "gem", "install", Dir.glob("thrift-*.gem").last
     $stderr.puts "Failed to install thrift gem"
     break

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -226,16 +226,16 @@ class BenchmarkManager
   end
 
   ANSI = {
-    :reset => 0,
-    :bold => 1,
-    :black => 30,
-    :red => 31,
-    :green => 32,
-    :yellow => 33,
-    :blue => 34,
-    :magenta => 35,
-    :cyan => 36,
-    :white => 37
+    reset: 0,
+    bold: 1,
+    black: 30,
+    red: 31,
+    green: 32,
+    yellow: 33,
+    blue: 34,
+    magenta: 35,
+    cyan: 36,
+    white: 37
   }
 
   def tabulate(fmt, *labels_and_values)

--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -248,7 +248,7 @@ module Thrift
     # Returns nothing.
     def write_field(field_info, fid, value, remaining_depth = nil)
       unless field_info.is_a?(Hash)
-        field_info = {:name => field_info, :type => fid}
+        field_info = {name: field_info, type: fid}
         fid = value
         value = remaining_depth
         remaining_depth = nil
@@ -272,7 +272,7 @@ module Thrift
       # if field_info is a Integer, assume it is a Thrift::Types constant
       # convert it into a field_info Hash for backwards compatibility
       if field_info.is_a? Integer
-        field_info = {:type => field_info}
+        field_info = {type: field_info}
       end
 
       case field_info[:type]
@@ -318,7 +318,7 @@ module Thrift
       # if field_info is a Integer, assume it is a Thrift::Types constant
       # convert it into a field_info Hash for backwards compatibility
       if field_info.is_a? Integer
-        field_info = {:type => field_info}
+        field_info = {type: field_info}
       end
 
       case field_info[:type]

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -160,11 +160,11 @@ module Thrift
     end
 
     def field_info(field)
-      { :type => field[:type],
-        :class => field[:class],
-        :key => field[:key],
-        :value => field[:value],
-        :element => field[:element] }
+      { type: field[:type],
+        class: field[:class],
+        key: field[:key],
+        value: field[:value],
+        element: field[:element] }
     end
 
     def inspect_field(value, field_info)

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -52,20 +52,20 @@ describe "BaseProtocol" do
 
     it "should write out a field nicely (deprecated write_field signature)" do
       expect(@prot).to receive(:write_field_begin).with("field", "type", "fid").ordered
-      expect(@prot).to receive(:write_type).with({:name => "field", :type => "type"}, "value", nil).ordered
+      expect(@prot).to receive(:write_type).with({name: "field", type: "type"}, "value", nil).ordered
       expect(@prot).to receive(:write_field_end).ordered
       @prot.write_field("field", "type", "fid", "value")
     end
 
     it "should write out a field nicely" do
       expect(@prot).to receive(:write_field_begin).with("field", "type", "fid").ordered
-      expect(@prot).to receive(:write_type).with({:name => "field", :type => "type", :binary => false}, "value", nil).ordered
+      expect(@prot).to receive(:write_type).with({name: "field", type: "type", binary: false}, "value", nil).ordered
       expect(@prot).to receive(:write_field_end).ordered
-      @prot.write_field({:name => "field", :type => "type", :binary => false}, "fid", "value")
+      @prot.write_field({name: "field", type: "type", binary: false}, "fid", "value")
     end
 
     it "should pass the remaining depth through write_field" do
-      field = {:name => "field", :type => "type"}
+      field = {name: "field", type: "type"}
       expect(@prot).to receive(:write_field_begin).with("field", "type", "fid").ordered
       expect(@prot).to receive(:write_type).with(field, "value", 7).ordered
       expect(@prot).to receive(:write_field_end).ordered
@@ -107,18 +107,18 @@ describe "BaseProtocol" do
       expect(@prot).to receive(:write_binary).with("binary").ordered
       struct = double("Struct")
       expect(struct).to receive(:write).with(@prot).ordered
-      @prot.write_type({:type => Thrift::Types::BOOL}, "bool")
-      @prot.write_type({:type => Thrift::Types::BYTE}, "byte")
-      @prot.write_type({:type => Thrift::Types::DOUBLE}, "double")
-      @prot.write_type({:type => Thrift::Types::I16}, "i16")
-      @prot.write_type({:type => Thrift::Types::I32}, "i32")
-      @prot.write_type({:type => Thrift::Types::I64}, "i64")
-      @prot.write_type({:type => Thrift::Types::STRING}, "string")
-      @prot.write_type({:type => Thrift::Types::STRING, :binary => true}, "binary")
-      @prot.write_type({:type => Thrift::Types::STRUCT}, struct)
+      @prot.write_type({type: Thrift::Types::BOOL}, "bool")
+      @prot.write_type({type: Thrift::Types::BYTE}, "byte")
+      @prot.write_type({type: Thrift::Types::DOUBLE}, "double")
+      @prot.write_type({type: Thrift::Types::I16}, "i16")
+      @prot.write_type({type: Thrift::Types::I32}, "i32")
+      @prot.write_type({type: Thrift::Types::I64}, "i64")
+      @prot.write_type({type: Thrift::Types::STRING}, "string")
+      @prot.write_type({type: Thrift::Types::STRING, binary: true}, "binary")
+      @prot.write_type({type: Thrift::Types::STRUCT}, struct)
       # all other types are not implemented
       [Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP, Thrift::Types::SET, Thrift::Types::LIST].each do |type|
-        expect { @prot.write_type({:type => type}, type.to_s) }.to raise_error(NotImplementedError)
+        expect { @prot.write_type({type: type}, type.to_s) }.to raise_error(NotImplementedError)
       end
     end
 
@@ -126,7 +126,7 @@ describe "BaseProtocol" do
       struct = double("Struct")
       expect(struct).to receive(:write).with(@prot, 6)
 
-      @prot.write_type({:type => Thrift::Types::STRUCT}, struct, 7)
+      @prot.write_type({type: Thrift::Types::STRUCT}, struct, 7)
     end
 
     it "should read the different types (deprecated read_type signature)" do
@@ -160,18 +160,18 @@ describe "BaseProtocol" do
       expect(@prot).to receive(:read_double).ordered
       expect(@prot).to receive(:read_string).ordered
       expect(@prot).to receive(:read_binary).ordered
-      @prot.read_type({:type => Thrift::Types::BOOL})
-      @prot.read_type({:type => Thrift::Types::BYTE})
-      @prot.read_type({:type => Thrift::Types::I16})
-      @prot.read_type({:type => Thrift::Types::I32})
-      @prot.read_type({:type => Thrift::Types::I64})
-      @prot.read_type({:type => Thrift::Types::DOUBLE})
-      @prot.read_type({:type => Thrift::Types::STRING})
-      @prot.read_type({:type => Thrift::Types::STRING, :binary => true})
+      @prot.read_type({type: Thrift::Types::BOOL})
+      @prot.read_type({type: Thrift::Types::BYTE})
+      @prot.read_type({type: Thrift::Types::I16})
+      @prot.read_type({type: Thrift::Types::I32})
+      @prot.read_type({type: Thrift::Types::I64})
+      @prot.read_type({type: Thrift::Types::DOUBLE})
+      @prot.read_type({type: Thrift::Types::STRING})
+      @prot.read_type({type: Thrift::Types::STRING, binary: true})
       # all other types are not implemented
       [Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP,
        Thrift::Types::SET, Thrift::Types::LIST, Thrift::Types::STRUCT].each do |type|
-        expect { @prot.read_type({:type => type}) }.to raise_error(NotImplementedError)
+        expect { @prot.read_type({type: type}) }.to raise_error(NotImplementedError)
       end
     end
 

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -545,8 +545,8 @@ describe "BaseTransport" do
 
   describe Thrift::IOStreamTransport do
     before(:each) do
-      @input = double("Input", :closed? => false)
-      @output = double("Output", :closed? => false)
+      @input = double("Input", closed?: false)
+      @output = double("Output", closed?: false)
       @trans = Thrift::IOStreamTransport.new(@input, @output)
     end
 

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -406,15 +406,15 @@ shared_examples_for "a binary protocol" do
 
   it "should decode fixed-width signed edge byte patterns" do
     {
-      :read_i16 => {
+      read_i16: {
         [0x80, 0x00] => -(2**15),
         [0xff, 0xff] => -1
       },
-      :read_i32 => {
+      read_i32: {
         [0x80, 0x00, 0x00, 0x00] => -(2**31),
         [0xff, 0xff, 0xff, 0xff] => -1
       },
-      :read_i64 => {
+      read_i64: {
         [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] => -(2**63),
         [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] => -1
       }

--- a/lib/rb/spec/client_spec.rb
+++ b/lib/rb/spec/client_spec.rb
@@ -74,6 +74,22 @@ describe "Client" do
   end
 
   describe Thrift::Client do
+    it "passes generated service arguments to the client" do
+      client = SpecNamespace::NonblockingService::Client.allocate
+      received_arguments = nil
+      client.define_singleton_method(:send_oneway_message) do |name, args_class, args|
+        received_arguments = [name, args_class, args]
+      end
+
+      client.send_unblock(9)
+
+      expect(received_arguments).to eq([
+        "unblock",
+        SpecNamespace::NonblockingService::Unblock_args,
+        {n: 9},
+      ])
+    end
+
     it "should re-use iprot for oprot if not otherwise specified" do
       expect(@client.instance_variable_get(:'@iprot')).to eql(@prot)
       expect(@client.instance_variable_get(:'@oprot')).to eql(@prot)
@@ -91,8 +107,8 @@ describe "Client" do
           expect(trans).to receive(:flush)
         end
       end
-      klass = double("TestMessage_args", :new => mock_args)
-      @client.send_message("testMessage", klass, :foo => "foo", :bar => 42)
+      klass = double("TestMessage_args", new: mock_args)
+      @client.send_message("testMessage", klass, {foo: "foo", bar: 42})
     end
 
     it "should increment the sequence id when sending messages" do
@@ -100,9 +116,9 @@ describe "Client" do
       expect(@prot).to receive(:write_message_begin).with("testMessage2", Thrift::MessageTypes::CALL, 1).ordered
       expect(@prot).to receive(:write_message_begin).with("testMessage3", Thrift::MessageTypes::CALL, 2).ordered
       allow(@prot).to receive(:write_message_end)
-      allow(@prot).to receive(:trans).and_return(double("trans", :flush => nil))
+      allow(@prot).to receive(:trans).and_return(double("trans", flush: nil))
 
-      args_class = double("ArgsClass", :new => EmptyArgs.new)
+      args_class = double("ArgsClass", new: EmptyArgs.new)
       @client.send_message("testMessage", args_class)
       @client.send_message("testMessage2", args_class)
       @client.send_message("testMessage3", args_class)
@@ -112,9 +128,9 @@ describe "Client" do
       expect(@prot).to receive(:write_message_begin).with("first", Thrift::MessageTypes::CALL, 0).ordered
       expect(@prot).to receive(:write_message_begin).with("second", Thrift::MessageTypes::CALL, 1).ordered
       allow(@prot).to receive(:write_message_end)
-      allow(@prot).to receive(:trans).and_return(double("trans", :flush => nil))
+      allow(@prot).to receive(:trans).and_return(double("trans", flush: nil))
 
-      args_class = double("ArgsClass", :new => EmptyArgs.new)
+      args_class = double("ArgsClass", new: EmptyArgs.new)
       @client.send_message("first", args_class)
       @client.send_message("second", args_class)
 
@@ -132,7 +148,7 @@ describe "Client" do
       mock_klass = double("#<MockClass:mock>")
       expect(mock_klass).to receive(:read).with(@prot)
       @client.receive_message_begin()
-      @client.receive_message(double("MockClass", :new => mock_klass))
+      @client.receive_message(double("MockClass", new: mock_klass))
     end
 
     it "should raise BAD_SEQUENCE_ID for mismatched replies" do
@@ -182,10 +198,10 @@ describe "Client" do
       expect(@prot).to receive(:write_message_begin).with("testMessage", Thrift::MessageTypes::CALL, Thrift::Client::MAX_SEQUENCE_ID).ordered
       expect(@prot).to receive(:write_message_begin).with("testMessage2", Thrift::MessageTypes::CALL, Thrift::Client::MIN_SEQUENCE_ID).ordered
       allow(@prot).to receive(:write_message_end)
-      allow(@prot).to receive(:trans).and_return(double("trans", :flush => nil))
+      allow(@prot).to receive(:trans).and_return(double("trans", flush: nil))
 
       @client.instance_variable_set(:@seqid, Thrift::Client::MAX_SEQUENCE_ID)
-      args_class = double("ArgsClass", :new => EmptyArgs.new)
+      args_class = double("ArgsClass", new: EmptyArgs.new)
       @client.send_message("testMessage", args_class)
       @client.send_message("testMessage2", args_class)
     end
@@ -198,7 +214,7 @@ describe "Client" do
       trans = double("MockTransport")
       allow(@prot).to receive(:trans).and_return(trans)
       expect(trans).to receive(:close)
-      klass = double("TestMessage_args", :new => mock_args)
+      klass = double("TestMessage_args", new: mock_args)
       expect { @client.send_message("testMessage", klass) }.to raise_error(StandardError)
     end
 
@@ -246,7 +262,7 @@ describe "Client" do
 
     it "should close the transport when message end fails" do
       transport = RecordingTransport.new
-      protocol = double("Protocol", :trans => transport)
+      protocol = double("Protocol", trans: transport)
       error = IOError.new("message end failed")
       expect(protocol).to receive(:write_message_begin)
       expect(protocol).to receive(:write_message_end).and_raise(error)

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -23,15 +23,15 @@ require "spec_helper"
 
 describe Thrift::CompactProtocol do
   INTEGER_BOUNDARY_TESTS = {
-    :byte => [-(2**7), (2**7) - 1],
-    :i16 => [-(2**15), (2**15) - 1],
-    :i32 => [-(2**31), (2**31) - 1],
-    :i64 => [-(2**63), (2**63) - 1]
+    byte: [-(2**7), (2**7) - 1],
+    i16: [-(2**15), (2**15) - 1],
+    i32: [-(2**31), (2**31) - 1],
+    i64: [-(2**63), (2**63) - 1]
   }
 
   INTEGER_MINIMUM_ENCODINGS = {
-    :i32 => [0xff, 0xff, 0xff, 0xff, 0x0f],
-    :i64 => [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]
+    i32: [0xff, 0xff, 0xff, 0xff, 0x0f],
+    i64: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]
   }
 
   VARINT32_SIZE_ENCODINGS = {
@@ -41,14 +41,14 @@ describe Thrift::CompactProtocol do
   }
 
   TESTS = {
-    :byte => (-127..127).to_a,
-    :i16 => (0..14).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
-    :i32 => (0..30).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
-    :i64 => (0..62).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
-    :string => ["", "1", "short", "fourteen123456", "fifteen12345678", "unicode characters: \u20AC \u20AD", "1" * 127, "1" * 3000],
-    :binary => ["", "\001", "\001" * 5, "\001" * 14, "\001" * 15, "\001" * 127, "\001" * 3000],
-    :double => [0.0, 1.0, -1.0, 1.1, -1.1, 10000000.1, 1.0/0.0, -1.0/0.0],
-    :bool => [true, false]
+    byte: (-127..127).to_a,
+    i16: (0..14).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
+    i32: (0..30).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
+    i64: (0..62).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
+    string: ["", "1", "short", "fourteen123456", "fifteen12345678", "unicode characters: \u20AC \u20AD", "1" * 127, "1" * 3000],
+    binary: ["", "\001", "\001" * 5, "\001" * 14, "\001" * 15, "\001" * 127, "\001" * 3000],
+    double: [0.0, 1.0, -1.0, 1.1, -1.1, 10000000.1, 1.0/0.0, -1.0/0.0],
+    bool: [true, false]
   }
 
   it "should encode and decode naked primitives correctly" do
@@ -281,8 +281,8 @@ describe Thrift::CompactProtocol do
 
   it "should reject unknown field and container types as invalid protocol data" do
     {
-      :read_field_begin => [0x1e],
-      :read_list_begin => [0x1e]
+      read_field_begin: [0x1e],
+      read_list_begin: [0x1e]
     }.each do |reader_method, bytes|
       trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
       proto = Thrift::CompactProtocol.new(trans)
@@ -303,9 +303,9 @@ describe Thrift::CompactProtocol do
 
   it "should reject container sizes above the signed 32-bit range" do
     {
-      :read_map_begin => [0x55],
-      :read_list_begin => [0xf5],
-      :read_set_begin => [0xf5]
+      read_map_begin: [0x55],
+      read_list_begin: [0xf5],
+      read_set_begin: [0xf5]
     }.each do |reader_method, container_header|
       [2**31, (2**32) - 1].each do |size|
         bytes = if reader_method == :read_map_begin
@@ -325,8 +325,8 @@ describe Thrift::CompactProtocol do
 
   it "should report the original unknown type when writing fields and containers" do
     {
-      :write_field_begin => [nil, 99, 1],
-      :write_list_begin => [99, 1]
+      write_field_begin: [nil, 99, 1],
+      write_list_begin: [99, 1]
     }.each do |writer_method, args|
       trans = Thrift::MemoryBufferTransport.new
       proto = Thrift::CompactProtocol.new(trans)
@@ -465,11 +465,11 @@ describe Thrift::CompactProtocol do
 
   it "should deal with fields following fields that have non-delta ids" do
     brcp = Thrift::Test::BreaksRubyCompactProtocol.new(
-      :field1 => "blah",
-      :field2 => Thrift::Test::BigFieldIdStruct.new(
-        :field1 => "string1",
-        :field2 => "string2"),
-      :field3 => 3)
+      field1: "blah",
+      field2: Thrift::Test::BigFieldIdStruct.new(
+        field1: "string1",
+        field2: "string2"),
+      field3: 3)
     ser = Thrift::Serializer.new(Thrift::CompactProtocolFactory.new)
     bytes = ser.serialize(brcp)
 
@@ -480,7 +480,7 @@ describe Thrift::CompactProtocol do
   end
 
   it "should deserialize an empty map to an empty hash" do
-    struct = Thrift::Test::SingleMapTestStruct.new(:i32_map => {})
+    struct = Thrift::Test::SingleMapTestStruct.new(i32_map: {})
     ser = Thrift::Serializer.new(Thrift::CompactProtocolFactory.new)
     bytes = ser.serialize(struct)
 

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -78,7 +78,7 @@ describe "Thrift::HTTPClientTransport" do
         client = Thrift::HTTPClientTransport.new("http://my.domain.com/service")
         client.write("request")
         http = instance_double(Net::HTTP)
-        response = instance_double(Net::HTTPResponse, :code => status, :body => body)
+        response = instance_double(Net::HTTPResponse, code: status, body: body)
 
         expect(Net::HTTP).to receive(:new).with("my.domain.com", 80).and_return(http)
         expect(http).to receive(:use_ssl=).with(false)
@@ -97,7 +97,7 @@ describe "Thrift::HTTPClientTransport" do
         transport = Thrift::HTTPClientTransport.new("http://my.domain.com/service")
         client = SpecNamespace::NonblockingService::Client.new(Thrift::BinaryProtocol.new(transport))
         http = instance_double(Net::HTTP)
-        response = instance_double(Net::HTTPResponse, :code => status, :body => body)
+        response = instance_double(Net::HTTPResponse, code: status, body: body)
 
         expect(Net::HTTP).to receive(:new).with("my.domain.com", 80).and_return(http)
         expect(http).to receive(:use_ssl=).with(false)
@@ -111,7 +111,7 @@ describe "Thrift::HTTPClientTransport" do
       client = Thrift::HTTPClientTransport.new("https://user:secret@my.domain.com/service?token=secret")
       client.write("request")
       http = instance_double(Net::HTTP)
-      response = instance_double(Net::HTTPNoContent, :code => "204", :body => nil)
+      response = instance_double(Net::HTTPNoContent, code: "204", body: nil)
 
       expect(Net::HTTP).to receive(:new).with("my.domain.com", 443).and_return(http)
       expect(http).to receive(:use_ssl=).with(true)
@@ -180,7 +180,7 @@ describe "Thrift::HTTPClientTransport" do
       client = Thrift::HTTPClientTransport.new("https://user:secret@my.domain.com/path/to/service?token=secret")
       client.write "test"
       http = double("Net::HTTP")
-      response = double("HTTP response", :code => "503")
+      response = double("HTTP response", code: "503")
 
       expect(Net::HTTP).to receive(:new).with("my.domain.com", 443).and_return(http)
       expect(http).to receive(:use_ssl=).with(true)
@@ -223,8 +223,7 @@ describe "Thrift::HTTPClientTransport" do
     end
 
     it "should set SSL verify mode when specified" do
-      client = Thrift::HTTPClientTransport.new("#{@server_uri}#{@service_path}",
-          :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE)
+      client = Thrift::HTTPClientTransport.new("#{@server_uri}#{@service_path}", {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
 
       client.write "test"
       expect(Net::HTTP).to receive(:new).with("my.domain.com", 443) do
@@ -245,8 +244,7 @@ describe "Thrift::HTTPClientTransport" do
     end
 
     it "should set the SSL CA file when specified" do
-      client = Thrift::HTTPClientTransport.new("#{@server_uri}#{@service_path}",
-          :ssl_ca_file => "/path/to/ca.pem")
+      client = Thrift::HTTPClientTransport.new("#{@server_uri}#{@service_path}", {ssl_ca_file: "/path/to/ca.pem"})
 
       client.write "test"
       expect(Net::HTTP).to receive(:new).with("my.domain.com", 443) do

--- a/lib/rb/spec/nonblocking_server_spec.rb
+++ b/lib/rb/spec/nonblocking_server_spec.rb
@@ -33,7 +33,7 @@ describe "NonblockingServer" do
       if english
         SpecNamespace::Hello.new
       else
-        SpecNamespace::Hello.new(:greeting => "Aloha!")
+        SpecNamespace::Hello.new(greeting: "Aloha!")
       end
     end
 
@@ -181,7 +181,7 @@ describe "NonblockingServer" do
     it "should handle basic message passing" do
       client = setup_client
       expect(client.greeting(true)).to eq(SpecNamespace::Hello.new)
-      expect(client.greeting(false)).to eq(SpecNamespace::Hello.new(:greeting => "Aloha!"))
+      expect(client.greeting(false)).to eq(SpecNamespace::Hello.new(greeting: "Aloha!"))
       @server.shutdown
     end
 
@@ -222,7 +222,7 @@ describe "NonblockingServer" do
       4.times { expect(result.pop).to be_truthy }
       queues[2] << :hello
       expect(result.pop).to eq(SpecNamespace::Hello.new)
-      expect(client.greeting(false)).to eq(SpecNamespace::Hello.new(:greeting => "Aloha!"))
+      expect(client.greeting(false)).to eq(SpecNamespace::Hello.new(greeting: "Aloha!"))
       7.times { queues.shift << :exit }
       expect(client.greeting(true)).to eq(SpecNamespace::Hello.new)
       @server.shutdown
@@ -271,12 +271,12 @@ describe "NonblockingServer" do
       error = RuntimeError.new("plain accept failed")
       server_transport = double(
         "server transport",
-        :listen => nil,
-        :closed? => false,
-        :close => nil
+        listen: nil,
+        closed?: false,
+        close: nil
       )
       allow(server_transport).to receive(:accept).and_raise(error)
-      io_manager = double("IOManager", :ensure_closed => nil)
+      io_manager = double("IOManager", ensure_closed: nil)
       server = Thrift::NonblockingServer.new(
         double("processor"),
         server_transport,
@@ -308,9 +308,9 @@ describe "NonblockingServer" do
 
     it "closes tracked connections and signal pipes during forced cleanup" do
       io_manager = build_io_manager
-      connection = double("connection", :close => nil)
-      pipe_a = double("pipe_a", :closed? => false, :close => nil)
-      pipe_b = double("pipe_b", :closed? => false, :close => nil)
+      connection = double("connection", close: nil)
+      pipe_a = double("pipe_a", closed?: false, close: nil)
+      pipe_b = double("pipe_b", closed?: false, close: nil)
 
       io_manager.instance_variable_set(:@connections, [connection])
       io_manager.instance_variable_set(:@buffers, { connection => "frame" })
@@ -328,8 +328,8 @@ describe "NonblockingServer" do
 
     it "continues closing remaining signal pipes when one close raises" do
       io_manager = build_io_manager
-      pipe_a = double("pipe_a", :closed? => false)
-      pipe_b = double("pipe_b", :closed? => false, :close => nil)
+      pipe_a = double("pipe_a", closed?: false)
+      pipe_b = double("pipe_b", closed?: false, close: nil)
 
       allow(pipe_a).to receive(:close).and_raise(IOError)
 
@@ -344,7 +344,7 @@ describe "NonblockingServer" do
 
     it "drops removed connections from bookkeeping" do
       io_manager = build_io_manager
-      connection = double("connection", :close => nil)
+      connection = double("connection", close: nil)
 
       io_manager.instance_variable_set(:@connections, [connection])
       io_manager.instance_variable_set(:@buffers, { connection => "frame" })

--- a/lib/rb/spec/processor_spec.rb
+++ b/lib/rb/spec/processor_spec.rb
@@ -110,7 +110,7 @@ describe "Processor" do
       handler = double("Handler")
       expect(handler).to receive(:unblock).with(9)
       processor = SpecNamespace::NonblockingService::Processor.new(handler)
-      args = SpecNamespace::NonblockingService::Unblock_args.new(:n => 9)
+      args = SpecNamespace::NonblockingService::Unblock_args.new(n: 9)
       input = input_protocol("unblock", Thrift::MessageTypes::CALL, 13, args)
       output_transport, output = output_protocol
 
@@ -122,7 +122,7 @@ describe "Processor" do
       handler = double("Handler")
       expect(handler).to receive(:sleep).with(3.0)
       processor = SpecNamespace::NonblockingService::Processor.new(handler)
-      args = SpecNamespace::NonblockingService::Sleep_args.new(:seconds => 3.0)
+      args = SpecNamespace::NonblockingService::Sleep_args.new(seconds: 3.0)
       input = input_protocol("sleep", Thrift::MessageTypes::ONEWAY, 14, args)
       output_transport, output = output_protocol
 

--- a/lib/rb/spec/recursion_depth_spec.rb
+++ b/lib/rb/spec/recursion_depth_spec.rb
@@ -316,11 +316,11 @@ describe "recursion depth limit" do
       error = Thrift::ApplicationException.new(Thrift::ApplicationException::UNKNOWN, "message")
       protocol = binary_protocol
 
-      protocol.write_type({:type => Thrift::Types::STRUCT}, error, 2)
+      protocol.write_type({type: Thrift::Types::STRUCT}, error, 2)
       expect {
         SpecNamespace::RecStruct.new.read_field(
           protocol,
-          {:type => Thrift::Types::STRUCT, :class => Thrift::ApplicationException},
+          {type: Thrift::Types::STRUCT, class: Thrift::ApplicationException},
           2
         )
       }.not_to raise_error

--- a/lib/rb/spec/serializer_spec.rb
+++ b/lib/rb/spec/serializer_spec.rb
@@ -138,7 +138,7 @@ describe "Serializer" do
   describe Thrift::Serializer do
     it "should serialize structs to binary by default" do
       serializer = Thrift::Serializer.new(Thrift::BinaryProtocolAcceleratedFactory.new)
-      data = serializer.serialize(SpecNamespace::Hello.new(:greeting => "'Ello guv'nor!"))
+      data = serializer.serialize(SpecNamespace::Hello.new(greeting: "'Ello guv'nor!"))
       expect(data).to eq("\x0B\x00\x01\x00\x00\x00\x0E'Ello guv'nor!\x00")
     end
 
@@ -155,13 +155,13 @@ describe "Serializer" do
       protocol_factory = double("ProtocolFactory")
       allow(protocol_factory).to receive(:get_protocol).and_return(protocol)
       serializer = Thrift::Serializer.new(protocol_factory)
-      serializer.serialize(SpecNamespace::Hello.new(:greeting => "Good day"))
+      serializer.serialize(SpecNamespace::Hello.new(greeting: "Good day"))
     end
 
     [:message, :struct, :field, :list, :set, :nested_map].each do |stage|
       it "isolates JSON protocol state after a #{stage} write failure" do
         serializer = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new)
-        value = SpecNamespace::Hello.new(:greeting => "Good day")
+        value = SpecNamespace::Hello.new(greeting: "Good day")
         expected = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value)
         error = RuntimeError.new("failed at #{stage}")
 
@@ -184,7 +184,7 @@ describe "Serializer" do
 
     it "recovers after repeated JSON serialization failures" do
       serializer = Thrift::Serializer.new(Thrift::JsonProtocolFactory.new)
-      value = SpecNamespace::Hello.new(:greeting => "recovered")
+      value = SpecNamespace::Hello.new(greeting: "recovered")
 
       [:field, :nested_map].each do |stage|
         error = RuntimeError.new("failed at #{stage}")
@@ -199,7 +199,7 @@ describe "Serializer" do
     end
 
     it "keeps ordinary protocol output byte-for-byte stable" do
-      value = SpecNamespace::Hello.new(:greeting => "Good day")
+      value = SpecNamespace::Hello.new(greeting: "Good day")
       expected = {
         Thrift::BinaryProtocolFactory => "\v\x00\x01\x00\x00\x00\bGood day\x00".b,
         Thrift::CompactProtocolFactory => "\x18\bGood day\x00".b,
@@ -212,7 +212,7 @@ describe "Serializer" do
     end
 
     it "finalizes and round-trips framed transport output" do
-      value = SpecNamespace::Hello.new(:greeting => "Good day")
+      value = SpecNamespace::Hello.new(greeting: "Good day")
       factory = SerializerFixtures::FramedBinaryProtocolFactory.new
 
       data = Thrift::Serializer.new(factory).serialize(value)
@@ -250,7 +250,7 @@ describe "Serializer" do
     it "should deserialize structs from binary by default" do
       deserializer = Thrift::Deserializer.new
       data = "\x0B\x00\x01\x00\x00\x00\x0E'Ello guv'nor!\x00"
-      expect(deserializer.deserialize(SpecNamespace::Hello.new, data)).to eq(SpecNamespace::Hello.new(:greeting => "'Ello guv'nor!"))
+      expect(deserializer.deserialize(SpecNamespace::Hello.new, data)).to eq(SpecNamespace::Hello.new(greeting: "'Ello guv'nor!"))
     end
 
     it "should deserialize structs from the given protocol" do
@@ -264,7 +264,7 @@ describe "Serializer" do
       protocol_factory = double("ProtocolFactory")
       allow(protocol_factory).to receive(:get_protocol).and_return(protocol)
       deserializer = Thrift::Deserializer.new(protocol_factory)
-      expect(deserializer.deserialize(SpecNamespace::Hello.new, "")).to eq(SpecNamespace::Hello.new(:greeting => "Good day"))
+      expect(deserializer.deserialize(SpecNamespace::Hello.new, "")).to eq(SpecNamespace::Hello.new(greeting: "Good day"))
     end
 
     it "resets absent struct fields and restores defaults before reuse" do
@@ -299,7 +299,7 @@ describe "Serializer" do
     end
 
     it "does not retain previous struct state when reading fails" do
-      target = SpecNamespace::Foo.new(:simple => 99, :opt_string => "old")
+      target = SpecNamespace::Foo.new(simple: 99, opt_string: "old")
       payload = binary_payload(finish: false) do |protocol, transport|
         protocol.write_field_begin("opt_string", Thrift::Types::STRING, 7)
         transport.write([5].pack("N"))
@@ -313,7 +313,7 @@ describe "Serializer" do
     end
 
     it "resets fields even when an accessor has the same name as the reset operation" do
-      target = DeserializerResetFixtures::ResetFieldsStruct.new(:reset_fields => "old")
+      target = DeserializerResetFixtures::ResetFieldsStruct.new(reset_fields: "old")
 
       Thrift::Deserializer.new.deserialize(target, binary_payload)
 
@@ -334,7 +334,7 @@ describe "Serializer" do
     end
 
     it "does not satisfy required-field validation with a value from the previous read" do
-      target = DeserializerResetFixtures::RequiredStruct.new(:required_value => "old")
+      target = DeserializerResetFixtures::RequiredStruct.new(required_value: "old")
 
       expect {
         Thrift::Deserializer.new.deserialize(target, binary_payload)

--- a/lib/rb/spec/server_socket_spec.rb
+++ b/lib/rb/spec/server_socket_spec.rb
@@ -72,7 +72,7 @@ describe "Thrift::ServerSocket" do
       allow(TCPServer).to receive(:new).with(nil, 1234).and_return(handle)
       @socket.listen
 
-      sock = double("sock", :closed? => false)
+      sock = double("sock", closed?: false)
       allow(sock).to receive(:setsockopt)
       allow(handle).to receive(:accept).and_return(sock)
 
@@ -91,7 +91,7 @@ describe "Thrift::ServerSocket" do
     end
 
     it "should close the handle when closed" do
-      handle = double("TCPServer", :closed? => false)
+      handle = double("TCPServer", closed?: false)
       expect(TCPServer).to receive(:new).with(nil, 1234).and_return(handle)
       @socket.listen
       expect(handle).to receive(:close)
@@ -103,7 +103,7 @@ describe "Thrift::ServerSocket" do
     end
 
     it "should return true for closed? when appropriate" do
-      handle = double("TCPServer", :closed? => false)
+      handle = double("TCPServer", closed?: false)
       allow(TCPServer).to receive(:new).and_return(handle)
       @socket.listen
       expect(@socket).not_to be_closed

--- a/lib/rb/spec/socket_spec.rb
+++ b/lib/rb/spec/socket_spec.rb
@@ -26,7 +26,7 @@ describe "Socket" do
     before(:each) do
       @socket = Thrift::Socket.new
       @addrinfo = double("Addrinfo")
-      @handle = double("Handle", :closed? => false)
+      @handle = double("Handle", closed?: false)
       allow(@handle).to receive(:close)
       allow(@handle).to receive(:setsockopt)
       allow(@addrinfo).to receive(:connect).and_return(@handle)
@@ -77,7 +77,7 @@ describe "Socket" do
     end
 
     it "should accept host/port options" do
-      handle = double("Handle", :closed? => false)
+      handle = double("Handle", closed?: false)
       allow(handle).to receive(:close)
       expect(handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
       expect(Addrinfo).to receive(:foreach).with("my.domain", 1234, nil, :STREAM).and_yield(@addrinfo)
@@ -173,7 +173,7 @@ describe "Socket" do
     it "should close a connected candidate before falling back when socket setup fails" do
       first_addrinfo = @addrinfo
       second_addrinfo = double("Addrinfo")
-      first_handle = double("Handle", :closed? => false)
+      first_handle = double("Handle", closed?: false)
       allow(first_handle).to receive(:close)
 
       expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(first_addrinfo).and_yield(second_addrinfo)

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -27,13 +27,13 @@ describe "SSLSocket" do
       @context = OpenSSL::SSL::SSLContext.new
       @socket = Thrift::SSLSocket.new
       @addrinfo = double("Addrinfo")
-      @simple_socket_handle = double("Handle", :closed? => false)
+      @simple_socket_handle = double("Handle", closed?: false)
       allow(@simple_socket_handle).to receive(:close)
       allow(@simple_socket_handle).to receive(:setsockopt)
       allow(@simple_socket_handle).to receive(:wait_readable)
       allow(@simple_socket_handle).to receive(:wait_writable)
 
-      @handle = double("SSLHandle", :closed? => false)
+      @handle = double("SSLHandle", closed?: false)
       allow(@handle).to receive(:connect).and_return(true)
       allow(@handle).to receive(:connect_nonblock).and_return(@handle)
       allow(@handle).to receive(:close)
@@ -71,7 +71,7 @@ describe "SSLSocket" do
     end
 
     it "should accept host/port options" do
-      handle = double("Handle", :closed? => false)
+      handle = double("Handle", closed?: false)
       allow(handle).to receive(:close)
       expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.0)
       expect(handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -68,7 +68,7 @@ describe "Struct" do
     def validate_default_arguments(object)
       expect(object.simple).to eq(53)
       expect(object.words).to eq("words")
-      expect(object.hello).to eq(SpecNamespace::Hello.new(:greeting => "hello, world!"))
+      expect(object.hello).to eq(SpecNamespace::Hello.new(greeting: "hello, world!"))
       expect(object.ints).to eq([1, 2, 2, 3])
       expect(object.complex).to be_nil
       expect(object.shorts).to eq(Set.new([5, 17, 239]))
@@ -86,14 +86,14 @@ describe "Struct" do
     end
 
     it "should properly initialize boolean values" do
-      struct = SpecNamespace::BoolStruct.new(:yesno => false)
+      struct = SpecNamespace::BoolStruct.new(yesno: false)
       expect(struct.yesno).to be_falsey
     end
 
     it "should have proper == semantics" do
       expect(SpecNamespace::Foo.new).not_to eq(SpecNamespace::Hello.new)
       expect(SpecNamespace::Foo.new).to eq(SpecNamespace::Foo.new)
-      expect(SpecNamespace::Foo.new(:simple => 52)).not_to eq(SpecNamespace::Foo.new)
+      expect(SpecNamespace::Foo.new(simple: 52)).not_to eq(SpecNamespace::Foo.new)
     end
 
     it "compares only structs of the same generated class" do
@@ -112,25 +112,25 @@ describe "Struct" do
     end
 
     it "should print enum value names in inspect" do
-      expect(SpecNamespace::StructWithSomeEnum.new(:some_enum => SpecNamespace::SomeEnum::ONE).inspect).to eq("<SpecNamespace::StructWithSomeEnum some_enum:ONE (0)>")
+      expect(SpecNamespace::StructWithSomeEnum.new(some_enum: SpecNamespace::SomeEnum::ONE).inspect).to eq("<SpecNamespace::StructWithSomeEnum some_enum:ONE (0)>")
 
-      expect(SpecNamespace::StructWithEnumMap.new(:my_map => {SpecNamespace::SomeEnum::ONE => [SpecNamespace::SomeEnum::TWO]}).inspect).to eq("<SpecNamespace::StructWithEnumMap my_map:{ONE (0): [TWO (1)]}>")
+      expect(SpecNamespace::StructWithEnumMap.new(my_map: {SpecNamespace::SomeEnum::ONE => [SpecNamespace::SomeEnum::TWO]}).inspect).to eq("<SpecNamespace::StructWithEnumMap my_map:{ONE (0): [TWO (1)]}>")
     end
 
     it "should pretty print binary fields" do
-      expect(SpecNamespace::Foo2.new(:my_binary => "\001\002\003").inspect).to eq("<SpecNamespace::Foo2 my_binary:010203>")
+      expect(SpecNamespace::Foo2.new(my_binary: "\001\002\003").inspect).to eq("<SpecNamespace::Foo2 my_binary:010203>")
     end
 
     it "should offer field? methods" do
       expect(SpecNamespace::Foo.new.opt_string?).to be_falsey
-      expect(SpecNamespace::Foo.new(:simple => 52).simple?).to be_truthy
-      expect(SpecNamespace::Foo.new(:my_bool => false).my_bool?).to be_truthy
-      expect(SpecNamespace::Foo.new(:my_bool => true).my_bool?).to be_truthy
+      expect(SpecNamespace::Foo.new(simple: 52).simple?).to be_truthy
+      expect(SpecNamespace::Foo.new(my_bool: false).my_bool?).to be_truthy
+      expect(SpecNamespace::Foo.new(my_bool: true).my_bool?).to be_truthy
     end
 
     it "should be comparable" do
-      s1 = SpecNamespace::StructWithSomeEnum.new(:some_enum => SpecNamespace::SomeEnum::ONE)
-      s2 = SpecNamespace::StructWithSomeEnum.new(:some_enum => SpecNamespace::SomeEnum::TWO)
+      s1 = SpecNamespace::StructWithSomeEnum.new(some_enum: SpecNamespace::SomeEnum::ONE)
+      s2 = SpecNamespace::StructWithSomeEnum.new(some_enum: SpecNamespace::SomeEnum::TWO)
 
       expect(s1 <=> s2).to eq(-1)
       expect(s2 <=> s1).to eq(1)
@@ -178,7 +178,7 @@ describe "Struct" do
 
       expect(struct.simple).to eq(42)
       expect(struct.complex).to eq({1 => {"pi" => Math::PI, "e" => Math::E}, 14 => {"feigenbaum" => 4.669201609}})
-      expect(struct.hello).to eq(SpecNamespace::Hello.new(:greeting => "what's up?"))
+      expect(struct.hello).to eq(SpecNamespace::Hello.new(greeting: "what's up?"))
       expect(struct.words).to eq("apple banana")
       expect(struct.ints).to eq([4, 23, 4, 29])
       expect(struct.shorts).to eq(Set.new([3, 2]))
@@ -233,7 +233,7 @@ describe "Struct" do
     end
 
     it "should serialize false boolean fields correctly" do
-      b = SpecNamespace::BoolStruct.new(:yesno => false)
+      b = SpecNamespace::BoolStruct.new(yesno: false)
       prot = Thrift::BinaryProtocol.new(Thrift::MemoryBufferTransport.new)
       expect(prot).to receive(:write_bool).with(false)
       b.write(prot)
@@ -265,7 +265,7 @@ describe "Struct" do
       expect(struct.simple).to eq(42)
       expect(struct.complex).to be_nil
       expect(struct.words).to eq("foobar")
-      expect(struct.hello).to eq(SpecNamespace::Hello.new(:greeting => "hello, world!"))
+      expect(struct.hello).to eq(SpecNamespace::Hello.new(greeting: "hello, world!"))
       expect(struct.ints).to eq([1, 2, 2, 3])
       expect(struct.shorts).to eq(Set.new([5, 17, 239]))
     end
@@ -310,8 +310,8 @@ describe "Struct" do
 
     it "should serialize subclasses of Set like Set" do
       set_subclass = Class.new(Set)
-      regular = SpecNamespace::Foo.new(:shorts => Set.new([5, 17, 239]))
-      subclassed = SpecNamespace::Foo.new(:shorts => set_subclass.new([5, 17, 239]))
+      regular = SpecNamespace::Foo.new(shorts: Set.new([5, 17, 239]))
+      subclassed = SpecNamespace::Foo.new(shorts: set_subclass.new([5, 17, 239]))
       serializer = Thrift::Serializer.new(Thrift::BinaryProtocolFactory.new)
 
       expect(serializer.serialize(subclassed)).to eq(serializer.serialize(regular))
@@ -320,17 +320,17 @@ describe "Struct" do
     it "should raise an exception if presented with an unknown container" do
       # yeah this is silly, but I'm going for code coverage here
       struct = SpecNamespace::Foo.new
-      expect { struct.send :write_container, nil, nil, {:type => "foo"} }.to raise_error(StandardError, "Not a container type: foo")
+      expect { struct.send :write_container, nil, nil, {type: "foo"} }.to raise_error(StandardError, "Not a container type: foo")
     end
 
     it "should support optional type-checking in Thrift::Struct.new" do
       Thrift.type_checking = true
       begin
-        expect { SpecNamespace::Hello.new(:greeting => 3) }.to raise_error(Thrift::TypeError, "Expected Types::STRING, received Integer for field greeting")
+        expect { SpecNamespace::Hello.new(greeting: 3) }.to raise_error(Thrift::TypeError, "Expected Types::STRING, received Integer for field greeting")
       ensure
         Thrift.type_checking = false
       end
-      expect { SpecNamespace::Hello.new(:greeting => 3) }.not_to raise_error
+      expect { SpecNamespace::Hello.new(greeting: 3) }.not_to raise_error
     end
 
     it "should support optional type-checking in field accessors" do
@@ -345,7 +345,7 @@ describe "Struct" do
     end
 
     it "should raise an exception when unknown types are given to Thrift::Struct.new" do
-      expect { SpecNamespace::Hello.new(:fish => "salmon") }.to raise_error(Exception, "Unknown key given to SpecNamespace::Hello.new: fish")
+      expect { SpecNamespace::Hello.new(fish: "salmon") }.to raise_error(Exception, "Unknown key given to SpecNamespace::Hello.new: fish")
     end
 
     it "should support `raise Xception, 'message'` for Exception structs" do
@@ -371,7 +371,7 @@ describe "Struct" do
 
     it "should support the regular initializer for exception structs" do
       begin
-        raise SpecNamespace::Xception, :message => "something happened", :code => 5
+        raise SpecNamespace::Xception, {message: "something happened", code: 5}
       rescue Thrift::Exception => e
         expect(e.message).to eq("something happened")
         expect(e.code).to eq(5)

--- a/lib/rb/spec/thin_http_server_spec.rb
+++ b/lib/rb/spec/thin_http_server_spec.rb
@@ -27,7 +27,7 @@ rescue LoadError
   # The thin gem is optional and may be excluded on unsupported Ruby versions.
 end
 
-thin_dependency = defined?(Thin) ? {} : { :skip => "thin not available" }
+thin_dependency = defined?(Thin) ? {} : { skip: "thin not available" }
 
 describe "Thrift::ThinHTTPServer", thin_dependency do
   let(:processor) { double("processor") }
@@ -81,22 +81,18 @@ describe "Thrift::ThinHTTPServer", thin_dependency do
         port = 3000
         path = "/thin"
         expect(Thin::Server).to receive(:new).with(ip, port, an_instance_of(Rack::Builder))
-        Thrift::ThinHTTPServer.new(processor,
-                           :ip => ip,
-                           :port => port,
-                           :path => path)
+        Thrift::ThinHTTPServer.new(processor, {ip: ip, port: port, path: path})
       end
 
       it "creates a ThinHTTPServer::RackApplicationContext with a different protocol factory" do
         expect(Thrift::ThinHTTPServer::RackApplication).to receive(:mapped).with("/", processor, an_instance_of(Thrift::JsonProtocolFactory)).and_return(anything)
-        Thrift::ThinHTTPServer.new(processor,
-                           :protocol_factory => Thrift::JsonProtocolFactory.new)
+        Thrift::ThinHTTPServer.new(processor, {protocol_factory: Thrift::JsonProtocolFactory.new})
       end
 
       it "configures SSL" do
         ssl_options = {
-          :private_key_file => "/path/to/server.key",
-          :cert_chain_file => "/path/to/server.crt"
+          private_key_file: "/path/to/server.key",
+          cert_chain_file: "/path/to/server.crt"
         }
         underlying_thin_server = double("thin server")
         allow(Thin::Server).to receive(:new).and_return(underlying_thin_server)
@@ -104,14 +100,14 @@ describe "Thrift::ThinHTTPServer", thin_dependency do
         expect(underlying_thin_server).to receive(:ssl=).with(true)
         expect(underlying_thin_server).to receive(:ssl_options=).with(ssl_options)
 
-        Thrift::ThinHTTPServer.new(processor, :ssl => true, :ssl_options => ssl_options)
+        Thrift::ThinHTTPServer.new(processor, {ssl: true, ssl_options: ssl_options})
       end
     end
   end
 
   describe "#serve" do
     it "starts the Thin server" do
-      underlying_thin_server = double("thin server", :start => true)
+      underlying_thin_server = double("thin server", start: true)
       allow(Thin::Server).to receive(:new).and_return(underlying_thin_server)
 
       thin_thrift_server = Thrift::ThinHTTPServer.new(processor)

--- a/lib/rb/spec/types_spec.rb
+++ b/lib/rb/spec/types_spec.rb
@@ -39,77 +39,77 @@ describe Thrift::Types do
 
     it "should check types properly" do
       # lambda { Thrift.check_type(nil, Thrift::Types::STOP) }.should raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(3,               {:type => Thrift::Types::STOP},   :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil,             {:type => Thrift::Types::VOID},   :foo) }.not_to raise_error
-      expect { Thrift.check_type(3,               {:type => Thrift::Types::VOID},   :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(true,            {:type => Thrift::Types::BOOL},   :foo) }.not_to raise_error
-      expect { Thrift.check_type(3,               {:type => Thrift::Types::BOOL},   :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(42,              {:type => Thrift::Types::BYTE},   :foo) }.not_to raise_error
-      expect { Thrift.check_type(42,              {:type => Thrift::Types::I16},    :foo) }.not_to raise_error
-      expect { Thrift.check_type(42,              {:type => Thrift::Types::I32},    :foo) }.not_to raise_error
-      expect { Thrift.check_type(42,              {:type => Thrift::Types::I64},    :foo) }.not_to raise_error
-      expect { Thrift.check_type(3.14,            {:type => Thrift::Types::I32},    :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(3.14,            {:type => Thrift::Types::DOUBLE}, :foo) }.not_to raise_error
-      expect { Thrift.check_type(3,               {:type => Thrift::Types::DOUBLE}, :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type("3",             {:type => Thrift::Types::STRING}, :foo) }.not_to raise_error
-      expect { Thrift.check_type(3,               {:type => Thrift::Types::STRING}, :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(3,               {type: Thrift::Types::STOP},   :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil,             {type: Thrift::Types::VOID},   :foo) }.not_to raise_error
+      expect { Thrift.check_type(3,               {type: Thrift::Types::VOID},   :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(true,            {type: Thrift::Types::BOOL},   :foo) }.not_to raise_error
+      expect { Thrift.check_type(3,               {type: Thrift::Types::BOOL},   :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(42,              {type: Thrift::Types::BYTE},   :foo) }.not_to raise_error
+      expect { Thrift.check_type(42,              {type: Thrift::Types::I16},    :foo) }.not_to raise_error
+      expect { Thrift.check_type(42,              {type: Thrift::Types::I32},    :foo) }.not_to raise_error
+      expect { Thrift.check_type(42,              {type: Thrift::Types::I64},    :foo) }.not_to raise_error
+      expect { Thrift.check_type(3.14,            {type: Thrift::Types::I32},    :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(3.14,            {type: Thrift::Types::DOUBLE}, :foo) }.not_to raise_error
+      expect { Thrift.check_type(3,               {type: Thrift::Types::DOUBLE}, :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type("3",             {type: Thrift::Types::STRING}, :foo) }.not_to raise_error
+      expect { Thrift.check_type(3,               {type: Thrift::Types::STRING}, :foo) }.to raise_error(Thrift::TypeError)
       hello = SpecNamespace::Hello.new
-      expect { Thrift.check_type(hello,           {:type => Thrift::Types::STRUCT, :class => SpecNamespace::Hello}, :foo) }.not_to raise_error
-      expect { Thrift.check_type("foo",           {:type => Thrift::Types::STRUCT}, :foo) }.to raise_error(Thrift::TypeError)
-      field = {:type => Thrift::Types::MAP, :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRING}}
+      expect { Thrift.check_type(hello,           {type: Thrift::Types::STRUCT, class: SpecNamespace::Hello}, :foo) }.not_to raise_error
+      expect { Thrift.check_type("foo",           {type: Thrift::Types::STRUCT}, :foo) }.to raise_error(Thrift::TypeError)
+      field = {type: Thrift::Types::MAP, key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRING}}
       expect { Thrift.check_type({1 => "one"},    field,                            :foo) }.not_to raise_error
       expect { Thrift.check_type([1],             field,                            :foo) }.to raise_error(Thrift::TypeError)
-      field = {:type => Thrift::Types::LIST, :element => {:type => Thrift::Types::I32}}
-      expect { Thrift.check_type([1],             field,                            :foo) }.not_to raise_error
-      expect { Thrift.check_type({:foo => 1},     field,                            :foo) }.to raise_error(Thrift::TypeError)
-      field = {:type => Thrift::Types::SET, :element => {:type => Thrift::Types::I32}}
+      field = {type: Thrift::Types::LIST, element: {type: Thrift::Types::I32}}
+      expect { Thrift.check_type([1], field, :foo) }.not_to raise_error
+      expect { Thrift.check_type({foo: 1}, field, :foo) }.to raise_error(Thrift::TypeError)
+      field = {type: Thrift::Types::SET, element: {type: Thrift::Types::I32}}
       expect { Thrift.check_type(Set.new([1, 2]), field,                            :foo) }.not_to raise_error
       expect { Thrift.check_type([1, 2],          field,                            :foo) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type({:foo => true},  field,                            :foo) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type({foo: true}, field, :foo) }.to raise_error(Thrift::TypeError)
     end
 
     it "should error out if nil is passed and skip_types is false" do
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::BOOL},   :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::BYTE},   :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::I16},    :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::I32},    :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::I64},    :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::DOUBLE}, :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::STRING}, :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::STRUCT}, :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::LIST},   :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::SET},    :foo, false) }.to raise_error(Thrift::TypeError)
-      expect { Thrift.check_type(nil, {:type => Thrift::Types::MAP},    :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::BOOL},   :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::BYTE},   :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::I16},    :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::I32},    :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::I64},    :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::DOUBLE}, :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::STRING}, :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::STRUCT}, :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::LIST},   :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::SET},    :foo, false) }.to raise_error(Thrift::TypeError)
+      expect { Thrift.check_type(nil, {type: Thrift::Types::MAP},    :foo, false) }.to raise_error(Thrift::TypeError)
     end
 
     it "should check element types on containers" do
-      field = {:type => Thrift::Types::LIST, :element => {:type => Thrift::Types::I32}}
+      field = {type: Thrift::Types::LIST, element: {type: Thrift::Types::I32}}
       expect { Thrift.check_type([1, 2], field, :foo) }.not_to raise_error
       expect { Thrift.check_type([1, nil, 2], field, :foo) }.to raise_error(Thrift::TypeError)
-      field = {:type => Thrift::Types::MAP, :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRING}}
+      field = {type: Thrift::Types::MAP, key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRING}}
       expect { Thrift.check_type({1 => "one", 2 => "two"}, field, :foo) }.not_to raise_error
       expect { Thrift.check_type({1 => "one", nil => "nil"}, field, :foo) }.to raise_error(Thrift::TypeError)
       expect { Thrift.check_type({1 => nil, 2 => "two"}, field, :foo) }.to raise_error(Thrift::TypeError)
-      field = {:type => Thrift::Types::SET, :element => {:type => Thrift::Types::I32}}
+      field = {type: Thrift::Types::SET, element: {type: Thrift::Types::I32}}
       expect { Thrift.check_type(Set.new([1, 2]), field, :foo) }.not_to raise_error
       expect { Thrift.check_type(Set.new([1, nil, 2]), field, :foo) }.to raise_error(Thrift::TypeError)
       expect { Thrift.check_type(Set.new([1, 2.3, 2]), field, :foo) }.to raise_error(Thrift::TypeError)
 
-      field = {:type => Thrift::Types::STRUCT, :class => SpecNamespace::Hello}
+      field = {type: Thrift::Types::STRUCT, class: SpecNamespace::Hello}
       expect { Thrift.check_type(SpecNamespace::BoolStruct, field, :foo) }.to raise_error(Thrift::TypeError)
     end
 
     it "should give the Thrift::TypeError a readable message" do
       msg = "Expected Types::STRING, received Integer for field foo"
-      expect { Thrift.check_type(3, {:type => Thrift::Types::STRING}, :foo) }.to raise_error(Thrift::TypeError, msg)
+      expect { Thrift.check_type(3, {type: Thrift::Types::STRING}, :foo) }.to raise_error(Thrift::TypeError, msg)
       msg = "Expected Types::STRING, received Integer for field foo.element"
-      field = {:type => Thrift::Types::LIST, :element => {:type => Thrift::Types::STRING}}
+      field = {type: Thrift::Types::LIST, element: {type: Thrift::Types::STRING}}
       expect { Thrift.check_type([3], field, :foo) }.to raise_error(Thrift::TypeError, msg)
       msg = "Expected Types::I32, received NilClass for field foo.element.key"
-      field = {:type => Thrift::Types::LIST,
-               :element => {:type => Thrift::Types::MAP,
-                            :key => {:type => Thrift::Types::I32},
-                            :value => {:type => Thrift::Types::I32}}}
+      field = {type: Thrift::Types::LIST,
+               element: {type: Thrift::Types::MAP,
+                            key: {type: Thrift::Types::I32},
+                            value: {type: Thrift::Types::I32}}}
       expect { Thrift.check_type([{nil => 3}], field, :foo) }.to raise_error(Thrift::TypeError, msg)
       msg = "Expected Types::I32, received NilClass for field foo.element.value"
       expect { Thrift.check_type([{1 => nil}], field, :foo) }.to raise_error(Thrift::TypeError, msg)

--- a/lib/rb/spec/union_spec.rb
+++ b/lib/rb/spec/union_spec.rb
@@ -171,7 +171,7 @@ describe "Union" do
 
     it "should properly serialize and match structs with a union" do
       union = SpecNamespace::My_union.new(:integer32, 26)
-      swu = SpecNamespace::Struct_with_union.new(:fun_union => union)
+      swu = SpecNamespace::Struct_with_union.new(fun_union: union)
 
       trans = Thrift::MemoryBufferTransport.new
       proto = Thrift::CompactProtocol.new(trans)
@@ -179,7 +179,7 @@ describe "Union" do
       swu.write(proto)
 
       other_union = SpecNamespace::My_union.new(:some_characters, "hello there")
-      swu2 = SpecNamespace::Struct_with_union.new(:fun_union => other_union)
+      swu2 = SpecNamespace::Struct_with_union.new(fun_union: other_union)
 
       expect(swu2).not_to eq(swu)
 
@@ -188,7 +188,7 @@ describe "Union" do
     end
 
     it "should support old style constructor" do
-      union = SpecNamespace::My_union.new(:integer32 => 26)
+      union = SpecNamespace::My_union.new(integer32: 26)
       expect(union.get_set_field).to eq(:integer32)
       expect(union.get_value).to eq(26)
     end
@@ -198,20 +198,20 @@ describe "Union" do
     end
 
     it "should print enum value name when inspected" do
-      expect(SpecNamespace::My_union.new(:some_enum => SpecNamespace::SomeEnum::ONE).inspect).to eq("<SpecNamespace::My_union some_enum: ONE (0)>")
+      expect(SpecNamespace::My_union.new(some_enum: SpecNamespace::SomeEnum::ONE).inspect).to eq("<SpecNamespace::My_union some_enum: ONE (0)>")
 
-      expect(SpecNamespace::My_union.new(:my_map => {SpecNamespace::SomeEnum::ONE => [SpecNamespace::SomeEnum::TWO]}).inspect).to eq("<SpecNamespace::My_union my_map: {ONE (0): [TWO (1)]}>")
+      expect(SpecNamespace::My_union.new(my_map: {SpecNamespace::SomeEnum::ONE => [SpecNamespace::SomeEnum::TWO]}).inspect).to eq("<SpecNamespace::My_union my_map: {ONE (0): [TWO (1)]}>")
     end
 
     it "should offer field? methods" do
       expect(SpecNamespace::My_union.new.some_enum?).to be_falsey
-      expect(SpecNamespace::My_union.new(:some_enum => SpecNamespace::SomeEnum::ONE).some_enum?).to be_truthy
-      expect(SpecNamespace::My_union.new(:im_true => false).im_true?).to be_truthy
-      expect(SpecNamespace::My_union.new(:im_true => true).im_true?).to be_truthy
+      expect(SpecNamespace::My_union.new(some_enum: SpecNamespace::SomeEnum::ONE).some_enum?).to be_truthy
+      expect(SpecNamespace::My_union.new(im_true: false).im_true?).to be_truthy
+      expect(SpecNamespace::My_union.new(im_true: true).im_true?).to be_truthy
     end
 
     it "should pretty print binary fields" do
-      expect(SpecNamespace::TestUnion.new(:binary_field => "\001\002\003").inspect).to eq("<SpecNamespace::TestUnion binary_field: 010203>")
+      expect(SpecNamespace::TestUnion.new(binary_field: "\001\002\003").inspect).to eq("<SpecNamespace::TestUnion binary_field: 010203>")
     end
 
     it "should be comparable" do

--- a/lib/rb/spec/unix_socket_spec.rb
+++ b/lib/rb/spec/unix_socket_spec.rb
@@ -26,7 +26,7 @@ describe "UNIXSocket" do
     before(:each) do
       @path = "/tmp/thrift_spec_socket"
       @socket = Thrift::UNIXSocket.new(@path)
-      @handle = double("Handle", :closed? => false)
+      @handle = double("Handle", closed?: false)
       allow(@handle).to receive(:close)
       allow(::UNIXSocket).to receive(:new).and_return(@handle)
     end
@@ -88,7 +88,7 @@ describe "UNIXSocket" do
     end
 
     it "should close the handle when closed" do
-      handle = double("UNIXServer", :closed? => false)
+      handle = double("UNIXServer", closed?: false)
       expect(UNIXServer).to receive(:new).with(@path).and_return(handle)
       @socket.listen
       expect(handle).to receive(:close)
@@ -97,7 +97,7 @@ describe "UNIXSocket" do
     end
 
     it "should delete the socket when closed" do
-      handle = double("UNIXServer", :closed? => false)
+      handle = double("UNIXServer", closed?: false)
       expect(UNIXServer).to receive(:new).with(@path).and_return(handle)
       @socket.listen
       allow(handle).to receive(:close)
@@ -110,7 +110,7 @@ describe "UNIXSocket" do
     end
 
     it "should return true for closed? when appropriate" do
-      handle = double("UNIXServer", :closed? => false)
+      handle = double("UNIXServer", closed?: false)
       allow(UNIXServer).to receive(:new).and_return(handle)
       allow(File).to receive(:delete)
       @socket.listen

--- a/test/rb/fixtures/structs.rb
+++ b/test/rb/fixtures/structs.rb
@@ -26,7 +26,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::BOOL, :name => "bool"}
+        1 => {type: Thrift::Types::BOOL, name: "bool"}
       }
 
       def struct_fields; FIELDS; end
@@ -41,7 +41,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::BYTE, :name => "byte"}
+        1 => {type: Thrift::Types::BYTE, name: "byte"}
       }
 
       def struct_fields; FIELDS; end
@@ -56,7 +56,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::I16, :name => "i16"}
+        1 => {type: Thrift::Types::I16, name: "i16"}
       }
 
       def struct_fields; FIELDS; end
@@ -71,7 +71,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::I32, :name => "i32"}
+        1 => {type: Thrift::Types::I32, name: "i32"}
       }
 
       def struct_fields; FIELDS; end
@@ -86,7 +86,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::I64, :name => "i64"}
+        1 => {type: Thrift::Types::I64, name: "i64"}
       }
 
       def struct_fields; FIELDS; end
@@ -101,7 +101,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::DOUBLE, :name => "double"}
+        1 => {type: Thrift::Types::DOUBLE, name: "double"}
       }
 
       def struct_fields; FIELDS; end
@@ -116,7 +116,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::STRING, :name => "string"}
+        1 => {type: Thrift::Types::STRING, name: "string"}
       }
 
       def struct_fields; FIELDS; end
@@ -131,7 +131,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::MAP, :name => "map", :key => {:type => Thrift::Types::STRING}, :value => {:type => Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRING}}
       }
 
       def struct_fields; FIELDS; end
@@ -146,7 +146,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        0 => {:type => Thrift::Types::MAP, :name => "map", :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::MAP, :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::I32}}}
+        0 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::MAP, key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::I32}}}
       }
 
       def struct_fields; FIELDS; end
@@ -161,7 +161,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::LIST, :name => "list", :element => {:type => Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::STRING}}
       }
 
       def struct_fields; FIELDS; end
@@ -176,7 +176,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        0 => {:type => Thrift::Types::LIST, :name => "list", :element => {:type => Thrift::Types::LIST, :element => { :type => Thrift::Types::I32 } } }
+        0 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::LIST, element: { type: Thrift::Types::I32 } } }
       }
 
       def struct_fields; FIELDS; end
@@ -191,7 +191,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::SET, :name => "set", :element => {:type => Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::STRING}}
       }
 
       def struct_fields; FIELDS; end
@@ -206,7 +206,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::SET, :name => "set", :element => {:type => Thrift::Types::SET, :element => { :type => Thrift::Types::STRING } }}
+        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::SET, element: { type: Thrift::Types::STRING } }}
       }
 
       def struct_fields; FIELDS; end
@@ -234,17 +234,17 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::BOOL, :name => "im_true"},
-        2 => {:type => Thrift::Types::BOOL, :name => "im_false"},
-        3 => {:type => Thrift::Types::BYTE, :name => "a_bite"},
-        4 => {:type => Thrift::Types::I16, :name => "integer16"},
-        5 => {:type => Thrift::Types::I32, :name => "integer32"},
-        6 => {:type => Thrift::Types::I64, :name => "integer64"},
-        7 => {:type => Thrift::Types::DOUBLE, :name => "double_precision"},
-        8 => {:type => Thrift::Types::STRING, :name => "some_characters"},
-        9 => {:type => Thrift::Types::STRING, :name => "zomg_unicode"},
-        10 => {:type => Thrift::Types::BOOL, :name => "what_who"},
-        11 => {:type => Thrift::Types::STRING, :name => "base64", :binary => true}
+        1 => {type: Thrift::Types::BOOL, name: "im_true"},
+        2 => {type: Thrift::Types::BOOL, name: "im_false"},
+        3 => {type: Thrift::Types::BYTE, name: "a_bite"},
+        4 => {type: Thrift::Types::I16, name: "integer16"},
+        5 => {type: Thrift::Types::I32, name: "integer32"},
+        6 => {type: Thrift::Types::I64, name: "integer64"},
+        7 => {type: Thrift::Types::DOUBLE, name: "double_precision"},
+        8 => {type: Thrift::Types::STRING, name: "some_characters"},
+        9 => {type: Thrift::Types::STRING, name: "zomg_unicode"},
+        10 => {type: Thrift::Types::BOOL, name: "what_who"},
+        11 => {type: Thrift::Types::STRING, name: "base64", binary: true}
       }
 
       def struct_fields; FIELDS; end
@@ -266,11 +266,11 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::LIST, :name => "a_list", :element => {:type => Thrift::Types::STRUCT, :class => OneOfEach}},
-        2 => {:type => Thrift::Types::MAP, :name => "i32_map", :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRUCT, :class => OneOfEach}},
-        3 => {:type => Thrift::Types::MAP, :name => "i64_map", :key => {:type => Thrift::Types::I64}, :value => {:type => Thrift::Types::STRUCT, :class => OneOfEach}},
-        4 => {:type => Thrift::Types::MAP, :name => "dbl_map", :key => {:type => Thrift::Types::DOUBLE}, :value => {:type => Thrift::Types::STRUCT, :class => OneOfEach}},
-        5 => {:type => Thrift::Types::MAP, :name => "str_map", :key => {:type => Thrift::Types::STRING}, :value => {:type => Thrift::Types::STRUCT, :class => OneOfEach}}
+        1 => {type: Thrift::Types::LIST, name: "a_list", element: {type: Thrift::Types::STRUCT, class: OneOfEach}},
+        2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
+        3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
+        4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}}
       }
 
       def struct_fields; FIELDS; end
@@ -292,11 +292,11 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::LIST, :name => "a_list", :element => {:type => Thrift::Types::STRUCT, :class => Nested1}},
-        2 => {:type => Thrift::Types::MAP, :name => "i32_map", :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRUCT, :class => Nested1}},
-        3 => {:type => Thrift::Types::MAP, :name => "i64_map", :key => {:type => Thrift::Types::I64}, :value => {:type => Thrift::Types::STRUCT, :class => Nested1}},
-        4 => {:type => Thrift::Types::MAP, :name => "dbl_map", :key => {:type => Thrift::Types::DOUBLE}, :value => {:type => Thrift::Types::STRUCT, :class => Nested1}},
-        5 => {:type => Thrift::Types::MAP, :name => "str_map", :key => {:type => Thrift::Types::STRING}, :value => {:type => Thrift::Types::STRUCT, :class => Nested1}}
+        1 => {type: Thrift::Types::LIST, name: "a_list", element: {type: Thrift::Types::STRUCT, class: Nested1}},
+        2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
+        3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
+        4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested1}}
       }
 
       def struct_fields; FIELDS; end
@@ -318,11 +318,11 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::LIST, :name => "a_list", :element => {:type => Thrift::Types::STRUCT, :class => Nested2}},
-        2 => {:type => Thrift::Types::MAP, :name => "i32_map", :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRUCT, :class => Nested2}},
-        3 => {:type => Thrift::Types::MAP, :name => "i64_map", :key => {:type => Thrift::Types::I64}, :value => {:type => Thrift::Types::STRUCT, :class => Nested2}},
-        4 => {:type => Thrift::Types::MAP, :name => "dbl_map", :key => {:type => Thrift::Types::DOUBLE}, :value => {:type => Thrift::Types::STRUCT, :class => Nested2}},
-        5 => {:type => Thrift::Types::MAP, :name => "str_map", :key => {:type => Thrift::Types::STRING}, :value => {:type => Thrift::Types::STRUCT, :class => Nested2}}
+        1 => {type: Thrift::Types::LIST, name: "a_list", element: {type: Thrift::Types::STRUCT, class: Nested2}},
+        2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
+        3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
+        4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested2}}
       }
 
       def struct_fields; FIELDS; end
@@ -344,11 +344,11 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {:type => Thrift::Types::LIST, :name => "a_list", :element => {:type => Thrift::Types::STRUCT, :class => Nested3}},
-        2 => {:type => Thrift::Types::MAP, :name => "i32_map", :key => {:type => Thrift::Types::I32}, :value => {:type => Thrift::Types::STRUCT, :class => Nested3}},
-        3 => {:type => Thrift::Types::MAP, :name => "i64_map", :key => {:type => Thrift::Types::I64}, :value => {:type => Thrift::Types::STRUCT, :class => Nested3}},
-        4 => {:type => Thrift::Types::MAP, :name => "dbl_map", :key => {:type => Thrift::Types::DOUBLE}, :value => {:type => Thrift::Types::STRUCT, :class => Nested3}},
-        5 => {:type => Thrift::Types::MAP, :name => "str_map", :key => {:type => Thrift::Types::STRING}, :value => {:type => Thrift::Types::STRUCT, :class => Nested3}}
+        1 => {type: Thrift::Types::LIST, name: "a_list", element: {type: Thrift::Types::STRUCT, class: Nested3}},
+        2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
+        3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
+        4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested3}}
       }
 
       def struct_fields; FIELDS; end

--- a/test/rb/generation/test_struct.rb
+++ b/test/rb/generation/test_struct.rb
@@ -38,7 +38,7 @@ class TestStructGeneration < Test::Unit::TestCase
     assert_kind_of(Hash, hello.complex)
     assert_equal(hello.complex, { 6243 => 632, 2355 => 532, 23 => 532})
 
-    bool_passer = TestNamespace::BoolPasser.new(:value => false)
+    bool_passer = TestNamespace::BoolPasser.new(value: false)
     assert_equal false, bool_passer.value
   end
 

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -390,10 +390,10 @@ class SimpleClientTest < Test::Unit::TestCase
     p "test_multi"
     ret = @client.testMulti(42, 4242, 424242, {1 => "blah", 2 => "thing"}, Thrift::Test::Numberz::EIGHT, 24)
     expected = Thrift::Test::Xtruct.new({
-      :string_thing => "Hello2",
-      :byte_thing =>   42,
-      :i32_thing =>    4242,
-      :i64_thing =>    424242
+      string_thing: "Hello2",
+      byte_thing: 42,
+      i32_thing: 4242,
+      i64_thing: 424242
     })
     assert_equal(expected, ret)
   end

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -84,9 +84,9 @@ class SimpleHandler
 
   def testException(thing)
     if thing == "Xception"
-      raise Thrift::Test::Xception, :errorCode => 1001, :message => thing
+      raise Thrift::Test::Xception, {errorCode: 1001, message: thing}
     elsif thing == "TException"
-      raise Thrift::Exception, :message => thing
+      raise Thrift::Exception, {message: thing}
     else
       # no-op
     end
@@ -94,9 +94,9 @@ class SimpleHandler
 
   def testMultiException(arg0, arg1)
     if arg0 == "Xception2"
-      raise Thrift::Test::Xception2, :errorCode => 2002, :struct_thing => ::Thrift::Test::Xtruct.new({ :string_thing => "This is an Xception2" })
+      raise Thrift::Test::Xception2, {errorCode: 2002, struct_thing: ::Thrift::Test::Xtruct.new({ string_thing: "This is an Xception2" })}
     elsif arg0 == "Xception"
-      raise Thrift::Test::Xception, :errorCode => 1001, :message => "This is an Xception"
+      raise Thrift::Test::Xception, {errorCode: 1001, message: "This is an Xception"}
     else
       return ::Thrift::Test::Xtruct.new({"string_thing" => arg1})
     end
@@ -275,13 +275,13 @@ end
 server = case normalized_server_type
 when "thin"
   require "thrift/server/thin_http_server"
-  thin_options = { :port => options[:port], :protocol_factory => protocol_factory }
+  thin_options = { port: options[:port], protocol_factory: protocol_factory }
   if options[:ssl]
     thin_options[:ssl] = true
     thin_options[:ssl_options] = {
-      :private_key_file => File.join(keys_dir, "server.key"),
-      :cert_chain_file => File.join(keys_dir, "server.crt"),
-      :verify_peer => false
+      private_key_file: File.join(keys_dir, "server.key"),
+      cert_chain_file: File.join(keys_dir, "server.crt"),
+      verify_peer: false
     }
   end
   Thrift::ThinHTTPServer.new(processor, thin_options)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby sources currently use a mixture of hash rockets and label syntax for symbol keys. This enables `Style/HashSyntax` and normalizes symbol-keyed hashes across the Ruby library and tests while continuing to allow either form of value shorthand.

The Ruby compiler now emits label syntax for generated field metadata and service arguments. Hash rockets remain in generated output where keys are dynamic or non-symbol values.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
