### PR TITLE
Enable multiline Ruby layout cops

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -718,10 +718,6 @@ void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct)
   out.indent() << "FIELDS = {" << '\n';
   out.indent_up();
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    if (f_iter != fields.begin()) {
-      out << "," << '\n';
-    }
-
     // generate the field docstrings within the FIELDS constant. no real better place...
     generate_rdoc(out, *f_iter);
 
@@ -732,9 +728,9 @@ void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct)
                         (*f_iter)->get_name(),
                         (*f_iter)->get_value(),
                         (*f_iter)->get_req() == t_field::T_OPTIONAL);
+    out << "," << '\n';
   }
   out.indent_down();
-  out << '\n';
   out.indent() << "}" << '\n' << '\n';
 
   out.indent() << "def struct_fields; FIELDS; end" << '\n' << '\n';
@@ -750,50 +746,115 @@ void t_rb_generator::generate_field_data(t_rb_ofstream& out,
                                          t_const_value* field_value = nullptr,
                                          bool optional = false) {
   field_type = get_true_type(field_type);
+  const bool multiline = field_value != nullptr
+                         && (field_type->is_struct() || field_type->is_xception()
+                             || field_type->is_map() || field_type->is_list()
+                             || field_type->is_set());
 
   // Begin this field's defn
-  out << "{type: " << type_to_enum(field_type);
+  out << "{";
+  if (multiline) {
+    out << '\n';
+    out.indent_up();
+    out.indent() << "type: " << type_to_enum(field_type) << "," << '\n';
+  } else {
+    out << "type: " << type_to_enum(field_type);
+  }
 
   if (!field_name.empty()) {
-    out << ", name: \"" << field_name << "\"";
+    if (multiline) {
+      out.indent() << "name: \"" << field_name << "\"," << '\n';
+    } else {
+      out << ", name: \"" << field_name << "\"";
+    }
   }
 
   if (field_value != nullptr) {
-    out << ", default: ";
-    render_const_value(out, field_type, field_value);
+    if (multiline) {
+      out.indent() << "default: ";
+      render_const_value(out, field_type, field_value) << "," << '\n';
+    } else {
+      out << ", default: ";
+      render_const_value(out, field_type, field_value);
+    }
   }
 
   if (!field_type->is_base_type()) {
     if (field_type->is_struct() || field_type->is_xception()) {
-      out << ", class: " << full_type_name((t_struct*)field_type);
+      if (multiline) {
+        out.indent() << "class: " << full_type_name((t_struct*)field_type) << "," << '\n';
+      } else {
+        out << ", class: " << full_type_name((t_struct*)field_type);
+      }
     } else if (field_type->is_list()) {
-      out << ", element: ";
+      if (multiline) {
+        out.indent() << "element: ";
+      } else {
+        out << ", element: ";
+      }
       generate_field_data(out, ((t_list*)field_type)->get_elem_type());
+      if (multiline) {
+        out << "," << '\n';
+      }
     } else if (field_type->is_map()) {
-      out << ", key: ";
+      if (multiline) {
+        out.indent() << "key: ";
+      } else {
+        out << ", key: ";
+      }
       generate_field_data(out, ((t_map*)field_type)->get_key_type());
-      out << ", value: ";
+      if (multiline) {
+        out << "," << '\n';
+        out.indent() << "value: ";
+      } else {
+        out << ", value: ";
+      }
       generate_field_data(out, ((t_map*)field_type)->get_val_type());
+      if (multiline) {
+        out << "," << '\n';
+      }
     } else if (field_type->is_set()) {
-      out << ", element: ";
+      if (multiline) {
+        out.indent() << "element: ";
+      } else {
+        out << ", element: ";
+      }
       generate_field_data(out, ((t_set*)field_type)->get_elem_type());
+      if (multiline) {
+        out << "," << '\n';
+      }
     }
-  } else {
-    if (((t_base_type*)field_type)->is_binary()) {
+  } else if (((t_base_type*)field_type)->is_binary()) {
+    if (multiline) {
+      out.indent() << "binary: true," << '\n';
+    } else {
       out << ", binary: true";
     }
   }
 
   if (optional) {
-    out << ", optional: true";
+    if (multiline) {
+      out.indent() << "optional: true," << '\n';
+    } else {
+      out << ", optional: true";
+    }
   }
 
   if (field_type->is_enum()) {
-    out << ", enum_class: " << full_type_name(field_type);
+    if (multiline) {
+      out.indent() << "enum_class: " << full_type_name(field_type) << "," << '\n';
+    } else {
+      out << ", enum_class: " << full_type_name(field_type);
+    }
   }
 
   // End of this field's defn
-  out << "}";
+  if (multiline) {
+    out.indent_down();
+    out.indent() << "}";
+  } else {
+    out << "}";
+  }
 }
 
 void t_rb_generator::begin_namespace(t_rb_ofstream& out, vector<std::string> modules) {

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -90,10 +90,10 @@ TEST_CASE("t_rb_generator uses suffixed field id constants to avoid FIELDS colli
     const string generated_content = read_file("gen-rb/test_field_id_conflict_types.rb");
     REQUIRE(!generated_content.empty());
     REQUIRE(generated_content.find("FIELDS_FIELD_ID = 1") != string::npos);
-    REQUIRE(generated_content.find("FIELDS_FIELD_ID => {type: ::Thrift::Types::STRING, name: \"fields\"}")
+    REQUIRE(generated_content.find("FIELDS_FIELD_ID => {type: ::Thrift::Types::STRING, name: \"fields\"},")
             != string::npos);
     REQUIRE(generated_content.find("FIELDS = 1") == string::npos);
-    REQUIRE(generated_content.find("FIELDS => {type: ::Thrift::Types::STRING, name: \"fields\"}")
+    REQUIRE(generated_content.find("FIELDS => {type: ::Thrift::Types::STRING, name: \"fields\"},")
             == string::npos);
 
     std::remove(thrift_path.c_str());
@@ -124,6 +124,47 @@ TEST_CASE("t_rb_generator emits service arguments as a positional hash", "[funct
 
     const string service = read_file("gen-rb/ping_service.rb");
     REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
+
+    std::remove(thrift_path.c_str());
+}
+
+TEST_CASE("t_rb_generator formats multiline Ruby literals, calls, and field metadata", "[functional]")
+{
+    const string thrift_path = "test_multiline_layout.thrift";
+    const string thrift_source =
+        "struct Item {\n"
+        "  1: string value\n"
+        "}\n"
+        "const Item ITEM = {\"value\": \"one\"}\n"
+        "const set<i32> IDS = [1, 2]\n"
+        "struct Defaults {\n"
+        "  1: list<i32> values = [1, 2]\n"
+        "}\n";
+
+    {
+        std::ofstream thrift_file(thrift_path, std::ios::binary);
+        REQUIRE(thrift_file.is_open());
+        thrift_file << thrift_source;
+    }
+
+    map<string, string> parsed_options;
+    std::unique_ptr<t_program> program(new t_program(thrift_path, "test_multiline_layout"));
+    parse_thrift_for_test(program.get());
+
+    std::unique_ptr<t_generator> gen(
+        t_generator_registry::get_generator(program.get(), "rb", parsed_options, ""));
+    REQUIRE(gen != nullptr);
+    REQUIRE_NOTHROW(gen->generate_program());
+
+    const string constants = read_file("gen-rb/test_multiline_layout_constants.rb");
+    REQUIRE(constants.find("ITEM = ::Item.new({\n  %q\"value\" => %q\"one\",\n})")
+            != string::npos);
+    REQUIRE(constants.find("IDS = Set.new([\n  1,\n  2,\n])") != string::npos);
+
+    const string types = read_file("gen-rb/test_multiline_layout_types.rb");
+    REQUIRE(types.find("VALUES_FIELD_ID => {\n      type: ::Thrift::Types::LIST,\n")
+            != string::npos);
+    REQUIRE(types.find("default: [\n        1,\n        2,\n      ],\n") != string::npos);
 
     std::remove(thrift_path.c_str());
 }

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -9,23 +9,93 @@ AllCops:
   Exclude:
     - "**/vendor/**/*"
 
+Layout/ArgumentAlignment:
+  Enabled: true
+
+Layout/ArrayAlignment:
+  Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_block
+
+Layout/CaseIndentation:
+  Enabled: true
+  EnforcedStyle: end
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Layout/CommentIndentation:
+  Enabled: true
+
 Layout/EmptyLines:
   Enabled: true
 
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
 
+Layout/ElseAlignment:
+  Enabled: true
+
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: variable
+
 Layout/ExtraSpacing:
   Enabled: true
 
+Layout/FirstArgumentIndentation:
+  Enabled: true
+
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+  AllowMultilineFinalElement: true
+
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedHashRocketStyle:
+    - key
+    - table
+
 Layout/IndentationConsistency:
   Enabled: true
+
+Layout/IndentationWidth:
+  Enabled: true
+  Width: 2
 
 Layout/LeadingCommentSpace:
   Enabled: true
 
 Layout/LeadingEmptyLines:
   Enabled: true
+
+Layout/MultilineArrayBraceLayout:
+  Enabled: true
+  EnforcedStyle: new_line
+
+Layout/MultilineHashBraceLayout:
+  Enabled: true
+  EnforcedStyle: new_line
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: true
+  EnforcedStyle: symmetrical
 
 Layout/SpaceAfterComma:
   Enabled: true
@@ -128,3 +198,15 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
+
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: diff_comma
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma

--- a/lib/rb/Rakefile
+++ b/lib/rb/Rakefile
@@ -84,18 +84,18 @@ end
 
 desc "Build the native library"
 task build_ext: :'gen-rb' do
-   next if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-   next if ENV["SKIP_BUILD_EXT"] == "1"
-   Dir::chdir(File::dirname("ext/extconf.rb")) do
-      unless sh "ruby #{File::basename("ext/extconf.rb")}"
-        $stderr.puts "Failed to run extconf"
-        break
-      end
-      unless sh "make"
-        $stderr.puts "make failed"
-        break
-      end
+  next if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+  next if ENV["SKIP_BUILD_EXT"] == "1"
+  Dir::chdir(File::dirname("ext/extconf.rb")) do
+    unless sh "ruby #{File::basename("ext/extconf.rb")}"
+      $stderr.puts "Failed to run extconf"
+      break
     end
+    unless sh "make"
+      $stderr.puts "make failed"
+      break
+    end
+  end
 end
 
 desc "Run the compiler tests (requires full thrift checkout)"
@@ -137,5 +137,5 @@ end
 CLEAN.include [
   ".bundle", "benchmark/gen-rb", "coverage", "ext/*.{o,bundle,so,dll}", "ext/mkmf.log",
   "ext/Makefile", "ext/conftest.dSYM", "ext/thrift_native.bundle.dSYM", "mkmf.log",
-  "pkg", "spec/gen-rb", "test/debug_proto/gen-rb", "thrift-*.gem"
+  "pkg", "spec/gen-rb", "test/debug_proto/gen-rb", "thrift-*.gem",
 ]

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -235,7 +235,7 @@ class BenchmarkManager
     blue: 34,
     magenta: 35,
     cyan: 36,
-    white: 37
+    white: 37,
   }
 
   def tabulate(fmt, *labels_and_values)

--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -57,14 +57,14 @@ module Thrift
       if mtype != MessageTypes::REPLY
         raise ApplicationException.new(
           ApplicationException::INVALID_MESSAGE_TYPE,
-          "#{expected_name} failed: invalid message type"
+          "#{expected_name} failed: invalid message type",
         )
       end
 
       if fname != expected_name
         raise ApplicationException.new(
           ApplicationException::WRONG_METHOD_NAME,
-          "#{expected_name} failed: wrong method name"
+          "#{expected_name} failed: wrong method name",
         )
       end
 
@@ -72,7 +72,7 @@ module Thrift
 
       raise ApplicationException.new(
         ApplicationException::BAD_SEQUENCE_ID,
-        "#{expected_name} failed: out of sequence response"
+        "#{expected_name} failed: out of sequence response",
       )
     end
 

--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -39,7 +39,7 @@ module Thrift
         iprot.read_message_end
         x = ApplicationException.new(
           ApplicationException::INVALID_MESSAGE_TYPE,
-          "Invalid message type #{type} for function #{name}"
+          "Invalid message type #{type} for function #{name}",
         )
         write_error(x, oprot, name, seqid)
         return false

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -78,23 +78,23 @@ module Thrift
         SET           => Types::SET,
         MAP           => Types::MAP,
         STRUCT        => Types::STRUCT,
-        UUID          => Types::UUID
+        UUID          => Types::UUID,
       }
 
       TTYPE_TO_COMPACT = {
-        Types::STOP           => Types::STOP,
-        Types::BOOL           => BOOLEAN_TRUE,
-        Types::BYTE           => BYTE,
-        Types::I16            => I16,
-        Types::I32            => I32,
-        Types::I64            => I64,
-        Types::DOUBLE         => DOUBLE,
-        Types::STRING         => BINARY,
-        Types::LIST           => LIST,
-        Types::SET            => SET,
-        Types::MAP            => MAP,
-        Types::STRUCT         => STRUCT,
-        Types::UUID           => UUID
+        Types::STOP   => Types::STOP,
+        Types::BOOL   => BOOLEAN_TRUE,
+        Types::BYTE   => BYTE,
+        Types::I16    => I16,
+        Types::I32    => I32,
+        Types::I64    => I64,
+        Types::DOUBLE => DOUBLE,
+        Types::STRING => BINARY,
+        Types::LIST   => LIST,
+        Types::SET    => SET,
+        Types::MAP    => MAP,
+        Types::STRUCT => STRUCT,
+        Types::UUID   => UUID,
       }
 
       def self.get_ttype(compact_type)
@@ -103,7 +103,7 @@ module Thrift
 
         raise ProtocolException.new(
           ProtocolException::INVALID_DATA,
-          "Unknown compact type: #{compact_type & 0x0f}"
+          "Unknown compact type: #{compact_type & 0x0f}",
         )
       end
 
@@ -113,7 +113,7 @@ module Thrift
 
         raise ProtocolException.new(
           ProtocolException::INVALID_DATA,
-          "Unknown compact type: #{ttype}"
+          "Unknown compact type: #{ttype}",
         )
       end
     end
@@ -296,7 +296,7 @@ module Thrift
       if protocol_id != PROTOCOL_ID
         raise ProtocolException.new(
           ProtocolException::BAD_VERSION,
-          "Expected protocol id #{PROTOCOL_ID} but got #{protocol_id}"
+          "Expected protocol id #{PROTOCOL_ID} but got #{protocol_id}",
         )
       end
 
@@ -305,7 +305,7 @@ module Thrift
       if (version != VERSION)
         raise ProtocolException.new(
           ProtocolException::BAD_VERSION,
-          "Expected version #{VERSION} but got #{version}"
+          "Expected version #{VERSION} but got #{version}",
         )
       end
 

--- a/lib/rb/lib/thrift/protocol/header_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/header_protocol.rb
@@ -304,7 +304,7 @@ module Thrift
       else
         raise ProtocolException.new(
           ProtocolException::INVALID_DATA,
-          "Unknown protocol ID: #{protocol_id}"
+          "Unknown protocol ID: #{protocol_id}",
         )
       end
     end

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -217,7 +217,7 @@ module Thrift
       end
     end
 
-   # Return true if the character ch is in [-+0-9.Ee]; false otherwise
+    # Return true if the character ch is in [-+0-9.Ee]; false otherwise
     def is_json_numeric(ch)
       case ch
       when "+", "-", ".", "0" .. "9", "E", "e"
@@ -253,10 +253,10 @@ module Thrift
       # 1 : just output index
       # <other> : escape using "\<other>" notation
       kJSONCharTable = [
-          # 0 1 2 3 4 5 6 7 8 9 A B C D E F
-          0, 0, 0, 0, 0, 0, 0, 0, "b", "t", "n", 0, "f", "r", 0, 0, # 0
-          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # 1
-          1, 1, '"', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, # 2
+        # 0 1 2 3 4 5 6 7 8 9 A B C D E F
+        0, 0, 0, 0, 0, 0, 0, 0, "b", "t", "n", 0, "f", "r", 0, 0, # 0
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, # 1
+        1, 1, '"', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, # 2
       ]
 
       ch_value = ch[0]

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -160,11 +160,13 @@ module Thrift
     end
 
     def field_info(field)
-      { type: field[:type],
+      {
+        type: field[:type],
         class: field[:class],
         key: field[:key],
         value: field[:value],
-        element: field[:element] }
+        element: field[:element],
+      }
     end
 
     def inspect_field(value, field_info)

--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -106,7 +106,7 @@ module Thrift
         HeaderClientType::FRAMED_BINARY,
         HeaderClientType::UNFRAMED_BINARY,
         HeaderClientType::FRAMED_COMPACT,
-        HeaderClientType::UNFRAMED_COMPACT
+        HeaderClientType::UNFRAMED_COMPACT,
       ]
 
       @read_buffer = StringIO.new(Bytes.empty_byte_buffer)
@@ -372,7 +372,7 @@ module Thrift
     def raise_unframed_size_limit
       raise TransportException.new(
         TransportException::SIZE_LIMIT,
-        "Unframed message size exceeds maximum #{@max_frame_size}"
+        "Unframed message size exceeds maximum #{@max_frame_size}",
       )
     end
 
@@ -452,7 +452,7 @@ module Thrift
         if buffer.bytesize + chunk.bytesize > @max_decompressed_size
           raise TransportException.new(
             TransportException::SIZE_LIMIT,
-            "Decompressed size exceeds limit of #{@max_decompressed_size}"
+            "Decompressed size exceeds limit of #{@max_decompressed_size}",
           )
         end
 
@@ -528,7 +528,7 @@ module Thrift
 
       raise TransportException.new(
         TransportException::UNKNOWN,
-        "Frame size #{frame_size} exceeds maximum #{@max_frame_size}"
+        "Frame size #{frame_size} exceeds maximum #{@max_frame_size}",
       )
     end
 

--- a/lib/rb/lib/thrift/transport/server_socket.rb
+++ b/lib/rb/lib/thrift/transport/server_socket.rb
@@ -54,8 +54,8 @@ module Thrift
     end
 
     def close
-     @handle.close unless @handle.nil? or @handle.closed?
-     @handle = nil
+      @handle.close unless @handle.nil? or @handle.closed?
+      @handle = nil
     end
 
     def closed?

--- a/lib/rb/lib/thrift/types.rb
+++ b/lib/rb/lib/thrift/types.rb
@@ -48,27 +48,27 @@ module Thrift
   def self.check_type(value, field, name, skip_nil = true)
     return if value.nil? and skip_nil
     klasses = case field[:type]
-              when Types::VOID
-                NilClass
-              when Types::BOOL
-                [TrueClass, FalseClass]
-              when Types::BYTE, Types::I16, Types::I32, Types::I64
-                Integer
-              when Types::DOUBLE
-                Float
-              when Types::STRING
-                String
-              when Types::UUID
-                String
-              when Types::STRUCT
-                [Struct, Union]
-              when Types::MAP
-                Hash
-              when Types::SET
-                Set
-              when Types::LIST
-                Array
-              end
+    when Types::VOID
+      NilClass
+    when Types::BOOL
+      [TrueClass, FalseClass]
+    when Types::BYTE, Types::I16, Types::I32, Types::I64
+      Integer
+    when Types::DOUBLE
+      Float
+    when Types::STRING
+      String
+    when Types::UUID
+      String
+    when Types::STRUCT
+      [Struct, Union]
+    when Types::MAP
+      Hash
+    when Types::SET
+      Set
+    when Types::LIST
+      Array
+    end
     valid = klasses && [*klasses].any? { |klass| klass === value }
     raise TypeError, "Expected #{type_name(field[:type])}, received #{value.class} for field #{name}" unless valid
     # check elements now

--- a/lib/rb/spec/base_protocol_spec.rb
+++ b/lib/rb/spec/base_protocol_spec.rb
@@ -145,8 +145,10 @@ describe "BaseProtocol" do
       @prot.read_type(Thrift::Types::DOUBLE)
       @prot.read_type(Thrift::Types::STRING)
       # all other types are not implemented
-      [Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP,
-       Thrift::Types::SET, Thrift::Types::LIST, Thrift::Types::STRUCT].each do |type|
+      [
+        Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP,
+        Thrift::Types::SET, Thrift::Types::LIST, Thrift::Types::STRUCT,
+      ].each do |type|
         expect { @prot.read_type(type) }.to raise_error(NotImplementedError)
       end
     end
@@ -169,8 +171,10 @@ describe "BaseProtocol" do
       @prot.read_type({type: Thrift::Types::STRING})
       @prot.read_type({type: Thrift::Types::STRING, binary: true})
       # all other types are not implemented
-      [Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP,
-       Thrift::Types::SET, Thrift::Types::LIST, Thrift::Types::STRUCT].each do |type|
+      [
+        Thrift::Types::STOP, Thrift::Types::VOID, Thrift::Types::MAP,
+        Thrift::Types::SET, Thrift::Types::LIST, Thrift::Types::STRUCT,
+      ].each do |type|
         expect { @prot.read_type({type: type}) }.to raise_error(NotImplementedError)
       end
     end
@@ -199,7 +203,7 @@ describe "BaseProtocol" do
         ["field 1", Thrift::Types::STRING, 1],
         ["field 2", Thrift::Types::I32, 2],
         ["field 3", Thrift::Types::MAP, 3],
-        [nil, Thrift::Types::STOP, 0]
+        [nil, Thrift::Types::STOP, 0],
       )
       expect(@prot).to receive(:read_field_end).exactly(3).times
       expect(@prot).to receive(:read_string).exactly(3).times

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -176,7 +176,8 @@ shared_examples_for "a binary protocol" do
     [-2**63, -12356123612323, -23512351, -234, 0, 1231, 2351236, 12361236213, 2**63-1].each do |i|
       @prot.write_i64(i)
     end
-    expect(@trans.read(@trans.available)).to eq(["\200\000\000\000\000\000\000\000",
+    expect(@trans.read(@trans.available)).to eq([
+      "\200\000\000\000\000\000\000\000",
       "\377\377\364\303\035\244+]",
       "\377\377\377\377\376\231:\341",
       "\377\377\377\377\377\377\377\026",
@@ -184,7 +185,8 @@ shared_examples_for "a binary protocol" do
       "\000\000\000\000\000\000\004\317",
       "\000\000\000\000\000#\340\204",
       "\000\000\000\002\340\311~\365",
-      "\177\377\377\377\377\377\377\377"].join(""))
+      "\177\377\377\377\377\377\377\377",
+    ].join(""))
     [-2 ** 63 - 1, 2 ** 63, 2 ** 65 + 5].each do |i|
       expect { @prot.write_i64(i) }.to raise_error(RangeError)
     end
@@ -235,8 +237,10 @@ shared_examples_for "a binary protocol" do
     @prot.write_string(str)
     a = @trans.read(@trans.available)
     expect(a.encoding).to eq(Encoding::BINARY)
-    expect(a.unpack("C*")).to eq([0x00, 0x00, 0x00, 0x0B, 0x61, 0x62, 0x63, 0x20,
-                              0xE2, 0x82, 0xAC, 0x20, 0xE2, 0x82, 0xAD])
+    expect(a.unpack("C*")).to eq([
+      0x00, 0x00, 0x00, 0x0B, 0x61, 0x62, 0x63, 0x20,
+      0xE2, 0x82, 0xAC, 0x20, 0xE2, 0x82, 0xAD,
+    ])
   end
 
   it "should write should write a string with unicode characters and transcoding" do
@@ -408,16 +412,16 @@ shared_examples_for "a binary protocol" do
     {
       read_i16: {
         [0x80, 0x00] => -(2**15),
-        [0xff, 0xff] => -1
+        [0xff, 0xff] => -1,
       },
       read_i32: {
         [0x80, 0x00, 0x00, 0x00] => -(2**31),
-        [0xff, 0xff, 0xff, 0xff] => -1
+        [0xff, 0xff, 0xff, 0xff] => -1,
       },
       read_i64: {
         [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] => -(2**63),
-        [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] => -1
-      }
+        [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] => -1,
+      },
     }.each do |reader, cases|
       cases.each do |bytes, expected|
         @trans.write(bytes.pack("C*"))
