### PR TITLE
Add Windows ARM64 wheel distribution

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -109,6 +109,10 @@ jobs:
             runner: windows-latest
             archs: AMD64
             build: "cp310-win_* cp311-win_* cp312-win_* cp313-win_* cp314-win_*"
+          - platform: windows-arm64
+            runner: windows-11-arm
+            archs: ARM64
+            build: "cp310-win_* cp311-win_* cp312-win_* cp313-win_* cp314-win_*"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/lib/py/pyproject.toml
+++ b/lib/py/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -35,7 +35,9 @@ if 'vagrant' in str(os.environ):
 
 include_dirs = ['src']
 if sys.platform == 'win32':
-    include_dirs.append('compat/win32')
+    # Windows ARM64 builds require the real stdint.h.
+    if os.environ.get('CIBUILDWHEEL') != '1':
+        include_dirs.append('compat/win32')
     ext_errors = (CompileError, ExecError, PlatformError, IOError)
 else:
     ext_errors = (CompileError, ExecError, PlatformError)


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
 As the title says. It's mostly straightforward.

One of the slightly hacky bits is the change in `lib/py/setup.py` to not include `compat/win32/stdint.h` when building in CI. That shim is not needed anyway for most versions of Visual C++/Build Tools found in the wild today. However I did not get rid of it altogether because someone, somewhere might have a version that does need it. The AMD64 build seems to work fine in any case, but on ARM64 the `arm64_neon.h` file chokes on it. Let me know if there is a better idea to handle this.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
