### PR TITLE
Enforce Ruby whitespace layout rules

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -606,7 +606,7 @@ void t_rb_generator::generate_rb_struct(t_rb_ofstream& out,
   out << '\n';
 
   out.indent_up();
-  out.indent() << "include ::Thrift::Struct, ::Thrift::Struct_Union" << '\n';
+  out.indent() << "include ::Thrift::Struct, ::Thrift::Struct_Union" << '\n' << '\n';
 
   if (is_exception) {
     generate_rb_simple_exception_constructor(out, tstruct);
@@ -635,7 +635,7 @@ void t_rb_generator::generate_rb_union(t_rb_ofstream& out,
   out.indent() << "class " << type_name(tstruct) << " < ::Thrift::Union" << '\n';
 
   out.indent_up();
-  out.indent() << "include ::Thrift::Struct_Union" << '\n';
+  out.indent() << "include ::Thrift::Struct_Union" << '\n' << '\n';
 
   generate_field_constructors(out, tstruct);
 
@@ -708,7 +708,9 @@ void t_rb_generator::generate_field_constants(t_rb_ofstream& out, t_struct* tstr
 
     out.indent() << field_id_constant_name(field_name) << " = " << (*f_iter)->get_key() << '\n';
   }
-  out << '\n';
+  if (!fields.empty()) {
+    out << '\n';
+  }
 }
 
 void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct) {
@@ -975,11 +977,14 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
   f_service_.indent() << "class Client" << extends_client << '\n';
   f_service_.indent_up();
 
-  f_service_.indent() << "include ::Thrift::Client" << '\n' << '\n';
-
   // Generate client method implementations
   vector<t_function*> functions = tservice->get_functions();
   vector<t_function*>::const_iterator f_iter;
+  f_service_.indent() << "include ::Thrift::Client" << '\n';
+  if (!functions.empty()) {
+    f_service_ << '\n';
+  }
+
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const vector<t_field*>& fields = arg_struct->get_members();
@@ -1080,7 +1085,11 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
       // Close function
       f_service_.indent_down();
-      f_service_.indent() << "end" << '\n' << '\n';
+      f_service_.indent() << "end" << '\n';
+    }
+
+    if (f_iter + 1 != functions.end()) {
+      f_service_ << '\n';
     }
   }
 
@@ -1110,11 +1119,17 @@ void t_rb_generator::generate_service_server(t_service* tservice) {
   f_service_.indent() << "class Processor" << extends_processor << '\n';
   f_service_.indent_up();
 
-  f_service_.indent() << "include ::Thrift::Processor" << '\n' << '\n';
+  f_service_.indent() << "include ::Thrift::Processor" << '\n';
+  if (!functions.empty()) {
+    f_service_ << '\n';
+  }
 
   // Generate the process subfunctions
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
     generate_process_function(tservice, *f_iter);
+    if (f_iter + 1 != functions.end()) {
+      f_service_ << '\n';
+    }
   }
 
   f_service_.indent_down();
@@ -1193,7 +1208,7 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
   if (tfunction->is_oneway()) {
     f_service_.indent() << "return" << '\n';
     f_service_.indent_down();
-    f_service_.indent() << "end" << '\n' << '\n';
+    f_service_.indent() << "end" << '\n';
     return;
   }
 
@@ -1202,7 +1217,7 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
 
   // Close function
   f_service_.indent_down();