@@ -470,14 +474,14 @@ shared_examples_for "a binary protocol" do
   it "should perform a complete rpc with no args or return" do
     srv_test(
       proc { |client| client.send_voidMethod() },
-      proc { |client| expect(client.recv_voidMethod).to eq(nil) }
+      proc { |client| expect(client.recv_voidMethod).to eq(nil) },
     )
   end
 
   it "should perform a complete rpc with a primitive return type" do
     srv_test(
       proc { |client| client.send_primitiveMethod() },
-      proc { |client| expect(client.recv_primitiveMethod).to eq(1) }
+      proc { |client| expect(client.recv_primitiveMethod).to eq(1) },
     )
   end
 
@@ -489,7 +493,7 @@ shared_examples_for "a binary protocol" do
         result.set_byte_map = nil
         result.map_byte_map = nil
         expect(result).to eq(Fixtures::COMPACT_PROTOCOL_TEST_STRUCT)
-      }
+      },
     )
   end
 

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -26,18 +26,18 @@ describe Thrift::CompactProtocol do
     byte: [-(2**7), (2**7) - 1],
     i16: [-(2**15), (2**15) - 1],
     i32: [-(2**31), (2**31) - 1],
-    i64: [-(2**63), (2**63) - 1]
+    i64: [-(2**63), (2**63) - 1],
   }
 
   INTEGER_MINIMUM_ENCODINGS = {
     i32: [0xff, 0xff, 0xff, 0xff, 0x0f],
-    i64: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]
+    i64: [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01],
   }
 
   VARINT32_SIZE_ENCODINGS = {
     (2**31) - 1 => [0xff, 0xff, 0xff, 0xff, 0x07],
     2**31 => [0x80, 0x80, 0x80, 0x80, 0x08],
-    (2**32) - 1 => [0xff, 0xff, 0xff, 0xff, 0x0f]
+    (2**32) - 1 => [0xff, 0xff, 0xff, 0xff, 0x0f],
   }
 
   TESTS = {
@@ -48,7 +48,7 @@ describe Thrift::CompactProtocol do
     string: ["", "1", "short", "fourteen123456", "fifteen12345678", "unicode characters: \u20AC \u20AD", "1" * 127, "1" * 3000],
     binary: ["", "\001", "\001" * 5, "\001" * 14, "\001" * 15, "\001" * 127, "\001" * 3000],
     double: [0.0, 1.0, -1.0, 1.1, -1.1, 10000000.1, 1.0/0.0, -1.0/0.0],
-    bool: [true, false]
+    bool: [true, false],
   }
 
   it "should encode and decode naked primitives correctly" do
