### PR TITLE
Fix GitHub Actions code scanning findings

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@8056239fafd626c8a4e2d6679506ba0d8e60f196 # main
+      - uses: apache/infrastructure-actions/allowlist-check@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # master
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-version }}
           extensions: intl, xml, curl
@@ -1003,7 +1003,7 @@ jobs:
           python -m pip install "tornado>=6.3.0" "twisted>=24.3.0" "zope.interface>=6.1"
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # master
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "8.3"
           extensions: intl, xml, curl, sockets
@@ -1111,8 +1111,8 @@ jobs:
 
       - name: Installs for nodets and nodejs
         run: |
-          npm install .
-          cd lib/nodejs/test/ && npm install .
+          npm ci
+          npm ci --prefix lib/nodejs/test
 
       - name: Create tmp domain socket folder
         run: mkdir /tmp/v0.16

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -311,7 +311,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends g++ $BUILD_DEPS
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # master
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           # Lowest supported PHP version
           php-version: "8.1"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        apache/infrastructure-actions/allowlist-check: ref-pin


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Fix the open zizmor findings in the GitHub Actions workflows. This updates the `setup-php` version comments to match their pinned commit and installs Node.js dependencies from the committed lockfiles.

The ASF allowlist check now follows the [Apache infrastructure-actions documentation](https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md), which specifies installation from `@main`. A narrowly scoped zizmor policy permits symbolic references for that composite action while retaining the default hash-pin requirement for every other action.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
