### PR TITLE
THRIFT-6154: Drop Ruby 2.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -902,10 +902,10 @@ jobs:
     name: lib-ruby (${{ matrix.ruby-version }}) ${{ matrix.skip-build-ext && 'noext' || '' }}
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "head"]
+        ruby-version: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "head"]
         skip-build-ext: [false]
         include:
-          - ruby-version: "2.7"
+          - ruby-version: "3.0"
             skip-build-ext: true
       fail-fast: false
     env:

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -401,7 +401,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.0"
           bundler-cache: true
           working-directory: "lib/rb"
 

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -312,7 +312,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/rb/README.md">Ruby</a></td>
 <!-- Since -----------------><td>0.2.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>2.7.8</td><td>4.0.0</td>
+<!-- Language Levels -------><td>3.0.7</td><td>4.0.0</td>
 <!-- Field types -----------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>

--- a/lib/rb/.rubocop.yml
+++ b/lib/rb/.rubocop.yml
@@ -5,7 +5,7 @@ plugins:
 AllCops:
   DisabledByDefault: true
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - "**/vendor/**/*"
 

--- a/lib/rb/README.md
+++ b/lib/rb/README.md
@@ -27,7 +27,7 @@ clients and services.
 
 ## Compatibility
 
-- Ruby MRI >= 2.7 (tested against current supported releases).
+- Ruby MRI >= 3.0 (tested against current supported releases).
 - JRuby works with the pure-Ruby implementation; the native extension is
   skipped automatically.
 - For the repo-wide transport, protocol, and server support matrix, see
@@ -36,7 +36,7 @@ clients and services.
 
 ## Installation
 
-- Requirements: Ruby >= 2.7.
+- Requirements: Ruby >= 3.0.
 - From RubyGems: `gem install thrift`
 - From source: `bundle install`, `gem build thrift.gemspec`, then install the
   resulting `thrift-*.gem`. The native accelerator is built when the gem is
@@ -143,6 +143,11 @@ mount Thrift::RackApplication.new(processor) => "/thrift"
 ## Breaking Changes
 
 ### 0.25.0
+
+Ruby 2.7 support has been removed because the runtime reached end of life on
+March 31, 2023. The Thrift gem now requires Ruby 3.0 or newer. Applications
+still running Ruby 2.7 must upgrade Ruby before installing Thrift 0.25.0 or
+remain on an earlier Thrift release.
 
 Ruby HTTP servers now share one Rack endpoint. Run `Thrift::RackApplication`
 as a Rack app, or mount it at one path in an app such as Rails. The

--- a/lib/rb/lib/thrift/struct_union.rb
+++ b/lib/rb/lib/thrift/struct_union.rb
@@ -174,9 +174,8 @@ module Thrift
         "#{enum_class.const_get(:VALUE_MAP)[value]} (#{value})"
       elsif value.is_a? Hash
         if field_info[:type] == Types::MAP
-          map_buf = []
-          value.each do |k, v|
-            map_buf << (inspect_field(k, field_info[:key]) + ": " + inspect_field(v, field_info[:value]))
+          map_buf = value.map do |k, v|
+            inspect_field(k, field_info[:key]) + ": " + inspect_field(v, field_info[:value])
           end
           "{" + map_buf.join(", ") + "}"
         else
@@ -195,9 +194,8 @@ module Thrift
     end
 
     def inspect_collection(collection, field_info)
-      buf = []
-      collection.each do |k|
-        buf << inspect_field(k, field_info[:element])
+      buf = collection.map do |element|
+        inspect_field(element, field_info[:element])
       end
       "[" + buf.join(", ") + "]"
     end

--- a/lib/rb/lib/thrift/transport/socket.rb
+++ b/lib/rb/lib/thrift/transport/socket.rb
@@ -56,7 +56,7 @@ module Thrift
 
           while len < str.length
             begin
-              len += @handle.write_nonblock(str[len..-1])
+              len += @handle.write_nonblock(str[len..])
             rescue IO::WaitWritable
               wait_for(:write, deadline, str.length)
             rescue IO::WaitReadable

--- a/lib/rb/lib/thrift/uuid.rb
+++ b/lib/rb/lib/thrift/uuid.rb
@@ -22,7 +22,7 @@ require "thrift/protocol/base_protocol"
 
 module Thrift
   module UUID
-    UUID_REGEX = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/.freeze
+    UUID_REGEX = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
 
     def self.validate_uuid!(uuid)
       unless uuid.is_a?(String)

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -1,6 +1,4 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
-$:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "thrift"
@@ -13,7 +11,7 @@ Gem::Specification.new do |s|
   s.license     = "Apache-2.0"
   s.extensions  = ["ext/extconf.rb"]
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.rdoc_options = %w[--line-numbers --inline-source --title Thrift --main README]
 


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Ruby 2.7 was released on December 25, 2019 and [reached end of life on March 31, 2023](https://www.ruby-lang.org/en/downloads/branches/), but the Thrift Ruby gem still declares and tests Ruby 2.7 support.

This raises the gem's minimum Ruby version to 3.0 and aligns the language matrix, Ruby documentation, RuboCop target, build matrix, and static-analysis workflow. The pure-Ruby CI variant moves to the new minimum instead of being removed.

The updated lint target also exposes a few behavior-preserving idiomatic cleanups: direct collection mapping, an endless range for partial socket writes, removal of a redundant regexp freeze, and removal of obsolete gemspec boilerplate.

This is a breaking support-policy change. Applications still running Ruby 2.7 must remain on an earlier Thrift gem until they upgrade Ruby.
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([THRIFT-6154](https://issues.apache.org/jira/browse/THRIFT-6154))
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