@@ -186,7 +186,7 @@ describe Thrift::CompactProtocol do
       Thrift::MessageTypes::REPLY => 0x41,
       Thrift::MessageTypes::EXCEPTION => 0x61,
       Thrift::MessageTypes::ONEWAY => 0x81,
-      140 => 0x81
+      140 => 0x81,
     }.each do |message_type, version_and_type|
       trans = Thrift::MemoryBufferTransport.new
       proto = Thrift::CompactProtocol.new(trans)
@@ -201,7 +201,7 @@ describe Thrift::CompactProtocol do
     writers = [
       [:write_map_begin, [Thrift::Types::STRING, Thrift::Types::I32]],
       [:write_list_begin, [Thrift::Types::I16]],
-      [:write_set_begin, [Thrift::Types::I16]]
+      [:write_set_begin, [Thrift::Types::I16]],
     ]
 
     writers.each do |method, arguments|
@@ -254,7 +254,7 @@ describe Thrift::CompactProtocol do
       nil => Thrift::CompactProtocol::CompactTypes::BOOLEAN_FALSE,
       0 => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
       1 => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
-      Object.new => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE
+      Object.new => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,
     }.each do |value, expected|
       trans = Thrift::MemoryBufferTransport.new
       proto = Thrift::CompactProtocol.new(trans)
@@ -268,7 +268,7 @@ describe Thrift::CompactProtocol do
   it "should report malformed message headers consistently" do
     {
       [0x00] => "Expected protocol id -126 but got 0",
-      [0x82, 0x00] => "Expected version 1 but got 0"
+      [0x82, 0x00] => "Expected version 1 but got 0",
     }.each do |bytes, expected_message|
       trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
       proto = Thrift::CompactProtocol.new(trans)
@@ -282,7 +282,7 @@ describe Thrift::CompactProtocol do
   it "should reject unknown field and container types as invalid protocol data" do
     {
       read_field_begin: [0x1e],
-      read_list_begin: [0x1e]
+      read_list_begin: [0x1e],
     }.each do |reader_method, bytes|
       trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
       proto = Thrift::CompactProtocol.new(trans)
@@ -305,14 +305,14 @@ describe Thrift::CompactProtocol do
     {
       read_map_begin: [0x55],
       read_list_begin: [0xf5],
-      read_set_begin: [0xf5]
+      read_set_begin: [0xf5],
     }.each do |reader_method, container_header|
       [2**31, (2**32) - 1].each do |size|
         bytes = if reader_method == :read_map_begin
