### PR TITLE
THRIFT-3874: Add PHP wakeup serializer regression coverage

### DIFF
--- a/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
+++ b/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
@@ -43,4 +43,19 @@ class BinarySerializerTest extends TestCase
         $deserialized = TBinarySerializer::deserialize($serialized, '\\Basic\\ThriftTest\\Xtruct');
         $this->assertEquals($struct, $deserialized);
     }
+
+    public function testBinarySerializerAfterPhpUnserialize(): void
+    {
+        $struct = new \Basic\ThriftTest\Xtruct(['string_thing' => 'abc']);
+
+        /** @var \Basic\ThriftTest\Xtruct $restored */
+        $restored = unserialize(serialize($struct));
+
+        // Guard THRIFT-3874: generated PHP classes must keep their type
+        // metadata usable after PHP wakeup/unserialize.
+        $serialized = TBinarySerializer::serialize($restored, '\\Basic\\ThriftTest\\Xtruct');
+        $deserialized = TBinarySerializer::deserialize($serialized, '\\Basic\\ThriftTest\\Xtruct');
+
+        $this->assertEquals($restored, $deserialized);
+    }
 }

--- a/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
+++ b/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
@@ -50,12 +50,13 @@ class BinarySerializerTest extends TestCase
 
         /** @var \Basic\ThriftTest\Xtruct $restored */
         $restored = unserialize(serialize($struct));
+        $this->assertEquals($struct, $restored);
 
         // Guard THRIFT-3874: generated PHP classes must keep their type
         // metadata usable after PHP wakeup/unserialize.
         $serialized = TBinarySerializer::serialize($restored, '\\Basic\\ThriftTest\\Xtruct');
         $deserialized = TBinarySerializer::deserialize($serialized, '\\Basic\\ThriftTest\\Xtruct');
 
-        $this->assertEquals($restored, $deserialized);
+        $this->assertEquals($struct, $deserialized);
     }
 }

--- a/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
+++ b/lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php
@@ -39,7 +39,7 @@ class BinarySerializerTest extends TestCase
     public function testBinarySerializer()
     {
         $struct = new \Basic\ThriftTest\Xtruct(['string_thing' => 'abc']);
-        $serialized = TBinarySerializer::serialize($struct, '\\Basic\\ThriftTest\\Xtruct');
+        $serialized = TBinarySerializer::serialize($struct);
         $deserialized = TBinarySerializer::deserialize($serialized, '\\Basic\\ThriftTest\\Xtruct');
         $this->assertEquals($struct, $deserialized);
     }
@@ -48,13 +48,13 @@ class BinarySerializerTest extends TestCase
     {
         $struct = new \Basic\ThriftTest\Xtruct(['string_thing' => 'abc']);
 
-        /** @var \Basic\ThriftTest\Xtruct $restored */
         $restored = unserialize(serialize($struct));
+        $this->assertInstanceOf(\Basic\ThriftTest\Xtruct::class, $restored);
         $this->assertEquals($struct, $restored);
 
         // Guard THRIFT-3874: generated PHP classes must keep their type
         // metadata usable after PHP wakeup/unserialize.
-        $serialized = TBinarySerializer::serialize($restored, '\\Basic\\ThriftTest\\Xtruct');
+        $serialized = TBinarySerializer::serialize($restored);
         $deserialized = TBinarySerializer::deserialize($serialized, '\\Basic\\ThriftTest\\Xtruct');
 
         $this->assertEquals($struct, $deserialized);


### PR DESCRIPTION
## Summary
- add a PHP integration regression test for a generated class that survives PHP `serialize()` / `unserialize()`
- verify the restored object still round-trips through `TBinarySerializer`
- lock in the current generator/runtime behavior that keeps generated type metadata usable after wakeup

## Testing
- `docker run --rm -v /home/v.panivko/github/thrift:/thrift -w /thrift thrift-php-dev:local vendor/bin/phpunit -c lib/php/phpunit.xml lib/php/test/Integration/Lib/Serializer/BinarySerializerTest.php`

Generated-by: OpenAI Codex GPT-5 <noreply@openai.com>
