### PR TITLE
THRIFT-6161: Charge reads against the message budget in the Haxe TStreamTransport

### DIFF
--- a/lib/haxe/src/org/apache/thrift/transport/TStreamTransport.hx
+++ b/lib/haxe/src/org/apache/thrift/transport/TStreamTransport.hx
@@ -76,6 +76,12 @@ class TStreamTransport extends TEndpointTransport {
         var data : Bytes =  Bytes.alloc(len);
         var size = InputStream.Read( data, off, len);
         buf.addBytes( data, 0, size);
+
+        // Charge the read against the message budget, as every other endpoint does.
+        // MaxMessageSize is expressed as the bytes remaining to be read, so without this
+        // it has no effect here however much a message reads, as long as no single read
+        // exceeds it on its own.
+        CountConsumedMessageBytes(size);
         return size;
     }
 
@@ -101,6 +107,11 @@ class TStreamTransport extends TEndpointTransport {
         }
 
         OutputStream.Flush();
+
+        // One message is done with; give the next one its allowance back. TSocket does the
+        // same at the same point -- without it the budget would only ever shrink, and a
+        // long-lived connection would run itself out of it.
+        ResetConsumedMessageSize();
     }
 
 }

--- a/lib/haxe/test/src/tests/StreamTest.hx
+++ b/lib/haxe/test/src/tests/StreamTest.hx
@@ -22,6 +22,8 @@ import tests.TestBase;
 #if sys
 
 import haxe.Int64;
+import haxe.io.Bytes;
+import haxe.io.BytesBuffer;
 import sys.FileSystem;
 
 import org.apache.thrift.*;
@@ -123,6 +125,62 @@ class StreamTest extends tests.TestBase {
         return true;
     }
 
+    // MaxMessageSize is meant as "a general device to be used with any transport or
+    // protocol" (doc/specs/thrift-tconfiguration.md), and it is expressed as the number of
+    // bytes *remaining* to be read -- which only means something if reads draw it down.
+    // Every other Haxe endpoint charges reads against it; TStreamTransport did not, so the
+    // limit had no effect on a stream-backed connection however much was read.
+    private static function streamTransportWithLimit( maxMessageSize : Int) : TStreamTransport {
+        var config = new TConfiguration();
+        config.MaxMessageSize = maxMessageSize;
+        var stream = new TMemoryStream( Bytes.alloc( 4 * maxMessageSize));
+        stream.Position = 0;
+        return new TStreamTransport( stream, stream, config);
+    }
+
+    // Reading past the limit, a chunk at a time, must be refused. No single read here
+    // exceeds it, so nothing but cumulative accounting can catch this.
+    public static function ReadsAreChargedAgainstTheBudget() : Void {
+        var limit = 256;
+        var trans = streamTransportWithLimit( limit);
+
+        var refused = false;
+        try {
+            var read = 0;
+            while( read < 4 * limit) {
+                var buf = new BytesBuffer();
+                trans.read( buf, 0, 32);
+                read += 32;
+            }
+        }
+        catch( e : TTransportException) {
+            refused = (e.errorID == TTransportException.MESSAGE_SIZE_LIMIT);
+        }
+        tests.TestBase.Expect( refused, "stream: reading past MaxMessageSize is refused");
+    }
+
+    // ... and the allowance has to come back, or one long-lived connection would run itself
+    // out of budget over successive messages. flush() is where the other endpoints do it.
+    public static function FlushRestoresTheBudget() : Void {
+        var limit = 256;
+        var trans = streamTransportWithLimit( limit);
+
+        var buf = new BytesBuffer();
+        trans.read( buf, 0, 200);
+        trans.flush();
+
+        var ok = true;
+        try {
+            var again = new BytesBuffer();
+            trans.read( again, 0, 200);
+        }
+        catch( e : TTransportException) {
+            ok = false;
+        }
+        tests.TestBase.Expect( ok, "stream: flush restores the allowance for the next message");
+    }
+
+
     public static function Run(server : Bool) : Void
     {
         try {
@@ -151,6 +209,10 @@ class StreamTest extends tests.TestBase {
             }
             throw e;
         }
+
+        // Outside the block above: neither of these uses the temp file.
+        ReadsAreChargedAgainstTheBudget();
+        FlushRestoresTheBudget();
     }
 
 }


### PR DESCRIPTION
[THRIFT-6161](https://issues.apache.org/jira/browse/THRIFT-6161) — follows [THRIFT-6160](https://issues.apache.org/jira/browse/THRIFT-6160) (#3755), same subsystem, independent change.

`TStreamTransport` does not charge reads against the message budget, so `MaxMessageSize` has no effect on a stream-backed connection however much a message reads, as long as no single read exceeds the limit on its own. Its `flush()` does not restore the allowance either.

### Why this is a defect in Haxe specifically

There is no single convention across the bindings — there are three, and every other binding keeps to one:

| Binding | Sockets / streams charge? | Boundary-aware endpoints (HTTP, pipe, whole-message buffer) |
|---|---|---|
| cpp, c_glib | no | no — only the zlib transport charges |
| java, netstd | no | yes |
| delphi | yes | yes |
| **haxe** | `TSocket` **yes**, `TStreamTransport` **no** | yes |

Haxe is the only binding that departs from *its own* convention. Its four endpoint transports are `TSocket` (charges, 3 sites), `THttpClient` (charges), `TFullDuplexHttpClient` (charges) and `TStreamTransport` (charges nothing).

`doc/specs/thrift-tconfiguration.md` describes `MaxMessageSize` as "a general device to be used with any transport or protocol", expressed as the bytes *remaining* to be read — which only means something if reads draw it down.

### Fix

Two coordinated changes, mirroring `TSocket`:

- `read()` charges what it read
- `flush()` resets the allowance, at the same point `TSocket` does

**Both are needed.** Charging without resetting would leave the budget only ever shrinking, so a long-lived connection would run itself out of it — which is exactly THRIFT-6160, fixed just before this.

### Tests

Two, in `StreamTest`, failing before and passing after. The first reads past the limit 32 bytes at a time, so nothing but cumulative accounting can catch it; the second checks the allowance comes back.

Verified on neko — full suite, including the existing stream, constants and recursion-limit tests, **all of which read through `TStreamTransport`** and now have charged reads. The python and php targets cross-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)