### PR TITLE
THRIFT-6164: Bound the depth thrift_protocol:skip/2 will follow

### DIFF
--- a/lib/erl/include/thrift_constants.hrl
+++ b/lib/erl/include/thrift_constants.hrl
@@ -66,3 +66,7 @@
 
 -define(MULTIPLEXED_SERVICE_SEPARATOR, ":").
 -define(MULTIPLEXED_ERROR_HANDLER_KEY, "error_handler").
+
+%% How far thrift_protocol:skip/2 will follow nesting that the peer, rather
+%% than the IDL, chose the shape of. Same value the other bindings use.
+-define(DEFAULT_RECURSION_DEPTH, 64).

--- a/lib/erl/src/thrift_protocol.erl
+++ b/lib/erl/src/thrift_protocol.erl
@@ -25,6 +25,7 @@
     read/2,
     read/3,
     skip/2,
+    skip/3,
     flush_transport/1,
     close_transport/1,
     typeid_to_atom/1
@@ -268,39 +269,55 @@ skip_field(FType, IProto0, SDict, RTuple) ->
 
 -spec skip(#protocol{}, atom()) -> {#protocol{}, ok}.
 
-skip(Proto0, struct) ->
+%% What this walks is decided by type ids taken off the wire rather than by
+%% the IDL, so the peer picks the nesting and pays three bytes a level for it.
+%% The allowance starts fresh here: everything that ran before this point came
+%% through the generated readers, whose depth is fixed by the declared types
+%% and cannot be driven from the wire, so there is nothing earlier to charge.
+skip(Proto, Type) ->
+    skip(Proto, Type, ?DEFAULT_RECURSION_DEPTH).
+
+-spec skip(#protocol{}, atom(), integer()) -> {#protocol{}, ok}.
+
+skip(_Proto, _Type, Depth) when Depth =< 0 ->
+    error({protocol_error, max_skip_depth_exceeded});
+skip(Proto0, struct, Depth) ->
     {Proto1, ok} = read(Proto0, struct_begin),
-    {Proto2, ok} = skip_struct_loop(Proto1),
+    {Proto2, ok} = skip_struct_loop(Proto1, Depth),
     {Proto3, ok} = read(Proto2, struct_end),
     {Proto3, ok};
-skip(Proto0, map) ->
+skip(Proto0, map, Depth) ->
     {Proto1, Map} = read(Proto0, map_begin),
-    {Proto2, ok} = skip_map_loop(Proto1, Map),
+    {Proto2, ok} = skip_map_loop(Proto1, Map, Depth),
     {Proto3, ok} = read(Proto2, map_end),
     {Proto3, ok};
-skip(Proto0, set) ->
+skip(Proto0, set, Depth) ->
     {Proto1, Set} = read(Proto0, set_begin),
-    {Proto2, ok} = skip_set_loop(Proto1, Set),
+    {Proto2, ok} = skip_set_loop(Proto1, Set, Depth),
     {Proto3, ok} = read(Proto2, set_end),
     {Proto3, ok};
-skip(Proto0, list) ->
+skip(Proto0, list, Depth) ->
     {Proto1, List} = read(Proto0, list_begin),
-    {Proto2, ok} = skip_list_loop(Proto1, List),
+    {Proto2, ok} = skip_list_loop(Proto1, List, Depth),
     {Proto3, ok} = read(Proto2, list_end),
     {Proto3, ok};
-skip(Proto0, Type) when is_atom(Type) ->
+skip(Proto0, Type, _Depth) when is_atom(Type) ->
     {Proto1, _Ignore} = read(Proto0, Type),
     {Proto1, ok}.
 
-skip_struct_loop(Proto0) ->
+%% The loops below recurse once per element, which is a tail call and costs no
+%% stack, and once per level of nesting, which does. Only the second dimension
+%% spends the allowance.
+
+skip_struct_loop(Proto0, Depth) ->
     {Proto1, #protocol_field_begin{type = Type}} = read(Proto0, field_begin),
     case Type of
         ?tType_STOP ->
             {Proto1, ok};
         _Else ->
-            {Proto2, ok} = skip(Proto1, typeid_to_atom(Type)),
+            {Proto2, ok} = skip(Proto1, typeid_to_atom(Type), Depth - 1),
             {Proto3, ok} = read(Proto2, field_end),
-            skip_struct_loop(Proto3)
+            skip_struct_loop(Proto3, Depth)
     end.
 
 skip_map_loop(
@@ -309,15 +326,17 @@ skip_map_loop(
         ktype = Ktype,
         vtype = Vtype,
         size = Size
-    }
+    },
+    Depth
 ) ->
     case Size of
         N when N > 0 ->
-            {Proto1, ok} = skip(Proto0, typeid_to_atom(Ktype)),
-            {Proto2, ok} = skip(Proto1, typeid_to_atom(Vtype)),
+            {Proto1, ok} = skip(Proto0, typeid_to_atom(Ktype), Depth - 1),
+            {Proto2, ok} = skip(Proto1, typeid_to_atom(Vtype), Depth - 1),
             skip_map_loop(
                 Proto2,
-                Map#protocol_map_begin{size = Size - 1}
+                Map#protocol_map_begin{size = Size - 1},
+                Depth
             );
         0 ->
             {Proto0, ok}
@@ -328,14 +347,16 @@ skip_set_loop(
     Map = #protocol_set_begin{
         etype = Etype,
         size = Size
-    }
+    },
+    Depth
 ) ->
     case Size of
         N when N > 0 ->
