### PR TITLE
Enable RuboCop Style/RedundantReturn

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -1009,9 +1009,6 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
     if (!(*f_iter)->is_oneway()) {
       f_service_.indent();
-      if (!(*f_iter)->get_returntype()->is_void()) {
-        f_service_ << "return ";
-      }
       f_service_ << "recv_" << funname << "()" << '\n';
     }
     f_service_.indent_down();
@@ -1075,7 +1072,7 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
       // Careful, only return _result if not a void function
       if ((*f_iter)->get_returntype()->is_void()) {
-        f_service_.indent() << "return" << '\n';
+        f_service_.indent() << "nil" << '\n';
       } else {
         f_service_.indent() << "raise "
                                "::Thrift::ApplicationException.new(::Thrift::ApplicationException::"
@@ -1206,7 +1203,7 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
 
   // Shortcut out here for oneway functions
   if (tfunction->is_oneway()) {
-    f_service_.indent() << "return" << '\n';
+    f_service_.indent() << "nil" << '\n';
     f_service_.indent_down();
     f_service_.indent() << "end" << '\n';
     return;

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -107,6 +107,7 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
         "}\n"
         "service PingService {\n"
         "  oneway void ping(1: i32 n)\n"
+        "  i32 pong()\n"
         "}\n";
 
     {
@@ -131,6 +132,8 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
         "\n"
         "    FIELDS";
     REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
+    REQUIRE(service.find("def pong()\n      send_pong()\n      recv_pong()\n    end")
+            != string::npos);
     REQUIRE(service.find(expected_empty_result) != string::npos);
     REQUIRE(service.find("\n\n  end\n") == string::npos);
 

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -327,6 +327,9 @@ Style/RedundantInterpolation:
 Style/RedundantParentheses:
   Enabled: true
 
+Style/RedundantReturn:
+  Enabled: true
+
 Style/RedundantSelf:
   Enabled: true
 

--- a/lib/rb/lib/thrift/protocol/binary_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/binary_protocol.rb
@@ -285,7 +285,7 @@ module Thrift
 
   class BinaryProtocolFactory < BaseProtocolFactory
     def get_protocol(trans)
-      return Thrift::BinaryProtocol.new(trans)
+      Thrift::BinaryProtocol.new(trans)
     end
 
     def to_s

--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -34,7 +34,7 @@ module Thrift
         @data = @trans.read(1)
       end
 
-      return @data
+      @data
     end
 
     def peek
@@ -42,7 +42,7 @@ module Thrift
         @data = @trans.read(1)
       end
       @hasData = true
-      return @data
+      @data
     end
   end
 
@@ -69,7 +69,7 @@ module Thrift
     # Default behavior is to return false.
     #
     def escapeNum
-      return false
+      false
     end
   end
 
@@ -105,7 +105,7 @@ module Thrift
 
     # Numbers must be turned into strings if they are the key part of a pair
     def escapeNum
-      return @colon
+      @colon
     end
   end
 
@@ -219,9 +219,9 @@ module Thrift
     def is_json_numeric(ch)
       case ch
       when "+", "-", ".", "0".."9", "E", "e"
-        return true
+        true
       else
-        return false
+        false
       end
     end
 
@@ -563,7 +563,7 @@ module Thrift
         ch = @reader.read
         str << ch
       end
-      return str
+      str
     end
 
     # Reads a sequence of characters and assembles them into a number,
@@ -585,7 +585,7 @@ module Thrift
         read_json_syntax_char(@@kJSONStringDelimiter)
       end
 
-      return num
+      num
     end
 
     # Reads a JSON number or string and interprets it as a double.
@@ -624,7 +624,7 @@ module Thrift
           raise ProtocolException.new(ProtocolException::INVALID_DATA, "Expected numeric value; got \"#{str}\"")
         end
       end
-      return num
+      num
     end
 
     def read_json_object_start
@@ -821,7 +821,7 @@ module Thrift
 
   class JsonProtocolFactory < BaseProtocolFactory
     def get_protocol(trans)
-      return Thrift::JsonProtocol.new(trans)
+      Thrift::JsonProtocol.new(trans)
     end
 
     def to_s

--- a/lib/rb/lib/thrift/transport/base_transport.rb
+++ b/lib/rb/lib/thrift/transport/base_transport.rb
@@ -73,7 +73,7 @@ module Thrift
     # Returns an unsigned byte as a Integer in the range (0..255).
     def read_byte
       buf = read_all(1)
-      return Bytes.get_string_byte(buf, 0)
+      Bytes.get_string_byte(buf, 0)
     end
 
     # Reads size bytes and copies them into buffer[0..size].
@@ -129,7 +129,7 @@ module Thrift
 
   class BaseTransportFactory
     def get_transport(trans)
-      return trans
+      trans
     end
 
     def to_s

--- a/lib/rb/lib/thrift/transport/buffered_transport.rb
+++ b/lib/rb/lib/thrift/transport/buffered_transport.rb
@@ -31,7 +31,7 @@ module Thrift
     end
 
     def open?
-      return @transport.open?
+      @transport.open?
     end
 
     def open
@@ -66,7 +66,7 @@ module Thrift
       # The read buffer has some data now, read a single byte. Using get_string_byte() avoids
       # allocating a temp string of size 1 unnecessarily.
       @index += 1
-      return Bytes.get_string_byte(@rbuf, @index - 1)
+      Bytes.get_string_byte(@rbuf, @index - 1)
     end
 
     # Reads a number of bytes from the transport into the buffer passed.
@@ -113,7 +113,7 @@ module Thrift
 
   class BufferedTransportFactory < BaseTransportFactory
     def get_transport(transport)
-      return BufferedTransport.new(transport)
+      BufferedTransport.new(transport)
     end
 
     def to_s

--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -61,7 +61,7 @@ module Thrift
       # The read buffer has some data now, read a single byte. Using get_string_byte() avoids
       # allocating a temp string of size 1 unnecessarily.
       @index += 1
-      return Bytes.get_string_byte(@rbuf, @index - 1)
+      Bytes.get_string_byte(@rbuf, @index - 1)
     end
 
     def read_into_buffer(buffer, size)
@@ -116,7 +116,7 @@ module Thrift
 
   class FramedTransportFactory < BaseTransportFactory
     def get_transport(transport)
-      return FramedTransport.new(transport)
+      FramedTransport.new(transport)
     end
 
     def to_s

--- a/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
+++ b/lib/rb/lib/thrift/transport/memory_buffer_transport.rb
@@ -30,7 +30,7 @@ module Thrift
     end
 
     def open?
-      return true
+      true
     end
 
     def open

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -47,7 +47,7 @@ class SimpleHandler
   end
 
   def testInsanity(thing)
-    return {
+    {
       1 => {
         2 => thing,
         3 => thing,
@@ -59,7 +59,7 @@ class SimpleHandler
   end
 
   def testMapMap(thing)
-    return {
+    {
       -4 => {
         -4 => -4,
         -3 => -3,
@@ -76,7 +76,7 @@ class SimpleHandler
   end
 
   def testMulti(arg0, arg1, arg2, arg3, arg4, arg5)
-    return Thrift::Test::Xtruct.new({
+    Thrift::Test::Xtruct.new({
       "string_thing" => "Hello2",
       "byte_thing" => arg0,
       "i32_thing" => arg1,
@@ -100,7 +100,7 @@ class SimpleHandler
     elsif arg0 == "Xception"
       raise Thrift::Test::Xception, {errorCode: 1001, message: "This is an Xception"}
     else
-      return ::Thrift::Test::Xtruct.new({"string_thing" => arg1})
+      ::Thrift::Test::Xtruct.new({"string_thing" => arg1})
     end
   end
 

--- a/tutorial/rb/RubyServer.rb
+++ b/tutorial/rb/RubyServer.rb
@@ -38,7 +38,7 @@ class CalculatorHandler
 
   def add(n1, n2)
     print "add(", n1, ",", n2, ")\n"
-    return n1 + n2
+    n1 + n2
   end
 
   def calculate(logid, work)
@@ -69,12 +69,12 @@ class CalculatorHandler
     entry.value = val.to_s
     @log[logid] = entry
 
-    return val
+    val
   end
 
   def getStruct(key)
     print "getStruct(", key, ")\n"
-    return @log[key]
+    @log[key]
   end
 
   def zip()


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Enable `Style/RedundantReturn` and remove explicit `return` keywords where Ruby already returns the final expression.

The Ruby generator now emits service client receive calls as final expressions. Generated void and oneway paths that previously used a bare early `return` emit `nil` instead, preserving their control flow and return value while keeping generated code compliant with the cop. Functional coverage verifies the generated non-void client method shape.

This follows the merged `Style/RedundantBegin` PR #3727; its diff contains only the `RedundantReturn` layer.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
