### PR TITLE
Enable RuboCop Style/LineEndConcatenation

### DIFF
--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -312,6 +312,9 @@ Style/HashSyntax:
   Enabled: true
   EnforcedShorthandSyntax: either
 
+Style/LineEndConcatenation:
+  Enabled: true
+
 Style/MethodDefParentheses:
   Enabled: true
 

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -159,36 +159,36 @@ class SimpleClientTest < Test::Unit::TestCase
   def test_string
     p "test_string"
     escaped_string =
-      'quote: \" backslash:' +
-      ' forwardslash-escaped: \/ ' +
-      ' backspace: \b formfeed: \f newline: \n return: \r tab: ' +
-      ' now-all-of-them-together: "\\\/\b\n\r\t' +
-      ' now-a-bunch-of-junk: !@#$%&()(&%$#{}{}<><><' +
+      'quote: \" backslash:' \
+      ' forwardslash-escaped: \/ ' \
+      ' backspace: \b formfeed: \f newline: \n return: \r tab: ' \
+      ' now-all-of-them-together: "\\\/\b\n\r\t' \
+      ' now-a-bunch-of-junk: !@#$%&()(&%$#{}{}<><><' \
       ' char-to-test-json-parsing: ]] \"]] \\" }}}{ [[[ '
-    unicode_string = "Afrikaans, Alemannisch, Aragonés, العربية, مصرى, " +
-      "Asturianu, Aymar aru, Azərbaycan, Башҡорт, Boarisch, Žemaitėška, " +
-      "Беларуская, Беларуская (тарашкевіца), Български, Bamanankan, " +
-      "বাংলা, Brezhoneg, Bosanski, Català, Mìng-dĕ̤ng-ngṳ̄, Нохчийн, " +
-      "Cebuano, ᏣᎳᎩ, Česky, Словѣ́ньскъ / ⰔⰎⰑⰂⰡⰐⰠⰔⰍⰟ, Чӑвашла, Cymraeg, " +
-      "Dansk, Zazaki, ދިވެހިބަސް, Ελληνικά, Emiliàn e rumagnòl, English, " +
-      "Esperanto, Español, Eesti, Euskara, فارسی, Suomi, Võro, Føroyskt, " +
-      "Français, Arpetan, Furlan, Frysk, Gaeilge, 贛語, Gàidhlig, Galego, " +
-      "Avañe'ẽ, ગુજરાતી, Gaelg, עברית, हिन्दी, Fiji Hindi, Hrvatski, " +
-      "Kreyòl ayisyen, Magyar, Հայերեն, Interlingua, Bahasa Indonesia, " +
-      "Ilokano, Ido, Íslenska, Italiano, 日本語, Lojban, Basa Jawa, " +
-      "ქართული, Kongo, Kalaallisut, ಕನ್ನಡ, 한국어, Къарачай-Малкъар, " +
-      "Ripoarisch, Kurdî, Коми, Kernewek, Кыргызча, Latina, Ladino, " +
-      "Lëtzebuergesch, Limburgs, Lingála, ລາວ, Lietuvių, Latviešu, Basa " +
-      "Banyumasan, Malagasy, Македонски, മലയാളം, मराठी, مازِرونی, Bahasa " +
-      "Melayu, Nnapulitano, Nedersaksisch, नेपाल भाषा, Nederlands, ‪" +
-      "Norsk (nynorsk)‬, ‪Norsk (bokmål)‬, Nouormand, Diné bizaad, " +
-      "Occitan, Иронау, Papiamentu, Deitsch, Polski, پنجابی, پښتو, " +
-      "Norfuk / Pitkern, Português, Runa Simi, Rumantsch, Romani, Română, " +
-      "Русский, Саха тыла, Sardu, Sicilianu, Scots, Sámegiella, Simple " +
-      "English, Slovenčina, Slovenščina, Српски / Srpski, Seeltersk, " +
-      "Svenska, Kiswahili, தமிழ், తెలుగు, Тоҷикӣ, ไทย, Türkmençe, Tagalog, " +
-      "Türkçe, Татарча/Tatarça, Українська, اردو, Tiếng Việt, Volapük, " +
-      "Walon, Winaray, 吴语, isiXhosa, ייִדיש, Yorùbá, Zeêuws, 中文, " +
+    unicode_string = "Afrikaans, Alemannisch, Aragonés, العربية, مصرى, " \
+      "Asturianu, Aymar aru, Azərbaycan, Башҡорт, Boarisch, Žemaitėška, " \
+      "Беларуская, Беларуская (тарашкевіца), Български, Bamanankan, " \
+      "বাংলা, Brezhoneg, Bosanski, Català, Mìng-dĕ̤ng-ngṳ̄, Нохчийн, " \
+      "Cebuano, ᏣᎳᎩ, Česky, Словѣ́ньскъ / ⰔⰎⰑⰂⰡⰐⰠⰔⰍⰟ, Чӑвашла, Cymraeg, " \
+      "Dansk, Zazaki, ދިވެހިބަސް, Ελληνικά, Emiliàn e rumagnòl, English, " \
+      "Esperanto, Español, Eesti, Euskara, فارسی, Suomi, Võro, Føroyskt, " \
+      "Français, Arpetan, Furlan, Frysk, Gaeilge, 贛語, Gàidhlig, Galego, " \
+      "Avañe'ẽ, ગુજરાતી, Gaelg, עברית, हिन्दी, Fiji Hindi, Hrvatski, " \
+      "Kreyòl ayisyen, Magyar, Հայերեն, Interlingua, Bahasa Indonesia, " \
+      "Ilokano, Ido, Íslenska, Italiano, 日本語, Lojban, Basa Jawa, " \
+      "ქართული, Kongo, Kalaallisut, ಕನ್ನಡ, 한국어, Къарачай-Малкъар, " \
+      "Ripoarisch, Kurdî, Коми, Kernewek, Кыргызча, Latina, Ladino, " \
+      "Lëtzebuergesch, Limburgs, Lingála, ລາວ, Lietuvių, Latviešu, Basa " \
+      "Banyumasan, Malagasy, Македонски, മലയാളം, मराठी, مازِرونی, Bahasa " \
+      "Melayu, Nnapulitano, Nedersaksisch, नेपाल भाषा, Nederlands, ‪" \
+      "Norsk (nynorsk)‬, ‪Norsk (bokmål)‬, Nouormand, Diné bizaad, " \
+      "Occitan, Иронау, Papiamentu, Deitsch, Polski, پنجابی, پښتو, " \
+      "Norfuk / Pitkern, Português, Runa Simi, Rumantsch, Romani, Română, " \
+      "Русский, Саха тыла, Sardu, Sicilianu, Scots, Sámegiella, Simple " \
+      "English, Slovenčina, Slovenščina, Српски / Srpski, Seeltersk, " \
+      "Svenska, Kiswahili, தமிழ், తెలుగు, Тоҷикӣ, ไทย, Türkmençe, Tagalog, " \
+      "Türkçe, Татарча/Tatarça, Українська, اردو, Tiếng Việt, Volapük, " \
+      "Walon, Winaray, 吴语, isiXhosa, ייִדיש, Yorùbá, Zeêuws, 中文, " \
       "Bân-lâm-gú, 粵語"
 
     [escaped_string, unicode_string].each do |test_string|


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Enable `Style/LineEndConcatenation` for Ruby and update the integration client's escaped and multilingual test payloads to use line continuations instead of trailing `+` operators.

This makes multiline literal concatenation consistent with the configured style while preserving the payloads byte-for-byte.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