-            {Proto1, ok} = skip(Proto0, typeid_to_atom(Etype)),
+            {Proto1, ok} = skip(Proto0, typeid_to_atom(Etype), Depth - 1),
             skip_set_loop(
                 Proto1,
-                Map#protocol_set_begin{size = Size - 1}
+                Map#protocol_set_begin{size = Size - 1},
+                Depth
             );
         0 ->
             {Proto0, ok}
@@ -346,14 +367,16 @@ skip_list_loop(
     Map = #protocol_list_begin{
         etype = Etype,
         size = Size
-    }
+    },
+    Depth
 ) ->
     case Size of
         N when N > 0 ->
-            {Proto1, ok} = skip(Proto0, typeid_to_atom(Etype)),
+            {Proto1, ok} = skip(Proto0, typeid_to_atom(Etype), Depth - 1),
             skip_list_loop(
                 Proto1,
-                Map#protocol_list_begin{size = Size - 1}
+                Map#protocol_list_begin{size = Size - 1},
+                Depth
             );
         0 ->
             {Proto0, ok}

--- a/lib/erl/test/test_thrift_skip_depth.erl
+++ b/lib/erl/test/test_thrift_skip_depth.erl
@@ -1,0 +1,135 @@
+%%
+%% Licensed to the Apache Software Foundation (ASF) under one
+%% or more contributor license agreements. See the NOTICE file
+%% distributed with this work for additional information
+%% regarding copyright ownership. The ASF licenses this file
+%% to you under the Apache License, Version 2.0 (the
+%% "License"); you may not use this file except in compliance
+%% with the License. You may obtain a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%% How deep thrift_protocol:skip/2 will follow a peer's nesting.
+%%
+%% skip/2 is driven by type ids taken off the wire, not by the IDL, so the
+%% peer picks the shape and the depth.  Three bytes buy a struct level and
+%% five buy a list level, which is the whole of the cost to the sender.
+%%
+%% The depth these tests use is far past anything a schema produces: the
+%% generated readers only recurse as deep as the declared types, so nothing
+%% legitimate comes near the ceiling.  The last two tests say so from the
+%% other side -- a reasonable nesting still skips, and a caller who wants a
+%% different ceiling can pass one.
+
+-module(test_thrift_skip_depth).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("thrift_constants.hrl").
+
+%% Comfortably past the ceiling, and still under half a kilobyte on the wire.
+-define(TOO_DEEP, 200).
+
+new(Buf) ->
+    {ok, Transport} = thrift_membuffer_transport:new(Buf),
+    {ok, Protocol} = thrift_binary_protocol:new(Transport),
+    Protocol.
+
+%% ---------------------------------------------------------------------------
+%% Each container type nests through its own skip loop, so each gets a test.
+%% ---------------------------------------------------------------------------
+
+deeply_nested_structs_are_refused_test() ->
+    P = new(nested_structs(?TOO_DEEP)),
+    ?assertError(
+        {protocol_error, max_skip_depth_exceeded},
+        thrift_protocol:skip(P, struct)
+    ).
+
+deeply_nested_lists_are_refused_test() ->
+    P = new(nested_lists(?TOO_DEEP)),
+    ?assertError(
+        {protocol_error, max_skip_depth_exceeded},
+        thrift_protocol:skip(P, list)
+    ).
+
+deeply_nested_sets_are_refused_test() ->
+    P = new(nested_sets(?TOO_DEEP)),
+    ?assertError(
+        {protocol_error, max_skip_depth_exceeded},
+        thrift_protocol:skip(P, set)
+    ).
+
+deeply_nested_maps_are_refused_test() ->
+    P = new(nested_maps(?TOO_DEEP)),
+    ?assertError(
+        {protocol_error, max_skip_depth_exceeded},
+        thrift_protocol:skip(P, map)
+    ).
+
+%% The wire cost of getting there, stated as a number so that a later change
+%% to the ceiling has to look at it: 200 struct levels is 801 bytes.
+nesting_is_cheap_to_send_test() ->
+    ?assertEqual(801, byte_size(nested_structs(?TOO_DEEP))).
+
+%% ---------------------------------------------------------------------------
+%% ...and the ceiling has to stay out of the way of real messages.
+%% ---------------------------------------------------------------------------
+
+ordinary_nesting_still_skips_test() ->
+    P = new(nested_structs(16)),
+    ?assertMatch({_, ok}, thrift_protocol:skip(P, struct)).
+
+%% skip/3 takes the ceiling as an argument, so a caller with a stricter idea
+%% of what its schema can contain can say so.
+an_explicit_ceiling_is_honoured_test() ->
+    P = new(nested_structs(16)),
+    ?assertError(
+        {protocol_error, max_skip_depth_exceeded},
+        thrift_protocol:skip(P, struct, 4)
+    ),
+    Q = new(nested_structs(16)),
+    ?assertMatch({_, ok}, thrift_protocol:skip(Q, struct, 32)).
+
+%% ---------------------------------------------------------------------------
+%% Wire shapes.  Each level holds exactly one thing, so the depth is the
+%% only dimension that grows.
+%% ---------------------------------------------------------------------------
+
+%% Level 0 is the empty struct; every level above it is one struct-typed
+%% field holding the level below.  3 bytes for the field header, 1 for the
+%% stop.
+nested_structs(0) ->
+    <<?tType_STOP>>;
+nested_structs(N) ->
+    Inner = nested_structs(N - 1),
+    <<?tType_STRUCT, 0, 1, Inner/binary, ?tType_STOP>>.
+
+%% Level 0 is an empty list of bool; every level above it is a one-element
+%% list of list.  5 bytes a level.
+nested_lists(0) ->
+    <<?tType_BOOL, 0, 0, 0, 0>>;
+nested_lists(N) ->
+    Inner = nested_lists(N - 1),
+    <<?tType_LIST, 0, 0, 0, 1, Inner/binary>>.
+
+nested_sets(0) ->
+    <<?tType_BOOL, 0, 0, 0, 0>>;
+nested_sets(N) ->
+    Inner = nested_sets(N - 1),
+    <<?tType_SET, 0, 0, 0, 1, Inner/binary>>.
+
+%% Maps carry a key as well, so each level is a bool key followed by the map
+%% below it.  7 bytes a level.
+nested_maps(0) ->
+    <<?tType_BOOL, ?tType_BOOL, 0, 0, 0, 0>>;
+nested_maps(N) ->
+    Inner = nested_maps(N - 1),
+    <<?tType_BOOL, ?tType_MAP, 0, 0, 0, 1, 0, Inner/binary>>.


