### PR TITLE
THRIFT-6174: Fix TSSLSocket build with OpenSSL 4.0

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
@@ -285,7 +285,6 @@ thrift_ssl_socket_close (ThriftTransport *transport, GError **error)
       SSL_shutdown(ssl_socket->ssl);
       SSL_free(ssl_socket->ssl);
       ssl_socket->ssl = NULL;
-      ERR_remove_state(0);
   }
   return thrift_socket_close(transport, error);
 }
@@ -710,7 +709,6 @@ void thrift_ssl_socket_finalize_openssl(void)
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
-  ERR_remove_state(0);
 }
 
 
@@ -835,6 +833,7 @@ thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GErro
     case SSLTLS:
       context = SSL_CTX_new(SSLv23_method());
       break;
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
 #ifndef OPENSSL_NO_SSL3
     case SSLv3:
       context = SSL_CTX_new(SSLv3_method());
@@ -849,6 +848,7 @@ thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GErro
     case TLSv1_2:
       context = SSL_CTX_new(TLSv1_2_method());
       break;
+#endif /* OPENSSL_VERSION_NUMBER < 0x40000000L */
     default:
       g_set_error (error, THRIFT_TRANSPORT_ERROR,
 		   THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE,

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -164,10 +164,7 @@ void cleanupOpenSSL() {
   OPENSSL_thread_stop();
 #  endif
 #else
-  // ERR_remove_state() was deprecated in OpenSSL 1.0.0 and ERR_remove_thread_state()
   // was deprecated in OpenSSL 1.1.0; these functions and should not be used.
-  // https://www.openssl.org/docs/manmaster/man3/ERR_remove_state.html
-  ERR_remove_state(0);
 #endif
   ERR_free_strings();
 
@@ -182,16 +179,26 @@ static char uppercase(char c);
 SSLContext::SSLContext(const SSLProtocol& protocol) {
   if (protocol == SSLTLS) {
     ctx_ = SSL_CTX_new(SSLv23_method());
-#ifndef OPENSSL_NO_SSL3
+#if !defined(OPENSSL_NO_SSL3) && OPENSSL_VERSION_NUMBER < 0x40000000L
   } else if (protocol == SSLv3) {
     ctx_ = SSL_CTX_new(SSLv3_method());
 #endif
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+  } else if (protocol == TLSv1_0 || protocol == TLSv1_1 || protocol == TLSv1_2) {
+    ctx_ = SSL_CTX_new(TLS_method());
+    if (ctx_) {
+      int ver = (protocol == TLSv1_0) ? TLS1_VERSION : (protocol == TLSv1_1) ? TLS1_1_VERSION : TLS1_2_VERSION;
+      SSL_CTX_set_min_proto_version(ctx_, ver);
+      SSL_CTX_set_max_proto_version(ctx_, ver);
+    }
+#else
   } else if (protocol == TLSv1_0) {
     ctx_ = SSL_CTX_new(TLSv1_method());
   } else if (protocol == TLSv1_1) {
     ctx_ = SSL_CTX_new(TLSv1_1_method());
   } else if (protocol == TLSv1_2) {
     ctx_ = SSL_CTX_new(TLSv1_2_method());
+#endif
   } else {
     /// UNKNOWN PROTOCOL!
     throw TSSLException("SSL_CTX_new: Unknown protocol");
@@ -412,10 +419,7 @@ void TSSLSocket::close() {
     OPENSSL_thread_stop();
 #  endif
 #else
-    // ERR_remove_state() was deprecated in OpenSSL 1.0.0 and ERR_remove_thread_state()
     // was deprecated in OpenSSL 1.1.0; these functions and should not be used.
-    // https://www.openssl.org/docs/manmaster/man3/ERR_remove_state.html
-    ERR_remove_state(0);
 #endif
   }
   TSocket::close();
@@ -773,7 +777,7 @@ void TSSLSocket::authorize() {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
       const char* data = (const char*)ASN1_STRING_get0_data(name->d.ia5);
 #else
-      char* data = (char*)ASN1_STRING_data(name->d.ia5);
+      const char* data = (const char*)ASN1_STRING_get0_data(name->d.ia5);
 #endif
       int length = ASN1_STRING_length(name->d.ia5);
       switch (name->type) {
@@ -800,19 +804,19 @@ void TSSLSocket::authorize() {
   }
 
   // extract commonName
-  X509_NAME* name = X509_get_subject_name(cert);
+  const X509_NAME* name = X509_get_subject_name(cert);
   if (name != nullptr) {
-    X509_NAME_ENTRY* entry;
+    const X509_NAME_ENTRY* entry;
     unsigned char* utf8;
     int last = -1;
     while (decision == AccessManager::SKIP) {
-      last = X509_NAME_get_index_by_NID(name, NID_commonName, last);
+      last = X509_NAME_get_index_by_NID((X509_NAME *)name, NID_commonName, last);
       if (last == -1)
         break;
       entry = X509_NAME_get_entry(name, last);
       if (entry == nullptr)
         continue;
-      ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
+      const ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
       int size = ASN1_STRING_to_UTF8(&utf8, common);
       if (host.empty()) {
         host = (server() ? getPeerHost() : getHost());


### PR DESCRIPTION
OpenSSL 4.0 removes SSLv3_method() and per-version TLS method functions (TLSv1_method, TLSv1_1_method, TLSv1_2_method), the deprecated ASN1_STRING_data() function, and returns const pointers from X509_get_subject_name(), X509_NAME_get_entry(), and X509_NAME_ENTRY_get_data().

- Guard SSLv3_method and TLS version methods with version check
- Replace ASN1_STRING_data with ASN1_STRING_get0_data
- Add const qualifiers for X509_NAME, X509_NAME_ENTRY, ASN1_STRING

This is backward-compatible with OpenSSL >= 1.1.0 since all replacement APIs exist since that version.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
