### PR TITLE
THRIFT-6066: c_glib base services reject every method call

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_c_glib_generator.cc
@@ -2758,14 +2758,9 @@ void t_c_glib_generator::generate_service_processor(t_service* tservice) {
              << "gobject_class->finalize = " << class_name_lc << "_finalize;" << '\n' << indent()
              << "gobject_class->set_property = " << class_name_lc << "_set_property;" << '\n'
              << indent() << "gobject_class->get_property = " << class_name_lc << "_get_property;"
-             << '\n' << '\n';
-
-  if (extends_service) {
-    f_service_ << indent() << "dispatch_processor_class->dispatch_call = " << class_name_lc
-               << "_dispatch_call;" << '\n';
-  }
-
-  f_service_ << indent() << "cls->dispatch_call = " << class_name_lc << "_dispatch_call;"
+             << '\n' << '\n' << indent()
+             << "dispatch_processor_class->dispatch_call = " << class_name_lc << "_dispatch_call;"
+             << '\n' << indent() << "cls->dispatch_call = " << class_name_lc << "_dispatch_call;"
              << '\n' << '\n' << indent() << "param_spec = g_param_spec_object (\"handler\","
              << '\n';
   args_indent = indent() + string(34, ' ');

--- a/lib/c_glib/test/CMakeLists.txt
+++ b/lib/c_glib/test/CMakeLists.txt
@@ -101,6 +101,7 @@ target_link_libraries(testmultiplexedprocessor thrift_c_glib)
 add_test(NAME testmultiplexedprocessor COMMAND testmultiplexedprocessor)
 
 add_executable(testdispatchprocessor testdispatchprocessor.c)
+target_link_libraries(testdispatchprocessor testgenc)
 target_link_libraries(testdispatchprocessor thrift_c_glib)
 add_test(NAME testdispatchprocessor COMMAND testdispatchprocessor)
 

--- a/lib/c_glib/test/Makefile.am
+++ b/lib/c_glib/test/Makefile.am
@@ -233,7 +233,8 @@ testdispatchprocessor_LDADD = \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift_application_exception.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift_struct.o \
     $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift.o \
-    $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift_configuration.o
+    $(top_builddir)/lib/c_glib/src/thrift/c_glib/libthrift_c_glib_la-thrift_configuration.o \
+    libtestgenc.la
 
 testdebugproto_SOURCES = testdebugproto.c
 testdebugproto_LDADD = libtestgenc.la

--- a/lib/c_glib/test/testdispatchprocessor.c
+++ b/lib/c_glib/test/testdispatchprocessor.c
@@ -352,12 +352,6 @@ test_dispatch_call_without_name (void)
   g_object_unref (processor);
 }
 
-/* A generated processor reaches its handler through the dispatch_call slot the
-   base class defines, so a service that has no parent must claim that slot for
-   itself. Srv is such a service: it extends nothing, so if its class_init only
-   sets its own dispatch_call member and leaves the inherited slot alone, every
-   call is answered by the base class' default with "Invalid method name". */
-
 static gboolean srv_handler_reached = FALSE;
 
 #define TEST_TYPE_SRV_HANDLER (test_srv_handler_get_type ())
@@ -427,8 +421,6 @@ test_generated_base_service_dispatches (void)
   protocol = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport", transport,
                            NULL);
 
-  /* Write a primitiveMethod call. It takes no arguments, so the argument
-     struct is empty. */
   g_assert (thrift_protocol_write_message_begin (THRIFT_PROTOCOL (protocol),
                                                  "primitiveMethod", T_CALL, 1,
                                                  &error) > 0);
@@ -450,8 +442,6 @@ test_generated_base_service_dispatches (void)
 
   g_assert (srv_handler_reached == TRUE);
 
-  /* The reply carries the handler's return value, not an application
-     exception reporting the method name was not recognized. */
   g_assert (thrift_protocol_read_message_begin (THRIFT_PROTOCOL (protocol),
                                                 &reply_name, &reply_type,
                                                 &reply_seqid, &error) > 0);

--- a/lib/c_glib/test/testdispatchprocessor.c
+++ b/lib/c_glib/test/testdispatchprocessor.c
@@ -27,6 +27,8 @@
 #include <thrift/c_glib/thrift_application_exception.h>
 #include <thrift/c_glib/thrift_struct.h>
 
