### PR TITLE
Enable RuboCop ambiguity rules

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -212,6 +212,24 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/AmbiguousAssignment:
+  Enabled: true
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+
+Lint/AmbiguousRange:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
 Lint/OrderedMagicComments:
   Enabled: true
 
@@ -273,6 +291,9 @@ Performance/UnfreezeString:
   Enabled: true
 
 Performance/UriDefaultParser:
+  Enabled: true
+
+Style/AmbiguousEndlessMethodDefinition:
   Enabled: true
 
 Style/FrozenStringLiteralComment:

--- a/lib/rb/benchmark/server.rb
+++ b/lib/rb/benchmark/server.rb
@@ -33,7 +33,7 @@ module Server
     def fibonacci(n)
       seq = [1, 1]
       3.upto(n) do
-        seq << seq[-1] + seq[-2]
+        seq << (seq[-1] + seq[-2])
       end
       seq[n - 1] # n is 1-based
     end

--- a/lib/rb/benchmark/thin_server.rb
+++ b/lib/rb/benchmark/thin_server.rb
@@ -31,7 +31,7 @@ class BenchmarkHandler
   def fibonacci(n)
     seq = [1, 1]
     3.upto(n) do
-      seq << seq[-1] + seq[-2]
+      seq << (seq[-1] + seq[-2])
     end
     seq[n - 1] # n is 1-based
   end

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -24,13 +24,13 @@ module Thrift
     VERSION_1 = 0x80010000
     TYPE_MASK = 0x000000ff
     BYTE_MIN = -2**7
-    BYTE_MAX = 2**7 - 1
+    BYTE_MAX = (2**7) - 1
     I16_MIN = -2**15
-    I16_MAX = 2**15 - 1
+    I16_MAX = (2**15) - 1
     I32_MIN = -2**31
-    I32_MAX = 2**31 - 1
+    I32_MAX = (2**31) - 1
     I64_MIN = -2**63
-    I64_MAX = 2**63 - 1
+    I64_MAX = (2**63) - 1
 
     attr_reader :strict_read, :strict_write
 

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -182,7 +182,7 @@ module Thrift
       # check if we can use delta encoding for the field id
       if id > last_id && id - last_id <= 15
         # write them together
-        write_byte_direct((id - last_id) << 4 | type_to_write)
+        write_byte_direct(((id - last_id) << 4) | type_to_write)
       else
         # write them separate
         write_byte_direct(type_to_write)
@@ -203,7 +203,7 @@ module Thrift
         write_byte_direct(0)
       else
         write_varint32(size)
-        write_byte_direct(CompactTypes.get_compact_type(ktype) << 4 | CompactTypes.get_compact_type(vtype))
+        write_byte_direct((CompactTypes.get_compact_type(ktype) << 4) | CompactTypes.get_compact_type(vtype))
       end
     end
 
@@ -449,7 +449,7 @@ module Thrift
       size = validate_size(size)
       compact_type = CompactTypes.get_compact_type(elem_type)
       if size <= 14
-        write_byte_direct(size << 4 | compact_type)
+        write_byte_direct((size << 4) | compact_type)
       else
         write_byte_direct(0xf0 | compact_type)
         write_varint32(size)

--- a/lib/rb/lib/thrift/server/nonblocking_server.rb
+++ b/lib/rb/lib/thrift/server/nonblocking_server.rb
@@ -89,7 +89,7 @@ module Thrift
       if block
         shutdown_proc.call
       else
-        Thread.new &shutdown_proc
+        Thread.new(&shutdown_proc)
       end
     end
 

--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -148,7 +148,7 @@ module Thrift
       each_field do |fid, field_info|
         name = field_info[:name]
         value = self.send(name)
-        total = (total * 37 + value.hash) & 0xffffffff
+        total = ((total * 37) + value.hash) & 0xffffffff
       end
       total
     end

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -176,7 +176,7 @@ module Thrift
         if field_info[:type] == Types::MAP
           map_buf = []
           value.each do |k, v|