-                  [*VARINT32_SIZE_ENCODINGS.fetch(size), *container_header]
-                else
-                  [*container_header, *VARINT32_SIZE_ENCODINGS.fetch(size)]
-                end
+          [*VARINT32_SIZE_ENCODINGS.fetch(size), *container_header]
+        else
+          [*container_header, *VARINT32_SIZE_ENCODINGS.fetch(size)]
+        end
         trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
         proto = Thrift::CompactProtocol.new(trans)
 
@@ -326,7 +326,7 @@ describe Thrift::CompactProtocol do
   it "should report the original unknown type when writing fields and containers" do
     {
       write_field_begin: [nil, 99, 1],
-      write_list_begin: [99, 1]
+      write_list_begin: [99, 1],
     }.each do |writer_method, args|
       trans = Thrift::MemoryBufferTransport.new
       proto = Thrift::CompactProtocol.new(trans)
@@ -357,7 +357,7 @@ describe Thrift::CompactProtocol do
   it "should preserve fixed-width double edge byte patterns" do
     [
       [0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00],
-      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80]
+      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
     ].each do |bytes|
       trans = Thrift::MemoryBufferTransport.new(bytes.pack("C*"))
       proto = Thrift::CompactProtocol.new(trans)
@@ -468,8 +468,10 @@ describe Thrift::CompactProtocol do
       field1: "blah",
       field2: Thrift::Test::BigFieldIdStruct.new(
         field1: "string1",
-        field2: "string2"),
-      field3: 3)
+        field2: "string2",
+      ),
+      field3: 3,
+    )
     ser = Thrift::Serializer.new(Thrift::CompactProtocolFactory.new)
     bytes = ser.serialize(brcp)
 

--- a/lib/rb/spec/exception_spec.rb
+++ b/lib/rb/spec/exception_spec.rb
@@ -48,7 +48,7 @@ describe "Exception" do
       expect(prot).to receive(:read_field_begin).exactly(3).times.and_return(
         ["message", Thrift::Types::STRING, 1],
         ["type", Thrift::Types::I32, 2],
-        [nil, Thrift::Types::STOP, 0]
+        [nil, Thrift::Types::STOP, 0],
       )
       expect(prot).to receive(:read_string).ordered.and_return "test message"
       expect(prot).to receive(:read_i32).ordered.and_return Thrift::ApplicationException::BAD_SEQUENCE_ID
@@ -69,7 +69,7 @@ describe "Exception" do
         ["type", Thrift::Types::STRING, 2],
         ["message", Thrift::Types::MAP, 1],
         ["message", Thrift::Types::STRING, 3],
-        [nil, Thrift::Types::STOP, 0]
+        [nil, Thrift::Types::STOP, 0],
       )
       expect(prot).to receive(:read_i32).and_return Thrift::ApplicationException::INVALID_MESSAGE_TYPE
       expect(prot).to receive(:skip).with(Thrift::Types::STRING).twice

--- a/lib/rb/spec/flat_spec.rb
+++ b/lib/rb/spec/flat_spec.rb
@@ -27,11 +27,12 @@ describe "generation" do
 
   it "did not generate the wrong files" do
     prefix = File.expand_path("../gen-rb/flat", __FILE__)
-    ["namespaced_spec_namespace/namespaced_nonblocking_service.rb",
-     "namespaced_spec_namespace/thrift_namespaced_spec_constants.rb",
-     "namespaced_spec_namespace/thrift_namespaced_spec_types.rb",
-     "other_namespace/referenced_constants.rb",
-     "other_namespace/referenced_types.rb"
+    [
+      "namespaced_spec_namespace/namespaced_nonblocking_service.rb",
+      "namespaced_spec_namespace/thrift_namespaced_spec_constants.rb",
+      "namespaced_spec_namespace/thrift_namespaced_spec_types.rb",
+      "other_namespace/referenced_constants.rb",
+      "other_namespace/referenced_types.rb",
     ].each do |name|
       expect(File.exist?(File.join(prefix, name))).not_to be_truthy
     end
@@ -39,11 +40,12 @@ describe "generation" do
 
   it "generated the right files" do
     prefix = File.expand_path("../gen-rb/flat", __FILE__)
-    ["namespaced_nonblocking_service.rb",
-     "thrift_namespaced_spec_constants.rb",
-     "thrift_namespaced_spec_types.rb",
-     "referenced_constants.rb",
-     "referenced_types.rb"
+    [
+      "namespaced_nonblocking_service.rb",
+      "thrift_namespaced_spec_constants.rb",
+      "thrift_namespaced_spec_types.rb",
+      "referenced_constants.rb",
+      "referenced_types.rb",
     ].each do |name|
       expect(File.exist?(File.join(prefix, name))).to be_truthy
     end

--- a/lib/rb/spec/header_protocol_spec.rb
+++ b/lib/rb/spec/header_protocol_spec.rb
@@ -237,7 +237,7 @@ describe "HeaderProtocol" do
         @protocol = Thrift::HeaderProtocol.new(
           @buffer,
           nil,
-          Thrift::HeaderSubprotocolID::COMPACT
+          Thrift::HeaderSubprotocolID::COMPACT,
         )
       end
 

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -194,7 +194,7 @@ describe "HeaderTransport" do
       it "should enforce the limit against the complete Header frame" do
         {
           5 => 19,
-          6 => 20
+          6 => 20,
         }.each do |payload_size, declared_size|
           underlying = Thrift::MemoryBufferTransport.new
           trans = Thrift::HeaderTransport.new(underlying)
@@ -214,7 +214,7 @@ describe "HeaderTransport" do
         @trans.write("x" * 7)
         expect { @trans.flush }.to raise_error(
           Thrift::TransportException,
-          "Frame size 21 exceeds maximum 20"
+          "Frame size 21 exceeds maximum 20",
         )
         expect(@underlying.available).to eq(0)
       end
@@ -243,7 +243,7 @@ describe "HeaderTransport" do
         rejected.write("payload")
         expect { rejected.flush }.to raise_error(
           Thrift::TransportException,
-          "Frame size #{declared_size} exceeds maximum #{declared_size - 1}"
+          "Frame size #{declared_size} exceeds maximum #{declared_size - 1}",
         )
 
         rejected.set_max_frame_size(declared_size)
@@ -287,7 +287,7 @@ describe "HeaderTransport" do
 
       {
         "binary" => Thrift::BinaryProtocol,
-        "compact" => Thrift::CompactProtocol
+        "compact" => Thrift::CompactProtocol,
       }.each do |protocol_name, protocol_class|
         it "enforces max frame size for unframed #{protocol_name} messages" do
           payload = unframed_message(protocol_class)
@@ -301,7 +301,7 @@ describe "HeaderTransport" do
           protocol = Thrift::HeaderProtocol.new(over_limit)
           expect { read_unframed_message(protocol) }.to raise_error(
             Thrift::TransportException,
-            "Unframed message size exceeds maximum #{payload.bytesize - 1}"
+            "Unframed message size exceeds maximum #{payload.bytesize - 1}",
           ) do |error|
             expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
           end
@@ -315,7 +315,7 @@ describe "HeaderTransport" do
 
         expect { read_trans.read(1) }.to raise_error(
           Thrift::TransportException,
-          "Unframed message size exceeds maximum 3"
+          "Unframed message size exceeds maximum 3",
         ) do |error|
           expect(error.type).to eq(Thrift::TransportException::SIZE_LIMIT)
         end
@@ -371,12 +371,12 @@ describe "HeaderTransport" do
 
       protocol_pairs = {
         "binary" => [Thrift::BinaryProtocol, Thrift::BinaryProtocol],
-        "compact" => [Thrift::CompactProtocol, Thrift::CompactProtocol]
+        "compact" => [Thrift::CompactProtocol, Thrift::CompactProtocol],
       }
       if defined?(Thrift::BinaryProtocolAccelerated)
         protocol_pairs["accelerated binary"] = [
           Thrift::BinaryProtocol,
-          Thrift::BinaryProtocolAccelerated
+          Thrift::BinaryProtocolAccelerated,
         ]
       end
 
@@ -385,7 +385,7 @@ describe "HeaderTransport" do
           first = unframed_message(writer_class, "first")
           second = unframed_message(writer_class, "second")
           read_trans = Thrift::HeaderTransport.new(
-            Thrift::MemoryBufferTransport.new(first + second)
+            Thrift::MemoryBufferTransport.new(first + second),
           )
           read_trans.set_max_frame_size([first.bytesize, second.bytesize].max)
           expect(read_trans).to receive(:message_boundaries?).once.and_return(true)
@@ -425,20 +425,20 @@ describe "HeaderTransport" do
 
       {
         "invalid" => "not-zlib",
-        "truncated" => Zlib::Deflate.deflate("valid payload")[0...-1]
+        "truncated" => Zlib::Deflate.deflate("valid payload")[0...-1],
       }.each do |failure_type, payload|
         it "adapts #{failure_type} ZLIB payloads to the transport exception boundary" do
           header_data = [
             Thrift::HeaderSubprotocolID::BINARY,
             1,
-            Thrift::HeaderTransformID::ZLIB
+            Thrift::HeaderTransformID::ZLIB,
           ].pack("C*")
           frame = build_header_frame(header_data, payload)
           read_trans = Thrift::HeaderTransport.new(Thrift::MemoryBufferTransport.new(frame))
 
           expect { read_trans.read(1) }.to raise_error(
             Thrift::TransportException,
-            "Invalid ZLIB payload"
+            "Invalid ZLIB payload",
           ) do |error|
             expect(error.type).to eq(Thrift::TransportException::UNKNOWN)
           end
@@ -548,7 +548,7 @@ describe "HeaderTransport" do
         "framed binary" => [:binary_message, true],
         "unframed binary" => [:binary_message, false],
         "framed compact" => [:compact_message, true],
-        "unframed compact" => [:compact_message, false]
+        "unframed compact" => [:compact_message, false],
       }.each do |legacy_name, (legacy_message, is_framed)|
         it "does not carry Header metadata through a #{legacy_name} protocol switch" do
           legacy_payload = public_send(legacy_message)
@@ -596,7 +596,7 @@ describe "HeaderTransport" do
 
         expect { read_trans.reset_protocol }.to raise_error(
           Thrift::TransportException,
-          "Could not detect client transport type"
+          "Could not detect client transport type",
         )
         expect(read_trans.get_headers).to eq({})
       end
@@ -639,7 +639,7 @@ describe "HeaderTransport" do
 
           expect { read_trans.read(1) }.to raise_error(
             Thrift::TransportException,
-            "Frame size #{frame_size} is too small"
+            "Frame size #{frame_size} is too small",
           ) do |error|
             expect(error.type).to eq(Thrift::TransportException::UNKNOWN)
           end
@@ -649,12 +649,12 @@ describe "HeaderTransport" do
       it "reports EOF when the frame size is fragmented" do
         (0..3).each do |available_size|
           read_trans = Thrift::HeaderTransport.new(
-            Thrift::MemoryBufferTransport.new("\x00" * available_size)
+            Thrift::MemoryBufferTransport.new("\x00" * available_size),
           )
 
           expect { read_trans.read(1) }.to raise_error(
             Thrift::TransportException,
-            "Unexpected EOF reading frame size"
+            "Unexpected EOF reading frame size",
           ) do |error|
             expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
           end
@@ -667,7 +667,7 @@ describe "HeaderTransport" do
 
         expect { read_trans.read(1) }.to raise_error(
           Thrift::TransportException,
-          "Unexpected EOF reading frame"
+          "Unexpected EOF reading frame",
         ) do |error|
           expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
         end

--- a/lib/rb/spec/http_client_spec.rb
+++ b/lib/rb/spec/http_client_spec.rb
@@ -154,7 +154,7 @@ describe "Thrift::HTTPClientTransport" do
         end
       end
 
-      @client.flush rescue
+      expect { @client.flush }.to raise_error(Net::ReadTimeout)
       expect(@client.instance_variable_get(:@outbuf)).to eq(Thrift::Bytes.empty_byte_buffer)
     end
 
@@ -209,8 +209,10 @@ describe "Thrift::HTTPClientTransport" do
         double("Net::HTTP").tap do |http|
           expect(http).to receive(:use_ssl=).with(true)
           expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
-          expect(http).to receive(:post).with(@service_path, "test",
-              {"Content-Type" => "application/x-thrift"}) do
+          expect(http).to receive(:post).with(
+            @service_path, "test",
+            {"Content-Type" => "application/x-thrift"},
+          ) do
             double("Net::HTTPOK").tap do |response|
               expect(response).to receive(:body).and_return "data"
               expect(response).to receive(:code).and_return "200"
@@ -230,8 +232,10 @@ describe "Thrift::HTTPClientTransport" do
         double("Net::HTTP").tap do |http|
           expect(http).to receive(:use_ssl=).with(true)
           expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-          expect(http).to receive(:post).with(@service_path, "test",
-              {"Content-Type" => "application/x-thrift"}) do
+          expect(http).to receive(:post).with(
+            @service_path, "test",
+            {"Content-Type" => "application/x-thrift"},
+          ) do
             double("Net::HTTPOK").tap do |response|
               expect(response).to receive(:body).and_return "data"
               expect(response).to receive(:code).and_return "200"
@@ -252,8 +256,10 @@ describe "Thrift::HTTPClientTransport" do
           expect(http).to receive(:use_ssl=).with(true)
           expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
           expect(http).to receive(:ca_file=).with("/path/to/ca.pem")
-          expect(http).to receive(:post).with(@service_path, "test",
-              {"Content-Type" => "application/x-thrift"}) do
+          expect(http).to receive(:post).with(
+            @service_path, "test",
+            {"Content-Type" => "application/x-thrift"},
+          ) do
             double("Net::HTTPOK").tap do |response|
               expect(response).to receive(:body).and_return "data"
               expect(response).to receive(:code).and_return "200"

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -367,7 +367,7 @@ describe "JsonProtocol" do
       {
         '"\u20AC"' => "\u20AC",
         '"\uD83D\uDE00"' => "\u{1F600}",
-        '"\ud83d\uDe00"' => "\u{1F600}"
+        '"\ud83d\uDe00"' => "\u{1F600}",
       }.each do |wire, value|
         trans = Thrift::MemoryBufferTransport.new(wire.b)
         protocol = Thrift::JsonProtocol.new(trans)
@@ -392,7 +392,7 @@ describe "JsonProtocol" do
         '"\u123"',
         '"\uD83D"',
         '"\uD83D\u0041"',
-        '"\uDE00"'
+        '"\uDE00"',
       ].each do |wire|
         protocol = Thrift::JsonProtocol.new(Thrift::MemoryBufferTransport.new(wire.b))
 

