### PR TITLE
Enable RuboCop Lint/UselessAssignment

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -1055,16 +1055,21 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
       f_service_.indent() << "validate_message_begin(fname, mtype, rseqid, \"" << funname << "\")"
                           << '\n';
 
-      f_service_.indent() << "result = receive_message(" << resultname << ")" << '\n';
+      t_struct* xs = (*f_iter)->get_xceptions();
+      const std::vector<t_field*>& xceptions = xs->get_members();
+      vector<t_field*>::const_iterator x_iter;
+
+      f_service_.indent();
+      if (!(*f_iter)->get_returntype()->is_void() || !xceptions.empty()) {
+        f_service_ << "result = ";
+      }
+      f_service_ << "receive_message(" << resultname << ")" << '\n';
 
       // Careful, only return _result if not a void function
       if (!(*f_iter)->get_returntype()->is_void()) {
         f_service_.indent() << "return result.success unless result.success.nil?" << '\n';
       }
 
-      t_struct* xs = (*f_iter)->get_xceptions();
-      const std::vector<t_field*>& xceptions = xs->get_members();
-      vector<t_field*>::const_iterator x_iter;
       for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
         f_service_.indent() << "raise result." << (*x_iter)->get_name() << " unless result."
                             << (*x_iter)->get_name() << ".nil?" << '\n';
@@ -1148,7 +1153,14 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
   string argsname = capitalize(tfunction->get_name()) + "_args";
   string resultname = capitalize(tfunction->get_name()) + "_result";
 
-  f_service_.indent() << "args = read_args(iprot, " << argsname << ")" << '\n';
+  t_struct* arg_struct = tfunction->get_arglist();
+  const std::vector<t_field*>& fields = arg_struct->get_members();
+
+  f_service_.indent();
+  if (!fields.empty()) {
+    f_service_ << "args = ";
+  }
+  f_service_ << "read_args(iprot, " << argsname << ")" << '\n';
 
   t_struct* xs = tfunction->get_xceptions();
   const std::vector<t_field*>& xceptions = xs->get_members();
@@ -1166,8 +1178,6 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
   }
 
   // Generate the function call
-  t_struct* arg_struct = tfunction->get_arglist();
-  const std::vector<t_field*>& fields = arg_struct->get_members();
   vector<t_field*>::const_iterator f_iter;
 
   f_service_.indent();

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -108,6 +108,7 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
         "service PingService {\n"
         "  oneway void ping(1: i32 n)\n"
         "  i32 pong()\n"
