### PR TITLE
THRIFT-6155: Reject zero-length framed messages

### DIFF
--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -108,6 +108,7 @@ module Thrift
 
     def read_frame
       sz = @transport.read_all(4).unpack1("N")
+      raise TransportException.new(TransportException::END_OF_FILE, "Cannot read from a zero-length frame") if sz == 0
 
       @index = 0
       @rbuf = @transport.read_all(sz)

--- a/lib/rb/spec/base_transport_spec.rb
+++ b/lib/rb/spec/base_transport_spec.rb
@@ -286,6 +286,22 @@ describe "BaseTransport" do
       expect(Thrift::FramedTransport.new(@trans).read(-2)).to eq("")
     end
 
+    {
+      "read" => proc { |transport| transport.read(1) },
+      "read_byte" => proc { |transport| transport.read_byte },
+      "read_into_buffer" => proc { |transport| transport.read_into_buffer("\0".b, 1) },
+    }.each do |operation, read|
+      it "rejects a zero-length frame through #{operation}" do
+        transport = Thrift::MemoryBufferTransport.new([0].pack("N"))
+        framed_transport = Thrift::FramedTransport.new(transport)
+
+        expect { read.call(framed_transport) }.to raise_error(Thrift::TransportException) do |error|
+          expect(error.type).to eq(Thrift::TransportException::END_OF_FILE)
+          expect(error.message).to eq("Cannot read from a zero-length frame")
+        end
+      end
+    end
+
     it "should pull a new frame when the first is exhausted" do
       frame = "this is a frame"
       frame2 = "yet another frame"

--- a/lib/rb/spec/server_spec.rb
+++ b/lib/rb/spec/server_spec.rb
@@ -191,6 +191,48 @@ describe "Server" do
         server_thread&.join
       end
     end
+
+    it "closes a zero-length framed connection and continues accepting clients" do
+      ready = Queue.new
+      errors = Queue.new
+      server_transport = EphemeralServerSocket.new(ready)
+      handler = StopAfterVoidHandler.new
+      processor = Thrift::Test::Srv::Processor.new(handler)
+      transport_factory = Thrift::FramedTransportFactory.new
+      protocol_factory = Thrift::CompactProtocolFactory.new
+      server = Thrift::SimpleServer.new(processor, server_transport, transport_factory, protocol_factory)
+      server_thread = Thread.new do
+        catch(:stop) { server.serve }
+      rescue StandardError, ScriptError => error
+        errors << error
+      end
+      server_thread.report_on_exception = false
+
+      port = Timeout.timeout(2) { ready.pop }
+      malformed_client = TCPSocket.new("127.0.0.1", port)
+      malformed_client.write([0].pack("N"))
+      malformed_client.close_write
+
+      expect(IO.select([malformed_client], nil, nil, 2)).not_to be_nil
+      expect(malformed_client.read).to eq("")
+      expect(server_thread).to be_alive
+
+      socket = Thrift::Socket.new("127.0.0.1", port)
+      valid_transport = Thrift::FramedTransport.new(socket)
+      valid_transport.open
+      valid_protocol = Thrift::CompactProtocol.new(valid_transport)
+      Thrift::Test::Srv::Client.new(valid_protocol).send_voidMethod
+
+      expect(server_thread.join(2)).to eq(server_thread)
+      expect(handler.calls).to eq(1)
+      expect(errors).to be_empty
+    ensure
+      malformed_client&.close
+      valid_transport&.close
+      server_transport&.close
+      server_thread&.kill
+      server_thread&.join
+    end
   end
 
   describe Thrift::ThreadedServer do


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby's `FramedTransport` accepts a frame whose declared payload length is zero. Its optimized read methods then operate on an empty buffer and leak native/pure-Ruby-specific exceptions. In `SimpleServer`, those raw exceptions escape the connection loop and close the listener.

This change rejects zero-length frames at the transport boundary with `TransportException::END_OF_FILE`. The same typed behavior now applies to `read`, `read_byte`, and `read_into_buffer`, allowing `SimpleServer` to close the malformed connection while continuing to accept later requests.

## Benchmarks

A temporary Ruby stdlib harness read 200,000 independent 32-byte frames through `FramedTransport` over `MemoryBufferTransport`. Both revisions used Ruby 4.0.6 in the same worktree container, with 5 warmup runs and 15 measured trials.

Command: `docker exec --workdir /thrift/src/lib/rb thrift-3422 bundle exec ruby -Ilib /thrift/src/.rb-zero-frame-benchmark.rb`

| Revision | Median | Throughput |
| --- | ---: | ---: |
| `upstream/master` (`04c87e89a`) | 0.095469 s | 2,094,925 frames/s |
| Proposed change | 0.100292 s | 1,994,170 frames/s |

The proposed median was 5.1% slower and throughput was 4.8% lower in this deliberately frame-overhead-heavy workload. The harness uses unusually small in-memory frames and excludes socket, protocol, and handler work, so it represents a worst-case view of the added per-frame integer check.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6155](https://issues.apache.org/jira/browse/THRIFT-6155)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