+#include "gen-c_glib/t_test_srv.h"
+
 /* A protocol whose read_message_begin behaviour can be selected per test, so
    the dispatch processor can be driven through the results a protocol
    implementation may produce for a message header. */
@@ -350,6 +352,135 @@ test_dispatch_call_without_name (void)
   g_object_unref (processor);
 }
 
+/* A generated processor reaches its handler through the dispatch_call slot the
+   base class defines, so a service that has no parent must claim that slot for
+   itself. Srv is such a service: it extends nothing, so if its class_init only
+   sets its own dispatch_call member and leaves the inherited slot alone, every
+   call is answered by the base class' default with "Invalid method name". */
+
+static gboolean srv_handler_reached = FALSE;
+
+#define TEST_TYPE_SRV_HANDLER (test_srv_handler_get_type ())
+
+struct _TestSrvHandler
+{
+  TTestSrvHandler parent;
+};
+typedef struct _TestSrvHandler TestSrvHandler;
+
+struct _TestSrvHandlerClass
+{
+  TTestSrvHandlerClass parent;
+};
+typedef struct _TestSrvHandlerClass TestSrvHandlerClass;
+
+G_DEFINE_TYPE (TestSrvHandler, test_srv_handler, T_TEST_TYPE_SRV_HANDLER)
+
+static gboolean
+test_srv_handler_primitive_method (TTestSrvIf *iface, gint32 *_return,
+                                   GError **error)
+{
+  THRIFT_UNUSED_VAR (iface);
+  THRIFT_UNUSED_VAR (error);
+
+  srv_handler_reached = TRUE;
+  *_return = 42;
+
+  return TRUE;
+}
+
+static void
+test_srv_handler_init (TestSrvHandler *handler)
+{
+  THRIFT_UNUSED_VAR (handler);
+}
+
+static void
+test_srv_handler_class_init (TestSrvHandlerClass *klass)
+{
+  T_TEST_SRV_HANDLER_CLASS (klass)->primitive_method =
+    test_srv_handler_primitive_method;
+}
+
+static void
+test_generated_base_service_dispatches (void)
+{
+  TestSrvHandler *handler = NULL;
+  TTestSrvProcessor *processor = NULL;
+  ThriftMemoryBuffer *transport = NULL;
+  ThriftBinaryProtocol *protocol = NULL;
+  GError *error = NULL;
+  gchar *reply_name = NULL;
+  ThriftMessageType reply_type = 0;
+  gint32 reply_seqid = 0;
+  gchar *field_name = NULL;
+  ThriftType field_type = 0;
+  gint16 field_id = 0;
+  gint32 result = 0;
+
+  srv_handler_reached = FALSE;
+
+  handler = g_object_new (TEST_TYPE_SRV_HANDLER, NULL);
+  processor = g_object_new (T_TEST_TYPE_SRV_PROCESSOR, "handler", handler,
+                            NULL);
+  transport = g_object_new (THRIFT_TYPE_MEMORY_BUFFER, "buf_size", 1024, NULL);
+  protocol = g_object_new (THRIFT_TYPE_BINARY_PROTOCOL, "transport", transport,
+                           NULL);
+
+  /* Write a primitiveMethod call. It takes no arguments, so the argument
+     struct is empty. */
+  g_assert (thrift_protocol_write_message_begin (THRIFT_PROTOCOL (protocol),
+                                                 "primitiveMethod", T_CALL, 1,
+                                                 &error) > 0);
+  g_assert (thrift_protocol_write_struct_begin (THRIFT_PROTOCOL (protocol),
+                                                "primitiveMethod_args",
+                                                &error) >= 0);
+  g_assert (thrift_protocol_write_field_stop (THRIFT_PROTOCOL (protocol),
+                                              &error) > 0);
+  g_assert (thrift_protocol_write_struct_end (THRIFT_PROTOCOL (protocol),
+                                              &error) >= 0);
+  g_assert (thrift_protocol_write_message_end (THRIFT_PROTOCOL (protocol),
+                                               &error) >= 0);
+  g_assert (error == NULL);
+
+  g_assert (thrift_processor_process (THRIFT_PROCESSOR (processor),
+                                      THRIFT_PROTOCOL (protocol),
+                                      THRIFT_PROTOCOL (protocol), &error));
+  g_assert (error == NULL);
+
+  g_assert (srv_handler_reached == TRUE);
+
+  /* The reply carries the handler's return value, not an application
+     exception reporting the method name was not recognized. */
+  g_assert (thrift_protocol_read_message_begin (THRIFT_PROTOCOL (protocol),
+                                                &reply_name, &reply_type,
+                                                &reply_seqid, &error) > 0);
+  g_assert_cmpint (reply_type, ==, T_REPLY);
+  g_assert_cmpint (reply_seqid, ==, 1);
+
+  g_assert (thrift_protocol_read_struct_begin (THRIFT_PROTOCOL (protocol),
+                                               &field_name, &error) >= 0);
+  g_free (field_name);
+  field_name = NULL;
+
+  g_assert (thrift_protocol_read_field_begin (THRIFT_PROTOCOL (protocol),
+                                              &field_name, &field_type,
+                                              &field_id, &error) > 0);
+  g_assert_cmpint (field_type, ==, T_I32);
+  g_assert_cmpint (field_id, ==, 0);
+  g_assert (thrift_protocol_read_i32 (THRIFT_PROTOCOL (protocol), &result,
+                                      &error) > 0);
+  g_assert_cmpint (result, ==, 42);
+  g_assert (error == NULL);
+
+  g_free (field_name);
+  g_free (reply_name);
+  g_object_unref (protocol);
+  g_object_unref (transport);
+  g_object_unref (processor);
+  g_object_unref (handler);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -367,6 +498,8 @@ main (int argc, char *argv[])
                    test_process_failed_message_begin);
   g_test_add_func ("/testdispatchprocessor/DispatchCallWithoutName",
                    test_dispatch_call_without_name);
