### PR TITLE
THRIFT-6172: Run the Dart tests, and build the binding in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -828,6 +828,66 @@ jobs:
             lib/nodets/test-compiled
           retention-days: 3
 
+  lib-dart:
+    needs: compiler
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        # The floor lib/dart/pubspec.yaml declares, and the version
+        # build/docker/ubuntu-*/Dockerfile pins. Keep LANGUAGES.md in step.
+        sdk: ["3.2.0", "3.13.3"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -y --no-install-recommends $BUILD_DEPS
+
+      # Has to run before configure, which looks for dart on PATH.
+      - name: Set up Dart SDK
+        uses: dart-lang/setup-dart@7654d458321ee25acccccfdb86cd48bd95768ff1 # v1.8.0
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Run configure for dart
+        run: |
+          summary=$(./configure $(echo $CONFIG_ARGS_FOR_LIBS | sed 's/without-dart/with-dart/'))
+          echo "$summary"
+          # configure disables a binding it cannot find rather than failing, and
+          # every step below would then pass without running a single test. A
+          # green job that tests nothing is what this one exists to end, so
+          # insist that Dart was actually found.
+          echo "$summary" | grep -qE "Building Dart Library [.]+ : yes"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: thrift-compiler
+          path: compiler/cpp
+
+      - name: Run thrift-compiler
+        run: |
+          chmod a+x compiler/cpp/thrift
+          compiler/cpp/thrift -version
+
+      - name: Run make for dart
+        run: make -C lib/dart
+
+      # dart pub get, then dart test over lib/dart/test.
+      - name: Run make check for dart
+        run: make -C lib/dart check
+
+      # Generates the cross-test client's stubs and runs the recursion-depth
+      # regression test from THRIFT-6056.
+      - name: Run make check for test/dart
+        run: make -C test/dart check
+
   lib-cpp:
     needs: compiler
     runs-on: ubuntu-24.04

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -120,7 +120,7 @@ Thrift's core protocol is TBinary, supported by all languages except for JavaScr
 <td align=left><a href="https://github.com/apache/thrift/blob/master/lib/dart/README.md">Dart</a></td>
 <!-- Since -----------------><td>0.10.0</td>
 <!-- Build Systems ---------><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
-<!-- Language Levels -------><td>2.0.0</td><td>2.4.0</td>
+<!-- Language Levels -------><td>3.2.0</td><td>3.13.3</td>
 <!-- Field types -----------><td><img src="/doc/images/cred.png" alt=""/></td>
 <!-- Low-Level Transports --><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>
 <!-- Transport Wrappers ----><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td><td><img src="/doc/images/cgrn.png" alt="Yes"/></td><td><img src="/doc/images/cred.png" alt=""/></td>

--- a/build/docker/ubuntu-focal/Dockerfile
+++ b/build/docker/ubuntu-focal/Dockerfile
@@ -125,7 +125,7 @@ RUN \
       mv deimos-openssl-1.1.0h/C/* /usr/include/dmd/druntime/import/C/ && \
       rm -rf deimos-openssl-1.1.0h
 
-ENV DART_VERSION=2.7.2-1
+ENV DART_VERSION=3.13.3-1
 RUN apt-get install -y --no-install-recommends \
       `# Dart dependencies` \
       dart=$DART_VERSION

--- a/build/docker/ubuntu-jammy/Dockerfile
+++ b/build/docker/ubuntu-jammy/Dockerfile
@@ -118,7 +118,7 @@ RUN \
   mv deimos-openssl-1.1.0h/C/* /usr/include/dmd/druntime/import/C/ && \
   rm -rf deimos-openssl-1.1.0h
 
-ENV DART_VERSION=2.7.2-1
+ENV DART_VERSION=3.13.3-1
 RUN apt-get install -y --no-install-recommends \
   `# Dart dependencies` \
   dart=$DART_VERSION

--- a/build/docker/ubuntu-noble/Dockerfile
+++ b/build/docker/ubuntu-noble/Dockerfile
@@ -117,7 +117,7 @@ RUN \
   mv deimos-openssl-1.1.0h/C/* /usr/include/dmd/druntime/import/C/ && \
   rm -rf deimos-openssl-1.1.0h
 
-ENV DART_VERSION=2.7.2-1
+ENV DART_VERSION=3.13.3-1
 RUN apt-get install -y --no-install-recommends \
   `# Dart dependencies` \
   dart=$DART_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -359,11 +359,22 @@ AM_CONDITIONAL(WITH_PHP_EXTENSION, [test "$have_php_extension" = "yes"])
 AX_THRIFT_LIB(dart, [DART], yes)
 if test "$with_dart" = "yes"; then
   AC_PATH_PROG([DART], [dart])
-  AC_PATH_PROG([DARTPUB], [pub])
-  if test "x$DART" != "x" -a "x$DARTPUB" != "x"; then
-    have_dart="yes"
+  if test "x$DART" != "x"; then
+    dnl "pub" as a standalone program was deprecated in Dart 2.15 and is gone
+    dnl in Dart 3, where "dart pub" is the only spelling left. Probing for the
+    dnl subcommand rather than the program is what makes the Dart library
+    dnl detectable on the SDK versions it actually supports.
+    AC_MSG_CHECKING([whether $DART has the pub subcommand])
+    if $DART pub --help >/dev/null 2>&1; then
+      AC_MSG_RESULT([yes])
+      DARTPUB="$DART pub"
+      have_dart="yes"
+    else
+      AC_MSG_RESULT([no])
+    fi
   fi
 fi
+AC_SUBST([DARTPUB])
 AM_CONDITIONAL(WITH_DART, [test "$have_dart" = "yes"])
 
 AX_THRIFT_LIB(ruby, [Ruby], yes)

--- a/lib/dart/Makefile.am
+++ b/lib/dart/Makefile.am
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-# Dart build command
-DARTPUB = dart pub
+# DART and DARTPUB come from configure. "pub" as a standalone program is gone
+# as of Dart 3, so DARTPUB is "$(DART) pub".
 
 all-local:
 	$(DARTPUB) get
@@ -30,6 +30,7 @@ clean-local:
 	find . -type d -name "packages" | xargs $(RM) -r
 
 check-local: all
+	$(DART) test
 
 distdir:
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -24,7 +24,9 @@ homepage: http://thrift.apache.org
 documentation: http://thrift.apache.org
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  # 3.2.0 rather than the 2.12.0 null-safety floor: the http 1.x dependency
+  # below does not resolve below it, so pub get already fails there.
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   fixnum: ">=0.10.2 <2.0.0"

--- a/test/dart/Makefile.am
+++ b/test/dart/Makefile.am
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-# Dart build command
-DARTPUB = dart pub
+# DART and DARTPUB come from configure. "pub" as a standalone program is gone
+# as of Dart 3, so DARTPUB is "$(DART) pub".
 
 gen-dart/thrift_test/lib/thrift_test.dart: ../v0.16/ThriftTest.thrift
 	$(THRIFT) --gen dart ../v0.16/ThriftTest.thrift
@@ -33,11 +33,10 @@ stubs: gen-dart/thrift_test/lib/thrift_test.dart pub-get
 
 precross: stubs
 
-check: stubs
+check: stubs recursion-test
 
-# Recursion-depth regression test (THRIFT-6056). Kept out of the default
-# cross-test chain because it needs a null-safe Dart SDK (>= 2.12); run it
-# explicitly with: make recursion-test
+# Recursion-depth regression test (THRIFT-6056). The null-safe SDK it needs is
+# now the only kind the library builds against, so it runs as part of check.
 gen-dart/Recursive/lib/Recursive.dart: ../Recursive.thrift
 	$(THRIFT) --gen dart ../Recursive.thrift
 

--- a/test/dart/recursion_depth_test/pubspec.yaml
+++ b/test/dart/recursion_depth_test/pubspec.yaml
@@ -22,7 +22,8 @@ author: Apache Thrift Developers <dev@thrift.apache.org>
 homepage: http://thrift.apache.org
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  # Matches the floor lib/dart declares; both depend on it by path.
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   thrift:

--- a/test/dart/test_client/pubspec.yaml
+++ b/test/dart/test_client/pubspec.yaml
@@ -22,7 +22,8 @@ author: Apache Thrift Developers <dev@thrift.apache.org>
 homepage: http://thrift.apache.org
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  # Matches the floor lib/dart declares; both depend on it by path.
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   args: "^2.4.2"


### PR DESCRIPTION
`lib/dart/test` holds nine test files — transport, protocol, serializer, `t_application_error` — and nothing in the build system ever ran them. `lib/dart/Makefile.am` had `check-local: all` with an empty recipe, and `all-local` is `dart pub get`, so `make check` resolved dependencies and reported success without executing a single test. No CI job built the binding either: both `build.yml` and `sca.yml` pass `--without-dart`.

Wiring up a job meant fixing two things underneath it first.

### configure could not detect Dart at all

Not on any SDK the library supports. It probed for `pub` as a standalone program:

```
AC_PATH_PROG([DART], [dart])
AC_PATH_PROG([DARTPUB], [pub])
```

`pub` was deprecated in 2.15 and **removed in Dart 3** — `dart pub` is the only spelling left. On anything newer than the 2.7.2 the images pinned, `AC_PATH_PROG` found no `pub`, `have_dart` stayed `no`, and `lib/dart` was skipped:

```
checking for dart... /usr/lib/dart/bin/dart
checking for pub... no
Building Dart Library ........ : no
```

So probe the subcommand instead, and let configure hand `DART` and `DARTPUB` to the two `Makefile.am` files that had been hardcoding `dart pub` themselves.

### The SDK pin, and the floor it was measured against

The images pinned `DART_VERSION=2.7.2-1`, older than the `">=2.12.0"` the library's own pubspec asked for — `dart pub get` could not have resolved in the project's own images.

That floor was itself wrong. The `http` 1.x dependency does not resolve below 3.2.0, so `pub get` already fails on 3.1, with a message about `http` rather than about thrift:

```
Because thrift depends on http >=1.1.1 which requires SDK version >=3.2.0 <4.0.0,
version solving failed.
```

Both now say 3.2.0, as do the two dependent pubspecs under `test/dart`. The images pin `3.13.3-1` — verified to install on focal, jammy and noble alike.

### With that, the tests run

`check-local` runs `dart test`: **87 tests**.

`test/dart`'s recursion-depth test (THRIFT-6056) was excluded from `check` with a comment saying it needs a null-safe SDK. That is no longer a distinction worth drawing — the floor is 3.2.0 — so it joins `check` as well: **27 more tests** that had never run.

### The job

Matrix is the declared floor and the pinned image version, 3.2.0 and 3.13.3. `setup-dart` has to come before configure. `LANGUAGES.md` now says the same pair instead of 2.0.0 to 2.4.0.

The configure step checks that Dart was actually found before the test steps run. That is not defensive habit: while writing this I had a job go green end to end against an unpatched configure that had disabled Dart — precisely the failure this ticket is about — and it is worth making impossible rather than unlikely.

### Verification

End to end on clean `ubuntu:24.04` containers with the job's own steps:

```
Dart 3.2.0    lib/dart  87 tests passed    test/dart  27 tests passed
Dart 3.13.3   lib/dart  87 tests passed    test/dart  27 tests passed
```

With the `dart` binary removed the job fails at configure instead of passing.

### Not in this PR

- `tutorial/dart`'s three pubspecs still declare `>=2.12.0`. Harmless — they depend on `lib/dart` by path, so pub intersects the constraints and the effective floor is already 3.2.0 — and no CI job builds them.
- Adding `dart` to the `cross-test` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
