### PR TITLE
THRIFT-6171: Add a GitHub Actions CI job for the Erlang library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -968,6 +968,74 @@ jobs:
             lib/rb/ext/*.so
           retention-days: 3
 
+  lib-erl:
+    needs: compiler
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        # OTP and rebar3 are one axis, not two: rebar3 3.18.0 -- the version
+        # build/docker/ubuntu-*/Dockerfile installs, next to OTP 25.3.2.9 --
+        # does not load on OTP 27 or later, and 3.27.0 does not load on OTP 25.
+        # OTP 29 is left out because the eunit-only meck 0.9.2 dependency does
+        # not compile there any more, deprecated 'catch' having become an
+        # error; add it here once THRIFT-6186 is closed.
+        include:
+          - otp-version: "25.3"
+            rebar3-version: "3.18.0"
+          - otp-version: "26.2"
+            rebar3-version: "3.27.0"
+          - otp-version: "27.3"
+            rebar3-version: "3.27.0"
+          - otp-version: "28.5"
+            rebar3-version: "3.27.0"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -y --no-install-recommends $BUILD_DEPS
+
+      # Has to run before configure, which locates erl and erlc on PATH.
+      - name: Set up Erlang/OTP
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          otp-version: ${{ matrix.otp-version }}
+          rebar3-version: ${{ matrix.rebar3-version }}
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Run configure for erlang
+        run: |
+          summary=$(./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-erlang/with-erlang/'))
+          echo "$summary"
+          # configure disables a binding it cannot find rather than failing, and
+          # the steps below would then pass without running a single test. A
+          # green job that tests nothing is worse than no job, so insist that
+          # Erlang was actually found.
+          echo "$summary" | grep -qE "Building Erlang Library [.]+ : yes"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Run thrift-compiler
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+
+      - name: Run make for erlang
+        run: make -C lib/erl
+
+      # Generates the test sources with the compiler above, then rebar3 eunit.
+      - name: Run make check for erlang
+        run: make -C lib/erl check
+
   cross-test:
     needs:
       - lib-php

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -156,7 +156,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/erl/README.md">Erlang</a></td>
 <!-- Since -----------------><td>0.3.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>18.3</td><td>22.0</td>
+<!-- Language Levels -------><td>25.3</td><td>28.5</td>
 <!-- Field types -----------><td><img src="/doc/images/cred.png" alt=""/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>


### PR DESCRIPTION
Nothing in CI builds or runs `lib/erl`. `build.yml` has jobs for php, go, java-kotlin, netstd, haxe, rust, python, nodejs, cpp and ruby, and both `build.yml` and `sca.yml` pass `--without-erlang`; `docker.yml` only builds and validates the images. `lib/erl` ships enabled by default in the release tarball, so this is code reaching users with no regression coverage at all — THRIFT-6163, THRIFT-6164 and THRIFT-6184 each had to be verified by running `rebar3 eunit` by hand.

Most of what a job needs already exists: `lib/erl/Makefile.am` has `check: .generated` followed by `$(REBAR) eunit`, and `configure.ac` gates the binding behind `--with-erlang` and locates `erl`/`erlc`.

### The job

Sets up OTP and rebar3, bootstraps, configures with `--with-erlang` and the other bindings off, runs `make -C lib/erl check`. The compiler artifact is needed because `.generated` runs the compiler over the test IDL. `setup-beam` has to come **before** configure, which looks for `erl` and `erlc` on `PATH`.

### Why a matrix, and not just the 25.3.2.9 the images pin

THRIFT-6184 (#3797) is the argument. The default Erlang TLS client stopped being able to connect when OTP 26 changed how `ssl:connect/3` reads its option list — a job pinned to 25.3 alone would have stayed green straight through it. So 25.3, 26.2, 27.3 and 28.5.

### OTP and rebar3 are one axis, not two

No single rebar3 covers the range:

```
OTP 25.3.2.9   rebar3 3.18.0  ok       rebar3 3.27.0  Error loading module rebar_log
OTP 26.2.5.21  rebar3 3.18.0  ok       rebar3 3.27.0  ok
OTP 27.3.4.17  rebar3 3.18.0  undefined function rebar3:main/1
OTP 28.5.0.6   rebar3 3.18.0  undefined function rebar3:main/1
```

3.18.0 is what the docker images install; it does not load on 27 or 28. 3.27.0 does not load on 25. They overlap only on 26, so each matrix entry carries its own pair.

### OTP 29 is left out

`lib/erl` itself compiles there. The eunit-only `meck 0.9.2` pinned in `rebar.config` does not — deprecated `catch` is an error as of 29, and `meck_matcher.erl` still uses it:

```
===> Compiling _build/test/lib/meck/src/meck_matcher.erl failed
 76 │  (catch erlang:apply(hamcrest, assert_that, [Value, HamcrestMatcher])) == true;
    │   ╰── 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
```

Raising that pin is a change to `lib/erl`'s test dependencies rather than to CI, so it is filed separately as THRIFT-6186. Once that is closed, 29 joins the matrix.

### A guard on configure

configure disables a binding it cannot locate rather than failing, so the step checks that Erlang was actually found. Without it, a job whose `setup-beam` step had quietly stopped working would keep reporting success while running no tests — worse than having no job.

### LANGUAGES.md

It recorded the tested OTP range as 18.3 to 22.0, which matched neither the docker images nor anything CI ran. #3797 flagged that as stale and said it should be raised "on the back of real CI coverage" — this is that. It now says 25.3 to 28.5, what the job pins.

### Verification

On a clean `ubuntu:24.04`, per matrix entry, using the same prebuilt OTP tarballs `setup-beam` pulls from `builds.hex.pm`:

```
OTP 25.3.2.9   349 tests, 0 failures
OTP 26.2.5.21  349 tests, 0 failures
OTP 27.3.4.17  349 tests, 0 failures
OTP 28.5.0.6   349 tests, 0 failures
```

With `erl` off `PATH` the job fails at configure instead of passing.

### Not in this PR

Adding `erl` to the `cross-test` matrix. `test/erl` has a `precross` target but no `check`, so that is a follow-up on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
