### PR TITLE
THRIFT-4244: Explain literal backslash escaping in parser errors

### DIFF
--- a/compiler/cpp/src/thrift/thriftl.ll
+++ b/compiler/cpp/src/thrift/thriftl.ll
@@ -66,6 +66,8 @@
 #include "thrift/globals.h"
 #include "thrift/parse/t_program.h"
 
+static bool yyinput_reached_eof = false;
+
 /**
  * Must be included AFTER parse/t_program.h, but I can't remember why anymore
  * because I wrote this a while ago.
@@ -98,11 +100,6 @@ void error_no_longer_supported(const char* text, const char* replace_with) {
  * Provides the yylineno global, useful for debugging output
  */
 %option lex-compat
-
-/**
- * Our inputs are all single files, so no need for yywrap
- */
-%option noyywrap
 
 /**
  * We don't use it, and it fires up warnings at -Wall
@@ -287,17 +284,33 @@ literal_begin (['\"])
   std::string result;
   for(;;)
   {
+    yyinput_reached_eof = false;
     int ch = yyinput();
     switch (ch) {
-      case EOF:
-        yyerror("End of file while read string at %d\n", yylineno);
-        exit(1);
+      case 0:
+        if (yyinput_reached_eof) {
+          yyerror("End of file while reading string at %d\n", yylineno);
+          exit(1);
+        }
+        result.push_back('\0');
+        continue;
       case '\n':
-        yyerror("End of line while read string at %d\n", yylineno - 1);
+        yyerror("End of line while reading string at %d\n", yylineno - 1);
         exit(1);
       case '\\':
+        yyinput_reached_eof = false;
         ch = yyinput();
         switch (ch) {
+          case 0:
+            if (yyinput_reached_eof) {
+              yyerror("End of file while reading string at %d\n", yylineno);
+              exit(1);
+            }
+            yyerror("Invalid escape byte 0x00. Use \\\\ for a literal backslash.\n");
+            return -1;
+          case '\n':
+            yyerror("End of line while reading string at %d\n", yylineno - 1);
+            exit(1);
           case 'r':
             result.push_back('\r');
             continue;
@@ -317,7 +330,12 @@ literal_begin (['\"])
             result.push_back('\\');
             continue;
           default:
-            yyerror("Bad escape character\n");
+            if (ch >= 0x20 && ch <= 0x7e) {
+              yyerror("Invalid escape sequence '\\%c'. Use \\\\ for a literal backslash.\n", ch);
+            } else {
+              yyerror("Invalid escape byte 0x%02X. Use \\\\ for a literal backslash.\n",
+                      static_cast<unsigned int>(ch));
+            }
             return -1;
         }
         break;
@@ -338,6 +356,12 @@ literal_begin (['\"])
 }
 
 %%
+
+// A zero from yyinput() can also be a literal NUL; yywrap marks actual EOF.
+int yywrap(void) {
+  yyinput_reached_eof = true;
+  return 1;
+}
 
 #ifdef _MSC_VER
 #pragma warning( pop )

--- a/compiler/cpp/tests/cpp/t_cpp_parser_string_constant_tests.cc
+++ b/compiler/cpp/tests/cpp/t_cpp_parser_string_constant_tests.cc
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "t_cpp_generator_test_utils.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+struct yy_buffer_state;
+extern yy_buffer_state* yy_scan_string(const char*);
+extern yy_buffer_state* yy_scan_bytes(const char*, int);
+extern yy_buffer_state* yy_create_buffer(FILE*, int);
+extern void yy_switch_to_buffer(yy_buffer_state*);
+extern int yylex_destroy();
+
+using cpp_generator_test_utils::join_path;
+using cpp_generator_test_utils::parse_thrift_for_test;
+using cpp_generator_test_utils::source_dir;
+
+TEST_CASE("parser preserves supported string escapes", "[parser]")
+{
+    const std::string path = join_path(source_dir(), "test_string_escapes.thrift");
+    std::unique_ptr<t_program> program(new t_program(path, "test_string_escapes"));
+    parse_thrift_for_test(program.get());
+
+    const std::vector<std::pair<std::string, std::string>> expected = {
+        {"DOUBLE_QUOTED", "Y-m-d\\TH:i:s.uP"},
+        {"SINGLE_QUOTED", "Y-m-d\\TH:i:s.uP"},
+        {"ALL_DOUBLE", "\r\n\t\"'\\"},
+        {"ALL_SINGLE", "\r\n\t\"'\\"}
+    };
+    REQUIRE(program->get_consts().size() == expected.size());
+    const t_scope& scope = *program->scope();
+    for (const auto& entry : expected) {
+        INFO(entry.first);
+        const t_const* constant = scope.get_constant(entry.first);
+        REQUIRE(constant != nullptr);
+        REQUIRE(constant->get_value()->get_type() == t_const_value::CV_STRING);
+        REQUIRE(constant->get_value()->get_string() == entry.second);
+    }
+}
+
+TEST_CASE("lexer explains how to escape a literal backslash", "[parser]")
+{
+    // Clear scanner state left by earlier parser tests.
+    yylex_destroy();
+    for (const std::string& escape : {"T", "x41", "0", "u00e9"}) {
+        for (const char quote : {'"', '\''}) {
+            const std::string source = std::string(1, quote) + "\\" + escape + quote;
+            INFO(source);
+            // Reset scanner state even when the expected parser exception is thrown.
+            auto cleanup = [](yy_buffer_state*) { yylex_destroy(); };
+            std::unique_ptr<yy_buffer_state, decltype(cleanup)> buffer(
+                yy_scan_string(source.c_str()), cleanup);
+            const std::string expected = "Invalid escape sequence '\\" + escape.substr(0, 1)
+                + "'. Use \\\\ for a literal backslash.\n";
+            REQUIRE_THROWS_WITH(yylex(), expected);
+        }
+    }
+}
+
+TEST_CASE("lexer diagnoses incomplete and non-printable escapes", "[parser]")
+{
+    yylex_destroy();
+    const std::vector<std::pair<std::string, std::string>> cases = {
+        {"", "End of file while reading string at 1\n"},
+        {"\n", "End of line while reading string at 1\n"},
+        {"\r\n", "Invalid escape byte 0x0D. Use \\\\ for a literal backslash.\n"},
+        {"\t", "Invalid escape byte 0x09. Use \\\\ for a literal backslash.\n"},
+        {"\x01", "Invalid escape byte 0x01. Use \\\\ for a literal backslash.\n"},
+        {"\x7f", "Invalid escape byte 0x7F. Use \\\\ for a literal backslash.\n"},
+        {"\xc3\xa9", "Invalid escape byte 0xC3. Use \\\\ for a literal backslash.\n"},
+        {"\xff", "Invalid escape byte 0xFF. Use \\\\ for a literal backslash.\n"},
+        {std::string(1, '\0'), "Invalid escape byte 0x00. Use \\\\ for a literal backslash.\n"},
+        {std::string("\0tail", 5), "Invalid escape byte 0x00. Use \\\\ for a literal backslash.\n"}
+    };
+    for (const auto& test : cases) {
+        for (const char quote : {'"', '\''}) {
+            const std::string source = std::string(1, quote) + "abc\\" + test.first;
+            INFO(test.second);
+            for (const bool from_file : {false, true}) {
+                INFO(from_file);
+                auto close_file = [](FILE* handle) { std::fclose(handle); };
+                std::unique_ptr<FILE, decltype(close_file)> file(nullptr, close_file);
+                auto cleanup = [](yy_buffer_state*) { yylex_destroy(); };
+                std::unique_ptr<yy_buffer_state, decltype(cleanup)> buffer(nullptr, cleanup);
+                if (from_file) {
+                    file.reset(std::tmpfile());
+                    REQUIRE(file != nullptr);
+                    REQUIRE(std::fwrite(source.data(), 1, source.size(), file.get()) == source.size());
+                    std::rewind(file.get());
+                    buffer.reset(yy_create_buffer(file.get(), 8));
+                    yy_switch_to_buffer(buffer.get());
+                } else {
+                    buffer.reset(yy_scan_bytes(source.data(), static_cast<int>(source.size())));
+                }
+                REQUIRE_THROWS_WITH(yylex(), test.second);
+            }
+        }
+    }
+}
+
+TEST_CASE("lexer diagnoses an unterminated string at end of file", "[parser]")
+{
+    yylex_destroy();
+    for (const char quote : {'"', '\''}) {
+        const std::string source = std::string(1, quote) + "abc";
+        INFO(source);
+        auto cleanup = [](yy_buffer_state*) { yylex_destroy(); };
+        std::unique_ptr<yy_buffer_state, decltype(cleanup)> buffer(
+            yy_scan_bytes(source.data(), static_cast<int>(source.size())), cleanup);
+        REQUIRE_THROWS_WITH(yylex(), "End of file while reading string at 1\n");
+    }
+}
+
+TEST_CASE("lexer keeps reading a string after a literal NUL", "[parser]")
+{
+    yylex_destroy();
+    for (const char quote : {'"', '\''}) {
+        const std::string source = std::string(1, quote) + std::string("a\0b", 3) + quote;
+        INFO(quote);
+        auto cleanup = [](yy_buffer_state*) { yylex_destroy(); };
+        std::unique_ptr<yy_buffer_state, decltype(cleanup)> buffer(
+            yy_scan_bytes(source.data(), static_cast<int>(source.size())), cleanup);
+        REQUIRE_NOTHROW(yylex());
+    }
+}

--- a/compiler/cpp/tests/cpp/test_string_escapes.thrift
+++ b/compiler/cpp/tests/cpp/test_string_escapes.thrift
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const string DOUBLE_QUOTED = "Y-m-d\\TH:i:s.uP"
+const string SINGLE_QUOTED = 'Y-m-d\\TH:i:s.uP'
+const string ALL_DOUBLE = "\r\n\t\"\'\\"
+const string ALL_SINGLE = '\r\n\t\"\'\\'

--- a/compiler/cpp/tests/thrift_test_parser_support.cc
+++ b/compiler/cpp/tests/thrift_test_parser_support.cc
@@ -43,14 +43,29 @@ extern std::vector<std::string> g_incl_searchpath;
 
 // Error reporting used by the parser.
 void yyerror(const char* fmt, ...) {
-  std::fprintf(stderr, "[ERROR:%s:%d] ", g_curpath.c_str(), yylineno);
   va_list args;
   va_start(args, fmt);
-  std::vfprintf(stderr, fmt, args);
+  va_list size_args;
+  va_copy(size_args, args);
+  const int size = std::vsnprintf(nullptr, 0, fmt, size_args);
+  va_end(size_args);
+  if (size < 0) {
+    va_end(args);
+    throw std::runtime_error("Unable to format thrift parser error");
+  }
+  std::vector<char> message(size + 1);
+  const int written = std::vsnprintf(message.data(), message.size(), fmt, args);
   va_end(args);
-  std::fprintf(stderr, "\n");
+  if (written != size) {
+    throw std::runtime_error("Unable to format thrift parser error");
+  }
+  std::fprintf(stderr, "[ERROR:%s:%d] ", g_curpath.c_str(), yylineno);
+  std::fwrite(message.data(), 1, static_cast<size_t>(size), stderr);
+  if (size == 0 || message[size - 1] != '\n') {
+    std::fprintf(stderr, "\n");
+  }
 
-  throw std::runtime_error("thrift parser error");
+  throw std::runtime_error(std::string(message.data(), static_cast<size_t>(size)));
 }
 
 // Simplified helpers referenced by the grammar.


### PR DESCRIPTION
## Summary

An unknown escape such as `\T` in an IDL string currently produces an unhelpful "Bad escape character" error. Keep unknown escapes invalid and report the offending escape with the hint `Use \\ for a literal backslash`. Authors can write `"Y-m-d\\TH:i:s.uP"` to obtain the intended format string.

Add a committed fixture covering literal backslashes and all six supported escapes in both quote styles. Negative lexer tests cover unknown T, x, 0 and u escapes and check the diagnostic. The test parser preserves diagnostic text in exceptions, and the negative tests clean up scanner state.

Distinguish a trailing backslash at EOF from a literal NUL using Flex's yywrap callback. Render non-printable and non-ASCII escape bytes in hexadecimal instead of writing raw bytes into diagnostics. Cover EOF, LF, CRLF, NUL, control bytes and UTF-8 input in both quote styles, using memory and file input and asserting complete error messages. The test error handler validates both formatting passes, writes diagnostics with explicit lengths and avoids duplicate newlines.

The lexer is shared by all language bindings; no generator changes are needed.

## Testing

- Test-first: the negative test failed against the previous PR behavior because no exception was thrown.
- Test-first: the trailing-backslash case reproduced the incorrect and truncated diagnostic before the fix.
- Test-first: literal NUL input reproduced the incorrect EOF diagnostic before the yywrap change.
- Full standalone compiler suite in Docker: 20 test cases, 314 assertions passed, also with randomized order (seed 4244).
- A standalone probe linked against the test parser verified embedded NUL preservation and single-newline output.
- git diff --check passed.
- make style attempted; blocked by the existing missing lib/swift/Makefile.am in the local build configuration.

## CI Investigation

On head 734522b5c, compiler and PHP jobs passed. Three jobs failed while downloading artifacts with HTTP 403, before their tests ran. The two failing Python cross-test jobs logged client certificate address mismatches for ::1 and ::ffff:127.0.0.1. These failures occur outside the lexer changes; no Python TLS behavior is changed by this PR. Results from the updated head are pending.

Generated-by: OpenAI Codex GPT-6