--- a/lib/rb/spec/multiplexed_processor_spec.rb
+++ b/lib/rb/spec/multiplexed_processor_spec.rb
@@ -60,7 +60,7 @@ describe Thrift::MultiplexedProcessor do
 
     expect { @processor.process(@iprot, @oprot) }.to raise_error(
       Thrift::Exception,
-      "Service name not found in message name: testVoid. Did you forget to use a Thrift::Protocol::MultiplexedProtocol in your client?"
+      "Service name not found in message name: testVoid. Did you forget to use a Thrift::Protocol::MultiplexedProtocol in your client?",
     )
   end
 
@@ -69,7 +69,7 @@ describe Thrift::MultiplexedProcessor do
 
     expect { @processor.process(@iprot, @oprot) }.to raise_error(
       Thrift::Exception,
-      "Service name not found: Missing. Did you forget to call Thrift::MultiplexedProcessor#register_processor?"
+      "Service name not found: Missing. Did you forget to call Thrift::MultiplexedProcessor#register_processor?",
     )
   end
 end

--- a/lib/rb/spec/namespaced_spec.rb
+++ b/lib/rb/spec/namespaced_spec.rb
@@ -27,11 +27,12 @@ describe "namespaced generation" do
 
   it "generated the right files" do
     prefix = File.expand_path("../gen-rb", __FILE__)
-    ["namespaced_spec_namespace/namespaced_nonblocking_service.rb",
-     "namespaced_spec_namespace/thrift_namespaced_spec_constants.rb",
-     "namespaced_spec_namespace/thrift_namespaced_spec_types.rb",
-     "other_namespace/referenced_constants.rb",
-     "other_namespace/referenced_types.rb"
+    [
+      "namespaced_spec_namespace/namespaced_nonblocking_service.rb",
+      "namespaced_spec_namespace/thrift_namespaced_spec_constants.rb",
+      "namespaced_spec_namespace/thrift_namespaced_spec_types.rb",
+      "other_namespace/referenced_constants.rb",
+      "other_namespace/referenced_types.rb",
     ].each do |name|
       expect(File.exist?(File.join(prefix, name))).to be_truthy
     end
@@ -39,11 +40,12 @@ describe "namespaced generation" do
 
   it "did not generate the wrong files" do
     prefix = File.expand_path("../gen-rb", __FILE__)
-    ["namespaced_nonblocking_service.rb",
-     "thrift_namespaced_spec_constants.rb",
-     "thrift_namespaced_spec_types.rb",
-     "referenced_constants.rb",
-     "referenced_types.rb"
+    [
+      "namespaced_nonblocking_service.rb",
+      "thrift_namespaced_spec_constants.rb",
+      "thrift_namespaced_spec_types.rb",
+      "referenced_constants.rb",
+      "referenced_types.rb",
     ].each do |name|
       expect(File.exist?(File.join(prefix, name))).not_to be_truthy
     end

--- a/lib/rb/spec/nonblocking_server_spec.rb
+++ b/lib/rb/spec/nonblocking_server_spec.rb
@@ -273,7 +273,7 @@ describe "NonblockingServer" do
         "server transport",
         listen: nil,
         closed?: false,
-        close: nil
+        close: nil,
       )
       allow(server_transport).to receive(:accept).and_raise(error)
       io_manager = double("IOManager", ensure_closed: nil)
@@ -283,7 +283,7 @@ describe "NonblockingServer" do
         nil,
         nil,
         1,
-        Logger.new(IO::NULL)
+        Logger.new(IO::NULL),
       )
       allow(server).to receive(:start_io_manager).and_return(io_manager)
       allow(server).to receive(:select).and_return([[server_transport], nil, nil])
@@ -302,7 +302,7 @@ describe "NonblockingServer" do
         Thrift::BaseTransportFactory.new,
         Thrift::BinaryProtocolFactory.new,
         1,
-        logger
+        logger,
       )
     end
 
@@ -367,7 +367,7 @@ describe "NonblockingServer" do
         "localhost",
         @port,
         create_server_ssl_context,
-        client_timeout: client_timeout
+        client_timeout: client_timeout,
       )
       transport_factory = Thrift::FramedTransportFactory.new
       logger = Logger.new(STDERR)
@@ -422,7 +422,7 @@ describe "NonblockingServer" do
 
     def setup_tls_client
       transport = Thrift::FramedTransport.new(
-        Thrift::SSLSocket.new("localhost", @port, nil, create_client_ssl_context)
+        Thrift::SSLSocket.new("localhost", @port, nil, create_client_ssl_context),
       )
       protocol = Thrift::BinaryProtocol.new(transport)
       client = SpecNamespace::NonblockingService::Client.new(protocol)