-            map_buf << inspect_field(k, field_info[:key]) + ": " + inspect_field(v, field_info[:value])
+            map_buf << (inspect_field(k, field_info[:key]) + ": " + inspect_field(v, field_info[:value]))
           end
           "{" + map_buf.join(", ") + "}"
         else

--- a/lib/rb/lib/thrift/union.rb
+++ b/lib/rb/lib/thrift/union.rb
@@ -103,7 +103,7 @@ module Thrift
     end
 
     def ==(other)
-      other.equal?(self) || other.instance_of?(self.class) && @setfield == other.get_set_field && @value == other.get_value
+      other.equal?(self) || (other.instance_of?(self.class) && @setfield == other.get_set_field && @value == other.get_value)
     end
     alias_method :eql?, :==
 

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -128,7 +128,7 @@ shared_examples_for "a binary protocol" do
   it "should write an i16" do
     # try a random scattering of values
     # include the signed i16 minimum/maximum
-    [-2**15, -1024, 17, 0, -10000, 1723, 2**15 - 1].each do |i|
+    [-2**15, -1024, 17, 0, -10000, 1723, (2**15) - 1].each do |i|
       @prot.write_i16(i)
     end
 
@@ -153,11 +153,11 @@ shared_examples_for "a binary protocol" do
   it "should write an i32" do
     # try a random scattering of values
     # include the signed i32 minimum/maximum
-    [-2**31, -123123, -2532, -3, 0, 2351235, 12331, 2**31 - 1].each do |i|
+    [-2**31, -123123, -2532, -3, 0, 2351235, 12331, (2**31) - 1].each do |i|
       @prot.write_i32(i)
     end
     expect(@trans.read(@trans.available)).to eq("\200\000\000\000" + "\377\376\037\r" + "\377\377\366\034" + "\377\377\377\375" + "\000\000\000\000" + "\000#\340\203" + "\000\0000+" + "\177\377\377\377")
-    [-2**31 - 1, 2**31, 2**65 + 5].each do |i|
+    [-2**31 - 1, 2**31, (2**65) + 5].each do |i|
       expect { @prot.write_i32(i) }.to raise_error(RangeError)
     end
   end
@@ -173,7 +173,7 @@ shared_examples_for "a binary protocol" do
   it "should write an i64" do
     # try a random scattering of values
     # try the signed i64 minimum/maximum
-    [-2**63, -12356123612323, -23512351, -234, 0, 1231, 2351236, 12361236213, 2**63 - 1].each do |i|
+    [-2**63, -12356123612323, -23512351, -234, 0, 1231, 2351236, 12361236213, (2**63) - 1].each do |i|
       @prot.write_i64(i)
     end
     expect(@trans.read(@trans.available)).to eq([
@@ -187,7 +187,7 @@ shared_examples_for "a binary protocol" do
       "\000\000\000\002\340\311~\365",
       "\177\377\377\377\377\377\377\377",
     ].join(""))
-    [-2**63 - 1, 2**63, 2**65 + 5].each do |i|
+    [-2**63 - 1, 2**63, (2**65) + 5].each do |i|
       expect { @prot.write_i64(i) }.to raise_error(RangeError)
     end
   end
@@ -386,7 +386,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i16" do
     # try a scattering of values, including min/max
-    [-2**15, -5237, -353, 0, 1527, 2234, 2**15 - 1].each do |i|
+    [-2**15, -5237, -353, 0, 1527, 2234, (2**15) - 1].each do |i|
       @trans.write([i].pack("n"));
       expect(@prot.read_i16).to eq(i)
     end
@@ -394,7 +394,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i32" do
     # try a scattering of values, including min/max
-    [-2**31, -235125, -6236, 0, 2351, 123123, 2**31 - 1].each do |i|
+    [-2**31, -235125, -6236, 0, 2351, 123123, (2**31) - 1].each do |i|
       @trans.write([i].pack("N"))
       expect(@prot.read_i32).to eq(i)
     end
@@ -402,7 +402,7 @@ shared_examples_for "a binary protocol" do
 
   it "should read an i64" do
     # try a scattering of values, including min/max
