### PR TITLE
THRIFT-6168: Bound the depth skip() will follow in the D library

### DIFF
--- a/lib/d/src/thrift/codegen/base.d
+++ b/lib/d/src/thrift/codegen/base.d
@@ -50,10 +50,6 @@ import thrift.internal.codegen;
 import thrift.protocol.base;
 import thrift.util.hashset;
 
-// Thread-local recursion depth counter used by readStruct/writeStruct.
-private uint currentRecursionDepth_;
-private enum uint DEFAULT_MAX_RECURSION_DEPTH = 64;
-
 /*
  * Thrift struct/service meta data, which is used to store information from
  * the interface definition files not representable in plain D, i.e. field
@@ -598,12 +594,8 @@ template TIsSetFlags(T, alias fieldMetaData) {
 void readStruct(T, Protocol, alias fieldMetaData = cast(TFieldMeta[])null,
   bool pointerStruct = false)(auto ref T s, Protocol p) if (isTProtocol!Protocol)
 {
-  if (++currentRecursionDepth_ > DEFAULT_MAX_RECURSION_DEPTH) {
-    --currentRecursionDepth_;
-    throw new TProtocolException("Maximum recursion depth exceeded",
-      TProtocolException.Type.DEPTH_LIMIT);
-  }
-  scope(exit) --currentRecursionDepth_;
+  incrementRecursionDepth();
+  scope(exit) decrementRecursionDepth();
   mixin({
     string code;
 
@@ -823,12 +815,8 @@ void writeStruct(T, Protocol, alias fieldMetaData = cast(TFieldMeta[])null,
     return code;
   }());
 
-  if (++currentRecursionDepth_ > DEFAULT_MAX_RECURSION_DEPTH) {
-    --currentRecursionDepth_;
-    throw new TProtocolException("Maximum recursion depth exceeded",
-      TProtocolException.Type.DEPTH_LIMIT);
-  }
-  scope(exit) --currentRecursionDepth_;
+  incrementRecursionDepth();
+  scope(exit) decrementRecursionDepth();
 
   p.writeStructBegin(TStruct(T.stringof));
   mixin({
@@ -1068,8 +1056,8 @@ unittest {
   // Reading a too-deep payload is likewise rejected. A normal write() of an
   // over-limit chain would itself be rejected, so craft the payload with raw
   // protocol primitives, bypassing the counter. Field id 1 / TType.LIST matches
-  // RecTree.children, so the reader recurses through the guarded readStruct and
-  // not the (separate, unbounded) skip() path.
+  // RecTree.children, so the reader recurses through readStruct rather than
+  // through skip(); the skip() path is covered on its own below.
   {
     auto buf = new TMemoryBuffer();
     auto p = tBinaryProtocol(buf);
@@ -1104,6 +1092,44 @@ unittest {
     }
     readTree(writeTree(wide));
     assert(currentRecursionDepth_ == 0, "counter must unwind to 0");
+  }
+
+  // readStruct and skip() draw on one shared budget, so the depth they reach
+  // adds up. RecTree has no field 99, so the generated reader hands that field
+  // to skip() from inside the already-counted readStruct: a chain of
+  // limit - 1 structs below it still fits, one more does not.
+  {
+    ubyte[] unknownFieldChain(uint chainDepth) {
+      auto buf = new TMemoryBuffer();
+      auto p = tBinaryProtocol(buf);
+      void emitChain(uint d) {
+        p.writeStructBegin(TStruct("Chain"));
+        if (d > 1) {
+          p.writeFieldBegin(TField("next", TType.STRUCT, 1));
+          emitChain(d - 1);
+          p.writeFieldEnd();
+        }
+        p.writeFieldStop();
+        p.writeStructEnd();
+      }
+
+      p.writeStructBegin(TStruct("RecTree"));
+      p.writeFieldBegin(TField("unknown", TType.STRUCT, 99));
+      emitChain(chainDepth);
+      p.writeFieldEnd();
+      p.writeFieldStop();
+      p.writeStructEnd();
+      return buf.getContents().dup;
+    }
+
+    readTree(unknownFieldChain(DEFAULT_MAX_RECURSION_DEPTH - 1));
+    assert(currentRecursionDepth_ == 0, "counter must unwind to 0");
+
+    auto ex = collectException!TProtocolException(
+      readTree(unknownFieldChain(DEFAULT_MAX_RECURSION_DEPTH)));
+    assert(ex !is null, "skipping past the shared limit must throw");
+    assert(ex.type == TProtocolException.Type.DEPTH_LIMIT);
+    assert(currentRecursionDepth_ == 0, "counter must unwind after a throw");
   }
 }
 
@@ -1169,8 +1195,7 @@ unittest {
   // Reading a too-deep payload is likewise rejected. A normal write() of an
   // over-limit chain would itself be rejected, so craft the payload with raw
   // protocol primitives. Field id 1 / TType.LIST matches RecError.children, so
-  // the reader recurses through the guarded readStruct and not the (separate,
-  // unbounded) skip() path.
+  // the reader recurses through readStruct rather than through skip().
   {
     auto buf = new TMemoryBuffer();
     auto p = tBinaryProtocol(buf);

--- a/lib/d/src/thrift/internal/test/protocol.d
+++ b/lib/d/src/thrift/internal/test/protocol.d
@@ -181,3 +181,98 @@ void testStringSizeLimit(Protocol)() if (isTProtocol!Protocol) {
     }
   }
 }
+
+/*
+ * skip() descends through nested structs and containers exactly the way
+ * reading them does, so it has to draw on the same recursion budget: a payload
+ * nested one level past the limit must be rejected instead of running the call
+ * stack down.
+ *
+ * The payloads are written with the raw protocol primitives, which carry no
+ * guard of their own -- writeStruct() would refuse to emit an over-deep chain
+ * in the first place.
+ */
+void testSkipDepthLimit(Protocol)() if (isTProtocol!Protocol) {
+  // Keep the test hermetic with respect to the thread-local counter.
+  uint savedDepth = currentRecursionDepth_;
+  scope(exit) currentRecursionDepth_ = savedDepth;
+  currentRecursionDepth_ = 0;
+
+  // Writes a chain of `depth` nested structs, each holding the next as field 1.
+  static void writeStructChain(Protocol prot, uint depth) {
+    prot.writeStructBegin(TStruct("Chain"));
+    if (depth > 1) {
+      prot.writeFieldBegin(TField("next", TType.STRUCT, 1));
+      writeStructChain(prot, depth - 1);
+      prot.writeFieldEnd();
+    }
+    prot.writeFieldStop();
+    prot.writeStructEnd();
+  }
+
+  // Writes a chain of `depth` nested one-element lists. The innermost one is
+  // empty so that the chain costs exactly `depth` levels and not one more.
+  static void writeListChain(Protocol prot, uint depth) {
+    if (depth > 1) {
+      prot.writeListBegin(TList(TType.LIST, 1));
+      writeListChain(prot, depth - 1);
+      prot.writeListEnd();
+    } else {
+      prot.writeListBegin(TList(TType.I32, 0));
+      prot.writeListEnd();
+    }
+  }
+
+  // Writes a payload into a fresh buffer, then skips it back off as `type`.
+  static void skipPayload(scope void delegate(Protocol) write, TType type) {
+    auto buffer = new TMemoryBuffer;
+    auto prot = new Protocol(buffer);
+    write(prot);
+    prot.reset();
+    skip(prot, type);
+  }
+
+  // A chain exactly at the limit is skipped (off-by-one guard), one level
+  // deeper is rejected with DEPTH_LIMIT. Both must leave the counter unwound.
+  {
+    skipPayload((Protocol p) { writeStructChain(p, DEFAULT_MAX_RECURSION_DEPTH); },
+      TType.STRUCT);
+    enforce(currentRecursionDepth_ == 0, "counter must unwind to 0");
+
+    auto e = cast(TProtocolException)collectException(
+      skipPayload((Protocol p) { writeStructChain(p, DEFAULT_MAX_RECURSION_DEPTH + 1); },
+        TType.STRUCT));
+    enforce(e && e.type == TProtocolException.Type.DEPTH_LIMIT,
+      "skipping a struct chain past the limit must throw DEPTH_LIMIT");
+    enforce(currentRecursionDepth_ == 0, "counter must unwind after a throw");
+  }
+
+  // Containers recurse through the same skip(), so they are bounded alike.
+  {
+    skipPayload((Protocol p) { writeListChain(p, DEFAULT_MAX_RECURSION_DEPTH); },
+      TType.LIST);
+    enforce(currentRecursionDepth_ == 0, "counter must unwind to 0");
+
+    auto e = cast(TProtocolException)collectException(
+      skipPayload((Protocol p) { writeListChain(p, DEFAULT_MAX_RECURSION_DEPTH + 1); },
+        TType.LIST));
+    enforce(e && e.type == TProtocolException.Type.DEPTH_LIMIT,
+      "skipping a list chain past the limit must throw DEPTH_LIMIT");
+    enforce(currentRecursionDepth_ == 0, "counter must unwind after a throw");
+  }
+
+  // Decrement regression guard: a wide, shallow struct holding far more fields
+  // than the limit is only one level deep and must still skip cleanly. This
+  // holds just if the counter is decremented as each field unwinds.
+  skipPayload((Protocol prot) {
+    prot.writeStructBegin(TStruct("Wide"));
+    foreach (i; 1 .. DEFAULT_MAX_RECURSION_DEPTH * 3) {
+      prot.writeFieldBegin(TField("f", TType.I32, cast(short)i));
+      prot.writeI32(cast(int)i);
+      prot.writeFieldEnd();
+    }
+    prot.writeFieldStop();
+    prot.writeStructEnd();
+  }, TType.STRUCT);
+  enforce(currentRecursionDepth_ == 0, "counter must unwind to 0");
+}

