### PR TITLE
THRIFT-6156: Normalize JSON Base64 errors

### DIFF
--- a/lib/rb/lib/thrift/protocol/json_protocol.rb
+++ b/lib/rb/lib/thrift/protocol/json_protocol.rb
@@ -548,7 +548,11 @@ module Thrift
           str += "="
         end
       end
-      str.unpack1("m0")
+      begin
+        str.unpack1("m0")
+      rescue ArgumentError
+        raise ProtocolException.new(ProtocolException::INVALID_DATA, "Invalid Base64 data")
+      end
     end
 
     # Reads a sequence of characters, stopping at the first one that is not

--- a/lib/rb/spec/json_protocol_spec.rb
+++ b/lib/rb/spec/json_protocol_spec.rb
@@ -424,6 +424,16 @@ describe "JsonProtocol" do
       expect(@prot.read_json_base64).to eq("this is a test string")
     end
 
+    it "rejects invalid Base64 alphabet and padding" do
+      ['"%"', '"Y=Q="'].each do |wire|
+        protocol = Thrift::JsonProtocol.new(Thrift::MemoryBufferTransport.new(wire))
+
+        expect { protocol.read_json_base64 }.to raise_error(Thrift::ProtocolException, "Invalid Base64 data") do |error|
+          expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+        end
+      end
+    end
+
     it "should is json numeric" do
       expect(@prot.is_json_numeric("A")).to eq(false)
       expect(@prot.is_json_numeric("+")).to eq(true)

--- a/lib/rb/spec/processor_spec.rb
+++ b/lib/rb/spec/processor_spec.rb
@@ -157,6 +157,16 @@ describe "Processor" do
       expect(@processor.read_args(@prot, args_class)).to eql(args)
     end
 
+    it "classifies malformed JSON binary arguments as invalid protocol data" do
+      input = Thrift::JsonProtocol.new(
+        Thrift::MemoryBufferTransport.new('{"1":{"str":"%"}}'),
+      )
+
+      expect { @processor.read_args(input, SpecNamespace::Foo2) }.to raise_error(Thrift::ProtocolException) do |error|
+        expect(error.type).to eq(Thrift::ProtocolException::INVALID_DATA)
+      end
+    end
+
     it "should write out a reply when asked" do
       expect(@prot).to receive(:write_message_begin).with("testMessage", Thrift::MessageTypes::REPLY, 23).ordered
       result = double("MockResult")


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->
  
Ruby's `JsonProtocol` lets `ArgumentError` escape when a JSON binary value contains an invalid Base64 alphabet or invalid padding. This bypasses the normal Thrift protocol-error path and can cause malformed method arguments to be classified as a generic application failure.

This change translates only strict Base64 decoding failures into `ProtocolException::INVALID_DATA`. Valid Base64 values, including the existing optional-padding behavior, continue to decode unchanged.

## Benchmarks

A temporary focused harness decoded 20,000 valid JSON binary values per trial through `JsonProtocol`. Both revisions used Ruby 4.0.6 in the same worktree container, with 3 warmup runs and 11 measured trials.

Command: `docker exec --workdir /thrift/src/lib/rb thrift-3422 bundle exec ruby -Ilib /thrift/src/.rb044-benchmark.rb`

| Revision | Median | Throughput |
| --- | ---: | ---: |
| `upstream/master` (`04c87e89a`) | 0.201569 s | 99,222 values/s |
| Proposed change | 0.202746 s | 98,646 values/s |

The proposed median was 0.6% slower and throughput was 0.6% lower. This in-memory workload isolates successful Base64 decoding and therefore amplifies the cost of the added exception boundary; it does not include transport, processor, or application work. No material valid-input regression was observed.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6156](https://issues.apache.org/jira/browse/THRIFT-6156)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
