### PR TITLE
THRIFT-6180: Frame empty and control WebSocket frames correctly in C++

### DIFF
--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -99,10 +99,10 @@ public:
 
   void flush() override {
     resetConsumedMessageSize();
-    writeFrameHeader();
     uint8_t* buffer;
     uint32_t length;
     writeBuffer_.getBuffer(&buffer, &length);
+    writeFrameHeader(Opcode::Continuation, length);
     transport_->write(buffer, length);
     transport_->flush();
     writeBuffer_.resetBuffer();
@@ -199,7 +199,7 @@ private:
   };
 
   void failConnection(CloseCode reason) {
-    writeFrameHeader(Opcode::Close);
+    writeFrameHeader(Opcode::Close, sizeof(uint16_t));
     auto buffer = htons(static_cast<uint16_t>(reason));
     transport_->write(reinterpret_cast<const uint8_t*>(&buffer), 2);
     transport_->flush();
@@ -211,10 +211,13 @@ private:
   }
 
   void pong() {
-    writeFrameHeader(Opcode::Pong);
+    // RFC 6455 5.5.3: the Pong carries the Ping's payload, which is what the
+    // read buffer holds at this point, and the header has to say so -- a peer
+    // told the frame is empty reads the payload as the next frame header.
     uint8_t* buffer;
     uint32_t size;
     readBuffer_.getBuffer(&buffer, &size);
+    writeFrameHeader(Opcode::Pong, size);
     transport_->write(buffer, size);
     transport_->flush();
   }
@@ -292,13 +295,17 @@ private:
 
       auto length = static_cast<uint32_t>(payloadLength);
 
