### PR TITLE
Stop StreamTest's cleanup handler from masking the failure it is cleaning up after

### DIFF
--- a/lib/haxe/test/src/tests/StreamTest.hx
+++ b/lib/haxe/test/src/tests/StreamTest.hx
@@ -143,7 +143,12 @@ class StreamTest extends tests.TestBase {
             tests.TestBase.Expect( MemoryStreamGrows(), "memory: grows across many writes");
 
         } catch(e:Dynamic) {
-            FileSystem.deleteFile(tmpfile);
+            // Only the two calls above leave the temp file behind, and everything after them
+            // has already deleted it -- so deleting unconditionally here throws
+            // std@file_delete over the top of whatever actually failed.
+            if( FileSystem.exists(tmpfile)) {
+                FileSystem.deleteFile(tmpfile);
+            }
             throw e;
         }
     }


### PR DESCRIPTION
Only the first two calls in `StreamTest.Run()` leave the temp file behind, and every step after them runs once it has already been deleted. The `catch` block deleted it unconditionally, so any failure past that point surfaced as `std@file_delete` instead of the assertion that actually failed.

### Demonstration

Injecting a failing assertion after the deletion point, same injected failure both times:

| | Reported error |
|---|---|
| before | `std@file_delete` |
| after | `Test "INJECTED FAILURE" failed at Run in src/tests/StreamTest.hx:143` |

### Notes

Test-only change; no library code is touched. Found while adding tests elsewhere in this file, where it hid a genuinely failing case until the cause was tracked down.

Verified on neko (full suite); no ticket, as a test-harness tidy-up under the "minor / quick fixes" heading in `AGENTS.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)