### PR TITLE
THRIFT-2151: Add PHP persistent socket close regression coverage

### DIFF
--- a/lib/php/phpunit.xml
+++ b/lib/php/phpunit.xml
@@ -21,7 +21,8 @@
          bootstrap="test/bootstrap.php"
          cacheResult="false"
          colors="true"
-         stopOnWarning="true"
+         stopOnWarning="false"
+         failOnWarning="true"
          stopOnFailure="true"
          processIsolation="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">

--- a/lib/php/test/Unit/Lib/Transport/Fixture/BufferedReadTransport.php
+++ b/lib/php/test/Unit/Lib/Transport/Fixture/BufferedReadTransport.php
@@ -35,27 +35,27 @@ class BufferedReadTransport extends TTransport
         $this->chunks = $chunks;
     }
 
-    public function isOpen()
+    public function isOpen(): bool
     {
         return true;
     }
 
-    public function open()
+    public function open(): void
     {
     }
 
-    public function close()
+    public function close(): void
     {
     }
 
-    public function read($len)
+    public function read(int $len): string
     {
         $this->readRequests[] = $len;
 
         return array_shift($this->chunks);
     }
 
-    public function write($buf)
+    public function write(string $buf): void
     {
     }
 }

--- a/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketPoolTest.php
@@ -178,6 +178,8 @@ class TSocketPoolTest extends TestCase
         $expectedException,
         $expectedExceptionMessage
     ) {
+        $this->assertCount(count($apcuFetchCallParams), $apcuFetchResult);
+
         $this->getFunctionMock('Thrift\Transport', 'function_exists')
              ->expects($this->exactly(count($functionExistCallParams)))
              ->willReturnCallback(function (...$callArgs) use ($functionExistCallParams, $functionExistResult) {
@@ -375,6 +377,7 @@ class TSocketPoolTest extends TestCase
                     ['thrift_failtime:localhost:9090~', Assert::anything()],
                     ['thrift_consecfails:localhost:9090~', Assert::anything()],
                 ],
+                'apcuFetchResult' => [false, false],
                 'apcuStoreCallParams' => [
                     ['thrift_failtime:localhost:9090~', Assert::anything()],
                     ['thrift_consecfails:localhost:9090~', Assert::anything(), 0],
@@ -416,6 +419,9 @@ class TSocketPoolTest extends TestCase
                     ['php://temp', 'r'],
                 ],
                 'apcuStoreCallParams' => [],
+                'debugHandlerCall' => [
+                    [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
+                ],
             ]
         );
         yield 'last time fail time is not expired' => array_merge(
@@ -467,6 +473,7 @@ class TSocketPoolTest extends TestCase
                 ],
                 'apcuFetchResult' => [
                     90,
+                    false,
                 ],
                 'apcuStoreCallParams' => [
                     ['thrift_failtime:localhost:9090~', Assert::anything()],
@@ -503,6 +510,7 @@ class TSocketPoolTest extends TestCase
                     ['thrift_failtime:localhost:9090~', Assert::anything()],
                     ['thrift_consecfails:localhost:9090~', Assert::anything()],
                 ],
+                'apcuFetchResult' => [false, false],
                 'apcuStoreCallParams' => [
                     ['thrift_consecfails:localhost:9090~', 1],
                 ],
@@ -534,6 +542,7 @@ class TSocketPoolTest extends TestCase
                     1,
                 ],
                 'apcuFetchCallParams' => [],
+                'apcuFetchResult' => [],
                 'apcuStoreCallParams' => [],
                 'debugHandlerCall' => [
                     [LogLevel::ERROR, 'TSocket: Could not connect to localhost:9090 ( [])'],
@@ -578,6 +587,7 @@ class TSocketPoolTest extends TestCase
                     ['thrift_consecfails:host2:9091~', Assert::anything()],
                     ['thrift_failtime:host1:9090~', Assert::anything()],
                 ],
+                'apcuFetchResult' => [false, false, false],
                 'apcuStoreCallParams' => [
                     ['thrift_failtime:host2:9091~', Assert::anything()],
                     ['thrift_consecfails:host2:9091~', Assert::anything(), 0],

--- a/lib/php/test/Unit/Lib/Transport/TSocketTest.php
+++ b/lib/php/test/Unit/Lib/Transport/TSocketTest.php
@@ -86,8 +86,8 @@ class TSocketTest extends TestCase
         yield 'host is empty' => [
             'host' => '',
             'port' => 9090,
-            'persist' => null,
-            'debugHandler' => false,
+            'persist' => false,
+            'debugHandler' => null,
             'fsockopenCallCount' => 0,
             'expectedException' => TTransportException::class,
             'expectedMessage' => 'Cannot open null host',
@@ -469,6 +469,23 @@ class TSocketTest extends TestCase
         $this->assertNull($this->getPropertyValue($transport, 'handle'));
     }
 
+    public function testClosePersistentSocket(): void
+    {
+        $transport = new TSocket('localhost', 9090, true, null);
+        $handle = fopen('php://memory', 'r+');
+        $this->assertIsResource($handle);
+        $transport->setHandle($handle);
+
+        $this->assertNotNull($this->getPropertyValue($transport, 'handle'));
+
+        // Guard THRIFT-2151: close() must remain effective even when the
+        // socket was opened in persistent mode.
+        $transport->close();
+
+        $this->assertIsClosedResource($handle);
+        $this->assertNull($this->getPropertyValue($transport, 'handle'));
+    }
+
     #[DataProvider('writeFailDataProvider')]
     public function testWriteFail(
         $streamSelectResult,
@@ -805,7 +822,7 @@ class TSocketTest extends TestCase
         });
 
         $this->assertCount(1, $deprecations);
-        $this->assertStringContainsString('setConnectTimeout()', $deprecations[0]);
+        $this->assertStringContainsString('setConnectTimeout()', $deprecations[0]['errstr']);
     }
 
     public function testOpenWithDefaultTimeoutsDoesNotTriggerDeprecation(): void


### PR DESCRIPTION
## Summary
- Add regression coverage keeping `TSocket::close()` effective for persistent sockets (THRIFT-2151).
- Fix existing socket tests to use valid constructor arguments and the deprecation capture record's `errstr` field.
- Complete APCu mock responses in `TSocketPoolTest`, check that each expected fetch has a result, and expect the error log from the first failed connection attempt before a successful retry.
- Align the `BufferedReadTransport` test fixture with the typed transport interface.
- Continue running tests after warnings and return a failing exit code when warnings occur.

## Why Include the Test Harness Fixes?
The upstream PHP 8.4 CI run after #3792 reported success after executing only 689 of 947 tests: `stopOnWarning` stopped the suite before the socket tests, while warnings did not cause a failing exit code. These test-only corrections let the persistent socket regression run as part of the full suite instead of hiding behind an earlier warning.

## Testing
- PHP 8.4 / PHPUnit 13.3.3 in Docker, with current Composer dependencies and freshly generated PHP fixtures.
- Full suite: 948 tests, 2756 assertions, exit code 0; no errors, failures, or warnings. There are 5 skipped tests, 13 PHPUnit deprecations, and 6 PHPUnit notices.
- `TSocketPoolTest`: 20 tests, 249 assertions, no warnings or failures.
- An isolated warning probe verified both tests execute and PHPUnit returns exit code 1.
- PHPCS passed for all changed PHP files; `git diff --check` passed.
- Repository-wide `make style` is blocked by stale local Autotools configuration referencing the removed Swift directory.

Generated-by: OpenAI Codex GPT-5 <noreply@openai.com>
