### PR TITLE
THRIFT-6165: Bind the Java read budget to the frame that carries the message

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/transport/TEndpointTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TEndpointTransport.java
@@ -78,6 +78,17 @@ public abstract class TEndpointTransport extends TTransport {
   }
 
   /**
+   * Sets the read budget to newSize, discarding whatever has been consumed against the previous
+   * one. A negative size restores the configured maximum.
+   *
+   * @param newSize
+   */
+  @Override
+  public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {
+    resetConsumedMessageSize(newSize);
+  }
+
+  /**
    * Updates RemainingMessageSize to reflect then known real message size (e.g. framed transport).
    * Will throw if we already consumed too many bytes or if the new size is larger than allowed.
    *

--- a/lib/java/src/main/java/org/apache/thrift/transport/TFileTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TFileTransport.java
@@ -567,6 +567,9 @@ public class TFileTransport extends TTransport {
   @Override
   public void checkReadBytesAvailable(long numBytes) throws TTransportException {}
 
+  @Override
+  public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {}
+
   /** test program */
   public static void main(String[] args) throws Exception {
 

--- a/lib/java/src/main/java/org/apache/thrift/transport/TMemoryInputTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TMemoryInputTransport.java
@@ -63,7 +63,12 @@ public final class TMemoryInputTransport extends TEndpointTransport {
     pos_ = offset;
     endPos_ = offset + length;
     try {
+      // The buffer holds one whole message and nothing more can arrive, so bind the budget to it,
+      // as the constructor already does. The reset first is what lets a larger message follow a
+      // smaller one. Reads here are clamped to the buffer and short-read rather than checked
+      // against the budget, so this only tightens what the protocol may declare.
       resetConsumedMessageSize(-1);
+      updateKnownMessageSize(length);
     } catch (TTransportException e) {
       // ignore
     }

--- a/lib/java/src/main/java/org/apache/thrift/transport/TTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TTransport.java
@@ -199,4 +199,23 @@ public abstract class TTransport implements Closeable {
   public abstract void updateKnownMessageSize(long size) throws TTransportException;
 
   public abstract void checkReadBytesAvailable(long numBytes) throws TTransportException;
+
+  /**
+   * Sets the read budget to {@code newSize}, discarding whatever has been consumed against the
+   * previous one. A negative size restores the configured maximum.
+   *
+   * <p>This is the only way to widen a budget that an earlier, smaller message narrowed:
+   * updateKnownMessageSize() refuses to grow one, and carries the previous message's consumption
+   * forward besides. A caller that learns the real size of a message -- a framed transport reading
+   * a frame header, say -- wants this rather than updateKnownMessageSize(), because the reads that
+   * told it the size were themselves charged against the budget it is about to replace.
+   *
+   * @param newSize the size to bind the budget to, or a negative value for the configured maximum
+   */
+  public abstract void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException;
+
+  /** Restores the read budget to the configured maximum. */
+  public void resetMessageSizeAndConsumedBytes() throws TTransportException {
+    resetMessageSizeAndConsumedBytes(-1);
+  }
 }

--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TFastFramedTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TFastFramedTransport.java
@@ -140,6 +140,9 @@ public class TFastFramedTransport extends TLayeredTransport {
   }
 
   private void readFrame() throws TTransportException {
+    // See TFramedTransport.readFrame(): the framing reads need a full budget of their own.
+    resetMessageSizeAndConsumedBytes();
+
     getInnerTransport().readAll(i32buf, 0, 4);
     int size = TFramedTransport.decodeFrameSize(i32buf);
 
@@ -157,6 +160,10 @@ public class TFastFramedTransport extends TLayeredTransport {
     }
 
     readBuffer.fill(getInnerTransport(), size);
+
+    // Bind the read budget to this frame; see TFramedTransport.readFrame() for why this discards
+    // consumption rather than accumulating it.
+    resetMessageSizeAndConsumedBytes(size);
   }
 
   @Override

--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TFramedTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TFramedTransport.java
@@ -129,6 +129,12 @@ public class TFramedTransport extends TLayeredTransport {
   private final byte[] i32buf = new byte[4];
 
   private void readFrame() throws TTransportException {
+    // Hand the framing reads below a full budget. Whatever is left of the previous frame's bound
+    // describes a frame we are done with, and an inner transport that decrements on read -- a
+    // TMemoryBuffer, or the TMemoryInputTransport the nonblocking server uses -- would otherwise
+    // refuse to let us read a frame larger than the last one.
+    resetMessageSizeAndConsumedBytes();
+
     getInnerTransport().readAll(i32buf, 0, 4);
     int size = decodeFrameSize(i32buf);
 
@@ -152,6 +158,16 @@ public class TFramedTransport extends TLayeredTransport {
     byte[] buff = new byte[size];
     getInnerTransport().readAll(buff, 0, size);
     readBuffer_.reset(buff);
+
+    // Bind the read budget to this frame, so that the protocol cannot be talked into sizing a
+    // field or a container from a number the frame is too small to carry.
+    //
+    // This has to discard consumption rather than accumulate it, which is why it is not
+    // updateKnownMessageSize(): getting the frame off the wire was itself charged to the inner
+    // transport whenever that one decrements, and charging it again against the frame's own bound
+    // would leave the frame unreadable. Everything the protocol reads from here on comes out of
+    // readBuffer_, so what is bound here stands for the whole frame.
+    resetMessageSizeAndConsumedBytes(size);
   }
 
   public void write(byte[] buf, int off, int len) throws TTransportException {

--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TLayeredTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TLayeredTransport.java
@@ -47,6 +47,11 @@ public abstract class TLayeredTransport extends TTransport {
     innerTransport.checkReadBytesAvailable(numBytes);
   }
 
+  @Override
+  public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {
+    innerTransport.resetMessageSizeAndConsumedBytes(newSize);
+  }
+
   public TTransport getInnerTransport() {
     return innerTransport;
   }

--- a/lib/java/src/test/java/org/apache/thrift/test/SerializationBenchmark.java
+++ b/lib/java/src/test/java/org/apache/thrift/test/SerializationBenchmark.java
@@ -54,6 +54,8 @@ public class SerializationBenchmark {
 
           public void checkReadBytesAvailable(long numBytes) throws TTransportException {}
 
+          public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {}
+
           public int read(byte[] bin, int x, int y) throws TTransportException {
             return 0;
           }

--- a/lib/java/src/test/java/org/apache/thrift/transport/ReadCountingTransport.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/ReadCountingTransport.java
@@ -74,4 +74,9 @@ public class ReadCountingTransport extends TTransport {
   public void checkReadBytesAvailable(long numBytes) throws TTransportException {
     trans.checkReadBytesAvailable(numBytes);
   }
+
+  @Override
+  public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {
+    trans.resetMessageSizeAndConsumedBytes(newSize);
+  }
 }

--- a/lib/java/src/test/java/org/apache/thrift/transport/TestFrameBoundReadBudget.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/TestFrameBoundReadBudget.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.thrift.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.layered.TFastFramedTransport;
+import org.apache.thrift.transport.layered.TFramedTransport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The read budget is bound to the size of the frame that carries the message, rather than staying
+ * at the configured maximum for the life of the connection.
+ *
+ * <p>Two groups of tests, and the distinction matters when reading a failure:
+ *
+ * <ul>
+ *   <li>The {@code testConsecutive*} tests describe traffic that has always been legitimate. They
+ *       pass on the unmodified library and must keep passing. They exist because the natural
+ *       implementation of frame binding breaks them: {@link
+ *       TEndpointTransport#resetConsumedMessageSize} refuses to grow a budget, so a second frame
+ *       larger than the first is rejected unless each frame performs a full reset before binding.
+ *       Java is exposed here in a way the other bindings are not, because its only reset on the
+ *       socket path lives in {@code TIOStreamTransport.flush()} — the write side — which a oneway
+ *       call never reaches.
+ *   <li>The {@code testDeclared*} tests describe the behaviour being added: a small frame may not
+ *       declare a field larger than itself.
+ * </ul>
+ */
+public class TestFrameBoundReadBudget {
+
+  /** Writes one frame: a 4-byte big-endian length followed by that many bytes. */
+  private static void writeFrame(DataOutputStream dos, byte[] payload) throws IOException {
+    dos.writeInt(payload.length);
+    dos.write(payload);
+  }
+
+  private static byte[] filler(int n) {
+    byte[] b = new byte[n];
+    for (int i = 0; i < n; i++) {
+      b[i] = (byte) i;
+    }
+    return b;
+  }
+
+  /**
+   * A binary-protocol string field body: a 4-byte length followed by that many bytes. Used to build
+   * a payload whose declared length disagrees with the bytes actually present.
+   */
+  private static byte[] declaredString(int declaredLength, int actualBytes) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeInt(declaredLength);
+    dos.write(filler(actualBytes));
+    return baos.toByteArray();
+  }
+
+  /**
+   * An endpoint that behaves like a socket for budget purposes: it never binds the budget to
+   * anything, and its only reset lives on the write side. {@code TMemoryBuffer} cannot stand in
+   * here — its constructor calls {@code updateKnownMessageSize}, which is the very behaviour under
+   * test.
+   */
+  private static TEndpointTransport socketLike(byte[] wire, int maxMessageSize)
+      throws TTransportException {
+    TConfiguration config = new TConfiguration();
+    config.setMaxMessageSize(maxMessageSize);
+    return new TIOStreamTransport(config, new ByteArrayInputStream(wire));
+  }
+
+  private static TTransport framedOver(byte[] wire, int maxMessageSize) throws TTransportException {
+    return new TFramedTransport(socketLike(wire, maxMessageSize));
+  }
+
+  private static TTransport fastFramedOver(byte[] wire, int maxMessageSize)
+      throws TTransportException {
+    return new TFastFramedTransport(socketLike(wire, maxMessageSize), 64, maxMessageSize);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Traffic that has always been legitimate, and must remain so.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Two frames on one connection, the second larger than the first, with nothing in between. This
+   * is what a stream of oneway calls looks like: {@code ProcessFunction} skips the response write
+   * for a oneway function, so no flush occurs and nothing resets the budget between messages.
+   */
+  @Test
+  public void testConsecutiveFramesGrowingInSize() throws IOException, TTransportException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    writeFrame(dos, filler(16));
+    writeFrame(dos, filler(4096));
+
+    TTransport trans = framedOver(baos.toByteArray(), 1024 * 1024);
+
+    byte[] first = new byte[16];
+    trans.readAll(first, 0, 16);
+
+    // Second frame is 256x the first. Nothing has reset the budget in between.
+    byte[] second = new byte[4096];
+    assertEquals(4096, trans.readAll(second, 0, 4096));
+  }
+
+  /** As above, for the second framed implementation. */
+  @Test
+  public void testConsecutiveFramesGrowingInSizeFastFramed()
+      throws IOException, TTransportException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    writeFrame(dos, filler(16));
+    writeFrame(dos, filler(4096));
+
+    TTransport trans = fastFramedOver(baos.toByteArray(), 1024 * 1024);
+
+    byte[] first = new byte[16];
+    trans.readAll(first, 0, 16);
+
+    byte[] second = new byte[4096];
+    assertEquals(4096, trans.readAll(second, 0, 4096));
+  }
+
+  /**
+   * Many frames in a row, alternating size. A budget that is bound but never reset would be
+   * consumed cumulatively and start rejecting valid frames partway through.
+   */
+  @Test
+  public void testManyConsecutiveFrames() throws IOException, TTransportException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    final int frames = 64;
+    for (int i = 0; i < frames; i++) {
+      writeFrame(dos, filler(i % 2 == 0 ? 32 : 512));
+    }
+
+    // A budget large enough for any single frame, but far smaller than their sum.
+    TTransport trans = framedOver(baos.toByteArray(), 4096);
+
+    for (int i = 0; i < frames; i++) {
+      int expected = i % 2 == 0 ? 32 : 512;
+      byte[] buf = new byte[expected];
+      assertEquals(expected, trans.readAll(buf, 0, expected), "frame " + i);
+    }
+  }
+
+  /** A field that fits inside its frame is read normally. */
+  @Test
+  public void testFieldFittingInFrameIsAccepted() throws IOException, TException {
+    byte[] payload = declaredString(64, 64);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeFrame(new DataOutputStream(baos), payload);
+
+    TTransport trans = framedOver(baos.toByteArray(), 100 * 1024 * 1024);
+    TProtocol proto = new TBinaryProtocol(trans);
+
+    assertEquals(64, proto.readBinary().remaining());
+  }
+
+  // ---------------------------------------------------------------------------
+  // The behaviour being added.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A 68-byte frame declares a 64 MB field. The bytes are not present and never will be, but while
+   * the declared size is checked against the full configured maximum the 64 MB array is allocated
+   * first and the mismatch only surfaces afterwards, when the read runs out of data.
+   *
+   * <p>The exception type is what distinguishes the two: {@code END_OF_FILE} means the size was
+   * accepted and discovered to be wrong after allocating; {@code MESSAGE_SIZE_LIMIT} means it was
+   * refused on the budget before anything was allocated. Unmodified, this throws {@code
+   * END_OF_FILE}.
+   */
+  @Test
+  public void testDeclaredFieldLargerThanFrameIsRejected() throws IOException, TTransportException {
+    byte[] payload = declaredString(64 * 1024 * 1024, 64);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeFrame(new DataOutputStream(baos), payload);
+
+    TTransport trans = framedOver(baos.toByteArray(), 100 * 1024 * 1024);
+    TProtocol proto = new TBinaryProtocol(trans);
+
+    TTransportException e = assertThrows(TTransportException.class, proto::readBinary);
+    assertEquals(TTransportException.MESSAGE_SIZE_LIMIT, e.getType());
+  }
+
+  /** As above, for the second framed implementation. */
+  @Test
+  public void testDeclaredFieldLargerThanFrameIsRejectedFastFramed()
+      throws IOException, TTransportException {
+    byte[] payload = declaredString(64 * 1024 * 1024, 64);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeFrame(new DataOutputStream(baos), payload);
+
+    TTransport trans = fastFramedOver(baos.toByteArray(), 100 * 1024 * 1024);
+    TProtocol proto = new TBinaryProtocol(trans);
+
+    TTransportException e = assertThrows(TTransportException.class, proto::readBinary);
+    assertEquals(TTransportException.MESSAGE_SIZE_LIMIT, e.getType());
+  }
+
+  /**
+   * The path the nonblocking servers take. They strip the frame themselves and hand the payload to
+   * a {@link TMemoryInputTransport} via {@code reset}, so a fix confined to the framed transports
+   * would not cover them. Unmodified, this throws {@code UNKNOWN} — the buffer simply runs out.
+   */
+  @Test
+  public void testDeclaredFieldLargerThanResetBufferIsRejected() throws TTransportException {
+    TConfiguration config = new TConfiguration();
+    config.setMaxMessageSize(100 * 1024 * 1024);
+
+    TMemoryInputTransport trans = new TMemoryInputTransport(config, new byte[0]);
+    TProtocol proto = new TBinaryProtocol(trans);
+
+    // A 68-byte message declaring a 64 MB field, as AbstractNonblockingServer would supply it.
+    byte[] payload;
+    try {
+      payload = declaredString(64 * 1024 * 1024, 64);
+    } catch (IOException io) {
+      throw new AssertionError(io);
+    }
+    trans.reset(payload);
+
+    TTransportException e = assertThrows(TTransportException.class, proto::readBinary);
+    assertEquals(TTransportException.MESSAGE_SIZE_LIMIT, e.getType());
+  }
+
+  /**
+   * The frame must be readable even when getting it off the wire spent the inner transport's whole
+   * budget -- which is the shape {@code AbstractNonblockingServer} has, and the reason the bound
+   * cannot simply be put on the inner transport.
+   *
+   * <p>{@link TFramedTransport} inherits {@code checkReadBytesAvailable} from {@link
+   * org.apache.thrift.transport.layered.TLayeredTransport}, which forwards it to the inner
+   * transport. Reading the frame is also done through the inner transport, so when that one
+   * decrements on read -- as {@link TMemoryInputTransport} does, and as the nonblocking server's
+   * {@code frameTrans_} therefore does -- the framing reads consume the budget before the protocol
+   * asks its first question. Here a 68-byte frame arrives in a 72-byte buffer bound to 72, and
+   * readFrame() takes all 72.
+   *
+   * <p>Without the full reset in readFrame(), the 64-byte field below is refused with {@code
+   * MESSAGE_SIZE_LIMIT} even though every one of its bytes is sitting in the frame buffer. This
+   * test failed exactly that way before the reset was added.
+   */
+  @Test
+  public void testFrameSurvivesTheFramingSpendingTheInnerBudget() throws IOException, TException {
+    byte[] payload = declaredString(64, 64); // 68 bytes
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeFrame(new DataOutputStream(baos), payload); // 72 bytes with the header
+
+    TConfiguration config = new TConfiguration();
+    config.setMaxMessageSize(100 * 1024 * 1024);
+    // The constructor binds the budget to the 72 bytes handed to it.
+    TMemoryInputTransport inner = new TMemoryInputTransport(config, baos.toByteArray());
+    TFramedTransport trans = new TFramedTransport(inner);
+    TProtocol proto = new TBinaryProtocol(trans);
+
+    assertEquals(64, proto.readBinary().remaining());
+  }
+
+  /** Successive {@code reset} calls must each start from a full budget, growing or shrinking. */
+  @Test
+  public void testConsecutiveResetsGrowingInSize() throws TTransportException {
+    TConfiguration config = new TConfiguration();
+    config.setMaxMessageSize(1024 * 1024);
+
+    TMemoryInputTransport trans = new TMemoryInputTransport(config, new byte[0]);
+
+    trans.reset(filler(16));
+    byte[] first = new byte[16];
+    assertEquals(16, trans.read(first, 0, 16));
+
+    trans.reset(filler(4096));
+    byte[] second = new byte[4096];
+    assertEquals(4096, trans.read(second, 0, 4096));
+  }
+}

--- a/lib/java/src/test/java/org/apache/thrift/transport/TestTSaslTransports.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/TestTSaslTransports.java
@@ -557,6 +557,11 @@ public class TestTSaslTransports {
     public void checkReadBytesAvailable(long numBytes) throws TTransportException {
       readBuffer.checkReadBytesAvailable(numBytes);
     }
+
+    @Override
+    public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {
+      readBuffer.resetMessageSizeAndConsumedBytes(newSize);
+    }
   }
 
   @Test

--- a/lib/java/src/test/java/org/apache/thrift/transport/WriteCountingTransport.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/WriteCountingTransport.java
@@ -69,4 +69,9 @@ public class WriteCountingTransport extends TTransport {
   public void checkReadBytesAvailable(long numBytes) throws TTransportException {
     trans.checkReadBytesAvailable(numBytes);
   }
+
+  @Override
+  public void resetMessageSizeAndConsumedBytes(long newSize) throws TTransportException {
+    trans.resetMessageSizeAndConsumedBytes(newSize);
+  }
 }


### PR DESCRIPTION
[THRIFT-6165](https://issues.apache.org/jira/browse/THRIFT-6165)

`TFramedTransport` and `TFastFramedTransport` read a frame header that tells them the exact size of the message they are about to hand to the protocol, and never tell the budget. `checkReadBytesAvailable` is therefore measured against `TConfiguration.maxMessageSize` for the life of the connection, so a 68-byte frame may declare a 64 MB field and the array is allocated before the shortfall is found.

### The API this needs

Binding the budget to the frame needs an entry point that does not exist today.

- `resetConsumedMessageSize(-1)` is the only genuine full reset, and it is `protected`, so a layered transport cannot call it on its inner transport.
- `updateKnownMessageSize()` refuses to grow a budget an earlier, smaller frame narrowed, and carries that frame's consumption forward besides.

So this adds `resetMessageSizeAndConsumedBytes(long)` to `TTransport`, mirroring netstd's `ResetMessageSizeAndConsumedBytes`, implemented on `TEndpointTransport`, delegated by `TLayeredTransport`, and a no-op on `TFileTransport` alongside its existing no-op budget methods.

### Change

`readFrame()` resets twice, for two different reasons.

- **Before** the framing reads, because what is left of the previous frame's bound describes a frame we are done with, and an inner transport that decrements on read — `TMemoryBuffer`, or the `TMemoryInputTransport` the nonblocking server uses — would otherwise refuse a frame larger than the last one.
- **After** them, binding to the frame, discarding what the framing itself spent rather than charging it twice.

`TMemoryInputTransport.reset()` binds to the buffer it is given, as its constructor already did. Reads there are clamped to the buffer and short-read rather than checked against the budget, so this only tightens what the protocol may declare.

### Source compatibility

The new abstract method is a **source-compatibility break** for anything extending `TTransport` directly rather than through `TEndpointTransport` or `TLayeredTransport`. Four test doubles in this repository needed it. Worth a release note.

### Tests

Nine in `TestFrameBoundReadBudget`, eight of them written before the change. Three fail against the unmodified library:

```
testDeclaredFieldLargerThanFrameIsRejected
testDeclaredFieldLargerThanFrameIsRejectedFastFramed
testDeclaredFieldLargerThanResetBufferIsRejected
```

The rest describe traffic that is legitimate today, and they exist precisely because the natural implementation of frame binding breaks them. The ninth records why the bound cannot go on the inner transport: with the nonblocking server's shape, getting the frame off the wire spends the inner budget entirely, and without the first reset the frame's own bytes are then unreadable.

The tests use `TIOStreamTransport` rather than `TMemoryBuffer` as the endpoint — `TMemoryBuffer`'s constructor calls `updateKnownMessageSize`, which is the behaviour under test, and using it made two of the three failing tests pass spuriously.

346 tests pass; `spotlessCheck` clean.

### Relationship to THRIFT-5371

[THRIFT-5371](https://issues.apache.org/jira/browse/THRIFT-5371) reports the C++ half of this and asks there whether Java is affected too. Partly. Java does **not** accumulate across frames the way C++ does, because `TIOStreamTransport` never decrements the budget on read — its only reset is the `flush()` one on the write side. What Java does share is the other half, the budget never being narrowed to the frame, which is what the three failing tests describe.

c_glib is [THRIFT-6166](https://issues.apache.org/jira/browse/THRIFT-6166). Separate PRs, one per binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
