### PR TITLE
Omit parentheses from zero-argument Ruby methods

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_rb_generator.cc
@@ -994,22 +994,22 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
     // Open function
     f_service_.indent() << "def " << function_signature(*f_iter) << '\n';
     f_service_.indent_up();
-    f_service_.indent() << "send_" << funname << "(";
-
-    bool first = true;
-    for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
-      if (first) {
-        first = false;
-      } else {
-        f_service_ << ", ";
+    f_service_.indent() << "send_" << funname;
+    if (!fields.empty()) {
+      f_service_ << "(";
+      for (fld_iter = fields.begin(); fld_iter != fields.end(); ++fld_iter) {
+        if (fld_iter != fields.begin()) {
+          f_service_ << ", ";
+        }
+        f_service_ << (*fld_iter)->get_name();
       }
-      f_service_ << (*fld_iter)->get_name();
+      f_service_ << ")";
     }
-    f_service_ << ")" << '\n';
+    f_service_ << '\n';
 
     if (!(*f_iter)->is_oneway()) {
       f_service_.indent();
-      f_service_ << "recv_" << funname << "()" << '\n';
+      f_service_ << "recv_" << funname << '\n';
     }
     f_service_.indent_down();
     f_service_.indent() << "end" << '\n';
@@ -1051,7 +1051,7 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
       f_service_.indent() << "def " << function_signature(&recv_function) << '\n';
       f_service_.indent_up();
 
-      f_service_.indent() << "fname, mtype, rseqid = receive_message_begin()" << '\n';
+      f_service_.indent() << "fname, mtype, rseqid = receive_message_begin" << '\n';
       f_service_.indent() << "validate_message_begin(fname, mtype, rseqid, \"" << funname << "\")"
                           << '\n';
 
@@ -1168,7 +1168,7 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
 
   // Declare result for non oneway function
   if (!tfunction->is_oneway()) {
-    f_service_.indent() << "result = " << resultname << ".new()" << '\n';
+    f_service_.indent() << "result = " << resultname << ".new" << '\n';
   }
 
   // Try block for a function with exceptions
@@ -1184,17 +1184,18 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
   if (!tfunction->is_oneway() && !tfunction->get_returntype()->is_void()) {
     f_service_ << "result.success = ";
   }
-  f_service_ << "@handler." << tfunction->get_name() << "(";
-  bool first = true;
-  for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    if (first) {
-      first = false;
-    } else {
-      f_service_ << ", ";
+  f_service_ << "@handler." << tfunction->get_name();
+  if (!fields.empty()) {
+    f_service_ << "(";
+    for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
+      if (f_iter != fields.begin()) {
+        f_service_ << ", ";
+      }
+      f_service_ << "args." << (*f_iter)->get_name();
     }
-    f_service_ << "args." << (*f_iter)->get_name();
+    f_service_ << ")";
   }
-  f_service_ << ")" << '\n';
+  f_service_ << '\n';
 
   if (!tfunction->is_oneway() && xceptions.size() > 0) {
     f_service_.indent_down();
@@ -1228,14 +1229,17 @@ void t_rb_generator::generate_process_function(t_service* tservice, t_function* 
 }
 
 /**
- * Renders a function signature of the form 'type name(args)'
+ * Renders a Ruby method signature, omitting parentheses when there are no arguments.
  *
  * @param tfunction Function definition
  * @return String of rendered function definition
  */
 string t_rb_generator::function_signature(t_function* tfunction, string prefix) {
-  // TODO(mcslee): Nitpicky, no ',' if argument_list is empty
-  return prefix + tfunction->get_name() + "(" + argument_list(tfunction->get_arglist()) + ")";
+  string arguments = argument_list(tfunction->get_arglist());
+  if (arguments.empty()) {
+    return prefix + tfunction->get_name();
+  }
+  return prefix + tfunction->get_name() + "(" + arguments + ")";
 }
 
 /**

--- a/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
+++ b/compiler/cpp/tests/rb/t_rb_generator_functional_tests.cc
@@ -99,7 +99,8 @@ TEST_CASE("t_rb_generator uses suffixed field id constants to avoid FIELDS colli
     std::remove(thrift_path.c_str());
 }
 
-TEST_CASE("t_rb_generator formats service classes and positional arguments", "[functional]")
+TEST_CASE("t_rb_generator formats service classes, call parentheses, and positional arguments",
+          "[functional]")
 {
     const string thrift_path = "test_service_arguments.thrift";
     const string thrift_source =
@@ -132,11 +133,25 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
         "    include ::Thrift::Struct, ::Thrift::Struct_Union\n"
         "\n"
         "    FIELDS";
+    const string expected_argument_method =
+        "    def ping(n)\n"
+        "      send_ping(n)\n"
+        "    end\n";
+    const string expected_no_argument_method =
+        "    def pong\n"
+        "      send_pong\n"
+        "      recv_pong\n"
+        "    end\n";
+    const string expected_no_argument_receive =
+        "    def recv_pong\n"
+        "      fname, mtype, rseqid = receive_message_begin\n";
+    REQUIRE(service.find(expected_argument_method) != string::npos);
     REQUIRE(service.find("send_oneway_message(\"ping\", Ping_args, {n: n})") != string::npos);
-    REQUIRE(service.find("def pong()\n      send_pong()\n      recv_pong()\n    end")
-            != string::npos);
-    REQUIRE(service.find("def recv_noop()\n"
-                         "      fname, mtype, rseqid = receive_message_begin()\n"
+    REQUIRE(service.find(expected_no_argument_method) != string::npos);
+    REQUIRE(service.find("    def send_pong\n") != string::npos);
+    REQUIRE(service.find(expected_no_argument_receive) != string::npos);
+    REQUIRE(service.find("def recv_noop\n"
+                         "      fname, mtype, rseqid = receive_message_begin\n"
                          "      validate_message_begin(fname, mtype, rseqid, \"noop\")\n"
                          "      receive_message(Noop_result)\n"
                          "      nil\n"
@@ -144,8 +159,9 @@ TEST_CASE("t_rb_generator formats service classes and positional arguments", "[f
             != string::npos);
     REQUIRE(service.find("def process_pong(seqid, iprot, oprot)\n"
                          "      read_args(iprot, Pong_args)\n"
-                         "      result = Pong_result.new()")
+                         "      result = Pong_result.new")
             != string::npos);
+    REQUIRE(service.find("      result.success = @handler.pong\n") != string::npos);
     REQUIRE(service.find(expected_empty_result) != string::npos);
     REQUIRE(service.find("\n\n  end\n") == string::npos);
 

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -305,6 +305,9 @@ Performance/UriDefaultParser:
 Style/AmbiguousEndlessMethodDefinition:
   Enabled: true
 
+Style/DefWithParentheses:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 
@@ -313,6 +316,9 @@ Style/HashSyntax:
   EnforcedShorthandSyntax: either
 
 Style/LineEndConcatenation:
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:

--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -42,7 +42,7 @@ module Thrift
       write_message(nil, nil, args_class, args)
     end
 
-    def receive_message_begin()
+    def receive_message_begin
       fname, mtype, rseqid = @iprot.read_message_begin
       [fname, mtype, rseqid]
     end

--- a/lib/rb/lib/thrift/protocol/compact_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/compact_protocol.rb
@@ -291,7 +291,7 @@ module Thrift
     def read_message_begin
       trans.reset_message_size if @reset_message_size
 
-      protocol_id = read_byte()
+      protocol_id = read_byte
       if protocol_id != PROTOCOL_ID
         raise ProtocolException.new(
           ProtocolException::BAD_VERSION,
@@ -299,7 +299,7 @@ module Thrift
         )
       end
 
-      version_and_type = read_byte()
+      version_and_type = read_byte
       version = version_and_type & VERSION_MASK
       if (version != VERSION)
         raise ProtocolException.new(
@@ -309,8 +309,8 @@ module Thrift
       end
 
       type = (version_and_type >> TYPE_SHIFT_AMOUNT) & TYPE_BITS
-      seqid = message_seqid_from_varint32(read_varint32())
-      messageName = read_string()
+      seqid = message_seqid_from_varint32(read_varint32)
+      messageName = read_string
       [messageName, type, seqid]
     end
 
@@ -320,12 +320,12 @@ module Thrift
     end
 
     def read_struct_end
-      @last_field.pop()
+      @last_field.pop
       nil
     end
 
     def read_field_begin
-      type = read_byte()
+      type = read_byte
 
       # if it's a stop, then we can return immediately, as the struct is over.
       if (type & 0x0f) == Types::STOP
@@ -338,7 +338,7 @@ module Thrift
         if modifier == 0
           # not a delta. look ahead for the zigzag varint field id.
           @last_field.pop
-          field_id = read_i16()
+          field_id = read_i16
         else
           # has a delta. add the delta to the last read field id.
           field_id = @last_field.pop + modifier
@@ -357,17 +357,17 @@ module Thrift
     end
 
     def read_map_begin
-      size = read_varint32()
+      size = read_varint32
       validate_container_size(size)
-      key_and_value_type = size == 0 ? 0 : read_byte()
+      key_and_value_type = size == 0 ? 0 : read_byte
       [CompactTypes.get_ttype(key_and_value_type >> 4), CompactTypes.get_ttype(key_and_value_type & 0xf), size]
     end
 
     def read_list_begin
-      size_and_type = read_byte()
+      size_and_type = read_byte
       size = (size_and_type >> 4) & 0x0f
       if size == 15
-        size = read_varint32()
+        size = read_varint32
       end
       validate_container_size(size)
       type = CompactTypes.get_ttype(size_and_type)
@@ -384,7 +384,7 @@ module Thrift
         @bool_value = nil
         bv
       else
-        read_byte() == CompactTypes::BOOLEAN_TRUE
+        read_byte == CompactTypes::BOOLEAN_TRUE
       end
     end
 
@@ -397,15 +397,15 @@ module Thrift
     end
 
     def read_i16
-      zig_zag_to_int(read_varint32())
+      zig_zag_to_int(read_varint32)
     end
 
     def read_i32
-      zig_zag_to_int(read_varint32())
+      zig_zag_to_int(read_varint32)
     end
 
     def read_i64
-      zig_zag_to_long(read_varint64())
+      zig_zag_to_long(read_varint64)
     end
 
     def read_double
@@ -419,7 +419,7 @@ module Thrift
     end
 
     def read_binary
-      size = read_varint32()
+      size = read_varint32
       if size > I32_MAX
         raise ProtocolException.new(ProtocolException::SIZE_LIMIT, "Binary size limit exceeded")
       end
@@ -492,17 +492,17 @@ module Thrift
       @trans.write(buffer)
     end
 
-    def read_varint32()
+    def read_varint32
       shift = 0
       result = 0
       VARINT32_PREFIX_BYTES.times do
-        b = read_byte()
+        b = read_byte
         result |= (b & 0x7f) << shift
         return result if (b & 0x80) != 0x80
         shift += 7
       end
 
-      b = read_byte()
+      b = read_byte
       if (b & 0x80) != 0
         raise ProtocolException.new(ProtocolException::INVALID_DATA, "Variable-length int over 5 bytes.")
       end
@@ -513,11 +513,11 @@ module Thrift
       result | (b << shift)
     end
 
-    def read_varint64()
+    def read_varint64
       shift = 0
       result = 0
       MAX_VARINT_BYTES.times do
-        b = read_byte()
+        b = read_byte
         result |= (b & 0x7f) << shift
         return result if (b & 0x80) != 0x80
         shift += 7

--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -233,7 +233,7 @@ module Thrift
       else
         # call the Struct initializer first with no args
         # this will set our field default values
-        method(:struct_initialize).call()
+        method(:struct_initialize).call
         # now give it to the exception
         self.class.send(:class_variable_get, :'@@__thrift_struct_real_initialize').bind_call(self, *args, &block) if args.size > 0
         # self.class.instance_method(:initialize).bind(self).call(*args, &block)

--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -54,7 +54,7 @@ module Thrift
     end
 
     def read_byte
-      return @transport.read_byte() unless @read
+      return @transport.read_byte unless @read
 
       read_frame if @index >= @rbuf.length
 

--- a/lib/rb/spec/binary_protocol_spec_shared.rb
+++ b/lib/rb/spec/binary_protocol_spec_shared.rb
@@ -473,21 +473,21 @@ shared_examples_for "a binary protocol" do
 
   it "should perform a complete rpc with no args or return" do
     srv_test(
-      proc { |client| client.send_voidMethod() },
+      proc { |client| client.send_voidMethod },
       proc { |client| expect(client.recv_voidMethod).to eq(nil) },
     )
   end
 
   it "should perform a complete rpc with a primitive return type" do
     srv_test(
-      proc { |client| client.send_primitiveMethod() },
+      proc { |client| client.send_primitiveMethod },
       proc { |client| expect(client.recv_primitiveMethod).to eq(1) },
     )
   end
 
   it "should perform a complete rpc with a struct return type" do
     srv_test(
-      proc { |client| client.send_structMethod() },
+      proc { |client| client.send_structMethod },
       proc { |client|
         result = client.recv_structMethod
         result.set_byte_map = nil
@@ -531,7 +531,7 @@ shared_examples_for "a binary protocol" do
   end
 
   class SrvHandler
-    def voidMethod()
+    def voidMethod
     end
 
     def primitiveMethod

--- a/lib/rb/spec/client_spec.rb
+++ b/lib/rb/spec/client_spec.rb
@@ -147,7 +147,7 @@ describe "Client" do
       expect(@prot).to receive(:read_message_end)
       mock_klass = double("#<MockClass:mock>")
       expect(mock_klass).to receive(:read).with(@prot)
-      @client.receive_message_begin()
+      @client.receive_message_begin
       @client.receive_message(double("MockClass", new: mock_klass))
     end
 

--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -38,7 +38,7 @@ describe "Server" do
     end
 
     it "should not serve" do
-      expect { @server.serve() }.to raise_error(NotImplementedError)
+      expect { @server.serve }.to raise_error(NotImplementedError)
     end
 
     it "should provide a reasonable to_s" do

--- a/lib/rb/spec/struct_spec.rb
+++ b/lib/rb/spec/struct_spec.rb
@@ -133,7 +133,7 @@ describe "Struct" do
       expect(s1 <=> s2).to eq(-1)
       expect(s2 <=> s1).to eq(1)
       expect(s1 <=> s1).to eq(0)
-      expect(s1 <=> SpecNamespace::StructWithSomeEnum.new()).to eq(-1)
+      expect(s1 <=> SpecNamespace::StructWithSomeEnum.new).to eq(-1)
     end
 
     it "should read itself off the wire" do

--- a/lib/rb/spec/union_spec.rb
+++ b/lib/rb/spec/union_spec.rb
@@ -194,7 +194,7 @@ describe "Union" do
     end
 
     it "should not throw an error when inspected and unset" do
-      expect { SpecNamespace::TestUnion.new().inspect }.not_to raise_error
+      expect { SpecNamespace::TestUnion.new.inspect }.not_to raise_error
     end
 
     it "should print enum value name when inspected" do
@@ -230,7 +230,7 @@ describe "Union" do
         SpecNamespace::TestUnion.new(:i32_field, 1),
         SpecNamespace::TestUnion.new(:uuid_field, "550e8400-e29b-41d4-a716-446655440000"),
         SpecNamespace::TestUnion.new(:uuid_field, "6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
-        SpecNamespace::TestUnion.new(),
+        SpecNamespace::TestUnion.new,
       ]
 
       objs.size.times do |y|

--- a/test/rb/integration/TestClient.rb
+++ b/test/rb/integration/TestClient.rb
@@ -153,7 +153,7 @@ class SimpleClientTest < Test::Unit::TestCase
 
   def test_void
     p "test_void"
-    @client.testVoid()
+    @client.testVoid
   end
 
   def test_string

--- a/test/rb/integration/TestServer.rb
+++ b/test/rb/integration/TestServer.rb
@@ -43,7 +43,7 @@ class SimpleHandler
     end
   end
 
-  def testVoid()
+  def testVoid
   end
 
   def testInsanity(thing)
@@ -53,7 +53,7 @@ class SimpleHandler
         3 => thing,
       },
       2 => {
-        6 => Thrift::Test::Insanity::new(),
+        6 => Thrift::Test::Insanity::new,
       },
     }
   end

--- a/tutorial/rb/RubyClient.rb
+++ b/tutorial/rb/RubyClient.rb
@@ -33,9 +33,9 @@ begin
   protocol = Thrift::BinaryProtocol.new(transport)
   client = Calculator::Client.new(protocol)
 
-  transport.open()
+  transport.open
 
-  client.ping()
+  client.ping
   print "ping()\n"
 
   sum = client.add(1, 1)
@@ -44,7 +44,7 @@ begin
   sum = client.add(1, 4)
   print "1+4=", sum, "\n"
 
-  work = Work.new()
+  work = Work.new
 
   work.op = Operation::SUBTRACT
   work.num1 = 15
@@ -65,10 +65,10 @@ begin
     print "InvalidOperation: ", io.why, "\n"
   end
 
-  client.zip()
+  client.zip
   print "zip\n"
 
-  transport.close()
+  transport.close
 rescue Thrift::Exception => tx
   print "Thrift::Exception: ", tx.message, "\n"
 end

--- a/tutorial/rb/RubyServer.rb
+++ b/tutorial/rb/RubyServer.rb
@@ -28,11 +28,11 @@ require "calculator"
 require "shared_types"
 
 class CalculatorHandler
-  def initialize()
+  def initialize
     @log = {}
   end
 
-  def ping()
+  def ping
     puts "ping()"
   end
 
@@ -51,20 +51,20 @@ class CalculatorHandler
       val = work.num1 * work.num2
     elsif work.op == Operation::DIVIDE
       if work.num2 == 0
-        x = InvalidOperation.new()
+        x = InvalidOperation.new
         x.whatOp = work.op
         x.why = "Cannot divide by 0"
         raise x
       end
       val = work.num1 / work.num2
     else
-      x = InvalidOperation.new()
+      x = InvalidOperation.new
       x.whatOp = work.op
       x.why = "Invalid operation"
       raise x
     end
 
-    entry = SharedStruct.new()
+    entry = SharedStruct.new
     entry.key = logid
     entry.value = val.to_s
     @log[logid] = entry
@@ -77,17 +77,17 @@ class CalculatorHandler
     @log[key]
   end
 
-  def zip()
+  def zip
     print "zip\n"
   end
 end
 
-handler = CalculatorHandler.new()
+handler = CalculatorHandler.new
 processor = Calculator::Processor.new(handler)
 transport = Thrift::ServerSocket.new(9090)
-transportFactory = Thrift::BufferedTransportFactory.new()
+transportFactory = Thrift::BufferedTransportFactory.new
 server = Thrift::SimpleServer.new(processor, transport, transportFactory)
 
 puts "Starting the server..."
-server.serve()
+server.serve
 puts "done."


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby sources and generated services currently mix parenthesized and bare forms for zero-argument method definitions and calls. Enable `Style/DefWithParentheses` and `Style/MethodCallWithoutArgsParentheses`, then apply the bare form consistently across the Ruby library, specs, integration code, and tutorials.

Update the Ruby generator to omit parentheses for zero-argument definitions and calls while retaining them when arguments are present. Extend its functional coverage for both forms alongside positional service arguments and empty-service formatting.


<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