-  f_service_.indent() << "end" << '\n' << '\n';
+  f_service_.indent() << "end" << '\n';
 }
 
 /**

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -99,10 +99,12 @@ TEST_CASE("t_rb_generator uses suffixed field id constants to avoid FIELDS colli
     std::remove(thrift_path.c_str());
 }
 
-TEST_CASE("t_rb_generator emits service arguments as a positional hash", "[functional]")
+TEST_CASE("t_rb_generator formats service classes and positional arguments", "[functional]")
 {
     const string thrift_path = "test_service_arguments.thrift";
     const string thrift_source =
+        "service EmptyService {\n"
+        "}\n"
         "service PingService {\n"
         "  oneway void ping(1: i32 n)\n"
         "}\n";
@@ -123,7 +125,18 @@ TEST_CASE("t_rb_generator emits service arguments as a positional hash", "[funct
     REQUIRE_NOTHROW(gen->generate_program());
 
     const string service = read_file("gen-rb/ping_service.rb");
+    const string expected_empty_result =
+        "  class Ping_result\n"
+        "    include ::Thrift::Struct, ::Thrift::Struct_Union\n"
+        "\n"
+        "    FIELDS";
     REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
+    REQUIRE(service.find(expected_empty_result) != string::npos);
+    REQUIRE(service.find("\n\n  end\n") == string::npos);
+
+    const string empty_service = read_file("gen-rb/empty_service.rb");
+    REQUIRE(!empty_service.empty());
+    REQUIRE(empty_service.find("\n\n  end\n") == string::npos);
 
     std::remove(thrift_path.c_str());
 }
@@ -133,6 +146,9 @@ TEST_CASE("t_rb_generator formats multiline Ruby literals, calls, and field meta
     const string thrift_path = "test_multiline_layout.thrift";
     const string thrift_source =
         "struct Item {\n"
+        "  1: string value\n"
+        "}\n"
+        "union Choice {\n"
         "  1: string value\n"
         "}\n"
         "const Item ITEM = {\"value\": \"one\"}\n"
@@ -157,14 +173,39 @@ TEST_CASE("t_rb_generator formats multiline Ruby literals, calls, and field meta
     REQUIRE_NOTHROW(gen->generate_program());
 
     const string constants = read_file("gen-rb/test_multiline_layout_constants.rb");
-    REQUIRE(constants.find("ITEM = ::Item.new({\n  %q\"value\" => %q\"one\",\n})")
-            != string::npos);
-    REQUIRE(constants.find("IDS = Set.new([\n  1,\n  2,\n])") != string::npos);
+    const string expected_item_constant =
+        "ITEM = ::Item.new({\n"
+        "  %q\"value\" => %q\"one\",\n"
+        "})";
+    const string expected_set_constant =
+        "IDS = Set.new([\n"
+        "  1,\n"
+        "  2,\n"
+        "])";
+    REQUIRE(constants.find(expected_item_constant) != string::npos);
+    REQUIRE(constants.find(expected_set_constant) != string::npos);
 
     const string types = read_file("gen-rb/test_multiline_layout_types.rb");
-    REQUIRE(types.find("VALUES_FIELD_ID => {\n      type: ::Thrift::Types::LIST,\n")
-            != string::npos);
-    REQUIRE(types.find("default: [\n        1,\n        2,\n      ],\n") != string::npos);
+    const string expected_struct =
+        "class Item\n"
+        "  include ::Thrift::Struct, ::Thrift::Struct_Union\n"
+        "\n";
+    const string expected_union =
+        "class Choice < ::Thrift::Union\n"
+        "  include ::Thrift::Struct_Union\n"
+        "\n";
+    const string expected_field_metadata =
+        "    VALUES_FIELD_ID => {\n"
+        "      type: ::Thrift::Types::LIST,\n";
+    const string expected_default =
+        "      default: [\n"
+        "        1,\n"
+        "        2,\n"
+        "      ],\n";
+    REQUIRE(types.find(expected_struct) != string::npos);
+    REQUIRE(types.find(expected_union) != string::npos);
+    REQUIRE(types.find(expected_field_metadata) != string::npos);
+    REQUIRE(types.find(expected_default) != string::npos);
 
     std::remove(thrift_path.c_str());
 }

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -15,6 +15,10 @@ Layout/ArgumentAlignment:
 Layout/ArrayAlignment:
   Enabled: true
 
+Layout/BeginEndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_line
+
 Layout/BlockAlignment:
   Enabled: true
   EnforcedStyleAlignWith: start_of_block
@@ -29,10 +33,40 @@ Layout/ClosingParenthesisIndentation:
 Layout/CommentIndentation:
   Enabled: true
 
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+
 Layout/EmptyLines:
   Enabled: true
 
+Layout/EmptyLinesAfterModuleInclusion:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundArguments:
+  Enabled: true
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: true
+
 Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
 Layout/ElseAlignment:
@@ -97,6 +131,9 @@ Layout/MultilineMethodCallBraceLayout:
   Enabled: true
   EnforcedStyle: symmetrical
 
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
 Layout/SpaceAfterComma:
   Enabled: true
 
@@ -104,6 +141,9 @@ Layout/SpaceAroundKeyword:
   Enabled: true
 
 Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
 Layout/SpaceBeforeComma:

--- a/lib/rb/ext/extconf.rb
+++ b/lib/rb/ext/extconf.rb
@@ -19,7 +19,7 @@
 #
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-  File.open("Makefile", "w"){ |f| f.puts "all:\n\ninstall:\n" }
+  File.open("Makefile", "w") { |f| f.puts "all:\n\ninstall:\n" }
 else
   require "mkmf"
 

--- a/lib/rb/lib/thrift/exceptions.rb
+++ b/lib/rb/lib/thrift/exceptions.rb
@@ -31,7 +31,6 @@ module Thrift
   end
 
   class ApplicationException < Exception
-
     UNKNOWN = 0
     UNKNOWN_METHOD = 1
     INVALID_MESSAGE_TYPE = 2
@@ -87,6 +86,5 @@ module Thrift
       oprot.write_field_stop
       oprot.write_struct_end
     end
-
   end
 end

--- a/lib/rb/lib/thrift/multiplexed_processor.rb
+++ b/lib/rb/lib/thrift/multiplexed_processor.rb
@@ -71,7 +71,6 @@ module Thrift
   end
 
   class StoredMessageProtocol < BaseProtocol
-
     include ProtocolDecorator
 
     def initialize(protocol, message_begin)

--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -24,7 +24,6 @@ require "thrift/exceptions"
 
 module Thrift
   class ProtocolException < Exception
-
     UNKNOWN = 0
     INVALID_DATA = 1
     NEGATIVE_SIZE = 2
@@ -42,7 +41,6 @@ module Thrift
   end
 
   class BaseProtocol
-
     MAX_CONTAINER_SIZE = (1 << 31) - 1
 
     attr_reader :trans

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -20,7 +20,6 @@
 
 module Thrift
   class CompactProtocol < BaseProtocol
-
     PROTOCOL_ID = [0x82].pack("c").unpack("c").first
     VERSION = 1
     VERSION_MASK = 0x1f

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -111,7 +111,6 @@ module Thrift
 
   # Context class for lists
   class JSONListContext < JSONContext
-
     def initialize
       @first = true
     end
@@ -134,7 +133,6 @@ module Thrift
   end
 
   class JsonProtocol < BaseProtocol
-
     @@kJSONObjectStart = "{"
     @@kJSONObjectEnd = "}"
     @@kJSONArrayStart = "["

--- a/lib/rb/lib/thrift/protocol/multiplexed_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/multiplexed_protocol.rb
@@ -21,7 +21,6 @@ require "thrift/protocol/protocol_decorator"
 
 module Thrift
   class MultiplexedProtocol < BaseProtocol
-
     include ProtocolDecorator
 
     def initialize(protocol, service_name)

--- a/lib/rb/lib/thrift/protocol/protocol_decorator.rb
+++ b/lib/rb/lib/thrift/protocol/protocol_decorator.rb
@@ -19,7 +19,6 @@
 
 module Thrift
   module ProtocolDecorator
-
     def initialize(protocol)
       @protocol = protocol
     end

--- a/lib/rb/lib/thrift/server/thin_http_server.rb
+++ b/lib/rb/lib/thrift/server/thin_http_server.rb
@@ -28,7 +28,6 @@ require "thrift/server/rack_application"
 # server instead.
 module Thrift
   class ThinHTTPServer < BaseServer
-
     ##
     # Accepts a Thrift::Processor
     # Options include:

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -201,6 +201,5 @@ module Thrift
       end
       "[" + buf.join(", ") + "]"
     end
-
   end
 end

--- a/lib/rb/lib/thrift/transport/http_client_transport.rb
+++ b/lib/rb/lib/thrift/transport/http_client_transport.rb
@@ -27,7 +27,6 @@ require "stringio"
 
 module Thrift
   class HTTPClientTransport < BaseTransport
-
     def initialize(url, opts = {})
       @url = URI url
       @headers = {"Content-Type" => "application/x-thrift"}
@@ -37,12 +36,14 @@ module Thrift
     end
 
     def open?; true end
+
     def read(sz)
       data = @inbuf.read sz
       return data unless data.nil?
 
       raise TransportException.new(TransportException::END_OF_FILE, "#{self.class.name} reached EOF reading response from #{to_s}, HTTP status code #{@response_code}")
     end
+
     def write(buf); @outbuf << Bytes.force_binary_encoding(buf) end
 
     def add_headers(headers)

--- a/lib/rb/lib/thrift/transport/io_stream_transport.rb
+++ b/lib/rb/lib/thrift/transport/io_stream_transport.rb
@@ -36,6 +36,7 @@ module Thrift
     def write(buf); @output.write(Bytes.force_binary_encoding(buf)) end
     def close; @input.close; @output.close end
     def to_io; @input end # we're assuming this is used in a IO.select for reading
+
     def to_s
       "iostream(input=#{@input.to_s},output=#{@output.to_s})"
     end

--- a/lib/rb/lib/thrift/transport/server_socket.rb
+++ b/lib/rb/lib/thrift/transport/server_socket.rb
@@ -69,6 +69,5 @@ module Thrift
     def to_s
       "socket(#{@host}:#{@port})"
     end
-
   end
 end

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -445,10 +445,10 @@ describe "BaseTransport" do
 
     it "should throw an EOFError when there isn't enough data in the buffer" do
       @buffer.reset_buffer("")
-      expect{ @buffer.read(1) }.to raise_error(EOFError)
+      expect { @buffer.read(1) }.to raise_error(EOFError)
 
       @buffer.reset_buffer("1234")
-      expect{ @buffer.read(5) }.to raise_error(EOFError)
+      expect { @buffer.read(5) }.to raise_error(EOFError)
     end
 
     it "should reject negative read sizes without consuming input" do

--- a/lib/rb/spec/union_spec.rb
+++ b/lib/rb/spec/union_spec.rb
@@ -194,7 +194,7 @@ describe "Union" do
     end
 
     it "should not throw an error when inspected and unset" do
-      expect{ SpecNamespace::TestUnion.new().inspect }.not_to raise_error
+      expect { SpecNamespace::TestUnion.new().inspect }.not_to raise_error
     end
 
     it "should print enum value name when inspected" do

--- a/test/rb/generation/test_enum.rb
+++ b/test/rb/generation/test_enum.rb
@@ -23,6 +23,7 @@ require "thrift_test"
 
 class TestEnumGeneration < Test::Unit::TestCase
   include Thrift::Test
+
   def test_enum_valid_values
     assert_equal(Numberz::VALID_VALUES, Set.new([Numberz::ONE, Numberz::TWO, Numberz::THREE, Numberz::FIVE, Numberz::SIX, Numberz::EIGHT]))
   end

--- a/test/rb/generation/test_recursive.rb
+++ b/test/rb/generation/test_recursive.rb
@@ -26,7 +26,6 @@ class TestRecursiveGeneration < Test::Unit::TestCase
   PARENT_ITEM = "parent item"
 
   def test_can_create_recursive_tree
-
     child_tree = RecTree.new
     child_tree.item = CHILD_ITEM
 

--- a/test/rb/generation/test_struct.rb
+++ b/test/rb/generation/test_struct.rb
@@ -22,7 +22,6 @@ require File.join(File.dirname(__FILE__), "../test_helper")
 require "small_service"
 
 class TestStructGeneration < Test::Unit::TestCase
-
   def test_default_values
     hello = TestNamespace::Hello.new
 
@@ -45,5 +44,4 @@ class TestStructGeneration < Test::Unit::TestCase
   def test_goodbyez
     assert_equal(TestNamespace::Goodbyez.new.val, 325)
   end
-
 end

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -433,5 +433,4 @@ class SimpleClientTest < Test::Unit::TestCase
     time2 = Time.now.to_f
     assert_operator (time2-time1), :<, 0.1
   end
-
 end

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -107,7 +107,6 @@ class SimpleHandler
   def testOneway(arg0)
     sleep(arg0)
   end
-
 end
 
 class SecondHandler

--- a/tutorial/rb/RubyClient.rb
+++ b/tutorial/rb/RubyClient.rb
@@ -69,7 +69,6 @@ begin
   print "zip\n"
 
   transport.close()
-
 rescue Thrift::Exception => tx
   print "Thrift::Exception: ", tx.message, "\n"
 end

--- a/tutorial/rb/RubyServer.rb
+++ b/tutorial/rb/RubyServer.rb
@@ -70,7 +70,6 @@ class CalculatorHandler
     @log[logid] = entry
 
     return val
-
   end
 
   def getStruct(key)
@@ -81,7 +80,6 @@ class CalculatorHandler
   def zip()
     print "zip\n"
   end
-
 end
 
 handler = CalculatorHandler.new()


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
This enables RuboCop checks for empty-line placement, rescue and ensure alignment, and spacing before block braces across the Ruby library, tests, and tutorials. Existing sources are autocorrected to match the rules.

The Ruby generator now emits the same empty-line layout for structs, unions, and service classes, including classes without fields or methods, so regenerating code does not reintroduce offenses. Functional generator coverage records the expected output shape.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