+  g_test_add_func ("/testdispatchprocessor/GeneratedBaseServiceDispatches",
+                   test_generated_base_service_dispatches);
 
   return g_test_run ();
 }


### PR DESCRIPTION
A c_glib service that extends nothing answers every method call with an application exception reading `Invalid method name`, so a base service is unusable while a derived one works.

The generated class declares its own `dispatch_call` member, which children read as `parent_class->dispatch_call` when chaining up. That is a different field from the one on `ThriftDispatchProcessorClass`, and the latter is what the runtime actually calls. The generator registered that slot only for a service extending another one, leaving a base service on the inherited default, whose job is to reject method names nothing in the hierarchy recognises.

The guard existed to skip a dispatch hop to a parent that does not exist. That hop is emitted in the generated dispatch body, which the guard never touched, so it saved no work and only cost base services their dispatch. Registering the slot unconditionally restores it. A service that extends another generates byte-identical output.

### Testing

The regression sends a binary-protocol call through a generated base-service processor, then checks the handler's return value.

```shell
cmake -S . -B build -G Ninja -DBUILD_TESTING=ON
cmake --build build --target testdispatchprocessor
ctest --test-dir build -R '^testdispatchprocessor$' --output-on-failure
```

```shell
./bootstrap.sh
./configure --with-c_glib --without-cpp --disable-tutorial
make -C compiler/cpp all
make -C lib/c_glib all
make -C lib/c_glib/test gen-c_glib/t_test_srv.h testdispatchprocessor
./lib/c_glib/test/testdispatchprocessor
```

<details>
<summary>Raw logs</summary>

The same regression on `upstream/master`:

```text
ERROR:testdispatchprocessor.c:451:test_generated_base_service_dispatches:
assertion failed: (srv_handler_reached == TRUE)
not ok /testdispatchprocessor/GeneratedBaseServiceDispatches
0% tests passed, 1 tests failed out of 1
```

CMake on this branch:

```text
1/1 Test #66: testdispatchprocessor ............ Passed
100% tests passed out of 1
```

Autotools on this branch:

```text
ok 1 /testdispatchprocessor/MessageWithoutName
ok 2 /testdispatchprocessor/MessageNotACall
ok 3 /testdispatchprocessor/FailedMessageBegin
ok 4 /testdispatchprocessor/DispatchCallWithoutName
ok 5 /testdispatchprocessor/GeneratedBaseServiceDispatches
```

The generated derived-service source is byte-identical to `upstream/master`. The base-service source adds only:

```text
dispatch_processor_class->dispatch_call = t_test_srv_processor_dispatch_call;
```

</details>
