### PR TITLE
Replace deprecated OpenSSL API ASN1_STRING_data()

### DIFF
--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -770,7 +770,11 @@ void TSSLSocket::authorize() {
       if (name == nullptr) {
         continue;
       }
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
+      const char* data = (const char*)ASN1_STRING_get0_data(name->d.ia5);
+#else
       char* data = (char*)ASN1_STRING_data(name->d.ia5);
+#endif
       int length = ASN1_STRING_length(name->d.ia5);
       switch (name->type) {
       case GEN_DNS:


### PR DESCRIPTION
ASN1_STRING_data() has been deprecated since OpenSSL 1.1.0. Replace
with ASN1_STRING_get0_data(). ASN1_STRING_data() has been removed
with OpenSSL 4.

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.