### PR TITLE
Enable additional RuboCop spacing rules

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -134,7 +134,22 @@ Layout/MultilineMethodCallBraceLayout:
 Layout/RescueEnsureAlignment:
   Enabled: true
 
+Layout/SpaceAfterColon:
+  Enabled: true
+
 Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundBlockParameters:
   Enabled: true
 
 Layout/SpaceAroundKeyword:
@@ -143,13 +158,52 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
 Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+Layout/SpaceBeforeBrackets:
   Enabled: true
 
 Layout/SpaceBeforeComma:
   Enabled: true
 
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceInLambdaLiteral:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
 Layout/SpaceInsideBlockBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+
+Layout/SpaceInsideStringInterpolation:
   Enabled: true
 
 Layout/TrailingEmptyLines:

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -244,11 +244,11 @@ class BenchmarkManager
     labels_and_values.each do |(l, v)|
       f = fmt
       l, f, c = l if Array === l
-      fmtstr = "%-#{label_width+1}s #{f}"
+      fmtstr = "%-#{label_width + 1}s #{f}"
       if STDOUT.tty? and c and v.to_i > 0
         fmtstr = "\e[#{[*c].map { |x| ANSI[x] } * ";"}m" + fmtstr + "\e[#{ANSI[:reset]}m"
       end
-      puts fmtstr % [l+":", v]
+      puts fmtstr % [l + ":", v]
     end
   end
 end

--- a/lib/rb/benchmark/server.rb
+++ b/lib/rb/benchmark/server.rb
@@ -35,7 +35,7 @@ module Server
       3.upto(n) do
         seq << seq[-1] + seq[-2]
       end
-      seq[n-1] # n is 1-based
+      seq[n - 1] # n is 1-based
     end
   end
 

--- a/lib/rb/benchmark/thin_server.rb
+++ b/lib/rb/benchmark/thin_server.rb
@@ -33,7 +33,7 @@ class BenchmarkHandler
     3.upto(n) do
       seq << seq[-1] + seq[-2]
     end
-    seq[n-1] # n is 1-based
+    seq[n - 1] # n is 1-based
   end
 end
 

--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -57,7 +57,7 @@ module Thrift
       else
         iprot.skip(Types::STRUCT)
         iprot.read_message_end
-        x = ApplicationException.new(ApplicationException::UNKNOWN_METHOD, "Unknown function "+name)
+        x = ApplicationException.new(ApplicationException::UNKNOWN_METHOD, "Unknown function " + name)
         write_error(x, oprot, name, seqid)
         false
       end

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -218,7 +218,7 @@ module Thrift
     # Return true if the character ch is in [-+0-9.Ee]; false otherwise
     def is_json_numeric(ch)
       case ch
-      when "+", "-", ".", "0" .. "9", "E", "e"
+      when "+", "-", ".", "0".."9", "E", "e"
         return true
       else
         return false
@@ -597,11 +597,11 @@ module Thrift
         str = read_json_string(true)
         # Check for NaN, Infinity and -Infinity
         if (str == @@kThriftNan)
-          num = (+1.0/0.0)/(+1.0/0.0)
+          num = (+1.0 / 0.0) / (+1.0 / 0.0)
         elsif (str == @@kThriftInfinity)
-          num = +1.0/0.0
+          num = +1.0 / 0.0
         elsif (str == @@kThriftNegativeInfinity)
-          num = -1.0/0.0
+          num = -1.0 / 0.0
         else
           if (!@context.escapeNum)
             # Raise exception -- we should not be in a string in this case

--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -21,7 +21,7 @@
 
 module Thrift
   class MemoryBufferTransport < BaseTransport
-    GARBAGE_BUFFER_SIZE = 4*(2**10) # 4kB
+    GARBAGE_BUFFER_SIZE = 4 * (2**10) # 4kB
 
     # The transport copies the input buffer and keeps its own mutable storage.
     def initialize(buffer = nil)

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -128,7 +128,7 @@ shared_examples_for "a binary protocol" do
   it "should write an i16" do
     # try a random scattering of values
     # include the signed i16 minimum/maximum
