### PR TITLE
Initialise maxFrameSize_ in the TFramedTransport configuration-only constructor

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -329,7 +329,8 @@ public:
       wBufSize_(DEFAULT_BUFFER_SIZE),
       rBuf_(),
       wBuf_(new uint8_t[wBufSize_]),
-      bufReclaimThresh_((std::numeric_limits<uint32_t>::max)()) {
+      bufReclaimThresh_((std::numeric_limits<uint32_t>::max)()),
+      maxFrameSize_(configuration_->getMaxFrameSize()) {
     initPointers();
   }
 

--- a/lib/cpp/test/TTransportFactoryConfigTest.cpp
+++ b/lib/cpp/test/TTransportFactoryConfigTest.cpp
@@ -250,3 +250,31 @@ BOOST_AUTO_TEST_CASE(test_header_transport_accepts_frame_within_max_frame_size) 
   BOOST_CHECK_NO_THROW(reader->readAll(&first, 1));
   BOOST_CHECK_EQUAL(first, static_cast<uint8_t>('B'));
 }
+
+// TFramedTransport has three constructors. The two that take an underlying
+// transport initialise maxFrameSize_ from the configuration; the one that takes
+// only a TConfiguration leaves it out of its member-init list entirely, so
+// getMaxFrameSize() reads an uninitialised member and the frame-size limit it
+// reports is whatever happened to be on the stack.
+//
+// Reading it is undefined, so this is not a guaranteed detector: it fails
+// whenever the indeterminate value differs from the configured limit, which is
+// to say very nearly always, but a run that happens to find the right bytes
+// there would pass. What it does state unconditionally is the contract, which
+// is that all three constructors agree.
+BOOST_AUTO_TEST_CASE(test_framed_transport_default_constructor_initialises_max_frame_size) {
+  TFramedTransport defaulted;
+  BOOST_CHECK_EQUAL(defaulted.getMaxFrameSize(),
+                    static_cast<uint32_t>(TConfiguration::DEFAULT_MAX_FRAME_SIZE));
+
+  const int kMaxFrameSize = 4096;
+  auto config
+      = std::make_shared<TConfiguration>(TConfiguration::DEFAULT_MAX_MESSAGE_SIZE, kMaxFrameSize);
+  TFramedTransport configured(config);
+  BOOST_CHECK_EQUAL(configured.getMaxFrameSize(), static_cast<uint32_t>(kMaxFrameSize));
+
+  // The constructors that take a transport already agree; pin that too, so the
+  // three cannot drift apart again.
+  TFramedTransport wrapped(std::make_shared<TMemoryBuffer>(), config);
+  BOOST_CHECK_EQUAL(wrapped.getMaxFrameSize(), static_cast<uint32_t>(kMaxFrameSize));
+}


### PR DESCRIPTION
`TFramedTransport` has three constructors. The two that take an underlying transport initialise `maxFrameSize_` from the configuration; the one that takes only a `TConfiguration` leaves it out of its member-init list, so `getMaxFrameSize()` reads an uninitialised member and the frame-size limit it reports is whatever happened to be on the stack.

The added test observed `0` and `21988` against a configured `4096` before the fix.

Nothing in the tree uses that constructor, so this is only reachable from outside the library, and a transport built that way has no underlying transport to read from until one is set. It is still an uninitialised read of a member that decides a size limit, and the three constructors should agree.

### Test

`TTransportFactoryConfigTest` gains one case pinning all three constructors against the configuration, so they cannot drift apart again. It states the contract rather than claiming to detect the defect reliably — reading an indeterminate value is undefined, so a run that happened to find the right bytes there would pass.

Verified in the `thrift:jammy` container: `TTransportFactoryConfigTest`, `UnitTests` and `TransportTest` all pass. Formatting checked with `clang-format` against `.clang-format` (the files carry pre-existing drift; the added lines are clean).

No JIRA ticket — this is a one-line fix under the "minor / quick fixes" heading in `AGENTS.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

