### PR TITLE
THRIFT-6158: Classify malformed request arguments as protocol errors

### DIFF
--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -19,9 +19,14 @@
 #
 
 require "logger"
+require "thrift/protocol/base_protocol"
 
 module Thrift
   module Processor
+    class ArgumentProtocolException < ProtocolException
+    end
+    private_constant :ArgumentProtocolException
+
     def initialize(handler, logger = nil)
       @handler = handler
       if logger.nil?
@@ -48,6 +53,9 @@ module Thrift
       if respond_to?("process_#{name}")
         begin
           send("process_#{name}", seqid, iprot, oprot)
+        rescue ArgumentProtocolException => e
+          x = ApplicationException.new(ApplicationException::PROTOCOL_ERROR, e.message)
+          write_error(x, oprot, name, seqid)
         rescue => e
           x = ApplicationException.new(ApplicationException::INTERNAL_ERROR, "Internal error")
           @logger.debug "Internal error : #{e.message}\n#{e.backtrace.join("\n")}"
@@ -68,6 +76,8 @@ module Thrift
       args.read(iprot)
       iprot.read_message_end
       args
+    rescue ProtocolException => e
+      raise ArgumentProtocolException.new(e.type, e.message)
     end
 
     def write_result(result, oprot, name, seqid)

--- a/lib/rb/spec/processor_spec.rb
+++ b/lib/rb/spec/processor_spec.rb
@@ -167,6 +167,49 @@ describe "Processor" do
       end
     end
 
+    it "returns protocol errors for malformed request arguments" do
+      handler = double("Handler")
+      expect(handler).not_to receive(:sleep)
+      processor = SpecNamespace::NonblockingService::Processor.new(handler)
+      input = Thrift::JsonProtocol.new(
+        Thrift::MemoryBufferTransport.new('[1,"sleep",1,17,{"1":{"dbl":x}}]'),
+      )
+      output_transport = Thrift::MemoryBufferTransport.new
+
+      expect(processor.process(input, Thrift::JsonProtocol.new(output_transport))).to be true
+
+      response = Thrift::JsonProtocol.new(output_transport)
+      expect(response.read_message_begin).to eq(["sleep", Thrift::MessageTypes::EXCEPTION, 17])
+      exception = Thrift::ApplicationException.new
+      exception.read(response)
+      response.read_message_end
+
+      expect(exception.type).to eq(Thrift::ApplicationException::PROTOCOL_ERROR)
+      expect(exception.message).to eq('Expected numeric value; got ""')
+    end
+
+    it "keeps protocol exceptions raised by handlers as internal errors" do
+      handler = double("Handler")
+      expect(handler).to receive(:sleep).with(3.0).and_raise(
+        Thrift::ProtocolException.new(Thrift::ProtocolException::INVALID_DATA, "handler failed"),
+      )
+      processor = SpecNamespace::NonblockingService::Processor.new(handler)
+      args = SpecNamespace::NonblockingService::Sleep_args.new(seconds: 3.0)
+      input = input_protocol("sleep", Thrift::MessageTypes::CALL, 18, args)
+      output_transport, output = output_protocol
+
+      expect(processor.process(input, output)).to be true
+
+      response = Thrift::BinaryProtocol.new(output_transport)
+      expect(response.read_message_begin).to eq(["sleep", Thrift::MessageTypes::EXCEPTION, 18])
+      exception = Thrift::ApplicationException.new
+      exception.read(response)
+      response.read_message_end
+
+      expect(exception.type).to eq(Thrift::ApplicationException::INTERNAL_ERROR)
+      expect(exception.message).to eq("Internal error")
+    end
+
     it "should write out a reply when asked" do
       expect(@prot).to receive(:write_message_begin).with("testMessage", Thrift::MessageTypes::REPLY, 23).ordered
       result = double("MockResult")


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Malformed request arguments can raise a `ProtocolException` while a generated Ruby processor is decoding its argument structure. The processor currently handles that exception together with handler failures and returns `INTERNAL_ERROR`, making malformed protocol data appear to clients as a server-side failure.

This change marks protocol exceptions at the argument-reading boundary and returns an application exception with the `PROTOCOL_ERROR` type, preserving the original message, method name, and sequence ID. Protocol exceptions raised later by application handlers remain classified as `INTERNAL_ERROR`.

## Benchmarks

The successful `read_args` path was measured on Ruby 4.0.6/aarch64-linux with one CPU pinned, a 500,000-call warmup, and 15 trials of 5,000,000 calls:

```sh
taskset -c 0 bundle exec ruby -e 'require "thrift"; class BenchProcessor; include Thrift::Processor; end; class BenchArgs; def read(_protocol); end; end; class BenchProtocol; def read_message_end; end; end; processor = BenchProcessor.new(Object.new, Logger.new(IO::NULL)); protocol = BenchProtocol.new; 500_000.times { processor.read_args(protocol, BenchArgs) }; samples = 15.times.map do; started = Process.clock_gettime(Process::CLOCK_MONOTONIC); 5_000_000.times { processor.read_args(protocol, BenchArgs) }; Process.clock_gettime(Process::CLOCK_MONOTONIC) - started; end; sorted = samples.sort; p samples; p sorted.fetch(7)'
```

Current master median: 0.786545 seconds  
Proposed change median: 0.780384 seconds  
Difference: -0.8%

This synthetic benchmark uses no-op argument and protocol objects to emphasize processor dispatch overhead; it excludes protocol decoding, transport, and network work. The difference is within run-to-run noise and shows no measurable regression.

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? [THRIFT-6158](https://issues.apache.org/jira/browse/THRIFT-6158)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