-    [-2**15, -1024, 17, 0, -10000, 1723, 2**15-1].each do |i|
+    [-2**15, -1024, 17, 0, -10000, 1723, 2**15 - 1].each do |i|
       @prot.write_i16(i)
     end
 
@@ -153,11 +153,11 @@ shared_examples_for "a binary protocol" do
   it "should write an i32" do
     # try a random scattering of values
     # include the signed i32 minimum/maximum
-    [-2**31, -123123, -2532, -3, 0, 2351235, 12331, 2**31-1].each do |i|
+    [-2**31, -123123, -2532, -3, 0, 2351235, 12331, 2**31 - 1].each do |i|
       @prot.write_i32(i)
     end
     expect(@trans.read(@trans.available)).to eq("\200\000\000\000" + "\377\376\037\r" + "\377\377\366\034" + "\377\377\377\375" + "\000\000\000\000" + "\000#\340\203" + "\000\0000+" + "\177\377\377\377")
-    [-2 ** 31 - 1, 2 ** 31, 2 ** 65 + 5].each do |i|
+    [-2**31 - 1, 2**31, 2**65 + 5].each do |i|
       expect { @prot.write_i32(i) }.to raise_error(RangeError)
     end
   end
@@ -173,7 +173,7 @@ shared_examples_for "a binary protocol" do
   it "should write an i64" do
     # try a random scattering of values
     # try the signed i64 minimum/maximum
-    [-2**63, -12356123612323, -23512351, -234, 0, 1231, 2351236, 12361236213, 2**63-1].each do |i|
+    [-2**63, -12356123612323, -23512351, -234, 0, 1231, 2351236, 12361236213, 2**63 - 1].each do |i|
       @prot.write_i64(i)
     end
     expect(@trans.read(@trans.available)).to eq([
@@ -187,7 +187,7 @@ shared_examples_for "a binary protocol" do
       "\000\000\000\002\340\311~\365",
       "\177\377\377\377\377\377\377\377",
     ].join(""))
-    [-2 ** 63 - 1, 2 ** 63, 2 ** 65 + 5].each do |i|
+    [-2**63 - 1, 2**63, 2**65 + 5].each do |i|
       expect { @prot.write_i64(i) }.to raise_error(RangeError)
     end
   end
@@ -386,7 +386,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i16" do
     # try a scattering of values, including min/max
-    [-2**15, -5237, -353, 0, 1527, 2234, 2**15-1].each do |i|
+    [-2**15, -5237, -353, 0, 1527, 2234, 2**15 - 1].each do |i|
       @trans.write([i].pack("n"));
       expect(@prot.read_i16).to eq(i)
     end
@@ -394,7 +394,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i32" do
     # try a scattering of values, including min/max
-    [-2**31, -235125, -6236, 0, 2351, 123123, 2**31-1].each do |i|
+    [-2**31, -235125, -6236, 0, 2351, 123123, 2**31 - 1].each do |i|
       @trans.write([i].pack("N"))
       expect(@prot.read_i32).to eq(i)
     end
@@ -402,7 +402,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i64" do
     # try a scattering of values, including min/max
-    [-2**63, -123512312, -6346, 0, 32, 2346322323, 2**63-1].each do |i|
+    [-2**63, -123512312, -6346, 0, 32, 2346322323, 2**63 - 1].each do |i|
       @trans.write([i >> 32, i & 0xFFFFFFFF].pack("NN"))
       expect(@prot.read_i64).to eq(i)
     end

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -47,7 +47,7 @@ describe Thrift::CompactProtocol do
     i64: (0..62).map { |shift| [1 << shift, -(1 << shift)] }.flatten.sort,
     string: ["", "1", "short", "fourteen123456", "fifteen12345678", "unicode characters: \u20AC \u20AD", "1" * 127, "1" * 3000],
     binary: ["", "\001", "\001" * 5, "\001" * 14, "\001" * 15, "\001" * 127, "\001" * 3000],