### PR DESCRIPTION
[THRIFT-6164](https://issues.apache.org/jira/browse/THRIFT-6164)

`thrift_protocol:skip/2` walks type ids taken off the wire rather than the types the IDL declared, so the peer chooses both the shape of the nesting and how deep it goes. `skip/2` and the four skip loops — `skip_struct_loop`, `skip_map_loop`, `skip_set_loop`, `skip_list_loop` — call one another with nothing carrying a depth.

A struct level costs the sender three bytes. 200 levels of nesting is 801 bytes on the wire.

### Change

`skip/2` seeds `DEFAULT_RECURSION_DEPTH`, 64 — the same value `lib/py` and `lib/cpp` already use — and each level of nesting spends one. `skip/3` is exported so a caller who knows what its own schema can contain can ask for a lower ceiling. Exceeding the ceiling raises `error({protocol_error, max_skip_depth_exceeded})`, matching the binding's existing `negative_size` idiom.

### Two things this deliberately does not do

- **No guard on the typed read path.** `read/2`'s `struct`, `list`, `map` and `set` clauses recurse on a type taken from the generated `struct_info`, never from the wire, so their depth is fixed by the IDL and a peer cannot drive it. That is why the allowance starts fresh at `skip/2` rather than being threaded down from the reader.
- **No charge for element counts.** The three container loops recurse once per element in tail position, which costs no stack. Charging them there would refuse large flat containers while leaving the dimension that does consume stack wide open.

### Tests

Seven over a memory buffer: one per container type, one pinning the wire cost of 200 struct levels at 801 bytes, one checking ordinary nesting still skips, and one checking an explicit ceiling passed to `skip/3` is honoured. Five of the seven fail against the unmodified library.

`rebar3 eunit` on OTP 25: 324 → 331 tests, 0 failures. `rebar3 xref` clean, `rebar3 fmt --check` clean apart from the pre-existing `src/thrift_binary_protocol.erl` warning.

### Not the last gap

`lib/d`'s `skip()` (`lib/d/src/thrift/protocol/base.d:262`) has no depth parameter either — worth knowing so this is not mistaken for closing the sweep. Separate change, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
