### PR TITLE
THRIFT-6183: Use the library-wide default frame size in TNonblockingServer

### DIFF
--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -21,6 +21,7 @@
 #define _THRIFT_SERVER_TNONBLOCKINGSERVER_H_ 1
 
 #include <thrift/Thrift.h>
+#include <thrift/TConfiguration.h>
 #include <memory>
 #include <thrift/server/TServer.h>
 #include <thrift/transport/PlatformSocket.h>
@@ -123,8 +124,9 @@ private:
   /// Default limit on size of idle connection pool
   static const size_t CONNECTION_STACK_LIMIT = 1024;
 
-  /// Default limit on frame size
-  static const int MAX_FRAME_SIZE = 256 * 1024 * 1024;
+  /// Default limit on frame size, taken from TConfiguration so that the server
+  /// and the transports it wraps start from the same limit.
+  static const int MAX_FRAME_SIZE = TConfiguration::DEFAULT_MAX_FRAME_SIZE;
 
   /// Default limit on total number of connected sockets
   static const int MAX_CONNECTIONS = INT_MAX;

--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -21,6 +21,7 @@
 #include <boost/test/unit_test.hpp>
 #include <memory>
 
+#include "thrift/TConfiguration.h"
 #include "thrift/concurrency/Monitor.h"
 #include "thrift/concurrency/Thread.h"
 #include "thrift/server/TNonblockingServer.h"
@@ -210,6 +211,23 @@ BOOST_FIXTURE_TEST_CASE(provide_event_base, Fixture) {
   // also assert that the event_base is actually used when it's easy
   BOOST_CHECK_GT(event_base_get_num_events(eb, EVENT_BASE_COUNT_ADDED), 0);
 #endif
+}
+
+// The frame cap TNonblockingServer applies to every accepted connection lives on
+// the server itself: TConfiguration appears nowhere in TNonblockingServer.{h,cpp},
+// so the default here and the library-wide default are two independent numbers
+// that have already drifted 16x apart once. Pin them together, and pin that the
+// setter still wins, so a caller that needs larger frames keeps its escape hatch.
+BOOST_AUTO_TEST_CASE(default_max_frame_size_matches_configuration) {
+  auto socket = make_shared<transport::TNonblockingServerSocket>(0);
+  auto processor = make_shared<test::ParentServiceProcessor>(make_shared<Handler>());
+  server::TNonblockingServer server(processor, socket);
+
+  BOOST_CHECK_EQUAL(server.getMaxFrameSize(),
+                    static_cast<size_t>(TConfiguration::DEFAULT_MAX_FRAME_SIZE));
+
+  server.setMaxFrameSize(4096);
+  BOOST_CHECK_EQUAL(server.getMaxFrameSize(), static_cast<size_t>(4096));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`TNonblockingServer` caps the frame it will accept from a connection at its own `MAX_FRAME_SIZE`, which has been `256 * 1024 * 1024` since THRIFT-1337 landed it in 2011 — years before `TConfiguration` existed. The library-wide default is `TConfiguration::DEFAULT_MAX_FRAME_SIZE = 16384000`, whose own comment reads *"this value is used consistently across all Thrift libraries"*.

The two disagree by a factor of 16:

```
TNonblockingServer::getMaxFrameSize()     268435456
TConfiguration::DEFAULT_MAX_FRAME_SIZE     16384000
```

`TConfiguration` appears zero times in `TNonblockingServer.h` and `TNonblockingServer.cpp`, so the server neither reads a configured value nor inherits the default. It starts from its own constant, and only `setMaxFrameSize()` moves it. That constant is what sizes the read buffer, since `TConnection::transition()` resets the buffer to the length the peer declared before any payload byte has arrived.

Java's `AbstractNonblockingServer` has no such gap: its per-frame limit comes from `trans_.getMaxFrameSize()`, that is from `TConfiguration`, and it keeps a separate aggregate read-buffer budget on top of it.

### The change

`MAX_FRAME_SIZE` now points at `TConfiguration::DEFAULT_MAX_FRAME_SIZE`. The constant is `private`, so this is not an API change, and `setMaxFrameSize()` still overrides it.

### Compatibility — worth a reviewer's attention

**This lowers a shipped default.** A deployment that today accepts frames between 16,384,000 and 268,435,456 bytes on `TNonblockingServer`, and does not call `setMaxFrameSize()`, will start closing those connections. Nothing in the tree relies on the old value — there is no `setMaxFrameSize()` caller outside the new test, and the largest payload anywhere near this path is `StressTestNonBlocking`'s 2 MB chunk size — but out-of-tree users may. Release note needed.

### Test

One case added to the existing `lib/cpp/test/TNonblockingServerTest.cpp`. It fails before the change:

```
error: in "TNonblockingServerTest/default_max_frame_size_matches_configuration":
check server.getMaxFrameSize() == static_cast<size_t>(TConfiguration::DEFAULT_MAX_FRAME_SIZE)
has failed [268435456 != 16384000]
```

and also pins that `setMaxFrameSize()` still wins, so the escape hatch cannot quietly go away.

`ctest` on this branch: 32 of 35. The three failures — `UnitTests`, `TInterruptTest`, `TServerIntegrationTest` (SEGFAULT) — are all `connect() failed: Connection refused` and reproduce identically on pristine `master` in the same container, so they are environmental and pre-existing.

### Not in this PR

- `TNonblockingServer` still does not consult `TConfiguration` at all. Wiring it up is a larger design change and belongs in its own ticket.
- `lib/cpp/src/thrift/transport/TBufferTransports.h:349` still carries `TFramedTransport::DEFAULT_MAX_FRAME_SIZE = 256 * 1024 * 1024`, which nothing in the tree reads any more — all three constructors take `configuration_->getMaxFrameSize()`. That one is `public`, so correcting or removing it is an API question, unlike this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
