### PR TITLE
THRIFT-5090: Add PHP JSON slash regression coverage

### DIFF
--- a/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
+++ b/lib/php/test/Unit/Lib/Protocol/TJSONProtocolTest.php
@@ -136,6 +136,21 @@ class TJSONProtocolTest extends TestCase
         }
     }
 
+    public function testWriteStringDoesNotEscapeForwardSlash(): void
+    {
+        $transport = new TMemoryBuffer();
+        $protocol = new TJSONProtocol($transport);
+
+        $protocol->writeStructBegin('Test');
+        $protocol->writeFieldBegin('f', TType::STRING, 1);
+        $protocol->writeString('a/b');
+        $protocol->writeFieldEnd();
+        $protocol->writeFieldStop();
+        $protocol->writeStructEnd();
+
+        $this->assertSame('{"1":{"str":"a/b"}}', $transport->getBuffer());
+    }
+
     public static function writeAndReadScalarDataProvider()
     {
         yield 'bool true' => [

--- a/test/php/TestClient.php
+++ b/test/php/TestClient.php
@@ -129,6 +129,7 @@ function roundtrip($testClient, $method, $value)
  * STRING TEST
  */
 roundtrip($testClient, 'testString', "Test");
+roundtrip($testClient, 'testString', 'path /tmp/thrift and url https://127.0.0.1/service');
 
 /**
  * BOOL TEST


### PR DESCRIPTION
## Summary

Add regression coverage for unescaped forward slashes in PHP JSON protocol output and exercise the same slash-heavy string in the PHP cross-test client.

## Status

Rebased onto upstream master 81103bf9c on 2026-09-11. This branch now contains only THRIFT-5090 and no longer depends on THRIFT-2950 / #3787.

## Testing

- PHP TJSONProtocol unit tests in Docker: 55 tests, 112 assertions passed on the rebased branch.
- PHP cross-test client syntax check passed.
- Cross-language execution awaits CI.

Generated-by: OpenAI Codex GPT-5 and GPT-6