--- a/lib/rb/spec/recursion_depth_spec.rb
+++ b/lib/rb/spec/recursion_depth_spec.rb
@@ -92,7 +92,7 @@ describe "recursion depth limit" do
       width = MAX_DEPTH * 3
       root = SpecNamespace::RecTree.new(
         item: 0,
-        children: (1..width).map { |item| SpecNamespace::RecTree.new(item: item, children: []) }
+        children: (1..width).map { |item| SpecNamespace::RecTree.new(item: item, children: []) },
       )
 
       protocol = binary_protocol
@@ -321,7 +321,7 @@ describe "recursion depth limit" do
         SpecNamespace::RecStruct.new.read_field(
           protocol,
           {type: Thrift::Types::STRUCT, class: Thrift::ApplicationException},
-          2
+          2,
         )
       }.not_to raise_error
 

--- a/lib/rb/spec/serializer_spec.rb
+++ b/lib/rb/spec/serializer_spec.rb
@@ -61,7 +61,7 @@ module DeserializerResetFixtures
     include Thrift::Struct, Thrift::Struct_Union
 
     FIELDS = {
-      1 => {type: Thrift::Types::STRING, name: "reset_fields", optional: true}
+      1 => {type: Thrift::Types::STRING, name: "reset_fields", optional: true},
     }.freeze
 
     def struct_fields
@@ -78,7 +78,7 @@ module DeserializerResetFixtures
     include Thrift::Struct, Thrift::Struct_Union
 
     FIELDS = {
-      1 => {type: Thrift::Types::STRING, name: "required_value"}
+      1 => {type: Thrift::Types::STRING, name: "required_value"},
     }.freeze
 
     def struct_fields
@@ -96,7 +96,7 @@ module DeserializerResetFixtures
     include Thrift::Struct_Union
 
     FIELDS = {
-      1 => {type: Thrift::Types::STRING, name: "reset_fields", optional: true}
+      1 => {type: Thrift::Types::STRING, name: "reset_fields", optional: true},
     }.freeze
 
     def struct_fields
@@ -175,8 +175,8 @@ describe "Serializer" do
           expect(
             Thrift::Deserializer.new(Thrift::JsonProtocolFactory.new).deserialize(
               SpecNamespace::Hello.new,
-              data
-            )
+              data,
+            ),
           ).to eq(value)
         end
       end
@@ -194,7 +194,7 @@ describe "Serializer" do
       end
 
       expect(serializer.serialize(value)).to eq(
-        Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value)
+        Thrift::Serializer.new(Thrift::JsonProtocolFactory.new).serialize(value),
       )
     end
 
@@ -203,7 +203,7 @@ describe "Serializer" do
       expected = {
         Thrift::BinaryProtocolFactory => "\v\x00\x01\x00\x00\x00\bGood day\x00".b,
         Thrift::CompactProtocolFactory => "\x18\bGood day\x00".b,
-        Thrift::JsonProtocolFactory => "{\"1\":{\"str\":\"Good day\"}}"
+        Thrift::JsonProtocolFactory => "{\"1\":{\"str\":\"Good day\"}}",
       }
 
       expected.each do |factory_class, bytes|
@@ -225,7 +225,7 @@ describe "Serializer" do
 
     [
       Thrift::HeaderSubprotocolID::BINARY,
-      Thrift::HeaderSubprotocolID::COMPACT
+      Thrift::HeaderSubprotocolID::COMPACT,
     ].each do |protocol_id|
       it "finalizes and round-trips Header protocol #{protocol_id}" do
         value = SpecNamespace::NonblockingService::Shutdown_args.new
@@ -256,8 +256,10 @@ describe "Serializer" do
     it "should deserialize structs from the given protocol" do
       protocol = Thrift::BaseProtocol.new(double("transport"))
       expect(protocol).to receive(:read_struct_begin).and_return("SpecNamespace::Hello")
-      expect(protocol).to receive(:read_field_begin).and_return(["greeting", Thrift::Types::STRING, 1],
-                                                            [nil, Thrift::Types::STOP, 0])
+      expect(protocol).to receive(:read_field_begin).and_return(
+        ["greeting", Thrift::Types::STRING, 1],
+        [nil, Thrift::Types::STOP, 0],
+      )
       expect(protocol).to receive(:read_string).and_return("Good day")
       expect(protocol).to receive(:read_field_end)
       expect(protocol).to receive(:read_struct_end)

--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -134,15 +134,17 @@ describe "Server" do
     end
 
     [
-      ["compact unknown type", Thrift::CompactProtocolFactory.new, proc do
-        trans = Thrift::MemoryBufferTransport.new
-        prot = Thrift::CompactProtocol.new(trans)
-        prot.write_message_begin("unknown", Thrift::MessageTypes::CALL, 1)
-        trans.write([0x1e, 0].pack("C*"))
-        trans.read(trans.available)
-      end],
+      [
+        "compact unknown type", Thrift::CompactProtocolFactory.new, proc do
+          trans = Thrift::MemoryBufferTransport.new
+          prot = Thrift::CompactProtocol.new(trans)
+          prot.write_message_begin("unknown", Thrift::MessageTypes::CALL, 1)
+          trans.write([0x1e, 0].pack("C*"))
+          trans.read(trans.available)
+        end,
+      ],
       ["JSON unknown type", Thrift::JsonProtocolFactory.new, proc { '[1,"unknown",1,1,{"1":{"wat":0}}]' }],
-      ["short JSON UUID", Thrift::JsonProtocolFactory.new, proc { '[1,"unknown",1,1,{"1":{"uid":"x"}}]' }]
+      ["short JSON UUID", Thrift::JsonProtocolFactory.new, proc { '[1,"unknown",1,1,{"1":{"uid":"x"}}]' }],
     ].each do |failure_type, protocol_factory, malformed_request|
       it "closes a malformed #{failure_type} connection and continues accepting clients" do
         ready = Queue.new

--- a/lib/rb/spec/socket_spec_shared.rb
+++ b/lib/rb/spec/socket_spec_shared.rb
@@ -144,7 +144,7 @@ shared_examples_for "a socket" do
 
     expect { @socket.read_all(4) }.to raise_error(
       Thrift::TransportException,
-      /Timed out reading 3 bytes/
+      /Timed out reading 3 bytes/,
     ) { |error|
       expect(error.type).to eq(Thrift::TransportException::TIMED_OUT)
     }
@@ -166,7 +166,7 @@ shared_examples_for "a socket" do
 
     expect { @socket.write("test data") }.to raise_error(
       Thrift::TransportException,
-      /Timed out writing 9 bytes/
+      /Timed out writing 9 bytes/,
     ) { |error|
       expect(error.type).to eq(Thrift::TransportException::TIMED_OUT)
     }

--- a/lib/rb/spec/ssl_socket_spec.rb
+++ b/lib/rb/spec/ssl_socket_spec.rb
@@ -369,7 +369,7 @@ describe "SSLSocket" do
         @tcp_server.local_address.ip_port,
         1,
         context,
-        server_hostname: "localhost"
+        server_hostname: "localhost",
       )
     end
 

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -37,7 +37,7 @@ module StructEqualityFixtures
 
     FIELDS = {
       1 => {type: Thrift::Types::STRING, name: "shared"},
-      2 => {type: Thrift::Types::STRING, name: "extra"}
+      2 => {type: Thrift::Types::STRING, name: "extra"},
     }
 
     def struct_fields; FIELDS; end
@@ -144,21 +144,21 @@ describe "Struct" do
       expect(prot).to receive(:read_struct_begin).twice
       expect(prot).to receive(:read_struct_end).twice
       expect(prot).to receive(:read_field_begin).and_return(
-        ["complex", Thrift::Types::MAP, 5], # Foo
-        ["words", Thrift::Types::STRING, 2], # Foo
-        ["hello", Thrift::Types::STRUCT, 3], # Foo
-          ["greeting", Thrift::Types::STRING, 1], # Hello
-          [nil, Thrift::Types::STOP, 0], # Hello
-        ["simple", Thrift::Types::I32, 1], # Foo
-        ["ints", Thrift::Types::LIST, 4], # Foo
-        ["shorts", Thrift::Types::SET, 6], # Foo
-        [nil, Thrift::Types::STOP, 0] # Hello
+        ["complex", Thrift::Types::MAP, 5], # Foo/complex
+        ["words", Thrift::Types::STRING, 2], # Foo/words
+        ["hello", Thrift::Types::STRUCT, 3], # Foo/hello
+        ["greeting", Thrift::Types::STRING, 1], # Foo/hello/greeting
+        [nil, Thrift::Types::STOP, 0], # Foo/hello
+        ["simple", Thrift::Types::I32, 1], # Foo/simple
+        ["ints", Thrift::Types::LIST, 4], # Foo/ints
+        ["shorts", Thrift::Types::SET, 6], # Foo/shorts
+        [nil, Thrift::Types::STOP, 0], # Foo
       )
       expect(prot).to receive(:read_field_end).exactly(7).times
       expect(prot).to receive(:read_map_begin).and_return(
-        [Thrift::Types::I32, Thrift::Types::MAP, 2], # complex
-          [Thrift::Types::STRING, Thrift::Types::DOUBLE, 2], # complex/1/value
-          [Thrift::Types::STRING, Thrift::Types::DOUBLE, 1] # complex/2/value
+        [Thrift::Types::I32, Thrift::Types::MAP, 2], # Foo/complex
+        [Thrift::Types::STRING, Thrift::Types::DOUBLE, 2], # Foo/complex/1/value
+        [Thrift::Types::STRING, Thrift::Types::DOUBLE, 1], # Foo/complex/2/value
       )
       expect(prot).to receive(:read_map_end).exactly(3).times
       expect(prot).to receive(:read_list_begin).and_return([Thrift::Types::I32, 4])
