### PR TITLE
Enable RuboCop Style/RedundantBegin

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -312,6 +312,9 @@ Style/MethodDefParentheses:
 Style/RedundantAssignment:
   Enabled: true
 
+Style/RedundantBegin:
+  Enabled: true
+
 Style/RedundantException:
   Enabled: true
 

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -122,11 +122,9 @@ class BenchmarkManager
       rd, = select(@pool)
       next if rd.nil?
       rd.each do |fd|
-        begin
-          @buffers[fd] << fd.readpartial(4096)
-        rescue EOFError
-          @pool.delete fd
-        end
+        @buffers[fd] << fd.readpartial(4096)
+      rescue EOFError
+        @pool.delete fd
       end
     end
   end

--- a/lib/rb/lib/thrift/server/nonblocking_server.rb
+++ b/lib/rb/lib/thrift/server/nonblocking_server.rb
@@ -163,15 +163,13 @@ module Thrift
             break if read_signals == :shutdown
           end
           rd.each do |fd|
-            begin
-              if fd.handle.eof?
-                remove_connection fd
-              else
-                read_connection fd
-              end
-            rescue Errno::ECONNRESET
+            if fd.handle.eof?
               remove_connection fd
+            else
+              read_connection fd
             end
+          rescue Errno::ECONNRESET
+            remove_connection fd
           end
         end
         join_worker_threads(@shutdown_timeout)
@@ -259,10 +257,8 @@ module Thrift
 
       def close_connections
         @connections.each do |fd|
-          begin
-            fd.close
-          rescue IOError, SystemCallError, TransportException
-          end
+          fd.close
+        rescue IOError, SystemCallError, TransportException
         end
         @connections.clear
         @buffers.clear
@@ -270,10 +266,8 @@ module Thrift
 
       def close_signal_pipes
         @signal_pipes.each do |pipe|
-          begin
-            pipe.close unless pipe.closed?
-          rescue IOError
-          end
+          pipe.close unless pipe.closed?
+        rescue IOError
         end
       end
 

--- a/lib/rb/lib/thrift/server/simple_server.rb
+++ b/lib/rb/lib/thrift/server/simple_server.rb
@@ -21,31 +21,29 @@
 module Thrift
   class SimpleServer < BaseServer
     def serve
-      begin
-        @server_transport.listen
-        loop do
-          begin
-            client = @server_transport.accept
-          rescue Errno::ECONNRESET, Errno::EPIPE
-            next
-          rescue => e
-            next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
-            raise
-          end
-          trans = @transport_factory.get_transport(client)
-          prot = @protocol_factory.get_protocol(trans)
-          begin
-            loop do
-              @processor.process(prot, prot)
-            end
-          rescue Thrift::TransportException, Thrift::ProtocolException
-          ensure
-            trans.close
-          end
+      @server_transport.listen
+      loop do
+        begin
+          client = @server_transport.accept
+        rescue Errno::ECONNRESET, Errno::EPIPE
+          next
+        rescue => e
+          next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise
         end
-      ensure
-        @server_transport.close
+        trans = @transport_factory.get_transport(client)
+        prot = @protocol_factory.get_protocol(trans)
+        begin
+          loop do
+            @processor.process(prot, prot)
+          end
+        rescue Thrift::TransportException, Thrift::ProtocolException
+        ensure
+          trans.close
+        end
       end
+    ensure
+      @server_transport.close
     end
 
     def to_s

--- a/lib/rb/lib/thrift/server/thread_pool_server.rb
+++ b/lib/rb/lib/thrift/server/thread_pool_server.rb
@@ -47,30 +47,28 @@ module Thrift
         loop do
           @thread_q.push(:token)
           Thread.new do