-      if (length > 0) {
-        // Read the masking key
-        read = transport_->read(headerBuffer, 4);
-        if (read < 4) {
-          return false;
-        }
+      // The masking key is part of the header of every frame whose MASK bit is
+      // set, whatever the payload length, and a client frame without MASK was
+      // already refused above. Reading it only for a frame that carries a
+      // payload leaves four bytes behind, and the next header is then parsed
+      // out of the masking key.
+      read = transport_->read(headerBuffer, 4);
+      if (read < 4) {
+        return false;
+      }
 
+      if (length > 0) {
         readBuffer_.resetBuffer(length);
         uint8_t* buffer = readBuffer_.getWritePtr(length);
         // Wait for the whole payload. A single read returns whatever one recv()
@@ -325,6 +332,9 @@ private:
 
         T_DEBUG("FIN=%d, Opcode=%X, length=%d, payload=%s", fin, opcode, length,
                 binary ? readBuffer_.toHexString() : cast(string) readBuffer_);
+      } else {
+        // Nothing for the caller, and nothing for pong() to echo back either.
+        readBuffer_.resetBuffer();
       }
 
       switch (opcode) {
@@ -364,9 +374,8 @@ private:
     transport_->close();
   }
 
-  void writeFrameHeader(Opcode opcode = Opcode::Continuation) {
+  void writeFrameHeader(Opcode opcode, uint32_t length) {
     uint32_t headerSize = 1;
-    uint32_t length = writeBuffer_.available_read();
     if (length < 126) {
       ++headerSize;
     } else if (length < 65536) {

--- a/lib/cpp/test/TWebSocketServerTest.cpp
+++ b/lib/cpp/test/TWebSocketServerTest.cpp
@@ -188,6 +188,26 @@ bool closedWith(const std::string& outbound, uint16_t code) {
 
 const uint16_t kMessageTooBig = 1009;
 
+// Everything the server wrote after the 101 that ends the handshake.
+std::string framesWritten(const std::string& outbound) {
+  auto end = outbound.find("\r\n\r\n");
+  return end == std::string::npos ? outbound : outbound.substr(end + 4);
+}
+
+std::string hex(const std::string& bytes) {
+  static const char* digits = "0123456789ABCDEF";
+  std::string out;
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    auto b = static_cast<unsigned char>(bytes[i]);
+    if (i > 0) {
+      out.push_back(' ');
+    }
+    out.push_back(digits[b >> 4]);
+    out.push_back(digits[b & 0x0F]);
+  }
+  return out;
+}
+
 const uint8_t kPingOpcode = 0x9;
 
 // Enough pings to separate a reader that recurses from one that does not, and
@@ -322,6 +342,82 @@ BOOST_AUTO_TEST_CASE(a_run_of_pings_is_answered_from_one_stack_frame) {
   BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
   BOOST_CHECK_EQUAL(std::string(got, 5), "hello");
   BOOST_CHECK_LE(inner->deepestStack(), kStackCeiling);
+}
+
+BOOST_AUTO_TEST_CASE(an_empty_masked_frame_does_not_desynchronise_the_stream) {
+  // The masking key is present in every frame whose MASK bit is set, whatever
+  // the payload length, and this server refuses a client frame that does not
+  // set it. Leaving those four bytes in the stream makes the next header be
+  // parsed out of the masking key.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(0, "", kPingOpcode) + clientFrame(5, "hello"));
+
+  char got[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
+  BOOST_CHECK_EQUAL(std::string(got, 5), "hello");
+}
+
+BOOST_AUTO_TEST_CASE(a_pong_declares_the_length_it_carries) {
+  // RFC 6455 wants a Pong to carry the Ping's payload, and the header has to
+  // describe it, or the peer reads the payload as the next frame header.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(8, "PINGDATA", kPingOpcode) + clientFrame(5, "hello"));
+
+  char got[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
+  BOOST_CHECK_EQUAL(hex(framesWritten(inner->outbound())), "8A 08 50 49 4E 47 44 41 54 41");
+}
+
+BOOST_AUTO_TEST_CASE(a_pong_for_an_empty_ping_carries_nothing) {
+  // The Pong echoes the read buffer, so a frame with no payload has to leave
+  // that buffer empty rather than whatever the frame before it left unread.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(5, "hello") + clientFrame(0, "", kPingOpcode) + clientFrame(5, "world"));
+
+  char got[1];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 1), 1u);
+  BOOST_CHECK_EQUAL(got[0], 'h');
+  // Four bytes of "hello" are still unread when the Ping arrives.
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 1), 1u);
+  BOOST_CHECK_EQUAL(got[0], 'e');
+  char rest[3];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(rest), 3), 3u);
+  char after[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(after), 5), 5u);
+  BOOST_CHECK_EQUAL(std::string(after, 5), "world");
+  BOOST_CHECK_EQUAL(hex(framesWritten(inner->outbound())), "8A 00");
+}
+
+BOOST_AUTO_TEST_CASE(a_response_frame_still_declares_its_own_length) {
+  // flush() is the one caller whose body really is the write buffer, and it
+  // has to keep saying so.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server);
+  inner->feed(clientFrame(5, "hello"));
+
+  char got[5];
+  BOOST_CHECK_EQUAL(server->readAll(reinterpret_cast<uint8_t*>(got), 5), 5u);
+  const std::string response = "world";
+  server->write(reinterpret_cast<const uint8_t*>(response.data()),
+                static_cast<uint32_t>(response.size()));
+  server->flush();
+
+  BOOST_CHECK_EQUAL(hex(framesWritten(inner->outbound())), "82 05 77 6F 72 6C 64");
+}
+
+BOOST_AUTO_TEST_CASE(a_close_declares_the_length_it_carries) {
+  // The close code is unreadable to a conforming peer if the header in front
+  // of it says the frame is empty.
+  std::shared_ptr<TTransport> server;
+  auto inner = connect(&server, withMaxFrameSize(4096));
+  inner->feed(clientFrame(32 * 1024, ""));
+
+  uint8_t out[16];
+  BOOST_CHECK_EQUAL(server->readAll(out, sizeof(out)), 0u);
+  BOOST_CHECK_EQUAL(hex(framesWritten(inner->outbound())), "88 02 03 F1");
 }
 
 BOOST_AUTO_TEST_CASE(a_length_with_the_high_bit_set_is_still_refused) {


### PR DESCRIPTION
> **Stacked on #3780, #3781 and #3782.** Only the fourth commit belongs to this ticket.

Three related framing defects in `TWebSocketServer`, all demonstrated against `master`.

### 1. The masking key of a zero-length masked frame is never consumed

`readFrame` reads the four masking-key bytes inside `if (length > 0)`. RFC 6455 §5.2 puts the masking key in every frame whose MASK bit is set, whatever the payload length — and `readFrame` itself refuses a client frame that does not set MASK. So for a zero-length frame the four bytes stay in the stream and the next header is parsed out of the masking key:

```
client: 89 80 37 37 37 37        an empty Ping
        82 85 37 37 37 37 ...    a five-byte data frame
server: TTransportException: Reserved bits must be zeroes
```

A masking key is arbitrary, so this fails in whatever way the key happens to encode. An empty Ping, an empty Pong and a Close with no status code are all ordinary traffic that browsers send.

### 2. A Pong declares a length of zero and writes the payload after it

`writeFrameHeader` took its length from `writeBuffer_.available_read()`, which describes the body only for `flush()` — the one caller whose body *is* the write buffer. `pong()` writes `readBuffer_` instead:

```
ping of 8 bytes "PINGDATA"  ->  8A 00 50 49 4E 47 44 41 54 41
```

Opcode `0x8A` is FIN|Pong, the declared length is 0, and eight bytes follow it. A conforming client reads a zero-length Pong and then parses `0x50` as the next frame header, whose reserved bits are set, and must fail the connection.

### 3. A Close frame does the same

`failConnection` writes its two-byte close code after a header declaring zero — `88 00 03 F1` — so the reason the connection ended is unreadable to a conforming peer.

### The change

Pass `writeFrameHeader` the length it is describing instead of letting it guess; read the masking key as part of the header it belongs to; and reset the read buffer for a frame with no payload, so a Pong for an empty Ping echoes nothing rather than whatever the frame before it left unread.

On the wire, after: `8A 08 50 49 4E 47 44 41 54 41` and `88 02 03 F1`.

### Tests

Five. Four fail before the change — two on the exception, two on the bytes written. The fifth is a regression guard on `flush()`, the caller whose body really is the write buffer, and passes either way.

Full `bin/UnitTests`: 114 of 115. The one failure, `TServerSocketTest/test_bind_to_address`, is a pre-existing environment failure on this host and is present on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