-    double: [0.0, 1.0, -1.0, 1.1, -1.1, 10000000.1, 1.0/0.0, -1.0/0.0],
+    double: [0.0, 1.0, -1.0, 1.1, -1.1, 10000000.1, 1.0 / 0.0, -1.0 / 0.0],
     bool: [true, false],
   }
 

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -81,13 +81,13 @@ describe "JsonProtocol" do
       @prot.write_json_double(-3.21)
       expect(@trans.read(@trans.available)).to eq("-3.21")
 
-      @prot.write_json_double(((+1.0/0.0)/(+1.0/0.0)))
+      @prot.write_json_double(((+1.0 / 0.0) / (+1.0 / 0.0)))
       expect(@trans.read(@trans.available)).to eq("\"NaN\"")
 
-      @prot.write_json_double((+1.0/0.0))
+      @prot.write_json_double((+1.0 / 0.0))
       expect(@trans.read(@trans.available)).to eq("\"Infinity\"")
 
-      @prot.write_json_double((-1.0/0.0))
+      @prot.write_json_double((-1.0 / 0.0))
       expect(@trans.read(@trans.available)).to eq("\"-Infinity\"")
     end
 
@@ -211,13 +211,13 @@ describe "JsonProtocol" do
       @prot.write_double(-32.1)
       expect(@trans.read(@trans.available)).to eq("-32.1")
 
-      @prot.write_double(((+1.0/0.0)/(+1.0/0.0)))
+      @prot.write_double(((+1.0 / 0.0) / (+1.0 / 0.0)))
       expect(@trans.read(@trans.available)).to eq("\"NaN\"")
 
-      @prot.write_double((+1.0/0.0))
+      @prot.write_double((+1.0 / 0.0))
       expect(@trans.read(@trans.available)).to eq("\"Infinity\"")
 
-      @prot.write_double((-1.0/0.0))
+      @prot.write_double((-1.0 / 0.0))
       expect(@trans.read(@trans.available)).to eq("\"-Infinity\"")
     end
 
@@ -473,10 +473,10 @@ describe "JsonProtocol" do
       expect(@prot.read_json_double.nan?).to eq(true)
 
       @trans.write("\"Infinity\"")
-      expect(@prot.read_json_double).to eq(+1.0/0.0)
+      expect(@prot.read_json_double).to eq(+1.0 / 0.0)
 
       @trans.write("\"-Infinity\"")
-      expect(@prot.read_json_double).to eq(-1.0/0.0)
+      expect(@prot.read_json_double).to eq(-1.0 / 0.0)
     end
 
     it "should read json object start" do

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -421,7 +421,7 @@ class SimpleClientTest < Test::Unit::TestCase
     assert_raise Thrift::Test::Xception2 do
       @client.testMultiException("Xception2", "test 2")
     end
-    assert_equal( @client.testMultiException("Success", "test 3").string_thing, "test 3")
+    assert_equal(@client.testMultiException("Success", "test 3").string_thing, "test 3")
   end
 
   def test_oneway
@@ -431,6 +431,6 @@ class SimpleClientTest < Test::Unit::TestCase
     time1 = Time.now.to_f
     @client.testOneway(1)
     time2 = Time.now.to_f
-    assert_operator (time2-time1), :<, 0.1
+    assert_operator (time2 - time1), :<, 0.1
   end
 end


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Enable the remaining neutral RuboCop spacing rules for operators, separators, comments, lambdas, and delimiters, then apply their autocorrections across the Ruby library, benchmarks, specs, and integration tests.

This intentionally leaves interior array and hash spacing unenforced, preserving forms such as `[1, 2, 3]` and `{a: 5, b: 6}` without creating avoidable churn.

This follows the merged `Style/UnpackFirst` PR #3722; its diff contains only this spacing layer.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
