### PR TITLE
THRIFT-6170: Add a GitHub Actions CI job for the D library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -895,6 +895,79 @@ jobs:
           path: lib/cpp/test/*.xml
           retention-days: 3
 
+  lib-d:
+    needs: compiler
+    runs-on: ubuntu-24.04
+    env:
+      # Keep in sync with build/docker/ubuntu-*/Dockerfile.
+      D_VERSION: 2.087.0
+      DEIMOS_LIBEVENT_REF: v2.0.2+2.0.16
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -y --no-install-recommends g++ wget ca-certificates $BUILD_DEPS
+
+      - name: Install dmd
+        run: |
+          wget -q "http://downloads.dlang.org/releases/2.x/$D_VERSION/dmd_$D_VERSION-0_amd64.deb"
+          # apt rather than dpkg, so that the deb's libcurl4 dependency is resolved.
+          sudo apt-get install -y --no-install-recommends "./dmd_$D_VERSION-0_amd64.deb"
+          rm -f "dmd_$D_VERSION-0_amd64.deb"
+          dmd --version
+
+      # The docker images also install the deimos OpenSSL 1.1.0h bindings, but
+      # the lib/d OpenSSL modules do not link against the OpenSSL 3.x that
+      # ubuntu-24.04 ships: ERR_put_error was dropped in 3.0 and
+      # SSL_get_peer_certificate was renamed to SSL_get1_peer_certificate.
+      # Leaving those headers out makes configure report
+      # "Building D SSL tests ... no", which drops the five OpenSSL-dependent
+      # modules from both the library and the test set. Install them here once
+      # THRIFT-6185 has taught lib/d to speak OpenSSL 3.x.
+      - name: Install deimos libevent bindings
+        run: |
+          sudo mkdir -p /usr/include/dmd/druntime/import/deimos /usr/include/dmd/druntime/import/C
+          git clone -q -b "$DEIMOS_LIBEVENT_REF" https://github.com/D-Programming-Deimos/libevent.git deimos-libevent
+          sudo mv deimos-libevent/deimos/* /usr/include/dmd/druntime/import/deimos/
+          sudo mv deimos-libevent/C/* /usr/include/dmd/druntime/import/C/
+          rm -rf deimos-libevent
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Run configure for d
+        run: |
+          # \b keeps --without-dart from matching before --without-d does.
+          summary=$(./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/--without-d\b/--with-d/'))
+          echo "$summary"
+          # configure disables a binding it cannot find rather than failing, and
+          # the steps below would then pass without running a single test. A
+          # green job that tests nothing is worse than no job, so insist that
+          # dmd was actually found.
+          echo "$summary" | grep -qE "Building D Library [.]+ : yes"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Run thrift-compiler
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+
+      - name: Run make for d
+        run: make -C lib/d
+
+      # Builds and runs every module's unit tests in both debug and release
+      # mode, then the lib/d/test client pool and transport tests.
+      - name: Run make check for d
+        run: make -C lib/d check
+
   lib-ruby:
     needs: compiler
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Nothing in CI builds or runs `lib/d`. `build.yml` has jobs for php, go, java-kotlin, netstd, haxe, rust, python, nodejs, cpp and ruby, and its shared `CONFIG_ARGS_FOR_LIBS` passes `--without-d`; `docker.yml` only builds and validates the images. A regression in `lib/d` can only be found by someone building D by hand — which is how THRIFT-6168 had to be verified.

Most of what a job needs already exists, so this is mostly wiring: the docker images pin dmd 2.087.0 and the deimos header sets, `configure.ac` has `AX_DMD`, and `lib/d/Makefile.am` already lists the debug and release unittest binaries in `TESTS`.

### The job

Installs dmd the way the images do, bootstraps, configures with `--with-d` and the other bindings off, and runs `make -C lib/d check`. The compiler artifact is needed because `lib/d/test` generates from `.thrift` sources.

### Four things here are easy to get wrong

**The deimos OpenSSL bindings are deliberately not installed.** They are in the docker images, but `lib/d`'s OpenSSL modules do not link against the OpenSSL 3.x that `ubuntu-24.04` ships:

```
libthriftd-ssl.a(ssl_347_3db.o):src/thrift/internal/ssl.d:
  undefined reference to 'SSL_get_peer_certificate'
libthriftd-ssl.a(ssl_bio_34b_356.o):src/thrift/internal/ssl_bio.d:
  undefined reference to 'ERR_put_error'
```

`ERR_put_error` was dropped in 3.0 and `SSL_get_peer_certificate` renamed to `SSL_get1_peer_certificate`. Leaving the headers out makes configure report `Building D SSL tests ... no`, which drops those five modules from both the library and the test set. That is a real `lib/d` gap rather than a CI one, filed as THRIFT-6185; the step carries a comment saying to put the headers back once it is closed. The libevent bindings **are** installed and their modules are covered.

**The sed matches `--without-d` with a word boundary.** Without `\b`, sed rewrites the first match in the argument list, which is `--without-dart`, and the job would quietly build Dart instead of D.

**dmd is installed with apt rather than dpkg**, because the deb depends on `libcurl4` and `dpkg --install` leaves the package unconfigured instead of pulling it in.

**The configure step checks that dmd was actually found.** configure disables a binding it cannot locate rather than failing, so without that check a job whose toolchain step had quietly stopped working would keep reporting success while running no tests at all — worse than having no job.

### Verification

Run end to end on a clean `ubuntu:24.04` with the job's own steps:

```
Building D Library ........... : yes
   Building D libevent tests . : yes
   Building D SSL tests ...... : no
   Using D version ........... : DMD64 D Compiler v2.087.0

92 PASS, 0 FAIL      (43 modules in debug and release, less the SSL ones)
All 2 tests passed   (lib/d/test: client_pool_test, transport_test)
```

With `dmd` removed the job fails at configure instead of passing.

### Not in this PR

- Adding `d` to the `cross-test` matrix. `lib/d/test` already has a `precross` target, so that is a follow-up on its own merits.
- The OpenSSL 3.x port of `lib/d` — THRIFT-6185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