+        "  void noop()\n"
         "}\n";
 
     {
@@ -133,6 +134,17 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
         "    FIELDS";
     REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
     REQUIRE(service.find("def pong()\n      send_pong()\n      recv_pong()\n    end")
+            != string::npos);
+    REQUIRE(service.find("def recv_noop()\n"
+                         "      fname, mtype, rseqid = receive_message_begin()\n"
+                         "      validate_message_begin(fname, mtype, rseqid, \"noop\")\n"
+                         "      receive_message(Noop_result)\n"
+                         "      nil\n"
+                         "    end")
+            != string::npos);
+    REQUIRE(service.find("def process_pong(seqid, iprot, oprot)\n"
+                         "      read_args(iprot, Pong_args)\n"
+                         "      result = Pong_result.new()")
             != string::npos);
     REQUIRE(service.find(expected_empty_result) != string::npos);
     REQUIRE(service.find("\n\n  end\n") == string::npos);

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -239,6 +239,9 @@ Lint/RedundantStringCoercion:
 Lint/UnreachableCode:
   Enabled: true
 
+Lint/UselessAssignment:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 

--- a/lib/rb/benchmark/benchmark.rb
+++ b/lib/rb/benchmark/benchmark.rb
@@ -183,9 +183,9 @@ class BenchmarkManager
       end
     end
     @report = {}
-    @report[:total_calls] = call_times.inject(0.0) { |a, t| a += t }
+    @report[:total_calls] = call_times.inject(0.0) { |a, t| a + t }
     @report[:avg_calls] = @report[:total_calls] / call_times.size
-    @report[:total_clients] = client_times.inject(0.0) { |a, t| a += t }
+    @report[:total_clients] = client_times.inject(0.0) { |a, t| a + t }
     @report[:avg_clients] = @report[:total_clients] / client_times.size
     @report[:connection_failures] = connection_failures.size
     @report[:connection_errors] = connection_errors.size
@@ -209,7 +209,6 @@ class BenchmarkManager
              ["Clients per process", @clients_per_process],
              ["Calls per client", @calls_per_client]
     puts
-    failures = (@report[:connection_failures] > 0)
     tabulate fmt,
              [["Connection failures", "%d", [:red, :bold]], @report[:connection_failures]],
              [["Connection errors", "%d", [:red, :bold]], @report[:connection_errors]],

--- a/lib/rb/lib/thrift/exceptions.rb
+++ b/lib/rb/lib/thrift/exceptions.rb
@@ -54,7 +54,7 @@ module Thrift
       raise ProtocolException.new(ProtocolException::DEPTH_LIMIT, "Maximum recursion depth exceeded") if remaining_depth <= 0
       iprot.read_struct_begin
       while true
-        fname, ftype, fid = iprot.read_field_begin
+        _, ftype, fid = iprot.read_field_begin
         if ftype == Types::STOP
           break
         end

--- a/lib/rb/lib/thrift/protocol/base_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/base_protocol.rb
@@ -367,7 +367,7 @@ module Thrift
       when Types::STRUCT
         read_struct_begin
         while true
-          name, type, id = read_field_begin
+          _, type, _ = read_field_begin
           break if type == Types::STOP
           skip(type, max_depth - 1)
           read_field_end

--- a/lib/rb/lib/thrift/server/nonblocking_server.rb
+++ b/lib/rb/lib/thrift/server/nonblocking_server.rb
@@ -62,7 +62,7 @@ module Thrift
           @logger.debug "Accepted socket: #{socket.inspect}"
           @io_manager.add_connection socket
         end
-      rescue IOError => e
+      rescue IOError
       end
       # we must be shutting down
       @logger.info "#{self} is shutting down, goodbye"

--- a/lib/rb/lib/thrift/server/thread_pool_server.rb
+++ b/lib/rb/lib/thrift/server/thread_pool_server.rb
@@ -60,7 +60,7 @@ module Thrift
                 loop do
                   @processor.process(prot, prot)
                 end
-              rescue Thrift::TransportException, Thrift::ProtocolException => e
+              rescue Thrift::TransportException, Thrift::ProtocolException
               ensure
                 trans.close
               end

--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -96,7 +96,7 @@ module Thrift
 
       iprot.read_struct_begin
       loop do
-        fname, ftype, fid = iprot.read_field_begin
+        _, ftype, fid = iprot.read_field_begin
         break if (ftype == Types::STOP)
         handle_message(iprot, fid, ftype, remaining_depth)
         iprot.read_field_end

--- a/lib/rb/lib/thrift/union.rb
+++ b/lib/rb/lib/thrift/union.rb
@@ -62,11 +62,11 @@ module Thrift
       @value = nil
 
       iprot.read_struct_begin
-      fname, ftype, fid = iprot.read_field_begin
+      _, ftype, fid = iprot.read_field_begin
       handle_message(iprot, fid, ftype, remaining_depth)
       iprot.read_field_end
 
-      fname, ftype, fid = iprot.read_field_begin
+      _, ftype, _ = iprot.read_field_begin
       unless (ftype == Types::STOP)
         raise ProtocolException.new(ProtocolException::INVALID_DATA, "Too many fields for union")
       end

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -92,7 +92,7 @@ describe Thrift::CompactProtocol do
         proto.write_field_end
 
         proto = Thrift::CompactProtocol.new(trans)
-        name, type, id = proto.read_field_begin
+        _, type, id = proto.read_field_begin
         expect(type).to eq(thrift_type)
         expect(id).to eq(15)
         read_back = proto.send(reader(primitive_type))

--- a/lib/rb/spec/header_protocol_spec.rb
+++ b/lib/rb/spec/header_protocol_spec.rb
@@ -136,7 +136,7 @@ describe "HeaderProtocol" do
 
         read_protocol.read_message_begin
         read_protocol.read_struct_begin
-        name, type, id = read_protocol.read_field_begin
+        _, type, id = read_protocol.read_field_begin
         expect(type).to eq(Thrift::Types::I32)
         expect(id).to eq(1)
         value = read_protocol.read_i32
@@ -389,7 +389,7 @@ describe "HeaderProtocol" do
         read_buffer = Thrift::MemoryBufferTransport.new(data)
         read_protocol = Thrift::HeaderProtocol.new(read_buffer)
 
-        name, type, seqid = read_protocol.read_message_begin
+        name, _, seqid = read_protocol.read_message_begin
         expect(name).to eq("compressed_test")
         expect(seqid).to eq(42)
 

--- a/lib/rb/spec/uuid_validation_spec.rb
+++ b/lib/rb/spec/uuid_validation_spec.rb
@@ -185,17 +185,17 @@ describe "UUID Validation" do
           @prot.write_struct_end
 
           @prot.read_struct_begin
-          name, type, id = @prot.read_field_begin
+          _, type, _ = @prot.read_field_begin
           expect(type).to eq(Thrift::Types::UUID)
           expect(@prot.read_uuid).to eq("550e8400-e29b-41d4-a716-446655440000")
           @prot.read_field_end
 
-          name, type, id = @prot.read_field_begin
+          _, type, _ = @prot.read_field_begin
           expect(type).to eq(Thrift::Types::UUID)
           expect(@prot.read_uuid).to eq("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
           @prot.read_field_end
 
-          name, type, id = @prot.read_field_begin
+          _, type, _ = @prot.read_field_begin
           expect(type).to eq(Thrift::Types::STOP)
         end
       end

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = %w[--line-numbers --inline-source --title Thrift --main README]
 
-  dir = File.expand_path(File.dirname(__FILE__))
-
   s.files = Dir.glob("{lib,ext}/**/*.{c,h,rb}")
   s.executables = Dir.glob("{bin}/**/*")
 

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -158,14 +158,14 @@ class SimpleClientTest < Test::Unit::TestCase
 
   def test_string
     p "test_string"
-    test_string =
+    escaped_string =
       'quote: \" backslash:' +
       ' forwardslash-escaped: \/ ' +
       ' backspace: \b formfeed: \f newline: \n return: \r tab: ' +
       ' now-all-of-them-together: "\\\/\b\n\r\t' +
       ' now-a-bunch-of-junk: !@#$%&()(&%$#{}{}<><><' +
       ' char-to-test-json-parsing: ]] \"]] \\" }}}{ [[[ '
-    test_string = "Afrikaans, Alemannisch, Aragonés, العربية, مصرى, " +
+    unicode_string = "Afrikaans, Alemannisch, Aragonés, العربية, مصرى, " +
       "Asturianu, Aymar aru, Azərbaycan, Башҡорт, Boarisch, Žemaitėška, " +
       "Беларуская, Беларуская (тарашкевіца), Български, Bamanankan, " +
       "বাংলা, Brezhoneg, Bosanski, Català, Mìng-dĕ̤ng-ngṳ̄, Нохчийн, " +
@@ -191,8 +191,10 @@ class SimpleClientTest < Test::Unit::TestCase
       "Walon, Winaray, 吴语, isiXhosa, ייִדיש, Yorùbá, Zeêuws, 中文, " +
       "Bân-lâm-gú, 粵語"
 
-    result_string = @client.testString(test_string)
-    assert_equal(test_string, result_string.force_encoding(Encoding::UTF_8))
+    [escaped_string, unicode_string].each do |test_string|
+      result_string = @client.testString(test_string)
+      assert_equal(test_string, result_string.force_encoding(Encoding::UTF_8))
+    end
   end
 
   def test_multiplexed

--- a/tutorial/rb/RubyClient.rb
+++ b/tutorial/rb/RubyClient.rb
@@ -59,7 +59,7 @@ begin
     work.op = Operation::DIVIDE
     work.num1 = 1
     work.num2 = 0
-    quot = client.calculate(1, work)
+    client.calculate(1, work)
     puts "Whoa, we can divide by 0 now?"
   rescue InvalidOperation => io
     print "InvalidOperation: ", io.why, "\n"


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Enable `Lint/UselessAssignment` and remove assignments whose values are never read across the Ruby library, benchmarks, specs, integration client, and tutorial.

The Ruby generator now binds decoded service arguments and results only when generated methods consume them. Focused functional coverage verifies zero-argument processor methods and void client receivers. The Ruby cross-test client also exercises its escape/junk string and multilingual string separately, fixing an overwritten test input exposed by the cop.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
