### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -73,6 +73,16 @@ check_function_exists(strerror_r HAVE_STRERROR_R)
 check_function_exists(sched_get_priority_max HAVE_SCHED_GET_PRIORITY_MAX)
 check_function_exists(sched_get_priority_min HAVE_SCHED_GET_PRIORITY_MIN)
 
+check_symbol_exists(AI_V4MAPPED
+  "sys/types.h;sys/socket.h;netdb.h"
+  HAVE_AI_V4MAPPED
+)
+
+if(NOT HAVE_AI_V4MAPPED)
+  set(AI_V4MAPPED 1)
+else()
+  unset(AI_V4MAPPED)
+endif()
 
 check_cxx_source_compiles(
   "

--- a/build/cmake/config.h.in
+++ b/build/cmake/config.h.in
@@ -46,8 +46,8 @@
 
 /************************** DEFINES *************************/
 
-/* Define if the AI_ADDRCONFIG symbol is unavailable */
-#cmakedefine AI_ADDRCONFIG 0
+/* Define if the AI_V4MAPPED symbol is unavailable */
+#cmakedefine AI_V4MAPPED 0
 
 /* Possible value for SIGNED_RIGHT_SHIFT_IS */
 /* TODO: This is just set to 1 for the moment

--- a/configure.ac
+++ b/configure.ac
@@ -658,10 +658,10 @@ AC_CHECK_TYPES([ptrdiff_t], [], [echo "ptrdiff_t not found or g++ not installed 
 
 AC_STRUCT_TM
 
-dnl NOTE(dreiss): AI_ADDRCONFIG is not defined on OpenBSD.
-AC_CHECK_DECL([AI_ADDRCONFIG], [],
-              [AC_DEFINE([AI_ADDRCONFIG], 0,
-                         [Define if the AI_ADDRCONFIG symbol is unavailable])],
+dnl NOTE(dreiss): AI_V4MAPPED is not defined on OpenBSD.
+AC_CHECK_DECL([AI_V4MAPPED], [],
+              [AC_DEFINE([AI_V4MAPPED], 0,
+                         [Define if the AI_V4MAPPED symbol is unavailable])],
               [
   #include <sys/types.h>
   #include <sys/socket.h>


### PR DESCRIPTION
Replace the check for AI_ADDRCONFIG with AI_V4MAPPED. OpenBSD
has had AI_ADDRCONFIG for 12 years / 23 releases ago. Fill in missing
CMake bits.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.