### PR TITLE
THRIFT-6153: Batch native Ruby Compact varint writes

### DIFF
--- a/lib/rb/ext/compact_protocol.c
+++ b/lib/rb/ext/compact_protocol.c
@@ -174,27 +174,29 @@ static int32_t message_seqid_from_varint32(uint32_t seqid) {
 }
 
 static void write_varint32(VALUE transport, uint32_t n) {
-  while (true) {
-    if ((n & ~0x7FU) == 0U) {
-      write_byte_direct(transport, n & 0x7FU);
-      break;
-    } else {
-      write_byte_direct(transport, (n & 0x7FU) | 0x80U);
-      n = n >> 7;
-    }
+  unsigned char bytes[5];
+  long length = 0;
+
+  while ((n & ~0x7FU) != 0U) {
+    bytes[length++] = (n & 0x7FU) | 0x80U;
+    n >>= 7;
   }
+  bytes[length++] = n;
+
+  WRITE(transport, (const char*)bytes, length);
 }
 
 static void write_varint64(VALUE transport, uint64_t n) {
-  while (true) {
-    if ((n & ~0x7FULL) == 0ULL) {
-      write_byte_direct(transport, n & 0x7FULL);
-      break;
-    } else {
-      write_byte_direct(transport, (n & 0x7FULL) | 0x80ULL);
-      n = n >> 7;
-    }
+  unsigned char bytes[10];
+  long length = 0;
+
+  while ((n & ~0x7FULL) != 0ULL) {
+    bytes[length++] = (n & 0x7FULL) | 0x80ULL;
+    n >>= 7;
   }
+  bytes[length++] = n;
+
+  WRITE(transport, (const char*)bytes, length);
 }
 
 static void write_collection_begin(VALUE transport, VALUE elem_type, VALUE size_value) {

--- a/lib/rb/spec/compact_protocol_spec.rb
+++ b/lib/rb/spec/compact_protocol_spec.rb
@@ -247,6 +247,31 @@ describe Thrift::CompactProtocol do
     end
   end
 
+  it "should batch each native multibyte varint into one transport write" do
+    probe = Thrift::CompactProtocol.new(Thrift::MemoryBufferTransport.new)
+    skip "requires the native Compact Protocol" unless probe.native?
+
+    recording_transport_class = Class.new(Thrift::BaseTransport) do
+      attr_reader :writes
+
+      def initialize
+        @writes = []
+      end
+
+      def write(data)
+        @writes << data
+      end
+    end
+
+    INTEGER_MINIMUM_ENCODINGS.each_pair do |primitive_type, expected_bytes|
+      trans = recording_transport_class.new
+      proto = Thrift::CompactProtocol.new(trans)
+
+      proto.send(writer(primitive_type), INTEGER_BOUNDARY_TESTS.fetch(primitive_type).first)
+      expect(trans.writes).to eq([expected_bytes.pack("C*")])
+    end
+  end
+
   it "should use Ruby truthiness when writing bools" do
     {
       true => Thrift::CompactProtocol::CompactTypes::BOOLEAN_TRUE,


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
The native Ruby Compact Protocol previously called the transport's write method once per encoded byte for multibyte varints. This created up to five one-byte Ruby strings for an i32 and ten for an i64, along with the corresponding dynamic method dispatches.

This change encodes each varint into a bounded C stack buffer and passes it through the existing transport write boundary once. It preserves the Compact wire format and generic transport behavior without specializing the optimization for `MemoryBufferTransport`.

## Benchmarks

Measured on Ruby 4.0.6, aarch64-linux, comparing master commit `c8f876181` with proposed commit `19af32b91` using:

```text
ruby test/rb/benchmarks/protocol_benchmark.rb --json --scenarios rb-cmp-write-small --small-runs 1000000
```

Each checkout was rebuilt before its trial. Six measured trials were arranged as alternating master/proposed pairs, with three pairs in each execution order. The JSON benchmark performs one warm-up before every measured trial.

| Scenario | master median (range) | proposed median (range) | Change |
| --- | ---: | ---: | ---: |
| Native Compact write, 1,000,000 small structs | 5.590s (5.243–6.451s) | 4.823s (4.575–4.894s) | 13.7% faster |

Allocations were measured around the same one-million-write scenario with `GC.stat(:total_allocated_objects)`, using one discarded warm-up and three measured trials.

| Allocation metric | master median (range) | proposed median (range) | Change |
| --- | ---: | ---: | ---: |
| Allocated objects per 1,000,000 writes | 33,000,007 (33,000,007–33,000,008) | 24,000,007 (24,000,007–24,000,008) | 27.3% fewer |
| Allocated objects per small struct | approximately 33 | approximately 24 | 9 fewer |

The benchmark serializes the small `OneOfEach` fixture through `MemoryBufferTransport` and measures this change as a standalone commit. Read timing is intentionally omitted because the change does not modify the read path. The allocation count includes protocol and transport setup but measures objects rather than allocated bytes or peak memory. These results do not cover large payloads or imply the earlier aggregate 2× result.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/browse/THRIFT-6153) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
