### PR TITLE
THRIFT-6060: Reconnect THttpClient after Connection: close

### DIFF
--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -18,10 +18,11 @@
  */
 
 #include <algorithm>
-#include <limits>
-#include <cstdlib>
-#include <sstream>
 #include <boost/algorithm/string.hpp>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <vector>
 
 #include <thrift/config.h>
 #include <thrift/transport/THttpClient.h>
@@ -38,23 +39,32 @@ THttpClient::THttpClient(std::shared_ptr<TTransport> transport,
                          std::string path,
                          std::shared_ptr<TConfiguration> config)
   : THttpTransport(transport, config),
-    host_(host), 
+    host_(host),
     path_(path),
-    onewayResponsePending_(false) {
-}
+    onewayResponsePending_(false),
+    closeAfterResponse_(false) {}
 
-THttpClient::THttpClient(string host, int port, string path, 
-                         std::shared_ptr<TConfiguration> config)
+THttpClient::THttpClient(string host, int port, string path, std::shared_ptr<TConfiguration> config)
   : THttpTransport(std::shared_ptr<TTransport>(new TSocket(host, port)), config),
     host_(host),
     path_(path),
-    onewayResponsePending_(false) {
-}
+    onewayResponsePending_(false),
+    closeAfterResponse_(false) {}
 
 THttpClient::~THttpClient() = default;
 
 void THttpClient::close() {
   onewayResponsePending_ = false;
+  closeAfterResponse_ = false;
+  readBuffer_.resetBuffer();
+  readHeaders_ = true;
+  chunked_ = false;
+  chunkedDone_ = false;
+  chunkSize_ = 0;
+  contentLength_ = 0;
+  httpPos_ = 0;
+  httpBufLen_ = 0;
+  httpBuf_[0] = '\0';
   THttpTransport::close();
 }
 