@@ -166,9 +166,9 @@ describe "Struct" do
       expect(prot).to receive(:read_set_begin).and_return([Thrift::Types::I16, 2])
       expect(prot).to receive(:read_set_end)
       expect(prot).to receive(:read_i32).and_return(
-        1, 14,        # complex keys
-        42,           # simple
-        4, 23, 4, 29  # ints
+        1, 14,        # Foo/complex/keys
+        42,           # Foo/simple
+        4, 23, 4, 29, # Foo/ints
       )
       expect(prot).to receive(:read_string).and_return("pi", "e", "feigenbaum", "apple banana", "what's up?")
       expect(prot).to receive(:read_double).and_return(Math::PI, Math::E, 4.669201609)
@@ -215,7 +215,7 @@ describe "Struct" do
     [
       ["map", Thrift::Types::MAP, 5, :read_map_begin, [Thrift::Types::I32, Thrift::Types::MAP]],
       ["list", Thrift::Types::LIST, 4, :read_list_begin, [Thrift::Types::I32]],
-      ["set", Thrift::Types::SET, 6, :read_set_begin, [Thrift::Types::I16]]
+      ["set", Thrift::Types::SET, 6, :read_set_begin, [Thrift::Types::I16]],
     ].each do |name, field_type, field_id, begin_method, header|
       it "rejects #{name} sizes above the signed 32-bit range" do
         struct = SpecNamespace::Foo.new
@@ -250,7 +250,7 @@ describe "Struct" do
         ["thinz", Thrift::Types::MAP, 7],
         ["foobar", Thrift::Types::I32, 3],
         ["words", Thrift::Types::STRING, 2],
-        [nil, Thrift::Types::STOP, 0]
+        [nil, Thrift::Types::STOP, 0],
       )
       expect(prot).to receive(:read_field_end).exactly(5).times
       expect(prot).to receive(:read_i32).and_return(42)
@@ -393,7 +393,7 @@ describe "Struct" do
       struct = SpecNamespace::Foo.new(
         simple: 42,
         words: "test",
-        opt_uuid: "550e8400-e29b-41d4-a716-446655440000"
+        opt_uuid: "550e8400-e29b-41d4-a716-446655440000",
       )
 
       trans = Thrift::MemoryBufferTransport.new
@@ -449,7 +449,7 @@ describe "Struct" do
         bools: [true, false],
         i32s: [1, 2, 3],
         strings: ["hello", "world"],
-        uuids: ["550e8400-e29b-41d4-a716-446655440000", "00000000-0000-0000-0000-000000000000"]
+        uuids: ["550e8400-e29b-41d4-a716-446655440000", "00000000-0000-0000-0000-000000000000"],
       )
 
       trans = Thrift::MemoryBufferTransport.new

--- a/lib/rb/spec/thin_http_server_spec.rb
+++ b/lib/rb/spec/thin_http_server_spec.rb
@@ -41,7 +41,7 @@ describe "Thrift::ThinHTTPServer", thin_dependency do
       allow(Thin::Server).to receive(:new)
 
       expect(Kernel).to receive(:warn).with(
-        "[DEPRECATION WARNING] `Thrift::ThinHTTPServer` is deprecated because Thin is no longer maintained. Please use `Thrift::RackApplication` with a maintained Rack server instead."
+        "[DEPRECATION WARNING] `Thrift::ThinHTTPServer` is deprecated because Thin is no longer maintained. Please use `Thrift::RackApplication` with a maintained Rack server instead.",
       )
 
       Thrift::ThinHTTPServer.new(processor)
@@ -92,7 +92,7 @@ describe "Thrift::ThinHTTPServer", thin_dependency do
       it "configures SSL" do
         ssl_options = {
           private_key_file: "/path/to/server.key",
-          cert_chain_file: "/path/to/server.crt"
+          cert_chain_file: "/path/to/server.crt",
         }
         underlying_thin_server = double("thin server")
         allow(Thin::Server).to receive(:new).and_return(underlying_thin_server)

--- a/lib/rb/spec/types_spec.rb
+++ b/lib/rb/spec/types_spec.rb
@@ -106,10 +106,14 @@ describe Thrift::Types do
       field = {type: Thrift::Types::LIST, element: {type: Thrift::Types::STRING}}
       expect { Thrift.check_type([3], field, :foo) }.to raise_error(Thrift::TypeError, msg)
       msg = "Expected Types::I32, received NilClass for field foo.element.key"
-      field = {type: Thrift::Types::LIST,
-               element: {type: Thrift::Types::MAP,
-                            key: {type: Thrift::Types::I32},
-                            value: {type: Thrift::Types::I32}}}
+      field = {
+        type: Thrift::Types::LIST,
+        element: {
+          type: Thrift::Types::MAP,
+          key: {type: Thrift::Types::I32},
+          value: {type: Thrift::Types::I32},
+        },
+      }
       expect { Thrift.check_type([{nil => 3}], field, :foo) }.to raise_error(Thrift::TypeError, msg)
       msg = "Expected Types::I32, received NilClass for field foo.element.value"
       expect { Thrift.check_type([{1 => nil}], field, :foo) }.to raise_error(Thrift::TypeError, msg)

--- a/lib/rb/spec/union_spec.rb
+++ b/lib/rb/spec/union_spec.rb
@@ -221,7 +221,8 @@ describe "Union" do
         [1,   1,  0,  -1, -1, -1],
         [1,   1,  1,  0,  -1, -1],
         [1,   1,  1,  1,  0,  -1],
-        [1,   1,  1,  1,  1,  0]]
+        [1,   1,  1,  1,  1,  0],
+      ]
 
       objs = [
         SpecNamespace::TestUnion.new(:string_field, "blah"),
@@ -229,7 +230,8 @@ describe "Union" do
         SpecNamespace::TestUnion.new(:i32_field, 1),
         SpecNamespace::TestUnion.new(:uuid_field, "550e8400-e29b-41d4-a716-446655440000"),
         SpecNamespace::TestUnion.new(:uuid_field, "6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
-        SpecNamespace::TestUnion.new()]
+        SpecNamespace::TestUnion.new(),
+      ]
 
       objs.size.times do |y|
         objs.size.times do |x|

--- a/lib/rb/spec/uuid_validation_spec.rb
+++ b/lib/rb/spec/uuid_validation_spec.rb
@@ -244,7 +244,7 @@ describe "UUID Validation" do
     context "with a complete malformed UUID string" do
       [
         "00000000-0000-0000-0000",
-        "00000000-0000-0000-0000-000000000"
+        "00000000-0000-0000-0000-000000000",
       ].each do |uuid|
         it "rejects a #{uuid.length}-character UUID" do
           trans = Thrift::MemoryBufferTransport.new("\"#{uuid}\"")
@@ -252,7 +252,7 @@ describe "UUID Validation" do
 
           expect { prot.read_uuid }.to raise_error(
             Thrift::ProtocolException,
-            "Invalid UUID format"
+            "Invalid UUID format",
           ) do |error|
             expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
           end

--- a/lib/rb/test/fuzz/fuzz_tracer.rb
+++ b/lib/rb/test/fuzz/fuzz_tracer.rb
@@ -23,7 +23,7 @@ require "ruzzy"
 def trace_fuzz_target(script_path)
   harness_path = File.expand_path(
     "#{File.basename(script_path, ".rb")}_harness.rb",
-    File.dirname(script_path)
+    File.dirname(script_path),
   )
   Ruzzy.trace(harness_path)
 end

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |s|
     "documentation_uri" => "https://thrift.apache.org/docs/",
     "homepage_uri" => "https://thrift.apache.org",
     "mailing_list_uri" => "https://thrift.apache.org/mailing",
-    "source_code_uri" => "https://github.com/apache/thrift/"
+    "source_code_uri" => "https://github.com/apache/thrift/",
   }
 end

--- a/test/rb/benchmarks/protocol_benchmark.rb
+++ b/test/rb/benchmarks/protocol_benchmark.rb
@@ -76,7 +76,7 @@ module ProtocolBenchmark
       large_runs: env.fetch("THRIFT_BENCHMARK_LARGE_RUNS", DEFAULT_LARGE_RUNS),
       small_runs: env.fetch("THRIFT_BENCHMARK_SMALL_RUNS", DEFAULT_SMALL_RUNS),
       scenarios: env["THRIFT_BENCHMARK_SCENARIOS"],
-      json: false
+      json: false,
     }
 
     OptionParser.new do |parser|
@@ -90,7 +90,7 @@ module ProtocolBenchmark
       large_runs: normalize_run_count(options[:large_runs], "large runs"),
       small_runs: normalize_run_count(options[:small_runs], "small runs"),
       scenarios: normalize_scenarios(options[:scenarios]),
-      json: options[:json]
+      json: options[:json],
     }
   end
 
@@ -302,7 +302,7 @@ module ProtocolBenchmark
         scenario("c-bin-write-large", "c binary write large (1MB) structure #{large_run_label(large_runs)}") { write(accelerated_binary, nested4, count: large_runs) },
         scenario("c-bin-read-large", "c binary read large (1MB) structure #{large_run_label(large_runs)}") { deserialize(accelerated_binary, Fixtures::Structs::Nested4, accelerated_large_payload, count: large_runs) },
         scenario("c-bin-write-small", "c binary write #{small_runs} small structures") { write(accelerated_binary, one_of_each, count: small_runs) },
-        scenario("c-bin-read-small", "c binary read #{small_runs} small structures") { deserialize(accelerated_binary, Fixtures::Structs::OneOfEach, accelerated_small_payload, count: small_runs) }
+        scenario("c-bin-read-small", "c binary read #{small_runs} small structures") { deserialize(accelerated_binary, Fixtures::Structs::OneOfEach, accelerated_small_payload, count: small_runs) },
       ]
     elsif !THRIFT_BENCHMARK_SKIP_NATIVE && with_scenario_selected(scenario_ids, *NATIVE_SCENARIO_IDS)
       warn "Skipping accelerated binary protocol benchmarks: thrift_native extension is unavailable."