-            begin
-              loop do
-                begin
-                  client = @server_transport.accept
-                rescue => e
-                  next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
-                  raise
-                end
-                trans = @transport_factory.get_transport(client)
-                prot = @protocol_factory.get_protocol(trans)
-                begin
-                  loop do
-                    @processor.process(prot, prot)
-                  end
-                rescue Thrift::TransportException, Thrift::ProtocolException => e
-                ensure
-                  trans.close
-                end
+            loop do
+              begin
+                client = @server_transport.accept
+              rescue => e
+                next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
+                raise
               end
-            rescue => e
-              @exception_q.push(e)
-            ensure
-              @thread_q.pop # thread died!
+              trans = @transport_factory.get_transport(client)
+              prot = @protocol_factory.get_protocol(trans)
+              begin
+                loop do
+                  @processor.process(prot, prot)
+                end
+              rescue Thrift::TransportException, Thrift::ProtocolException => e
+              ensure
+                trans.close
+              end
             end
+          rescue => e
+            @exception_q.push(e)
+          ensure
+            @thread_q.pop # thread died!
           end
         end
       ensure

--- a/lib/rb/lib/thrift/server/threaded_server.rb
+++ b/lib/rb/lib/thrift/server/threaded_server.rb
@@ -23,33 +23,29 @@ require "thread"
 module Thrift
   class ThreadedServer < BaseServer
     def serve
-      begin
-        @server_transport.listen
-        loop do
-          begin
-            client = @server_transport.accept
-          rescue Errno::ECONNRESET, Errno::EPIPE
-            next
-          rescue => e
-            next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
-            raise
-          end
-          trans = @transport_factory.get_transport(client)
-          prot = @protocol_factory.get_protocol(trans)
-          Thread.new(prot, trans) do |p, t|
-            begin
-              loop do
-                @processor.process(p, p)
-              end
-            rescue Thrift::TransportException, Thrift::ProtocolException
-            ensure
-              t.close
-            end
-          end
+      @server_transport.listen
+      loop do
+        begin
+          client = @server_transport.accept
+        rescue Errno::ECONNRESET, Errno::EPIPE
+          next
+        rescue => e
+          next if defined?(OpenSSL::SSL::SSLError) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise
         end
-      ensure
-        @server_transport.close
+        trans = @transport_factory.get_transport(client)
+        prot = @protocol_factory.get_protocol(trans)
+        Thread.new(prot, trans) do |p, t|
+          loop do
+            @processor.process(p, p)
+          end
+        rescue Thrift::TransportException, Thrift::ProtocolException
+        ensure
+          t.close
+        end
       end
+    ensure
+      @server_transport.close
     end
 
     def to_s

--- a/lib/rb/lib/thrift/transport/socket.rb
+++ b/lib/rb/lib/thrift/transport/socket.rb
@@ -85,13 +85,11 @@ module Thrift
           deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
 
           data = loop do
-            begin
-              break @handle.read_nonblock(sz)
-            rescue IO::WaitReadable
-              wait_for(:read, deadline, sz)
-            rescue IO::WaitWritable
-              wait_for(:write, deadline, sz)
-            end
+            break @handle.read_nonblock(sz)
+          rescue IO::WaitReadable
+            wait_for(:read, deadline, sz)
+          rescue IO::WaitWritable
+            wait_for(:write, deadline, sz)
           end
         end
       rescue TransportException

--- a/lib/rb/lib/thrift/transport/unix_socket.rb
+++ b/lib/rb/lib/thrift/transport/unix_socket.rb
@@ -31,11 +31,9 @@ module Thrift
     end
 
     def open
-      begin
-        @handle = ::UNIXSocket.new(@path)
-      rescue StandardError
-        raise TransportException.new(TransportException::NOT_OPEN, "Could not open UNIX socket at #{@path}")
-      end
+      @handle = ::UNIXSocket.new(@path)
+    rescue StandardError
+      raise TransportException.new(TransportException::NOT_OPEN, "Could not open UNIX socket at #{@path}")
     end
 
     def to_s

