### PR TITLE
THRIFT-6174: Make it compatible with OpenSSL 4.0

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
@@ -285,7 +285,9 @@ thrift_ssl_socket_close (ThriftTransport *transport, GError **error)
       SSL_shutdown(ssl_socket->ssl);
       SSL_free(ssl_socket->ssl);
       ssl_socket->ssl = NULL;
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
       ERR_remove_state(0);
+#endif
   }
   return thrift_socket_close(transport, error);
 }
@@ -710,7 +712,9 @@ void thrift_ssl_socket_finalize_openssl(void)
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
   ERR_remove_state(0);
+#endif
 }
 
 
@@ -832,6 +836,12 @@ thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GErro
 {
   SSL_CTX* context = NULL;
   switch(ssl_protocol){
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+    case SSLTLS:
+    case LATEST:
+      context = SSL_CTX_new(TLS_method());
+      break;
+#else
     case SSLTLS:
       context = SSL_CTX_new(SSLv23_method());
       break;
@@ -849,6 +859,7 @@ thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GErro
     case TLSv1_2:
       context = SSL_CTX_new(TLSv1_2_method());
       break;
+#endif
     default:
       g_set_error (error, THRIFT_TRANSPORT_ERROR,
 		   THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE,

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -157,7 +157,7 @@ void cleanupOpenSSL() {
 #endif
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
   // Do nothing unless an openssl derivative is detected
 #  if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
   // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
@@ -180,6 +180,10 @@ static char uppercase(char c);
 
 // SSLContext implementation
 SSLContext::SSLContext(const SSLProtocol& protocol) {
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+  if (protocol == SSLTLS || protocol == LATEST) {
+    ctx_ = SSL_CTX_new(TLS_method());
+#else
   if (protocol == SSLTLS) {
     ctx_ = SSL_CTX_new(SSLv23_method());
 #ifndef OPENSSL_NO_SSL3
@@ -192,6 +196,7 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
     ctx_ = SSL_CTX_new(TLSv1_1_method());
   } else if (protocol == TLSv1_2) {
     ctx_ = SSL_CTX_new(TLSv1_2_method());
+#endif
   } else {
     /// UNKNOWN PROTOCOL!
     throw TSSLException("SSL_CTX_new: Unknown protocol");
@@ -405,7 +410,7 @@ void TSSLSocket::close() {
     SSL_free(ssl_);
     ssl_ = nullptr;
     handshakeCompleted_ = false;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
     // Do nothing unless an openssl derivative is detected
 #  if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
@@ -800,9 +805,16 @@ void TSSLSocket::authorize() {
   }
 
   // extract commonName
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+  const X509_NAME* name = X509_get_subject_name(cert);
+  const X509_NAME_ENTRY* entry;
+  const ASN1_STRING* common;
+#else
   X509_NAME* name = X509_get_subject_name(cert);
+  X509_NAME_ENTRY* entry;
+  ASN1_STRING* common;
+#endif
   if (name != nullptr) {
-    X509_NAME_ENTRY* entry;
     unsigned char* utf8;
     int last = -1;
     while (decision == AccessManager::SKIP) {
@@ -812,7 +824,7 @@ void TSSLSocket::authorize() {
       entry = X509_NAME_get_entry(name, last);
       if (entry == nullptr)
         continue;
-      ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
+      common = X509_NAME_ENTRY_get_data(entry);
       int size = ASN1_STRING_to_UTF8(&utf8, common);
       if (host.empty()) {
         host = (server() ? getPeerHost() : getHost());

--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -235,6 +235,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
           continue;
         }
 #endif
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+	if (!(si == apache::thrift::transport::SSLTLS ||
+	      si == apache::thrift::transport::LATEST) ||
+	    !(ci == apache::thrift::transport::SSLTLS ||
+	      ci == apache::thrift::transport::LATEST))
+	{
+		// Only SSLTLS / LATEST is supported.
+		continue;
+	}
+#endif
 
         boost::mutex::scoped_lock lock(mMutex);
 

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -364,6 +364,16 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
                     continue;
                 }
 #endif
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+		if (!(si == apache::thrift::transport::SSLTLS ||
+		     si == apache::thrift::transport::LATEST) ||
+		    !(ci == apache::thrift::transport::SSLTLS ||
+		      ci == apache::thrift::transport::LATEST))
+                {
+                    // Only SSLTLS / LATEST is supported.
+                    continue;
+                }
+#endif
 
                 boost::mutex::scoped_lock lock(mMutex);
 


### PR DESCRIPTION
Make it compatible with OpenSSL 4.0:
- Remove ERR_remove_state(). It has been an empty stub since OpenSSL 1.1.0. Given that it was doing nothingfor so long, there is no need to preserve anything for the earlier versions.

- SSLv3_method(), TLSv1_method(), TLSv1_1_method() and TLSv1_2_method() have been removed. The recommendation is to use TLS_method() instead. SSLv23_method() is an alias for TLS_method(). It is possible to allow a different TLS version by using SSL_CTX_set_min_proto_version()/ SSL_CTX_set_max_proto_version() but be aware that TLSv1.2 is usually the lower supported version and TLSv1.3 should be the default.

- The return value of a few functions such as X509_get_subject_name() has been made const. The return value should not be modified before that change.

<!-- Explain the changes in the pull request below: -->
  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
Now, I guess this is trivial.

- [X] Did you squash your changes to a single commit?  (not required, but preferred)
- [X] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
Yes
- [X] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.