### PR TITLE
THRIFT-6182: Keep the configured maximum frame size when wrapping (Java)

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TFastFramedTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TFastFramedTransport.java
@@ -34,24 +34,32 @@ public class TFastFramedTransport extends TLayeredTransport {
 
   public static class Factory extends TTransportFactory {
     private final int initialCapacity;
-    private final int maxLength;
+
+    /** Null when no maximum was asked for, which leaves each transport's own alone. */
+    private final Integer maxLength;
 
     public Factory() {
-      this(DEFAULT_BUF_CAPACITY, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
+      this(DEFAULT_BUF_CAPACITY, null);
     }
 
     public Factory(int initialCapacity) {
-      this(initialCapacity, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
+      this(initialCapacity, null);
     }
 
     public Factory(int initialCapacity, int maxLength) {
+      this(initialCapacity, Integer.valueOf(maxLength));
+    }
+
+    private Factory(int initialCapacity, Integer maxLength) {
       this.initialCapacity = initialCapacity;
       this.maxLength = maxLength;
     }
 
     @Override
     public TTransport getTransport(TTransport trans) throws TTransportException {
-      return new TFastFramedTransport(trans, initialCapacity, maxLength);
+      return Objects.isNull(maxLength)
+          ? new TFastFramedTransport(trans, initialCapacity)
+          : new TFastFramedTransport(trans, initialCapacity, maxLength);
     }
   }
 
@@ -71,7 +79,9 @@ public class TFastFramedTransport extends TLayeredTransport {
    * @param underlying Transport that real reads and writes will go through to.
    */
   public TFastFramedTransport(TTransport underlying) throws TTransportException {
-    this(underlying, DEFAULT_BUF_CAPACITY, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
+    // No maximum was asked for, so keep the one the transport already carries.
+    // See TFramedTransport's single-argument constructor.
+    this(underlying, DEFAULT_BUF_CAPACITY, configuredMaxFrameSize(underlying));
   }
 
   /**
@@ -85,7 +95,7 @@ public class TFastFramedTransport extends TLayeredTransport {
    */
   public TFastFramedTransport(TTransport underlying, int initialBufferCapacity)
       throws TTransportException {
-    this(underlying, initialBufferCapacity, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
+    this(underlying, initialBufferCapacity, configuredMaxFrameSize(underlying));
   }
 
   /**

--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TFramedTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TFramedTransport.java
@@ -40,10 +40,11 @@ public class TFramedTransport extends TLayeredTransport {
   private final TMemoryInputTransport readBuffer_;
 
   public static class Factory extends TTransportFactory {
-    private final int maxLength_;
+    /** Null when no maximum was asked for, which leaves each transport's own alone. */
+    private final Integer maxLength_;
 
     public Factory() {
-      maxLength_ = TConfiguration.DEFAULT_MAX_FRAME_SIZE;
+      maxLength_ = null;
     }
 
     public Factory(int maxLength) {
@@ -52,7 +53,9 @@ public class TFramedTransport extends TLayeredTransport {
 
     @Override
     public TTransport getTransport(TTransport base) throws TTransportException {
-      return new TFramedTransport(base, maxLength_);
+      return Objects.isNull(maxLength_)
+          ? new TFramedTransport(base)
+          : new TFramedTransport(base, maxLength_);
     }
   }
 
@@ -75,7 +78,11 @@ public class TFramedTransport extends TLayeredTransport {
   }
 
   public TFramedTransport(TTransport transport) throws TTransportException {
-    this(transport, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
+    // No maximum was asked for, so keep the one the transport already carries.
+    // Passing the library default here would silently raise a limit its owner
+    // had lowered -- and, because the configuration object belongs to the
+    // transport underneath, would do so for everything else sharing it.
+    this(transport, configuredMaxFrameSize(transport));
   }
 
   public void open() throws TTransportException {

--- a/lib/java/src/main/java/org/apache/thrift/transport/layered/TLayeredTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/layered/TLayeredTransport.java
@@ -55,4 +55,16 @@ public abstract class TLayeredTransport extends TTransport {
   public TTransport getInnerTransport() {
     return innerTransport;
   }
+
+  /**
+   * The maximum frame size a transport is already configured with, or the library default if it
+   * carries no configuration at all. A layered transport that was not asked for a maximum of its
+   * own passes this back, so that wrapping a transport cannot raise a limit its owner lowered.
+   */
+  protected static int configuredMaxFrameSize(TTransport transport) {
+    TConfiguration configuration = transport.getConfiguration();
+    return Objects.isNull(configuration)
+        ? TConfiguration.DEFAULT_MAX_FRAME_SIZE
+        : configuration.getMaxFrameSize();
+  }
 }

--- a/lib/java/src/test/java/org/apache/thrift/transport/TestTFastFramedTransport.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/TestTFastFramedTransport.java
@@ -33,4 +33,15 @@ public class TestTFastFramedTransport extends TestTFramedTransport {
       throws TTransportException {
     return new TFastFramedTransport(underlying, INITIAL_CAPACITY, maxLength);
   }
+
+  @Override
+  protected TTransport getTransportWithoutMaxLength(TTransport underlying)
+      throws TTransportException {
+    return new TFastFramedTransport(underlying, INITIAL_CAPACITY);
+  }
+
+  @Override
+  protected TTransportFactory getFactoryWithoutMaxLength() {
+    return new TFastFramedTransport.Factory(INITIAL_CAPACITY);
+  }
 }

--- a/lib/java/src/test/java/org/apache/thrift/transport/TestTFramedTransport.java
+++ b/lib/java/src/test/java/org/apache/thrift/transport/TestTFramedTransport.java
@@ -46,6 +46,17 @@ public class TestTFramedTransport {
     return new TFramedTransport(underlying, maxLength);
   }
 
+  /** Wraps without asking for a maximum, which is the case that must leave one alone. */
+  protected TTransport getTransportWithoutMaxLength(TTransport underlying)
+      throws TTransportException {
+    return new TFramedTransport(underlying);
+  }
+
+  /** The same, through the factory a server is configured with. */
+  protected TTransportFactory getFactoryWithoutMaxLength() {
+    return new TFramedTransport.Factory();
+  }
+
   public static byte[] byteSequence(int start, int end) {
     byte[] result = new byte[end - start + 1];
     for (int i = 0; i <= (end - start); i++) {
@@ -87,6 +98,63 @@ public class TestTFramedTransport {
     assertEquals(220, trans.read(readBuf, 0, 220));
     assertArrayEquals(readBuf, byteSequence(0, 219));
     assertEquals(4, countTrans.readCount);
+  }
+
+  @Test
+  public void testWrappingKeepsALoweredMaxFrameSize() throws IOException, TTransportException {
+    TMemoryBuffer membuf = new TMemoryBuffer(0);
+    membuf.getConfiguration().setMaxFrameSize(1024);
+
+    getTransportWithoutMaxLength(membuf);
+
+    assertEquals(
+        1024,
+        membuf.getConfiguration().getMaxFrameSize(),
+        "wrapping a transport must not raise a maximum its owner lowered");
+  }
+
+  @Test
+  public void testFactoryKeepsALoweredMaxFrameSize() throws IOException, TTransportException {
+    TMemoryBuffer membuf = new TMemoryBuffer(0);
+    membuf.getConfiguration().setMaxFrameSize(1024);
+
+    getFactoryWithoutMaxLength().getTransport(membuf);
+
+    assertEquals(
+        1024,
+        membuf.getConfiguration().getMaxFrameSize(),
+        "a factory that was not given a maximum must not impose one");
+  }
+
+  @Test
+  public void testAnExplicitMaxFrameSizeIsStillApplied() throws IOException, TTransportException {
+    TMemoryBuffer membuf = new TMemoryBuffer(0);
+    membuf.getConfiguration().setMaxFrameSize(1024);
+
+    getTransport(membuf, 2048);
+
+    assertEquals(2048, membuf.getConfiguration().getMaxFrameSize());
+  }
+
+  @Test
+  public void testALoweredMaxFrameSizeStillRefusesAFrame() throws IOException, TTransportException {
+    // The point of the three above: a maximum that is silently raised is not a
+    // maximum. This reads an actual frame through it.
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+    dos.writeInt(2048);
+    dos.write(new byte[2048]);
+
+    TMemoryBuffer membuf = new TMemoryBuffer(0);
+    membuf.write(baos.toByteArray());
+    membuf.getConfiguration().setMaxFrameSize(1024);
+
+    TTransport trans = getTransportWithoutMaxLength(membuf);
+
+    byte[] readBuf = new byte[10];
+    TTransportException e =
+        assertThrows(TTransportException.class, () -> trans.read(readBuf, 0, 4));
+    assertEquals(TTransportException.CORRUPTED_DATA, e.getType());
   }
 
   @Test


### PR DESCRIPTION
Wrapping a transport in `TFramedTransport` or `TFastFramedTransport` overwrote the maximum frame size it was configured with, even when no maximum had been asked for:

```java
public TFramedTransport(TTransport transport) throws TTransportException {
  this(transport, TConfiguration.DEFAULT_MAX_FRAME_SIZE);
}

public TFramedTransport(TTransport transport, int maxLength) throws TTransportException {
  TConfiguration _configuration = ... transport.getConfiguration();
  _configuration.setMaxFrameSize(maxLength);
```

So

```java
socket.getConfiguration().setMaxFrameSize(1024);
TTransport framed = new TFramedTransport(socket);
```

left the socket configured for `16384000`.

Two things went wrong at once. A maximum the operator set was replaced by the library default; and the object written into belongs to the transport underneath, so anything else sharing that `TConfiguration` changed with it. A layered transport has no configuration of its own to write into — `TLayeredTransport.getConfiguration()` delegates to the inner transport by design.

`TFastFramedTransport(underlying)` and `TFastFramedTransport(underlying, initialBufferCapacity)` did the same, as did `TFramedTransport.Factory()` and `TFastFramedTransport.Factory()` / `Factory(initialCapacity)` — so a server configured with `new TFramedTransport.Factory()` raised the limit on **every connection it accepted**.

### The change

A constructor or factory that was not given a maximum now passes back the one the transport already carries, so wrapping changes nothing. Given one explicitly, the behaviour is unchanged: it is applied, as the argument's javadoc promises.

### The rest of the tree

Go solved this for its own deprecated constructors, and the reason is written into its `TConfiguration`:

> `noPropagation` — *"Used internally by deprecated constructors, to avoid overriding underlying TTransport/TProtocol's cfg by accidental propagations."*

C++ (`TFramedTransport` copies `configuration_->getMaxFrameSize()` into its own `maxFrameSize_`), netstd, Delphi and Haxe all read the configured maximum and never write it. Java was the only binding where wrapping wrote it.

### Tests

Four in `TestTFramedTransport`, inherited by `TestTFastFramedTransport`, so both classes are covered:

- wrapping keeps a lowered maximum,
- the factory keeps it,
- an explicit maximum is still applied,
- and — the point of the other three — a frame declaring 2048 bytes is still refused by a transport configured for 1024 after being wrapped.

Three of the four fail on each class beforehand (`expected: <1024> but was: <16384000>`, and *"Expected TTransportException to be thrown, but nothing was thrown"*). The explicit-maximum one is a regression guard and passes either way.

Full `gradle test spotlessCheck`: BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