@@ -328,7 +328,7 @@ module ProtocolBenchmark
       scenario("hdr-cmp-write-small", "header compact write #{small_runs} small structures") { write(header_compact, one_of_each, count: small_runs) },
       scenario("hdr-cmp-read-small", "header compact read #{small_runs} small structures") { deserialize(header_compact, Fixtures::Structs::OneOfEach, header_compact_payload, count: small_runs) },
       scenario("hdr-zlib-write-small", "header zlib write #{small_runs} small structures") { write(header_zlib, one_of_each, count: small_runs) },
-      scenario("hdr-zlib-read-small", "header zlib read #{small_runs} small structures") { deserialize(header_zlib, Fixtures::Structs::OneOfEach, header_zlib_payload, count: small_runs) }
+      scenario("hdr-zlib-read-small", "header zlib read #{small_runs} small structures") { deserialize(header_zlib, Fixtures::Structs::OneOfEach, header_zlib_payload, count: small_runs) },
     ]
 
     select_scenarios(scenario_list, scenario_ids, native_available: native_available)
@@ -340,7 +340,7 @@ module ProtocolBenchmark
       user: result.utime,
       system: result.stime,
       total: result.total,
-      real: result.real
+      real: result.real,
     }
   end
 
@@ -354,7 +354,7 @@ module ProtocolBenchmark
       {
         id: entry[:id],
         label: entry[:label],
-        benchmark: measure_job(entry[:job], label: entry[:label])
+        benchmark: measure_job(entry[:job], label: entry[:label]),
       }
     end
   end
@@ -371,9 +371,9 @@ module ProtocolBenchmark
           small_runs: small_runs,
           scenarios: scenario_list.map { |entry| entry[:id] },
           skip_native: THRIFT_BENCHMARK_SKIP_NATIVE,
-          native_available: native_available?
+          native_available: native_available?,
         },
-        results: benchmark_scenarios(scenario_list)
+        results: benchmark_scenarios(scenario_list),
       )
       return
     end

--- a/test/rb/fixtures/structs.rb
+++ b/test/rb/fixtures/structs.rb
@@ -26,7 +26,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::BOOL, name: "bool"}
+        1 => {type: Thrift::Types::BOOL, name: "bool"},
       }
 
       def struct_fields; FIELDS; end
@@ -41,7 +41,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::BYTE, name: "byte"}
+        1 => {type: Thrift::Types::BYTE, name: "byte"},
       }
 
       def struct_fields; FIELDS; end
@@ -56,7 +56,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::I16, name: "i16"}
+        1 => {type: Thrift::Types::I16, name: "i16"},
       }
 
       def struct_fields; FIELDS; end
@@ -71,7 +71,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::I32, name: "i32"}
+        1 => {type: Thrift::Types::I32, name: "i32"},
       }
 
       def struct_fields; FIELDS; end
@@ -86,7 +86,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::I64, name: "i64"}
+        1 => {type: Thrift::Types::I64, name: "i64"},
       }
 
       def struct_fields; FIELDS; end
@@ -101,7 +101,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::DOUBLE, name: "double"}
+        1 => {type: Thrift::Types::DOUBLE, name: "double"},
       }
 
       def struct_fields; FIELDS; end
@@ -116,7 +116,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::STRING, name: "string"}
+        1 => {type: Thrift::Types::STRING, name: "string"},
       }
 
       def struct_fields; FIELDS; end
@@ -131,7 +131,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRING}},
       }
 
       def struct_fields; FIELDS; end
@@ -146,7 +146,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        0 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::MAP, key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::I32}}}
+        0 => {type: Thrift::Types::MAP, name: "map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::MAP, key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::I32}}},
       }
 
       def struct_fields; FIELDS; end
@@ -161,7 +161,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::STRING}},
       }
 
       def struct_fields; FIELDS; end
@@ -176,7 +176,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        0 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::LIST, element: { type: Thrift::Types::I32 } } }
+        0 => {type: Thrift::Types::LIST, name: "list", element: {type: Thrift::Types::LIST, element: { type: Thrift::Types::I32 } } },
       }
 
       def struct_fields; FIELDS; end
@@ -191,7 +191,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::STRING}}
+        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::STRING}},
       }
 
       def struct_fields; FIELDS; end
@@ -206,7 +206,7 @@ module Fixtures
       include Thrift::Struct, Thrift::Struct_Union
 
       FIELDS = {
-        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::SET, element: { type: Thrift::Types::STRING } }}
+        1 => {type: Thrift::Types::SET, name: "set", element: {type: Thrift::Types::SET, element: { type: Thrift::Types::STRING } }},
       }
 
       def struct_fields; FIELDS; end
@@ -244,7 +244,7 @@ module Fixtures
         8 => {type: Thrift::Types::STRING, name: "some_characters"},
         9 => {type: Thrift::Types::STRING, name: "zomg_unicode"},
         10 => {type: Thrift::Types::BOOL, name: "what_who"},
-        11 => {type: Thrift::Types::STRING, name: "base64", binary: true}
+        11 => {type: Thrift::Types::STRING, name: "base64", binary: true},
       }
 
       def struct_fields; FIELDS; end
@@ -270,7 +270,7 @@ module Fixtures
         2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
         3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
         4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
-        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}}
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: OneOfEach}},
       }
 
       def struct_fields; FIELDS; end
@@ -296,7 +296,7 @@ module Fixtures
         2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
         3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
         4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
-        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested1}}
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested1}},
       }
 
       def struct_fields; FIELDS; end
@@ -322,7 +322,7 @@ module Fixtures
         2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
         3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
         4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
-        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested2}}
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested2}},
       }
 
       def struct_fields; FIELDS; end
@@ -348,7 +348,7 @@ module Fixtures
         2 => {type: Thrift::Types::MAP, name: "i32_map", key: {type: Thrift::Types::I32}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
         3 => {type: Thrift::Types::MAP, name: "i64_map", key: {type: Thrift::Types::I64}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
         4 => {type: Thrift::Types::MAP, name: "dbl_map", key: {type: Thrift::Types::DOUBLE}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
-        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested3}}
+        5 => {type: Thrift::Types::MAP, name: "str_map", key: {type: Thrift::Types::STRING}, value: {type: Thrift::Types::STRUCT, class: Nested3}},
       }
 
       def struct_fields; FIELDS; end

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -352,8 +352,8 @@ class SimpleClientTest < Test::Unit::TestCase
           "byte_thing" => 2,
           "i32_thing" => 2,
           "i64_thing" => 2,
-        })
-      ]
+        }),
+      ],
     })
 
     ret = @client.testInsanity(insane)
@@ -381,7 +381,7 @@ class SimpleClientTest < Test::Unit::TestCase
         3 => 3,
         2 => 2,
         1 => 1,
-      }
+      },
     }
     assert_equal(expected, ret)
   end
@@ -393,7 +393,7 @@ class SimpleClientTest < Test::Unit::TestCase
       string_thing: "Hello2",
       byte_thing: 42,
       i32_thing: 4242,
-      i64_thing: 424242
+      i64_thing: 424242,
     })
     assert_equal(expected, ret)
   end

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -31,9 +31,11 @@ require "logger"
 require "optparse"
 
 class SimpleHandler
-  [:testVoid, :testString, :testBool, :testByte, :testI32, :testI64, :testDouble, :testBinary,
-   :testStruct, :testMap, :testStringMap, :testSet, :testList, :testNest, :testEnum, :testTypedef,
-   :testEnum, :testTypedef, :testMultiException, :testUuid].each do |meth|
+  [
+    :testVoid, :testString, :testBool, :testByte, :testI32, :testI64, :testDouble, :testBinary,
+    :testStruct, :testMap, :testStringMap, :testSet, :testList, :testNest, :testEnum, :testTypedef,
+    :testMultiException, :testUuid,
+  ].each do |meth|
     define_method(meth) do |thing|
       p meth
       p thing
@@ -48,11 +50,11 @@ class SimpleHandler
     return {
       1 => {
         2 => thing,
-        3 => thing
+        3 => thing,
       },
       2 => {
-        6 => Thrift::Test::Insanity::new()
-      }
+        6 => Thrift::Test::Insanity::new(),
+      },
     }
   end
 
@@ -69,7 +71,7 @@ class SimpleHandler
         3 => 3,
         2 => 2,
         1 => 1,
-      }
+      },
     }
   end
 
@@ -281,7 +283,7 @@ when "thin"
     thin_options[:ssl_options] = {
       private_key_file: File.join(keys_dir, "server.key"),
       cert_chain_file: File.join(keys_dir, "server.crt"),
-      verify_peer: false
+      verify_peer: false,
     }
   end
   Thrift::ThinHTTPServer.new(processor, thin_options)
@@ -296,7 +298,7 @@ when "puma"
     app: rack_app,
     server: "puma",
     Host: host,
-    Port: options[:port]
+    Port: options[:port],
   )
 when "falcon"
   require "falcon"
@@ -311,7 +313,7 @@ when "falcon"
     ssl_context.min_version = :TLS1_2
     endpoint = Falcon::Endpoint.parse(
       "https://0.0.0.0:#{options[:port]}",
-      ssl_context: ssl_context
+      ssl_context: ssl_context,
     )
     Falcon::Server.new(Protocol::Rack::Adapter.new(rack_app), endpoint)
   else
@@ -319,7 +321,7 @@ when "falcon"
       app: rack_app,
       server: "falcon",
       Host: "0.0.0.0",
-      Port: options[:port]
+      Port: options[:port],
     )
   end
 when "simple"


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby sources currently use inconsistent indentation, delimiter placement, and trailing commas in multiline arrays, hashes, and method calls. This enables the relevant RuboCop layout and trailing-comma rules and applies their formatting consistently across the Ruby library, tests, and benchmarks.

The Ruby compiler now emits symmetrical multiline literals and field metadata with trailing commas, so generated sources follow the same rules without requiring a separate autocorrection pass. Functional coverage locks down the generated formatting.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
