### PR TITLE
THRIFT-6176: Mangle Go identifiers that start with IsSet

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -254,6 +254,13 @@ std::string t_go_generator::publicize(const std::string& value, bool is_args_or_
     value2 += '_';
   }
 
+  // IDL identifiers may start with "IsSet" which interferes with the IsSetX() accessor
+  // generated for a sibling field X (e.g. fields "x" and "isSetX" in one struct)
+  // Adding an extra underscore to all those identifiers solves this
+  if ((len_before >= 5) && (value2.substr(0, 5) == "IsSet")) {
+    value2 += '_';
+  }
+
   // IDL identifiers may end with "Args"/"Result" which interferes with the implicit service
   // function structs
   // Adding another extra underscore to all those identifiers solves this

--- a/lib/go/test/NamesTest.thrift
+++ b/lib/go/test/NamesTest.thrift
@@ -30,3 +30,12 @@ service NameCollisionTwo
 {
     void blahBlah()
 }
+
+// A field named isSetX next to a field named x must not collide with the
+// generated IsSetX() accessor.
+struct SetFlagNamesTest {
+    1: optional i32 queryParallelism
+    2: optional bool isSetQueryParallelism
+    3: optional string default_pool_path
+    4: optional bool is_set_default_pool_path
+}

--- a/lib/go/test/tests/names_test.go
+++ b/lib/go/test/tests/names_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/apache/thrift/lib/go/test/gopath/src/namestest"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 func TestThatAttributeNameSubstituionDoesNotOccur(t *testing.T) {
@@ -31,5 +32,31 @@ func TestThatAttributeNameSubstituionDoesNotOccur(t *testing.T) {
 	_, ok := st.FieldByName("Type")
 	if !ok {
 		t.Error("Type attribute is missing!")
+	}
+}
+
+func TestIsSetFieldDoesNotCollideWithAccessor(t *testing.T) {
+	st := reflect.TypeFor[namestest.SetFlagNamesTest]()
+	for _, name := range []string{"IsSetQueryParallelism_", "IsSetDefaultPoolPath_"} {
+		if _, ok := st.FieldByName(name); !ok {
+			t.Errorf("%s attribute is missing!", name)
+		}
+	}
+
+	v := &namestest.SetFlagNamesTest{
+		QueryParallelism:       thrift.Int32Ptr(4),
+		IsSetQueryParallelism_: thrift.BoolPtr(false),
+	}
+	if !v.IsSetQueryParallelism() {
+		t.Error("IsSetQueryParallelism() should report the queryParallelism field")
+	}
+	if !v.IsSetIsSetQueryParallelism_() {
+		t.Error("IsSetIsSetQueryParallelism_() should report the isSetQueryParallelism field")
+	}
+	if v.GetIsSetQueryParallelism_() {
+		t.Error("GetIsSetQueryParallelism_() should return the field value, not the accessor result")
+	}
+	if v.IsSetDefaultPoolPath() || v.IsSetIsSetDefaultPoolPath_() {
+		t.Error("unset fields reported as set")
 	}
 }


### PR DESCRIPTION
A Thrift field named `isSetX` next to a field `x` generated a Go struct field `IsSetX` and an `IsSetX()` accessor, so the package did not compile. The generator now appends an underscore to identifiers that start with `IsSet`, the same rule it applies to `New*`, `*Args` and `*Result`. Hive's `hive_metastore.thrift` (`WMNullableResourcePlan`, `WMNullablePool`) is the real-world case.

The rename only affects generated Go identifiers; field IDs and the wire format are unchanged. A field that starts with `isSet` but has no colliding sibling compiled before and is renamed too, which keeps the rule predictable.

Verified: regenerated `lib/go/test` with the patched compiler → `go test ./tests/` passes, and the new `TestIsSetFieldDoesNotCollideWithAccessor` fails to compile with the unpatched compiler. `make style` not run: clang-format is not installed here.

- [x] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?
- [x] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?
- [x] Did you do your best to avoid breaking changes?

*This change was created with AI assistance.*
