### PR TITLE
Enable RuboCop Style/UnpackFirst

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -250,3 +250,6 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma
+
+Style/UnpackFirst:
+  Enabled: true

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -214,7 +214,7 @@ module Thrift
 
     def read_i16
       trans.read_into_buffer(@rbuf, 2)
-      val, = @rbuf.unpack("n")
+      val = @rbuf.unpack1("n")
       if (val > 0x7fff)
         val = 0 - ((val - 1) ^ 0xffff)
       end
@@ -223,7 +223,7 @@ module Thrift
 
     def read_i32
       trans.read_into_buffer(@rbuf, 4)
-      val, = @rbuf.unpack("N")
+      val = @rbuf.unpack1("N")
       if (val > 0x7fffffff)
         val = 0 - ((val - 1) ^ 0xffffffff)
       end
@@ -244,7 +244,7 @@ module Thrift
 
     def read_double
       trans.read_into_buffer(@rbuf, 8)
-      val = @rbuf.unpack("G").first
+      val = @rbuf.unpack1("G")
       val
     end
 

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -20,7 +20,7 @@
 
 module Thrift
   class CompactProtocol < BaseProtocol
-    PROTOCOL_ID = [0x82].pack("c").unpack("c").first
+    PROTOCOL_ID = [0x82].pack("c").unpack1("c")
     VERSION = 1
     VERSION_MASK = 0x1f
     TYPE_MASK = 0xE0
@@ -410,7 +410,7 @@ module Thrift
 
     def read_double
       trans.read_into_buffer(@rbuf, 8)
-      val = @rbuf.reverse.unpack("G").first
+      val = @rbuf.reverse.unpack1("G")
       val
     end
 

--- a/lib/rb/lib/thrift/server/nonblocking_server.rb
+++ b/lib/rb/lib/thrift/server/nonblocking_server.rb
@@ -279,7 +279,7 @@ module Thrift
 
       def slice_frame!(buf)
         if buf.length >= 4
-          size = buf.unpack("N").first
+          size = buf.unpack1("N")
           if buf.length >= size + 4
             buf.slice!(0, size + 4)
           else

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -188,7 +188,7 @@ module Thrift
       elsif value.is_a? Set
         inspect_collection(value, field_info)
       elsif value.is_a?(String) && field_info[:binary]
-        value.unpack("H*").first
+        value.unpack1("H*")
       else
         value.inspect
       end

--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -107,7 +107,7 @@ module Thrift
     private
 
     def read_frame
-      sz = @transport.read_all(4).unpack("N").first
+      sz = @transport.read_all(4).unpack1("N")
 
       @index = 0
       @rbuf = @transport.read_all(sz)

--- a/lib/rb/lib/thrift/transport/header_transport.rb
+++ b/lib/rb/lib/thrift/transport/header_transport.rb
@@ -285,7 +285,7 @@ module Thrift
       rescue EOFError
         raise TransportException.new(TransportException::END_OF_FILE, "Unexpected EOF reading frame size")
       end
-      frame_size = first_word.unpack("N").first
+      frame_size = first_word.unpack1("N")
 
       # Check for unframed binary protocol
       if (frame_size & BINARY_VERSION_MASK) == BINARY_VERSION_1
@@ -324,7 +324,7 @@ module Thrift
       second_word = frame_buf.read(4)
       frame_buf.rewind
 
-      magic = second_word.unpack("n").first
+      magic = second_word.unpack1("n")
 
       if magic == HEADER_MAGIC
         if frame_size < 10
@@ -332,7 +332,7 @@ module Thrift
         end
         set_client_type(HeaderClientType::HEADERS)
         @read_buffer = parse_header_format(frame_buf)
-      elsif (second_word.unpack("N").first & BINARY_VERSION_MASK) == BINARY_VERSION_1
+      elsif (second_word.unpack1("N") & BINARY_VERSION_MASK) == BINARY_VERSION_1
         set_client_type(HeaderClientType::FRAMED_BINARY)
         @protocol_id = HeaderSubprotocolID::BINARY
         @read_buffer = frame_buf
@@ -382,11 +382,11 @@ module Thrift
       buf.read(2)
 
       # Read flags and sequence ID
-      @flags = buf.read(2).unpack("n").first
-      @sequence_id = signed_int32(buf.read(4).unpack("N").first)
+      @flags = buf.read(2).unpack1("n")
+      @sequence_id = signed_int32(buf.read(4).unpack1("N"))
 
       # Read header length (in 32-bit words)
