### PR TITLE
Enable RuboCop Lint/Void

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -242,6 +242,9 @@ Lint/UnreachableCode:
 Lint/UselessAssignment:
   Enabled: true
 
+Lint/Void:
+  Enabled: true
+
 Performance/BindCall:
   Enabled: true
 

--- a/lib/rb/spec/server_socket_spec.rb
+++ b/lib/rb/spec/server_socket_spec.rb
@@ -35,7 +35,6 @@ describe "Thrift::ServerSocket" do
     it "should accept an optional host argument" do
       @socket = Thrift::ServerSocket.new("localhost", 1234)
       expect(TCPServer).to receive(:new).with("localhost", 1234)
-      @socket.to_s == "server(localhost:1234)"
       @socket.listen
     end
 

--- a/lib/rb/spec/socket_spec.rb
+++ b/lib/rb/spec/socket_spec.rb
@@ -48,7 +48,6 @@ describe "Socket" do
       expect(Addrinfo).to receive(:foreach).with("localhost", 9090, nil, :STREAM).and_yield(@addrinfo)
       expect(@addrinfo).to receive(:connect).with(no_args).and_return(@handle)
       expect(@handle).to receive(:setsockopt).with(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
-      @socket.to_s == "socket(localhost:9090)"
       @socket.open
     end
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Enable `Lint/Void` and remove two comparison expressions whose results were discarded in the Ruby socket specs.

Both socket string representations already have dedicated expectations elsewhere in their respective spec files. Removing these no-op comparisons keeps the optional-host and socket-opening examples focused while allowing the lint cop to prevent similar ineffective expressions.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