@@ -72,10 +82,20 @@ void THttpClient::parseHeader(char* header) {
   } else if (boost::istarts_with(header, "Content-Length")) {
     chunked_ = false;
     contentLength_ = atoi(value);
+  } else if (boost::istarts_with(header, "Connection")) {
+    std::vector<string> options;
+    boost::split(options, value, boost::is_any_of(","));
+    for (const string& option : options) {
+      if (boost::iequals(boost::trim_copy(option), "close")) {
+        closeAfterResponse_ = true;
+        break;
+      }
+    }
   }
 }
 
 bool THttpClient::parseStatusLine(char* status) {
+  closeAfterResponse_ = false;
   char* http = status;
 
   char* code = strchr(http, ' ');
@@ -107,6 +127,13 @@ bool THttpClient::parseStatusLine(char* status) {
 void THttpClient::flush() {
   resetConsumedMessageSize();
 
+  uint8_t* buf;
+  uint32_t len;
+  writeBuffer_.getBuffer(&buf, &len);
+  if (len == 0) {
+    return;
+  }
+
   if (onewayResponsePending_) {
     if (transport_->isOpen()) {
       drainPendingOnewayResponse();
@@ -115,14 +142,13 @@ void THttpClient::flush() {
     }
   }
 
+  if (closeAfterResponse_) {
+    close();
+  }
+
   if (!transport_->isOpen()) {
     transport_->open();
   }
-
-  // Fetch the contents of the write buffer
-  uint8_t* buf;
-  uint32_t len;
-  writeBuffer_.getBuffer(&buf, &len);
 
   // Construct the HTTP header
   std::ostringstream h;

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -82,7 +82,7 @@ void THttpClient::parseHeader(char* header) {
   } else if (boost::istarts_with(header, "Content-Length")) {
     chunked_ = false;
     contentLength_ = atoi(value);
-  } else if (boost::istarts_with(header, "Connection")) {
+  } else if (boost::iequals(string(header, colon), "Connection")) {
     std::vector<string> options;
     boost::split(options, value, boost::is_any_of(","));
     for (const string& option : options) {

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -75,14 +75,15 @@ void THttpClient::parseHeader(char* header) {
   }
   char* value = colon + 1;
 
-  if (boost::istarts_with(header, "Transfer-Encoding")) {
+  const string name(header, colon);
+  if (boost::iequals(name, "Transfer-Encoding")) {
     if (boost::iends_with(value, "chunked")) {
       chunked_ = true;
     }
-  } else if (boost::istarts_with(header, "Content-Length")) {
+  } else if (boost::iequals(name, "Content-Length")) {
     chunked_ = false;
     contentLength_ = atoi(value);
-  } else if (boost::iequals(string(header, colon), "Connection")) {
+  } else if (boost::iequals(name, "Connection")) {
     std::vector<string> options;
     boost::split(options, value, boost::is_any_of(","));
     for (const string& option : options) {

--- a/lib/cpp/src/thrift/transport/THttpClient.h
+++ b/lib/cpp/src/thrift/transport/THttpClient.h
@@ -65,6 +65,7 @@ protected:
   std::string host_;
   std::string path_;
   bool onewayResponsePending_;
+  bool closeAfterResponse_;
 
   void parseHeader(char* header) override;
   bool parseStatusLine(char* status) override;

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -150,21 +150,23 @@ public:
     writeBuffer_.getBuffer(&buf, &len);
 
     std::ostringstream header;
-    header << "HTTP/1.1 200 OK" << CRLF << "Content-Type: application/x-thrift" << CRLF
-           << "Transfer-Encoding: chunked" << CRLF << "Connection: keep-alive, close" << CRLF
-           << "Connection: keep-alive" << CRLF << CRLF;
+    header << "HTTP/1.1 200 OK\r\n"
+           << "Content-Type: application/x-thrift\r\n"
+           << "Transfer-Encoding: chunked\r\n"
+           << "Connection: keep-alive, close\r\n"
+           << "Connection: keep-alive\r\n\r\n";
     const string headerText = header.str();
     transport_->write(reinterpret_cast<const uint8_t*>(headerText.data()),
                       static_cast<uint32_t>(headerText.size()));
 
     if (len > 0) {
       std::ostringstream chunkSize;
-      chunkSize << std::hex << len << CRLF;
+      chunkSize << std::hex << len << "\r\n";
       const string chunkPrefix = chunkSize.str();
       transport_->write(reinterpret_cast<const uint8_t*>(chunkPrefix.data()),
                         static_cast<uint32_t>(chunkPrefix.size()));
       transport_->write(buf, len);
-      transport_->write(reinterpret_cast<const uint8_t*>(CRLF), CRLF_LEN);
+      transport_->write(reinterpret_cast<const uint8_t*>("\r\n"), 2);
     }
     transport_->write(reinterpret_cast<const uint8_t*>("0\r\n\r\n"), 5);
     transport_->flush();

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -17,22 +17,23 @@
  * under the License.
  */
 
+#include "gen-cpp/OneWayService.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
-#include <iostream>
 #include <climits>
-#include <vector>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <thrift/concurrency/Monitor.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/protocol/TJSONProtocol.h>
 #include <thrift/server/TThreadedServer.h>
-#include <thrift/transport/THttpServer.h>
+#include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/THttpClient.h>
+#include <thrift/transport/THttpServer.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TSocket.h>
-#include <memory>
-#include <thrift/transport/TBufferTransports.h>
-#include "gen-cpp/OneWayService.h"
+#include <vector>
 
 BOOST_AUTO_TEST_SUITE(OneWayHTTPTest)
 
@@ -126,11 +127,59 @@ public:
     return nullptr;
   }
   bool isListening() const { return isListening_; }
-  uint64_t acceptedCount() const { return accepted_; }
+  uint64_t acceptedCount() {
+    Synchronized sync(*this);
+    return accepted_;
+  }
 
 private:
   bool isListening_;
   uint64_t accepted_;
+};
+
+class TClosingHttpServer : public THttpServer {
+public:
+  explicit TClosingHttpServer(std::shared_ptr<TTransport> transport)
+    : THttpServer(transport, transport->getConfiguration()) {}
+
+  void flush() override {
+    resetConsumedMessageSize();
+
+    uint8_t* buf;
+    uint32_t len;
+    writeBuffer_.getBuffer(&buf, &len);
+
+    std::ostringstream header;
+    header << "HTTP/1.1 200 OK" << CRLF << "Content-Type: application/x-thrift" << CRLF
+           << "Transfer-Encoding: chunked" << CRLF << "Connection: keep-alive, close" << CRLF
+           << "Connection: keep-alive" << CRLF << CRLF;
+    const string headerText = header.str();
+    transport_->write(reinterpret_cast<const uint8_t*>(headerText.data()),
+                      static_cast<uint32_t>(headerText.size()));
+
+    if (len > 0) {
+      std::ostringstream chunkSize;
+      chunkSize << std::hex << len << CRLF;
+      const string chunkPrefix = chunkSize.str();
+      transport_->write(reinterpret_cast<const uint8_t*>(chunkPrefix.data()),
+                        static_cast<uint32_t>(chunkPrefix.size()));
+      transport_->write(buf, len);
+      transport_->write(reinterpret_cast<const uint8_t*>(CRLF), CRLF_LEN);
+    }
+    transport_->write(reinterpret_cast<const uint8_t*>("0\r\n\r\n"), 5);
+    transport_->flush();
+
+    writeBuffer_.resetBuffer();
+    readHeaders_ = true;
+    close();
+  }
+};
+
+class TClosingHttpServerTransportFactory : public apache::thrift::transport::TTransportFactory {
+public:
+  std::shared_ptr<TTransport> getTransport(std::shared_ptr<TTransport> transport) override {
+    return std::make_shared<TClosingHttpServer>(transport);
+  }
 };
 
 class TBlockableBufferedTransport : public TBufferedTransport {
@@ -280,6 +329,50 @@ BOOST_AUTO_TEST_CASE( JSON_HTTP_OneWayWrapperDoesNotPoisonNextCall )
     }
     BOOST_CHECK_EQUAL(pEventHandler->acceptedCount(), 1U);
     transport->close();
+  }
+
+  server.stop();
+  thread.join();
+}
+
+BOOST_AUTO_TEST_CASE(HTTP_ClientReconnectsAfterConnectionClose) {
+  std::shared_ptr<TServerSocket> ss = std::make_shared<TServerSocket>(0);
+  TThreadedServer server(std::make_shared<onewaytest::OneWayServiceProcessorFactory>(
+                             std::make_shared<OneWayServiceCloneFactory>()),
+                         ss, std::make_shared<TClosingHttpServerTransportFactory>(),
+                         std::make_shared<TBinaryProtocolFactory>());
+
+  std::shared_ptr<TServerReadyEventHandler> pEventHandler(new TServerReadyEventHandler);
+  server.setServerEventHandler(pEventHandler);
+
+  RPC0ThreadClass t(server);
+  boost::thread thread(&RPC0ThreadClass::Run, &t);
+
+  {
+    Synchronized sync(*(pEventHandler.get()));
+    while (!pEventHandler->isListening()) {
+      pEventHandler->wait();
+    }
+  }
+
+  {
+    std::shared_ptr<TSocket> socket(new TSocket("localhost", ss->getPort()));
+    socket->setRecvTimeout(10000);
+    std::shared_ptr<TTransport> httpTransport(new THttpClient(socket, "localhost", "/service"));
+    std::shared_ptr<TTransport> transport(new TBufferedTransport(httpTransport));
+    std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+    onewaytest::OneWayServiceClient client(protocol);
+
+    transport->open();
+    client.roundTripRPC();
+    BOOST_CHECK_EQUAL(pEventHandler->acceptedCount(), 1U);
+    BOOST_CHECK_NO_THROW(client.roundTripRPC());
+    BOOST_CHECK_EQUAL(pEventHandler->acceptedCount(), 2U);
+    client.oneWayRPC();
+    BOOST_CHECK_NO_THROW(client.roundTripRPC());
+    BOOST_CHECK_EQUAL(pEventHandler->acceptedCount(), 4U);
+    transport->close();
+    BOOST_CHECK_EQUAL(pEventHandler->acceptedCount(), 4U);
   }
 
   server.stop();

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -62,6 +62,18 @@ namespace utf = boost::unit_test;
 // Define this env var to enable some logging (in case you need to debug)
 #undef ENABLE_STDERR_LOGGING
 
+class TInspectableHttpClient : public THttpClient {
+public:
+  explicit TInspectableHttpClient(std::shared_ptr<TTransport> transport) : THttpClient(transport) {}
+
+  bool closesAfterHeader(const string& header) {
+    std::vector<char> buffer(header.begin(), header.end());
+    buffer.push_back('\0');
+    parseHeader(buffer.data());
+    return closeAfterResponse_;
+  }
+};
+
 class OneWayServiceHandler : public onewaytest::OneWayServiceIf {
 public:
   OneWayServiceHandler() = default;
@@ -379,6 +391,13 @@ BOOST_AUTO_TEST_CASE(HTTP_ClientReconnectsAfterConnectionClose) {
 
   server.stop();
   thread.join();
+}
+
+BOOST_AUTO_TEST_CASE(HTTP_ClientRequiresExactConnectionHeaderName) {
+  TInspectableHttpClient client(std::make_shared<TMemoryBuffer>());
+
+  BOOST_CHECK(!client.closesAfterHeader("Connection-Timeout: close"));
+  BOOST_CHECK(client.closesAfterHeader("Connection: keep-alive, close"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -73,6 +73,22 @@ public:
     parseHeader(buffer.data());
     return closeAfterResponse_;
   }
+
+  bool chunksAfterHeader(const string& header) {
+    chunked_ = false;
+    std::vector<char> buffer(header.begin(), header.end());
+    buffer.push_back('\0');
+    parseHeader(buffer.data());
+    return chunked_;
+  }
+
+  uint32_t contentLengthAfterHeader(const string& header) {
+    contentLength_ = 0;
+    std::vector<char> buffer(header.begin(), header.end());
+    buffer.push_back('\0');
+    parseHeader(buffer.data());
+    return contentLength_;
+  }
 };
 
 class OneWayServiceHandler : public onewaytest::OneWayServiceIf {
@@ -399,6 +415,10 @@ BOOST_AUTO_TEST_CASE(HTTP_ClientRequiresExactConnectionHeaderName) {
 
   BOOST_CHECK(client.closesAfterHeader("Connection: keep-alive, close"));
   BOOST_CHECK(!client.closesAfterHeader("Connection-Timeout: close"));
+  BOOST_CHECK(client.chunksAfterHeader("Transfer-Encoding: chunked"));
+  BOOST_CHECK(!client.chunksAfterHeader("Transfer-Encoding-Other: chunked"));
+  BOOST_CHECK_EQUAL(client.contentLengthAfterHeader("Content-Length: 42"), 42U);
+  BOOST_CHECK_EQUAL(client.contentLengthAfterHeader("Content-Length-Mismatch: 42"), 0U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/OneWayHTTPTest.cpp
+++ b/lib/cpp/test/OneWayHTTPTest.cpp
@@ -67,6 +67,7 @@ public:
   explicit TInspectableHttpClient(std::shared_ptr<TTransport> transport) : THttpClient(transport) {}
 
   bool closesAfterHeader(const string& header) {
+    closeAfterResponse_ = false;
     std::vector<char> buffer(header.begin(), header.end());
     buffer.push_back('\0');
     parseHeader(buffer.data());
@@ -396,8 +397,8 @@ BOOST_AUTO_TEST_CASE(HTTP_ClientReconnectsAfterConnectionClose) {
 BOOST_AUTO_TEST_CASE(HTTP_ClientRequiresExactConnectionHeaderName) {
   TInspectableHttpClient client(std::make_shared<TMemoryBuffer>());
 
-  BOOST_CHECK(!client.closesAfterHeader("Connection-Timeout: close"));
   BOOST_CHECK(client.closesAfterHeader("Connection: keep-alive, close"));
+  BOOST_CHECK(!client.closesAfterHeader("Connection-Timeout: close"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A C++ `THttpClient` can complete one RPC, then fail the next when an HTTP/1.1 server sends `Connection: close`. The client leaves the socket marked open and writes the next request to a connection the server already closed.

The client now records `close` from comma-separated or repeated `Connection` headers. It matches every recognized field name exactly, so prefixed custom fields such as `Connection-Timeout`, `Content-Length-Mismatch`, and `Transfer-Encoding-Other` cannot alter parser state. Before the next non-empty request, it clears buffered HTTP state, closes the old socket, and reconnects. Empty flushes remain no-ops, including when a buffered wrapper closes.

Jira: https://issues.apache.org/jira/browse/THRIFT-6060

### Testing

```shell
cmake -S . -B build -G Ninja -DBUILD_TESTING=ON
cmake --build build --target UnitTests
build/bin/UnitTests --run_test=OneWayHTTPTest --log_level=test_suite
build/bin/UnitTests
```

<details>
<summary>Raw logs</summary>

On `upstream/master`, with only the regression test applied:

```text
error: in "OneWayHTTPTest/HTTP_ClientReconnectsAfterConnectionClose":
unexpected exception thrown by client.roundTripRPC()
check acceptedCount() == 2U has failed [1 != 2]
TSocket::write_partial() send(): Broken pipe
fatal error: TTransportException: write() send(): Broken pipe
```

On `3946ebe16740f097ffeea37cbb5e00022c6a8465`, the exact-name regression fails:

```text
check !client.chunksAfterHeader("Transfer-Encoding-Other: chunked") has failed
check client.contentLengthAfterHeader("Content-Length-Mismatch: 42") == 0U
has failed [42 != 0]
*** 2 failures are detected in the test module "thrift"
```

On this branch:

```text
Running 4 test cases...
*** No errors detected

Running 89 test cases...
*** No errors detected
```

</details>

- [x] Jira ticket exists and the PR title uses the `THRIFT-NNNN` prefix.
- [x] Every commit is signed.
- [x] The change preserves the HTTP/1.1 keep-alive path and adds no breaking API change.
- [x] This change includes code, so `[skip ci]` does not apply.