-    [-2**63, -123512312, -6346, 0, 32, 2346322323, 2**63 - 1].each do |i|
+    [-2**63, -123512312, -6346, 0, 32, 2346322323, (2**63) - 1].each do |i|
       @trans.write([i >> 32, i & 0xFFFFFFFF].pack("NN"))
       expect(@prot.read_i64).to eq(i)
     end

--- a/lib/rb/spec/header_transport_spec.rb
+++ b/lib/rb/spec/header_transport_spec.rb
@@ -720,7 +720,7 @@ describe "HeaderTransport" do
       end
 
       it "should reject uint32 varints with an overflowing fifth byte" do
-        header_data = ([0x80] * 4 + [0x10]).pack("C*")
+        header_data = (([0x80] * 4) + [0x10]).pack("C*")
         frame = build_header_frame(header_data)
         read_transport = Thrift::MemoryBufferTransport.new(frame)
         read_trans = Thrift::HeaderTransport.new(read_transport)
@@ -729,7 +729,7 @@ describe "HeaderTransport" do
       end
 
       it "should accept uint32 varints with a valid fifth byte" do
-        header_data = ([0x80] * 4 + [0x0f, 0]).pack("C*")
+        header_data = (([0x80] * 4) + [0x0f, 0]).pack("C*")
         frame = build_header_frame(header_data)
         read_transport = Thrift::MemoryBufferTransport.new(frame)
         read_trans = Thrift::HeaderTransport.new(read_transport)

--- a/lib/rb/spec/serializer_spec.rb
+++ b/lib/rb/spec/serializer_spec.rb
@@ -167,7 +167,7 @@ describe "Serializer" do
 
         expect {
           serializer.serialize(SerializerFailureFixtures::Value.new(stage, error))
-        }.to raise_error { |raised| expect(raised).to equal(error) }
+        }.to(raise_error { |raised| expect(raised).to equal(error) })
 
         2.times do
           data = serializer.serialize(value)
@@ -190,7 +190,7 @@ describe "Serializer" do
         error = RuntimeError.new("failed at #{stage}")
         expect {
           serializer.serialize(SerializerFailureFixtures::Value.new(stage, error))
-        }.to raise_error { |raised| expect(raised).to equal(error) }
+        }.to(raise_error { |raised| expect(raised).to equal(error) })
       end
 
       expect(serializer.serialize(value)).to eq(

--- a/lib/rb/spec/socket_spec_shared.rb
+++ b/lib/rb/spec/socket_spec_shared.rb
@@ -121,7 +121,7 @@ shared_examples_for "a socket" do
     @socket.timeout = 0.5
     @socket.open
     expect(@handle).to receive(:read_nonblock).with(17).and_raise(IO::EAGAINWaitReadable)
-    expect(IO).to receive(:select).once { sleep(0.6); nil }
+    expect(IO).to(receive(:select).once { sleep(0.6); nil })
     expect { @socket.read(17) }.to raise_error(Thrift::TransportException) { |e| expect(e.type).to eq(Thrift::TransportException::TIMED_OUT) }
   end
 
@@ -129,7 +129,7 @@ shared_examples_for "a socket" do
     @socket.timeout = 0.5
     @socket.open
     expect(@handle).to receive(:write_nonblock).with("test data").and_raise(IO::EAGAINWaitWritable)
-    expect(IO).to receive(:select).once { sleep(0.6); nil }
+    expect(IO).to(receive(:select).once { sleep(0.6); nil })
     expect { @socket.write("test data") }.to raise_error(Thrift::TransportException) { |e| expect(e.type).to eq(Thrift::TransportException::TIMED_OUT) }
   end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Enable RuboCop's ambiguity cops for assignments, block association, operators, precedence, ranges, regular expressions, and endless method definitions.

The autocorrections add explicit grouping where Ruby's parse could otherwise be unclear, including mixed arithmetic and bitwise expressions, proc arguments, and RSpec matchers with blocks. These changes preserve behavior while making operator precedence and block ownership visible in the source.

This follows the merged spacing PR #3723; its diff contains only the ambiguity layer.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
