### PR TITLE
THRIFT-6179: Read WebSocket frames iteratively in the C++ library

### DIFF
--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -270,8 +270,17 @@ private:
       }
     }
 
-    // size_t is smaller than a ulong on a 32-bit system
-    if (payloadLength > UINT32_MAX) {
+    // The read buffer below is sized from this number before a single payload
+    // byte has arrived, so the frame header on its own decides how much memory
+    // the server commits unless something bounds it. Hold it to the configured
+    // maximum frame size, the same ceiling TFramedTransport applies to its own
+    // frames. The UINT32_MAX arm stays for its own reason: size_t is narrower
+    // than the length field on a 32-bit system.
+    //
+    // The cast is safe because the first arm has already ruled out anything
+    // wider than 32 bits by the time the second is evaluated.
+    if (payloadLength > UINT32_MAX
+        || static_cast<int64_t>(payloadLength) > getConfiguration()->getMaxFrameSize()) {
       failConnection(CloseCode::MessageTooBig);
       return false;
     }

--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -220,125 +220,131 @@ private:
   }
 
   bool readFrame() {
-    uint8_t headerBuffer[8];
+    // Loop rather than recurse: a Ping carries nothing for the caller, so the
+    // reader has to go on to the next frame to satisfy it, and a peer may send
+    // as many Pings as it likes. Re-entering readFrame() for each one cost a
+    // stack frame per seven bytes on the wire.
+    while (true) {
+      uint8_t headerBuffer[8];
 
-    auto read = transport_->read(headerBuffer, 2);
-    if (read < 2) {
-      return false;
-    }
-    // Since Thrift has its own message end marker and we read frame by frame,
-    // it doesn't really matter if the frame is marked as FIN.
-    // Capture it only for debugging only.
-    auto fin = (headerBuffer[0] & 0x80) != 0;
-    THRIFT_UNUSED_VARIABLE(fin);
-
-    // RSV1, RSV2, RSV3
-    if ((headerBuffer[0] & 0x70) != 0) {
-      failConnection(CloseCode::ProtocolError);
-      throw TTransportException(TTransportException::CORRUPTED_DATA,
-                                "Reserved bits must be zeroes");
-    }
-
-    auto opcode = (Opcode)(headerBuffer[0] & 0x0F);
-
-    // Mask
-    if ((headerBuffer[1] & 0x80) == 0) {
-      failConnection(CloseCode::ProtocolError);
-      throw TTransportException(TTransportException::CORRUPTED_DATA,
-                                "Messages from the client must be masked");
-    }
-
-    // Read the length
-    uint64_t payloadLength = headerBuffer[1] & 0x7F;
-    if (payloadLength == 126) {
-      read = transport_->read(headerBuffer, 2);
+      auto read = transport_->read(headerBuffer, 2);
       if (read < 2) {
         return false;
       }
-      payloadLength = ntohs(*reinterpret_cast<uint16_t*>(headerBuffer));
-    } else if (payloadLength == 127) {
-      read = transport_->read(headerBuffer, 8);
-      if (read < 8) {
-        return false;
-      }
-      payloadLength = THRIFT_ntohll(*reinterpret_cast<uint64_t*>(headerBuffer));
-      if ((payloadLength & 0x8000000000000000) != 0) {
+      // Since Thrift has its own message end marker and we read frame by frame,
+      // it doesn't really matter if the frame is marked as FIN.
+      // Capture it only for debugging only.
+      auto fin = (headerBuffer[0] & 0x80) != 0;
+      THRIFT_UNUSED_VARIABLE(fin);
+
+      // RSV1, RSV2, RSV3
+      if ((headerBuffer[0] & 0x70) != 0) {
         failConnection(CloseCode::ProtocolError);
-        throw TTransportException(
-            TTransportException::CORRUPTED_DATA,
-            "The most significant bit of the payload length must be zero");
-      }
-    }
-
-    // The read buffer below is sized from this number before a single payload
-    // byte has arrived, so the frame header on its own decides how much memory
-    // the server commits unless something bounds it. Hold it to the configured
-    // maximum frame size, the same ceiling TFramedTransport applies to its own
-    // frames. The UINT32_MAX arm stays for its own reason: size_t is narrower
-    // than the length field on a 32-bit system.
-    //
-    // The cast is safe because the first arm has already ruled out anything
-    // wider than 32 bits by the time the second is evaluated.
-    if (payloadLength > UINT32_MAX
-        || static_cast<int64_t>(payloadLength) > getConfiguration()->getMaxFrameSize()) {
-      failConnection(CloseCode::MessageTooBig);
-      return false;
-    }
-
-    auto length = static_cast<uint32_t>(payloadLength);
-
-    if (length > 0) {
-      // Read the masking key
-      read = transport_->read(headerBuffer, 4);
-      if (read < 4) {
-        return false;
+        throw TTransportException(TTransportException::CORRUPTED_DATA,
+                                  "Reserved bits must be zeroes");
       }
 
-      readBuffer_.resetBuffer(length);
-      uint8_t* buffer = readBuffer_.getWritePtr(length);
-      // Wait for the whole payload. A single read returns whatever one recv()
-      // produced, so anything the network split across segments used to be
-      // reported as end of stream and the frame lost. Waiting is only safe
-      // because length has been held to the configured maximum frame size
-      // above; TFramedTransport reads its own frames the same way.
-      try {
-        transport_->readAll(buffer, length);
-      } catch (const TTransportException& e) {
-        if (e.getType() == TTransportException::END_OF_FILE) {
-          // The peer went away part-way through the frame. That is what the
-          // caller has always been told about a payload that does not turn up.
+      auto opcode = (Opcode)(headerBuffer[0] & 0x0F);
+
+      // Mask
+      if ((headerBuffer[1] & 0x80) == 0) {
+        failConnection(CloseCode::ProtocolError);
+        throw TTransportException(TTransportException::CORRUPTED_DATA,
+                                  "Messages from the client must be masked");
+      }
+
+      // Read the length
+      uint64_t payloadLength = headerBuffer[1] & 0x7F;
+      if (payloadLength == 126) {
+        read = transport_->read(headerBuffer, 2);
+        if (read < 2) {
           return false;
         }
-        throw;
+        payloadLength = ntohs(*reinterpret_cast<uint16_t*>(headerBuffer));
+      } else if (payloadLength == 127) {
+        read = transport_->read(headerBuffer, 8);
+        if (read < 8) {
+          return false;
+        }
+        payloadLength = THRIFT_ntohll(*reinterpret_cast<uint64_t*>(headerBuffer));
+        if ((payloadLength & 0x8000000000000000) != 0) {
+          failConnection(CloseCode::ProtocolError);
+          throw TTransportException(
+              TTransportException::CORRUPTED_DATA,
+              "The most significant bit of the payload length must be zero");
+        }
       }
-      readBuffer_.wroteBytes(length);
+
+      // The read buffer below is sized from this number before a single payload
+      // byte has arrived, so the frame header on its own decides how much memory
+      // the server commits unless something bounds it. Hold it to the configured
+      // maximum frame size, the same ceiling TFramedTransport applies to its own
+      // frames. The UINT32_MAX arm stays for its own reason: size_t is narrower
+      // than the length field on a 32-bit system.
+      //
+      // The cast is safe because the first arm has already ruled out anything
+      // wider than 32 bits by the time the second is evaluated.
+      if (payloadLength > UINT32_MAX
+          || static_cast<int64_t>(payloadLength) > getConfiguration()->getMaxFrameSize()) {
+        failConnection(CloseCode::MessageTooBig);
+        return false;
+      }
+
+      auto length = static_cast<uint32_t>(payloadLength);
+
+      if (length > 0) {
+        // Read the masking key
+        read = transport_->read(headerBuffer, 4);
+        if (read < 4) {
+          return false;
+        }
+
+        readBuffer_.resetBuffer(length);
+        uint8_t* buffer = readBuffer_.getWritePtr(length);
+        // Wait for the whole payload. A single read returns whatever one recv()
+        // produced, so anything the network split across segments used to be
+        // reported as end of stream and the frame lost. Waiting is only safe
+        // because length has been held to the configured maximum frame size
+        // above; TFramedTransport reads its own frames the same way.
+        try {
+          transport_->readAll(buffer, length);
+        } catch (const TTransportException& e) {
+          if (e.getType() == TTransportException::END_OF_FILE) {
+            // The peer went away part-way through the frame. That is what the
+            // caller has always been told about a payload that does not turn up.
+            return false;
+          }
+          throw;
+        }
+        readBuffer_.wroteBytes(length);
       
-      // Unmask the data
-      for (size_t i = 0; i < length; i++) {
-        buffer[i] ^= headerBuffer[i % 4];
+        // Unmask the data
+        for (size_t i = 0; i < length; i++) {
+          buffer[i] ^= headerBuffer[i % 4];
+        }
+
+        T_DEBUG("FIN=%d, Opcode=%X, length=%d, payload=%s", fin, opcode, length,
+                binary ? readBuffer_.toHexString() : cast(string) readBuffer_);
       }
 
-      T_DEBUG("FIN=%d, Opcode=%X, length=%d, payload=%s", fin, opcode, length,
-              binary ? readBuffer_.toHexString() : cast(string) readBuffer_);
-    }
-
-    switch (opcode) {
-    case Opcode::Close:
-      if (length >= 2) {
-        uint8_t buffer[2];
-        readBuffer_.read(buffer, 2);
-        CloseCode closeCode = static_cast<CloseCode>(ntohs(*reinterpret_cast<uint16_t*>(buffer)));
-        THRIFT_UNUSED_VARIABLE(closeCode);
-        string closeReason = readBuffer_.readAsString(length - 2);
-        T_DEBUG("Connection closed: %d %s", closeCode, closeReason);
+      switch (opcode) {
+      case Opcode::Close:
+        if (length >= 2) {
+          uint8_t buffer[2];
+          readBuffer_.read(buffer, 2);
+          CloseCode closeCode = static_cast<CloseCode>(ntohs(*reinterpret_cast<uint16_t*>(buffer)));
+          THRIFT_UNUSED_VARIABLE(closeCode);
+          string closeReason = readBuffer_.readAsString(length - 2);
+          T_DEBUG("Connection closed: %d %s", closeCode, closeReason);
+        }
+        transport_->close();
+        return false;
+      case Opcode::Ping:
+        pong();
+        continue;
+      default:
+        return true;
       }
-      transport_->close();
-      return false;
-    case Opcode::Ping:
-      pong();
-      return readFrame();
-    default:
-      return true;
     }
   }
 

--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -296,11 +296,22 @@ private:
 
       readBuffer_.resetBuffer(length);
       uint8_t* buffer = readBuffer_.getWritePtr(length);
-      read = transport_->read(buffer, length);
-      readBuffer_.wroteBytes(read);
-      if (read < length) {
-        return false;
+      // Wait for the whole payload. A single read returns whatever one recv()
+      // produced, so anything the network split across segments used to be
+      // reported as end of stream and the frame lost. Waiting is only safe
+      // because length has been held to the configured maximum frame size
+      // above; TFramedTransport reads its own frames the same way.
+      try {
+        transport_->readAll(buffer, length);
+      } catch (const TTransportException& e) {
+        if (e.getType() == TTransportException::END_OF_FILE) {
+          // The peer went away part-way through the frame. That is what the
+          // caller has always been told about a payload that does not turn up.
+          return false;
+        }
+        throw;
       }
+      readBuffer_.wroteBytes(length);
       
       // Unmask the data
       for (size_t i = 0; i < length; i++) {

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -94,6 +94,11 @@ set(UnitTest_SOURCES
     Thrift5272.cpp
 )
 
+# TWebSocketServer is only built when OpenSSL is available.
+if(OPENSSL_FOUND AND WITH_OPENSSL)
+    list(APPEND UnitTest_SOURCES TWebSocketServerTest.cpp)
+endif()
+
 add_executable(UnitTests ${UnitTest_SOURCES})
 target_link_libraries(UnitTests testgencpp ${Boost_LIBRARIES})
 target_link_libraries(UnitTests thrift)

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -143,6 +143,7 @@ UnitTests_SOURCES = \
 	TTransportCheckThrow.h \
 	ThrifttReadCheckTests.cpp \
 	FrameBoundReadBudgetTest.cpp \
+	TWebSocketServerTest.cpp \
 	Thrift5272.cpp \
 	TUuidTest.cpp
 

--- a/lib/cpp/test/TWebSocketServerTest.cpp
+++ b/lib/cpp/test/TWebSocketServerTest.cpp
@@ -20,6 +20,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <deque>
 #include <memory>
@@ -63,6 +64,7 @@ public:
 
   uint32_t read(uint8_t* buf, uint32_t len) {
     largestRead_ = (std::max)(largestRead_, len);
+    noteStackDepth();
     if (inbound_.empty()) {
       return 0;
     }
@@ -87,10 +89,31 @@ public:
   uint32_t largestRead() const { return largestRead_; }
   const std::string& outbound() const { return outbound_; }
 
+  // How far below the caller's own frame the reader got. A reader that
+  // re-enters itself per frame shows up here and nowhere else: the frames it
+  // consumes and the bytes it hands over are the same either way.
+  void anchorStack(const void* here) {
+    anchor_ = reinterpret_cast<uintptr_t>(here);
+    deepestStack_ = 0;
+  }
+  size_t deepestStack() const { return deepestStack_; }
+
 private:
+  void noteStackDepth() {
+    if (anchor_ == 0) {
+      return;
+    }
+    char here;
+    auto now = reinterpret_cast<uintptr_t>(&here);
+    size_t depth = (now > anchor_) ? (now - anchor_) : (anchor_ - now);
+    deepestStack_ = (std::max)(deepestStack_, depth);
+  }
+
   std::deque<std::string> inbound_;
   std::string outbound_;
   uint32_t largestRead_ = 0;
+  uintptr_t anchor_ = 0;
+  size_t deepestStack_ = 0;
   bool open_ = true;
 };
 
@@ -164,6 +187,15 @@ bool closedWith(const std::string& outbound, uint16_t code) {
 }
 
 const uint16_t kMessageTooBig = 1009;
+
+const uint8_t kPingOpcode = 0x9;
+
+// Enough pings to separate a reader that recurses from one that does not, and
+// far too few to run any stack out: at the ~160 bytes a frame costs, the
+// unmodified reader passes 300 kB here while the whole run stays four orders of
+// magnitude inside the eight megabytes a Linux thread starts with.
+const int kPings = 2000;
+const size_t kStackCeiling = 64 * 1024;
 
 } // namespace
 
@@ -268,6 +300,28 @@ BOOST_AUTO_TEST_CASE(a_payload_that_stops_early_is_still_end_of_stream) {
 
   uint8_t out[16];
   BOOST_CHECK_EQUAL(server->readAll(out, sizeof(out)), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(a_run_of_pings_is_answered_from_one_stack_frame) {
+  // A Ping carries nothing for the caller, so the reader has to go on to the
+  // next frame to satisfy it. Doing that by re-entering itself costs a stack
+  // frame per Ping, and a Ping is seven bytes on the wire.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  std::string wire;
+  for (int i = 0; i < kPings; ++i) {
+    wire += clientFrame(1, "x", kPingOpcode);
+  }
+  wire += clientFrame(5, "hello");
+  inner->feed(wire);
+
+  char anchor;
+  inner->anchorStack(&anchor);
+
+  char got[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
+  BOOST_CHECK_EQUAL(std::string(got, 5), "hello");
+  BOOST_CHECK_LE(inner->deepestStack(), kStackCeiling);
 }
 
 BOOST_AUTO_TEST_CASE(a_length_with_the_high_bit_set_is_still_refused) {

--- a/lib/cpp/test/TWebSocketServerTest.cpp
+++ b/lib/cpp/test/TWebSocketServerTest.cpp
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <string>
+
+#include <thrift/TConfiguration.h>
+#include <thrift/transport/TVirtualTransport.h>
+#include <thrift/transport/TWebSocketServer.h>
+
+/*
+ * A WebSocket frame header carries the payload length, and readFrame() used it
+ * to size the read buffer before any payload byte had arrived.  Fourteen bytes
+ * on the wire therefore decided how much memory the server committed, up to
+ * the 4 GiB a 64-bit length field can name.
+ *
+ * These tests hold the declared length to TConfiguration::maxFrameSize, the
+ * same ceiling TFramedTransport applies to its own frames.  What they measure
+ * is the largest read the server asked of the transport underneath it: a frame
+ * that was refused before the allocation never asks for its payload, while one
+ * that was believed asks for all of it whether or not it ever arrives.  Asking
+ * only "did the read fail?" would pass on the unmodified library too, because
+ * a payload that never arrives ends the frame either way.
+ */
+
+BOOST_AUTO_TEST_SUITE(TWebSocketServerTest)
+
+using apache::thrift::TConfiguration;
+using apache::thrift::transport::TTransport;
+using apache::thrift::transport::TVirtualTransport;
+using apache::thrift::transport::TWebSocketServer;
+
+namespace {
+
+// A transport whose inbound side is a script of chunks: one read() is served
+// from one chunk, so a test says exactly how the peer's bytes arrive.  It also
+// remembers the largest read it was asked for, which is what distinguishes a
+// declared length that was believed from one that was not.
+class ScriptedTransport : public TVirtualTransport<ScriptedTransport> {
+public:
+  void feed(const std::string& chunk) { inbound_.push_back(chunk); }
+
+  uint32_t read(uint8_t* buf, uint32_t len) {
+    largestRead_ = (std::max)(largestRead_, len);
+    if (inbound_.empty()) {
+      return 0;
+    }
+    std::string& front = inbound_.front();
+    auto give = (std::min)(static_cast<size_t>(len), front.size());
+    std::memcpy(buf, front.data(), give);
+    front.erase(0, give);
+    if (front.empty()) {
+      inbound_.pop_front();
+    }
+    return static_cast<uint32_t>(give);
+  }
+
+  void write(const uint8_t* buf, uint32_t len) {
+    outbound_.append(reinterpret_cast<const char*>(buf), len);
+  }
+
+  void open() override { open_ = true; }
+  bool isOpen() const override { return open_; }
+  void close() override { open_ = false; }
+
+  uint32_t largestRead() const { return largestRead_; }
+  const std::string& outbound() const { return outbound_; }
+
+private:
+  std::deque<std::string> inbound_;
+  std::string outbound_;
+  uint32_t largestRead_ = 0;
+  bool open_ = true;
+};
+
+const char* kHandshake
+    = "GET / HTTP/1.1\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+      "Sec-WebSocket-Version: 13\r\n"
+      "\r\n";
+
+// Everything the handshake itself reads: refill() asks for the initial HTTP
+// buffer, and the frame header reads that follow ask for 2, 8 and 4 bytes.
+// Any read larger than this came from a declared payload length.
+const uint32_t kHandshakeReadCeiling = 1024;
+
+const uint8_t kMask[4] = {0x37, 0xFA, 0x21, 0x3D};
+
+void appendBigEndian(std::string& out, uint64_t value, int bytes) {
+  for (int i = bytes - 1; i >= 0; --i) {
+    out.push_back(static_cast<char>((value >> (i * 8)) & 0xFF));
+  }
+}
+
+// A masked client frame declaring `declaredLength` bytes of payload and
+// actually carrying `payload`.  The two differ in the tests where the point is
+// that the declaration alone must not be acted on.
+std::string clientFrame(uint64_t declaredLength, const std::string& payload, uint8_t opcode = 0x2) {
+  std::string frame;
+  frame.push_back(static_cast<char>(0x80 | opcode)); // FIN
+  if (declaredLength < 126) {
+    frame.push_back(static_cast<char>(0x80 | declaredLength)); // MASK
+  } else if (declaredLength < 65536) {
+    frame.push_back(static_cast<char>(0x80 | 126));
+    appendBigEndian(frame, declaredLength, 2);
+  } else {
+    frame.push_back(static_cast<char>(0x80 | 127));
+    appendBigEndian(frame, declaredLength, 8);
+  }
+  frame.append(reinterpret_cast<const char*>(kMask), 4);
+  for (size_t i = 0; i < payload.size(); ++i) {
+    frame.push_back(static_cast<char>(payload[i] ^ kMask[i % 4]));
+  }
+  return frame;
+}
+
+std::shared_ptr<TConfiguration> withMaxFrameSize(int maxFrameSize) {
+  return std::make_shared<TConfiguration>(TConfiguration::DEFAULT_MAX_MESSAGE_SIZE, maxFrameSize);
+}
+
+// The server is handed back as a TTransport, which is how a transport factory
+// hands it to a protocol: readAll() on the concrete type resolves to the CRTP
+// helper in TVirtualTransport and would never reach the WebSocket framing.
+std::shared_ptr<ScriptedTransport> connect(std::shared_ptr<TTransport>* server,
+                                           std::shared_ptr<TConfiguration> config = nullptr) {
+  auto inner = std::make_shared<ScriptedTransport>();
+  inner->feed(kHandshake);
+  *server = std::make_shared<TWebSocketServer<true> >(inner, config);
+  return inner;
+}
+
+// True if the last frame written to the peer is a Close carrying `code`.  The
+// length byte is deliberately not asserted on: what matters here is that the
+// peer was told why the connection ended.
+bool closedWith(const std::string& outbound, uint16_t code) {
+  if (outbound.size() < 4) {
+    return false;
+  }
+  const auto* tail = reinterpret_cast<const uint8_t*>(outbound.data()) + outbound.size() - 4;
+  return tail[0] == 0x88 && ((tail[2] << 8) | tail[3]) == code;
+}
+
+const uint16_t kMessageTooBig = 1009;
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(a_frame_over_the_default_maximum_is_refused) {
+  // Sixty-four megabytes declared, fourteen bytes sent.  The library default
+  // for maxFrameSize is 16 MB, so this frame has to be refused on its header.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(64 * 1024 * 1024, ""));
+
+  uint8_t out[16];
+  BOOST_CHECK_EQUAL(server->readAll(out, sizeof(out)), 0u);
+  BOOST_CHECK_LE(inner->largestRead(), kHandshakeReadCeiling);
+  BOOST_CHECK(closedWith(inner->outbound(), kMessageTooBig));
+}
+
+BOOST_AUTO_TEST_CASE(the_bound_is_the_configured_maximum) {
+  // An operator who lowers maxFrameSize gets the lower bound, and one who
+  // raises it gets the higher one.  4 KiB is far below any default, so a frame
+  // of 32 KiB tells the two apart.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server, withMaxFrameSize(4096));
+  inner->feed(clientFrame(32 * 1024, ""));
+
+  uint8_t out[16];
+  BOOST_CHECK_EQUAL(server->readAll(out, sizeof(out)), 0u);
+  BOOST_CHECK_LE(inner->largestRead(), kHandshakeReadCeiling);
+  BOOST_CHECK(closedWith(inner->outbound(), kMessageTooBig));
+}
+
+BOOST_AUTO_TEST_CASE(a_frame_of_the_maximum_size_is_still_accepted) {
+  // The bound is a maximum, not a limit one below it: a frame of exactly
+  // maxFrameSize still has to be read.
+  const uint32_t kMax = 4096;
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server, withMaxFrameSize(kMax));
+  std::string payload(kMax, 'x');
+  inner->feed(clientFrame(kMax, payload));
+
+  std::string got(kMax, '\0');
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(&got[0]), kMax), kMax);
+  BOOST_CHECK_EQUAL(got, payload);
+}
+
+BOOST_AUTO_TEST_CASE(an_ordinary_frame_still_reads) {
+  // The regression guard: a small frame is unmasked and handed over whole.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  const std::string payload = "the quick brown fox jumps over the lazy dog";
+  inner->feed(clientFrame(payload.size(), payload));
+
+  std::string got(payload.size(), '\0');
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(&got[0]),
+                                    static_cast<uint32_t>(payload.size())),
+                    payload.size());
+  BOOST_CHECK_EQUAL(got, payload);
+}
+
+BOOST_AUTO_TEST_CASE(consecutive_frames_still_read) {
+  // Each frame is bounded on its own, so a second one has to be readable after
+  // the first.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(5, "alpha"));
+  inner->feed(clientFrame(4, "beta"));
+
+  char got[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
+  BOOST_CHECK_EQUAL(std::string(got, 5), "alpha");
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 4), 4u);
+  BOOST_CHECK_EQUAL(std::string(got, 4), "beta");
+}
+
+BOOST_AUTO_TEST_CASE(a_length_with_the_high_bit_set_is_still_refused) {
+  // Unchanged behaviour, kept here so the new bound cannot be mistaken for the
+  // only thing standing between the header and the allocation.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(0x8000000000000000ULL, ""));
+
+  uint8_t out[16];
+  BOOST_CHECK_THROW(server->readAll(out, sizeof(out)),
+                    apache::thrift::transport::TTransportException);
+  BOOST_CHECK_LE(inner->largestRead(), kHandshakeReadCeiling);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/lib/cpp/test/TWebSocketServerTest.cpp
+++ b/lib/cpp/test/TWebSocketServerTest.cpp
@@ -237,6 +237,39 @@ BOOST_AUTO_TEST_CASE(consecutive_frames_still_read) {
   BOOST_CHECK_EQUAL(std::string(got, 4), "beta");
 }
 
+BOOST_AUTO_TEST_CASE(a_payload_split_across_reads_still_arrives_whole) {
+  // The transport underneath hands over one chunk per read, which is what a
+  // socket does with anything larger than a segment. The frame is ordinary and
+  // well inside every limit; the only thing unusual about it is that it does
+  // not arrive all at once.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  const std::string payload(4000, 'A');
+  const std::string frame = clientFrame(payload.size(), payload);
+  inner->feed(frame.substr(0, 8));
+  inner->feed(frame.substr(8, 1000));
+  inner->feed(frame.substr(1008));
+
+  std::string got(payload.size(), '\0');
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(&got[0]),
+                                    static_cast<uint32_t>(payload.size())),
+                    payload.size());
+  BOOST_CHECK_EQUAL(got, payload);
+}
+
+BOOST_AUTO_TEST_CASE(a_payload_that_stops_early_is_still_end_of_stream) {
+  // Waiting for the rest of a frame must not turn a peer that went away into a
+  // half-read frame handed to the protocol.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  const std::string payload(4000, 'A');
+  const std::string frame = clientFrame(payload.size(), payload);
+  inner->feed(frame.substr(0, 500));
+
+  uint8_t out[16];
+  BOOST_CHECK_EQUAL(server->readAll(out, sizeof(out)), 0u);
+}
+
 BOOST_AUTO_TEST_CASE(a_length_with_the_high_bit_set_is_still_refused) {
   // Unchanged behaviour, kept here so the new bound cannot be mistaken for the
   // only thing standing between the header and the allocation.


### PR DESCRIPTION
> **Stacked on #3780 and #3781.** Only the third commit belongs to this ticket; the diff below it rebases away once those merge.

`TWebSocketServer::readFrame` answered a Ping by calling itself:

```cpp
case Opcode::Ping:
  pong();
  return readFrame();
```

A Ping carries nothing for the caller, so the reader has to go on to the next frame to satisfy it. Doing that by re-entering `readFrame` costs one stack frame per Ping, and nothing bounds how many a peer may send.

### Measured against `master`

Ping frames of one payload byte — seven bytes each on the wire — followed by one ordinary data frame:

| pings | on the wire | stack |
|---|---|---|
| 20,000 | 140 kB | 3,200,344 bytes |
| 40,000 | 280 kB | 6,400,344 bytes |
| 60,000 | 420 kB | **segmentation fault** |

160 bytes of stack for every seven bytes of input, so the 8 MB a Linux thread starts with is gone by about 52,000 pings. **It is not build-dependent** — gcc 11 does not turn the call into a jump at `-O2` any more than at `-O0`, and both builds fault at the same point. With the loop, the same run reads from a constant depth: 416 bytes at 60,000 pings, and 416 bytes at a million, where the wire cost is 7 MB.

### The change

A loop, and that is all. Pings are still answered one after another for as long as a peer cares to send them, no configuration is involved, and the body of `readFrame` is untouched apart from its indentation — `git diff -w` shows five added lines and one changed one.

### Test

It asserts how far below its own frame the reader got, rather than waiting for a crash: 2,000 pings — four orders of magnitude short of exhausting anything, so it is safe in CI — take the unmodified reader 320,480 bytes deep against a 64 kB ceiling. The fix holds it constant.

Full `bin/UnitTests`: 109 of 110. The one failure, `TServerSocketTest/test_bind_to_address`, is a pre-existing environment failure on this host and is present on `master`.

### Worth knowing for anyone reading this code

A Ping with **no** payload does not reach this path at all: `readFrame` does not consume the four masking-key bytes of a zero-length masked frame, so the next header is parsed out of the masking key and the connection dies with *"Reserved bits must be zeroes"*. That is a separate defect, filed separately, and it is why the numbers above use one-byte pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