-      header_words = buf.read(2).unpack("n").first
+      header_words = buf.read(2).unpack1("n")
       if header_words >= 16_384
         raise TransportException.new(TransportException::UNKNOWN, "Header size is unreasonable")
       end

--- a/lib/rb/lib/thrift/uuid.rb
+++ b/lib/rb/lib/thrift/uuid.rb
@@ -43,7 +43,7 @@ module Thrift
         raise ProtocolException.new(ProtocolException::INVALID_DATA, "Invalid UUID data length")
       end
 
-      hex = bytes.unpack("H*").first
+      hex = bytes.unpack1("H*")
       "#{hex[0, 8]}-#{hex[8, 4]}-#{hex[12, 4]}-#{hex[16, 4]}-#{hex[20, 12]}"
     end
   end

--- a/lib/rb/spec/header_protocol_spec.rb
+++ b/lib/rb/spec/header_protocol_spec.rb
@@ -116,7 +116,7 @@ describe "HeaderProtocol" do
         @protocol.trans.flush
 
         data = @buffer.read(@buffer.available)
-        expect(data[8, 4].unpack("N").first).to eq(123)
+        expect(data[8, 4].unpack1("N")).to eq(123)
       end
 
       it "should write and read structs" do

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -151,11 +151,11 @@ describe "HeaderTransport" do
         expect(data.bytesize).to be > 16
 
         # First 4 bytes are frame length
-        frame_size = data[0, 4].unpack("N").first
+        frame_size = data[0, 4].unpack1("N")
         expect(frame_size).to eq(data.bytesize - 4)
 
         # Next 2 bytes should be header magic
-        magic = data[4, 2].unpack("n").first
+        magic = data[4, 2].unpack1("n")
         expect(magic).to eq(Thrift::HeaderTransport::HEADER_MAGIC)
       end
 
@@ -175,7 +175,7 @@ describe "HeaderTransport" do
         @trans.flush
 
         data = @underlying.read(@underlying.available)
-        expect(data[8, 4].unpack("N").first).to eq(456)
+        expect(data[8, 4].unpack1("N")).to eq(456)
       end
 
       it "should apply ZLIB transform" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Enable `Style/UnpackFirst` and replace single-value `unpack(...).first` and parallel-assignment unpacking with `unpack1` throughout the Ruby library and tests. Binary protocol i16 and i32 reads now avoid an intermediate array alongside double reads and UUID byte decoding.

## Benchmarks

The repository protocol benchmark compared `upstream/master` with this branch using Ruby 4.0.6 on aarch64 Linux. Each result is the median of seven isolated invocations; every invocation includes the harness warm-up pass.

```text
THRIFT_BENCHMARK_SKIP_NATIVE=1 ruby test/rb/benchmarks/protocol_benchmark.rb \
  --json \
  --large-runs 3 \
  --small-runs 20000 \
  --scenarios rb-bin-read-large,rb-cmp-read-large,rb-bin-read-small,rb-cmp-read-small,hdr-bin-read-small,hdr-cmp-read-small,hdr-zlib-read-small
```

| Read scenario | `upstream/master` | This branch | Change |
| --- | ---: | ---: | ---: |
| Ruby binary, three large structures | 1.3304 s | 1.2904 s | -3.0% |
| Ruby compact, three large structures | 1.2256 s | 1.2251 s | -0.04% |
| Ruby binary, 20,000 small structures | 0.3874 s | 0.3704 s | -4.4% |
| Ruby compact, 20,000 small structures | 0.3578 s | 0.3531 s | -1.3% |
| Header binary, 20,000 small structures | 0.6312 s | 0.5973 s | -5.4% |
| Header compact, 20,000 small structures | 0.6115 s | 0.5965 s | -2.4% |
| Header zlib, 20,000 small structures | 0.7031 s | 0.6749 s | -4.0% |

A separate stdlib-only primitive benchmark measured 500,000 operations in isolated processes with GC disabled. Each replacement removed one allocation per operation and reduced retained memory:

| Operation | Allocations/op | Retained RSS |
| --- | ---: | ---: |
| double (`G`) | 2 → 1 | 38.7 → 19.1 MiB |
| UUID hex (`H*`) | 3 → 2 | 77.6 → 57.9 MiB |
| i16 (`n`) | 2 → 1 | 38.7 → 19.1 MiB |
| i32 (`N`) | 2 → 1 | 38.8 → 19.1 MiB |

The protocol benchmark measures only the selected pure-Ruby read scenarios, while the primitive benchmark isolates unpacking allocation cost; neither predicts complete application throughput.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