--- a/lib/rb/spec/nonblocking_server_spec.rb
+++ b/lib/rb/spec/nonblocking_server_spec.rb
@@ -113,13 +113,11 @@ describe "NonblockingServer" do
       @server = Thrift::NonblockingServer.new(processor, @transport, transport_factory, nil, 5, logger)
       handler.server = @server
       @server_thread = Thread.new(Thread.current) do |master_thread|
-        begin
-          @server.serve
-        rescue => e
-          p e
-          puts e.backtrace * "\n"
-          master_thread.raise e
-        end
+        @server.serve
+      rescue => e
+        p e
+        puts e.backtrace * "\n"
+        master_thread.raise e
       end
       queue.pop
       wait_until_listening(@transport, @server_thread)
@@ -149,31 +147,29 @@ describe "NonblockingServer" do
     def setup_client_thread(result)
       queue = Queue.new
       Thread.new do
-        begin
-          client = setup_client
-          while (cmd = queue.pop)
-            msg, *args = cmd
-            case msg
-            when :block
-              result << client.block
-            when :unblock
-              client.unblock(args.first)
-            when :hello
-              result << client.greeting(true) # ignore result
-            when :sleep
-              client.sleep(args[0] || 0.5)
-              result << :slept
-            when :shutdown
-              client.shutdown
-            when :exit
-              result << :done
-              break
-            end
+        client = setup_client
+        while (cmd = queue.pop)
+          msg, *args = cmd
+          case msg
+          when :block
+            result << client.block
+          when :unblock
+            client.unblock(args.first)
+          when :hello
+            result << client.greeting(true) # ignore result
+          when :sleep
+            client.sleep(args[0] || 0.5)
+            result << :slept
+          when :shutdown
+            client.shutdown
+          when :exit
+            result << :done
+            break
           end
-          @clients.each { |c, t| t.close and break if c == client } # close the transport
-        rescue => e
-          raise e unless @catch_exceptions
         end
+        @clients.each { |c, t| t.close and break if c == client } # close the transport
+      rescue => e
+        raise e unless @catch_exceptions
       end
       queue
     end
@@ -190,11 +186,9 @@ describe "NonblockingServer" do
       trans_queue = Queue.new
       4.times do
         Thread.new(Thread.current) do |main_thread|
-          begin
-            queue.push setup_client(trans_queue).block
-          rescue => e
-            main_thread.raise e
-          end
+          queue.push setup_client(trans_queue).block
+        rescue => e
+          main_thread.raise e
         end
       end
       4.times { trans_queue.pop }
@@ -376,11 +370,9 @@ describe "NonblockingServer" do
       handler.server = @server
 
       @server_thread = Thread.new(Thread.current) do |master_thread|
-        begin
-          @server.serve
-        rescue => e
-          master_thread.raise e
-        end
+        @server.serve
+      rescue => e
+        master_thread.raise e
       end
 
       @clients = []

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -75,14 +75,12 @@ describe "Struct" do
     end
 
     it "should not share default values between instances" do
-      begin
-        struct = SpecNamespace::Foo.new
-        struct.ints << 17
-        expect(SpecNamespace::Foo.new.ints).to eq([1, 2, 2, 3])
-      ensure
-        # ensure no leakage to other tests
-        SpecNamespace::Foo::FIELDS[4][:default] = [1, 2, 2, 3]
-      end
+      struct = SpecNamespace::Foo.new
+      struct.ints << 17
+      expect(SpecNamespace::Foo.new.ints).to eq([1, 2, 2, 3])
+    ensure
+      # ensure no leakage to other tests
+      SpecNamespace::Foo::FIELDS[4][:default] = [1, 2, 2, 3]
     end
 
     it "should properly initialize boolean values" do
@@ -349,44 +347,40 @@ describe "Struct" do
     end
 
     it "should support `raise Xception, 'message'` for Exception structs" do