--- a/lib/d/src/thrift/protocol/base.d
+++ b/lib/d/src/thrift/protocol/base.d
@@ -252,14 +252,41 @@ protected:
   Type type_;
 }
 
+// Thread-local recursion depth counter. It is shared between skip() below and
+// the readStruct/writeStruct templates in thrift.codegen.base: skipping
+// descends through nested structs and containers the same way reading them
+// does, so it draws on the same depth budget.
+package(thrift) uint currentRecursionDepth_;
+package(thrift) enum uint DEFAULT_MAX_RECURSION_DEPTH = 64;
+
+package(thrift) void incrementRecursionDepth() {
+  if (++currentRecursionDepth_ > DEFAULT_MAX_RECURSION_DEPTH) {
+    --currentRecursionDepth_;
+    throw new TProtocolException("Maximum recursion depth exceeded",
+      TProtocolException.Type.DEPTH_LIMIT);
+  }
+}
+
+package(thrift) void decrementRecursionDepth() {
+  --currentRecursionDepth_;
+}
+
 /**
  * Skips a field of the given type on the protocol.
  *
  * The main purpose of skip() is to allow treating struct and container types,
  * (where multiple primitive types have to be skipped) the same as scalar types
  * in generated code.
+ *
+ * Nested structs and containers are descended into recursively, so skip()
+ * draws on the same depth budget as readStruct(): a payload nested deeper
+ * than DEFAULT_MAX_RECURSION_DEPTH is rejected with
+ * TProtocolException.Type.DEPTH_LIMIT.
  */
 void skip(Protocol)(Protocol prot, TType type) if (is(Protocol : TProtocol)) {
+  incrementRecursionDepth();
+  scope(exit) decrementRecursionDepth();
+
   switch (type) {
     case TType.BOOL:
       prot.readBool();

--- a/lib/d/src/thrift/protocol/binary.d
+++ b/lib/d/src/thrift/protocol/binary.d
@@ -369,6 +369,7 @@ unittest {
   import thrift.internal.test.protocol;
   testContainerSizeLimit!(TBinaryProtocol!())();
   testStringSizeLimit!(TBinaryProtocol!())();
+  testSkipDepthLimit!(TBinaryProtocol!())();
 }
 
 /**

--- a/lib/d/src/thrift/protocol/compact.d
+++ b/lib/d/src/thrift/protocol/compact.d
@@ -661,6 +661,7 @@ unittest {
   import thrift.internal.test.protocol;
   testContainerSizeLimit!(TCompactProtocol!())();
   testStringSizeLimit!(TCompactProtocol!())();
+  testSkipDepthLimit!(TCompactProtocol!())();
 }
 
 /**

--- a/lib/d/src/thrift/protocol/json.d
+++ b/lib/d/src/thrift/protocol/json.d
@@ -830,6 +830,7 @@ unittest {
   import thrift.internal.test.protocol;
   testContainerSizeLimit!(TJsonProtocol!())();
   testStringSizeLimit!(TJsonProtocol!())();
+  testSkipDepthLimit!(TJsonProtocol!())();
 }
 
 /**


### PR DESCRIPTION
`skip()` in `lib/d/src/thrift/protocol/base.d` walks type ids taken off the wire rather than the types the IDL declared, so the peer picks both the shape of the nesting and how deep it goes. Every branch that can nest — struct, list, map, set — calls `skip()` again, and nothing carries a depth. A struct level costs the sender four bytes and a list level five, so 200 levels is 797 bytes as a struct chain and 1000 as a list chain.

### Why the existing counter did not cover it

D has had a recursion depth counter since THRIFT-6053 (shipped in 0.24.0), but `skip()` could not reach it: it was module-private to `thrift.codegen.base`, and that module imports `thrift.protocol.base` rather than the other way round. Only `readStruct`/`writeStruct` were counted.

That matters because `skip()` sits on the pre-dispatch path. The generated processor skips the whole argument struct *before* it knows the method — once on an unexpected message type and once on an unknown method name (`codegen/processor.d:115`, `:126`). It is also reached from the generated readers for a field the struct does not declare or whose type does not match (`codegen/base.d:711`, `:766`), and from `TApplicationException.read()`.

### The change

`currentRecursionDepth_` and `DEFAULT_MAX_RECURSION_DEPTH` move into `thrift.protocol.base` as `package(thrift)`, gain `incrementRecursionDepth()` / `decrementRecursionDepth()` helpers, and `skip()` opens with the pair. Past 64 levels it throws `TProtocolException` with `DEPTH_LIMIT`. `readStruct`/`writeStruct` now call the same two helpers instead of open-coding the identical five lines twice — the counter, its value and their behaviour are unchanged.

**One budget, not two.** `skip()` is called from inside `readStruct`, so a payload can alternate between the two paths; charging them separately would let it reach twice the ceiling. It is also what the other bindings do — C++ opens `skip()` with `TInputRecursionTracker`, the same tracker its generated readers use, and Haxe, netstd, Delphi, Lua, Perl, PHP, Smalltalk and OCaml all wrap `skip()` in the protocol's own increment/decrement pair.

### Cross-binding check

Every binding's `skip()` was read for this. Bounded already: C++ (`TProtocol.h:703`), c_glib (`recursion_depth` parameter), Dart, Delphi, Erlang (THRIFT-6164), Go, Haxe, Java, JavaME, browser JS (THRIFT-6014), Lua, netstd, Node.js, OCaml, Perl, PHP, Python incl. the C extension, Ruby (THRIFT-6013), Rust, Smalltalk. Kotlin uses the Java library; `lib/cl` carries no protocol implementation of its own. **D was the last one with no bound at all.**

### Tests

Five checks in a helper instantiated for the binary, compact and JSON protocols: a struct chain and a list chain at exactly the limit are still skipped, one level deeper is refused, and a struct 191 fields wide but one level deep still skips — which only holds if the counter unwinds per field. A sixth, in the codegen tests, drives an over-deep chain in as an undeclared field so it is skipped from inside an already-counted `readStruct`: `limit - 1` fits, `limit` does not.

Two comments in `codegen/base.d` that described `skip()` as "the (separate, unbounded) skip() path" are now wrong, and are corrected.

Eight unittest binaries — binary, compact, json and codegen/base, each built debug and release the way `lib/d/Makefile.am` builds them — fail against the unmodified library. With the change the full set of 43 modules passes in both modes, 86 binaries, no warnings under `-w -wi`.

**No CI job builds D**, so that local run (dmd 2.087 in the project's `thrift:jammy` image) is the only coverage this gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