-      begin
-        raise SpecNamespace::Xception, "something happened"
-      rescue Thrift::Exception => e
-        expect(e.message).to eq("something happened")
-        expect(e.code).to eq(1)
-        # ensure it gets serialized properly, this is the really important part
-        prot = Thrift::BaseProtocol.new(double("trans"))
-        expect(prot).to receive(:write_struct_begin).with("SpecNamespace::Xception")
-        expect(prot).to receive(:write_struct_end)
-        expect(prot).to receive(:write_field_begin).with("message", Thrift::Types::STRING, 1)
-        expect(prot).to receive(:write_string).with("something happened")
-        expect(prot).to receive(:write_field_begin).with("code", Thrift::Types::I32, 2)
-        expect(prot).to receive(:write_i32).with(1)
-        expect(prot).to receive(:write_field_stop)
-        expect(prot).to receive(:write_field_end).twice
+      raise SpecNamespace::Xception, "something happened"
+    rescue Thrift::Exception => e
+      expect(e.message).to eq("something happened")
+      expect(e.code).to eq(1)
+      # ensure it gets serialized properly, this is the really important part
+      prot = Thrift::BaseProtocol.new(double("trans"))
+      expect(prot).to receive(:write_struct_begin).with("SpecNamespace::Xception")
+      expect(prot).to receive(:write_struct_end)
+      expect(prot).to receive(:write_field_begin).with("message", Thrift::Types::STRING, 1)
+      expect(prot).to receive(:write_string).with("something happened")
+      expect(prot).to receive(:write_field_begin).with("code", Thrift::Types::I32, 2)
+      expect(prot).to receive(:write_i32).with(1)
+      expect(prot).to receive(:write_field_stop)
+      expect(prot).to receive(:write_field_end).twice
 
-        e.write(prot)
-      end
+      e.write(prot)
     end
 
     it "should support the regular initializer for exception structs" do
-      begin
-        raise SpecNamespace::Xception, {message: "something happened", code: 5}
-      rescue Thrift::Exception => e
-        expect(e.message).to eq("something happened")
-        expect(e.code).to eq(5)
-        prot = Thrift::BaseProtocol.new(double("trans"))
-        expect(prot).to receive(:write_struct_begin).with("SpecNamespace::Xception")
-        expect(prot).to receive(:write_struct_end)
-        expect(prot).to receive(:write_field_begin).with("message", Thrift::Types::STRING, 1)
-        expect(prot).to receive(:write_string).with("something happened")
-        expect(prot).to receive(:write_field_begin).with("code", Thrift::Types::I32, 2)
-        expect(prot).to receive(:write_i32).with(5)
-        expect(prot).to receive(:write_field_stop)
-        expect(prot).to receive(:write_field_end).twice
+      raise SpecNamespace::Xception, {message: "something happened", code: 5}
+    rescue Thrift::Exception => e
+      expect(e.message).to eq("something happened")
+      expect(e.code).to eq(5)
+      prot = Thrift::BaseProtocol.new(double("trans"))
+      expect(prot).to receive(:write_struct_begin).with("SpecNamespace::Xception")
+      expect(prot).to receive(:write_struct_end)
+      expect(prot).to receive(:write_field_begin).with("message", Thrift::Types::STRING, 1)
+      expect(prot).to receive(:write_string).with("something happened")
+      expect(prot).to receive(:write_field_begin).with("code", Thrift::Types::I32, 2)
+      expect(prot).to receive(:write_i32).with(5)
+      expect(prot).to receive(:write_field_stop)
+      expect(prot).to receive(:write_field_end).twice
 
-        e.write(prot)
-      end
+      e.write(prot)
     end
 
     it "should handle UUID fields in structs" do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Enable `Style/RedundantBegin` and remove unnecessary `begin`/`end` wrappers where Ruby method and block bodies already support `rescue` and `ensure` clauses directly.

The autocorrections flatten exception-handling structure in server loops, socket operations, benchmarks, and specs while preserving the existing protected expressions, rescue clauses, ensure clauses, and return behavior.

`Style/RedundantReturn` remains a separate follow-up change.

This follows the merged general redundancy PR #3726; its diff contains only the `RedundantBegin` layer.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
