### PR TITLE
THRIFT-6192: Match HTTP header names in full rather than by prefix

### DIFF
--- a/lib/cpp/README.md
+++ b/lib/cpp/README.md
@@ -276,6 +276,21 @@ Support for Boost at runtime was deprecated.
 
 # Breaking Changes
 
+## 0.25.0
+
+The HTTP transport reads a header name as the whole token before the colon.  It
+used to compare only as many characters as the peer had sent, so any name that
+is a prefix of one it knows was accepted as that name: `C: 5` set the content
+length, `T: chunked` switched on chunked decoding, `X: 1.2.3.4` set the origin,
+and on the WebSocket server `U:`, `C:` and `S:` satisfied the handshake.  A
+deployment that relied on any of those abbreviations has to send the full name;
+every other HTTP implementation already required it.
+
+`Content-Length` is now parsed against RFC 9110 8.6's `1*DIGIT`.  `atoi()` could
+not report a negative number, a value too large for the field, or text that is
+not a number at all -- `Content-length: -1` used to arrive as 4294967295 -- and
+all three are now refused with a `TTransportException`.
+
 ## 1.0.0
 
 THRIFT-4720:

--- a/lib/cpp/src/thrift/transport/THttpClient.cpp
+++ b/lib/cpp/src/thrift/transport/THttpClient.cpp
@@ -82,7 +82,7 @@ void THttpClient::parseHeader(char* header) {
     }
   } else if (boost::iequals(name, "Content-Length")) {
     chunked_ = false;
-    contentLength_ = atoi(value);
+    contentLength_ = parseContentLength(value);
   } else if (boost::iequals(name, "Connection")) {
     std::vector<string> options;
     boost::split(options, value, boost::is_any_of(","));

--- a/lib/cpp/src/thrift/transport/THttpServer.cpp
+++ b/lib/cpp/src/thrift/transport/THttpServer.cpp
@@ -51,6 +51,20 @@ THttpServer::~THttpServer() = default;
   #define THRIFT_strcasestr(haystack, needle) strcasestr(haystack, needle)
 #endif
 
+namespace {
+
+// sz is the length of the name the peer sent, so comparing only that many
+// characters accepted every name that is a prefix of one below: "C: 5" was a
+// content length and "T: chunked" switched on chunked decoding.  A header name
+// is the whole token before the colon (RFC 9110 5.1), and a transport that
+// reads it otherwise disagrees with every other party on the connection about
+// where the message ends.
+bool headerNameIs(const char* header, size_t sz, const char* name) {
+  return sz == strlen(name) && THRIFT_strncasecmp(header, name, sz) == 0;
+}
+
+} // namespace
+
 void THttpServer::parseHeader(char* header) {
   char* colon = strchr(header, ':');
   if (colon == nullptr) {
@@ -59,14 +73,14 @@ void THttpServer::parseHeader(char* header) {
   size_t sz = colon - header;
   char* value = colon + 1;
 
-  if (THRIFT_strncasecmp(header, "Transfer-Encoding", sz) == 0) {
+  if (headerNameIs(header, sz, "Transfer-Encoding")) {
     if (THRIFT_strcasestr(value, "chunked") != nullptr) {
       chunked_ = true;
     }
-  } else if (THRIFT_strncasecmp(header, "Content-length", sz) == 0) {
+  } else if (headerNameIs(header, sz, "Content-length")) {
     chunked_ = false;
-    contentLength_ = atoi(value);
-  } else if (strncmp(header, "X-Forwarded-For", sz) == 0) {
+    contentLength_ = parseContentLength(value);
+  } else if (sz == strlen("X-Forwarded-For") && strncmp(header, "X-Forwarded-For", sz) == 0) {
     origin_ = value;
   }
 }

--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -19,6 +19,11 @@
 
 #include <sstream>
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <string>
+
 #include <thrift/transport/THttpTransport.h>
 
 using std::string;
@@ -55,6 +60,31 @@ uint32_t THttpTransport::maxHttpBufSize() {
     return httpBufSize_;
   }
   return static_cast<uint32_t>(configured);
+}
+
+uint32_t THttpTransport::parseContentLength(const char* value) {
+  errno = 0;
+  char* end = nullptr;
+  const long long parsed = std::strtoll(value, &end, 10);
+
+  // strtoll skips leading whitespace, so end == value means there were no
+  // digits at all.  RFC 9110 8.6 has Content-Length as 1*DIGIT, which leaves
+  // no room for a sign, for trailing text, or for a value the member cannot
+  // hold.
+  if (end == value || errno == ERANGE || parsed < 0
+      || parsed > static_cast<long long>((std::numeric_limits<uint32_t>::max)())) {
+    throw TTransportException(TTransportException::CORRUPTED_DATA,
+                              "Bad Content-Length: " + std::string(value));
+  }
+  while (*end == ' ' || *end == '\t') {
+    ++end;
+  }
+  if (*end != '\0') {
+    throw TTransportException(TTransportException::CORRUPTED_DATA,
+                              "Bad Content-Length: " + std::string(value));
+  }
+
+  return static_cast<uint32_t>(parsed);
 }
 
 void THttpTransport::init() {

--- a/lib/cpp/src/thrift/transport/THttpTransport.h
+++ b/lib/cpp/src/thrift/transport/THttpTransport.h
@@ -99,6 +99,11 @@ protected:
   /// Upper bound on httpBufSize_, from TConfiguration::maxMessageSize.
   uint32_t maxHttpBufSize();
 
+  /// Reads a Content-Length header value.  Throws TTransportException unless
+  /// it is a decimal number that fits contentLength_, which atoi() could
+  /// neither check nor report on: "-1" used to arrive here as 4294967295.
+  static uint32_t parseContentLength(const char* value);
+
   static const char* CRLF;
   static const int CRLF_LEN;
 };

--- a/lib/cpp/src/thrift/transport/TWebSocketServer.h
+++ b/lib/cpp/src/thrift/transport/TWebSocketServer.h
@@ -118,6 +118,14 @@ protected:
     return h.str();
   }
 
+  // sz is the length of the name the peer sent, so comparing only that many
+  // characters accepted every name that is a prefix of one below: "U:", "C:"
+  // and "S:" were enough to satisfy the handshake, and "S:" reached the key
+  // arm because it is tested before the version one.
+  static bool headerNameIs(const char* header, size_t sz, const char* name) {
+    return sz == strlen(name) && THRIFT_strncasecmp(header, name, sz) == 0;
+  }
+
   void parseHeader(char* header) override {
     char* colon = strchr(header, ':');
     if (colon == nullptr) {
@@ -126,22 +134,29 @@ protected:
     size_t sz = colon - header;
     char* value = colon + 1;
 
-    if (THRIFT_strncasecmp(header, "Upgrade", sz) == 0) {
+    if (headerNameIs(header, sz, "Upgrade")) {
       if (THRIFT_strcasestr(value, "websocket") != nullptr) {
         upgrade_ = true;
       }
-    } else if (THRIFT_strncasecmp(header, "Connection", sz) == 0) {
+    } else if (headerNameIs(header, sz, "Connection")) {
       if (THRIFT_strcasestr(value, "Upgrade") != nullptr) {
         connection_ = true;
       }
-    } else if (THRIFT_strncasecmp(header, "Sec-WebSocket-Key", sz) == 0) {
-      std::string toHash = value + 1;
+    } else if (headerNameIs(header, sz, "Sec-WebSocket-Key")) {
+      // value + 1 dropped the space that a header usually has after the colon,
+      // and read past the terminator when it did not: "Sec-WebSocket-Key:" on
+      // its own leaves *value at '\0'.  Skip the optional whitespace instead.
+      const char* key = value;
+      while (*key == ' ' || *key == '\t') {
+        ++key;
+      }
+      std::string toHash = key;
       toHash += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
       unsigned char hash[20];
       SHA1((const unsigned char*)toHash.c_str(), toHash.length(), hash);
       acceptKey_ = base64Encode(hash, 20);
       secWebSocketKey_ = true;
-    } else if (THRIFT_strncasecmp(header, "Sec-WebSocket-Version", sz) == 0) {
+    } else if (headerNameIs(header, sz, "Sec-WebSocket-Version")) {
       if (THRIFT_strcasestr(value, "13") != nullptr) {
         secWebSocketVersion_ = true;
       }

--- a/lib/cpp/test/CMakeLists.txt
+++ b/lib/cpp/test/CMakeLists.txt
@@ -91,6 +91,7 @@ set(UnitTest_SOURCES
     ThrifttReadCheckTests.cpp
     FrameBoundReadBudgetTest.cpp
     THttpBufferBoundTest.cpp
+    THttpHeaderParseTest.cpp
     TUuidTest.cpp
     Thrift5272.cpp
 )

--- a/lib/cpp/test/Makefile.am
+++ b/lib/cpp/test/Makefile.am
@@ -145,6 +145,7 @@ UnitTests_SOURCES = \
 	FrameBoundReadBudgetTest.cpp \
 	TWebSocketServerTest.cpp \
 	THttpBufferBoundTest.cpp \
+	THttpHeaderParseTest.cpp \
 	Thrift5272.cpp \
 	TUuidTest.cpp
 

--- a/lib/cpp/test/THttpHeaderParseTest.cpp
+++ b/lib/cpp/test/THttpHeaderParseTest.cpp
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <string>
+
+#include <thrift/TConfiguration.h>
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/transport/THttpClient.h>
+#include <thrift/transport/THttpServer.h>
+#include <thrift/transport/TTransportException.h>
+
+/*
+ * THttpServer::parseHeader compared a header name for as many characters as
+ * the *received* name happened to have:
+ *
+ *   size_t sz = colon - header;
+ *   if (THRIFT_strncasecmp(header, "Content-length", sz) == 0) ...
+ *
+ * so every name that is a prefix of a name the transport knows was accepted
+ * as that name -- "C: 5" set the content length and "T: chunked" switched on
+ * chunked decoding.  A header name means what RFC 9110 5.1 says it means, and
+ * a transport that reads it otherwise ends up disagreeing with every other
+ * party on the connection about where the message ends.
+ *
+ * The value side is the same question about a number: atoi() cannot report
+ * that it was handed a negative value or something that is not a number at
+ * all, and "Content-length: -1" therefore arrived in the uint32_t member as
+ * 4294967295.
+ */
+
+BOOST_AUTO_TEST_SUITE(THttpHeaderParseTest)
+
+using apache::thrift::TConfiguration;
+using apache::thrift::transport::THttpClient;
+using apache::thrift::transport::THttpServer;
+using apache::thrift::transport::TMemoryBuffer;
+using apache::thrift::transport::TTransport;
+using apache::thrift::transport::TTransportException;
+
+namespace {
+
+// The parsed framing is what these tests are about, so they read it directly
+// rather than inferring it from how many bytes came back.
+class TestHttpServer : public THttpServer {
+public:
+  TestHttpServer(std::shared_ptr<TTransport> transport, std::shared_ptr<TConfiguration> config)
+    : THttpServer(transport, config) {}
+  uint32_t contentLength() const { return contentLength_; }
+  bool chunked() const { return chunked_; }
+  const std::string& origin() const { return origin_; }
+};
+
+class TestHttpClient : public THttpClient {
+public:
+  TestHttpClient(std::shared_ptr<TTransport> transport,
+                 std::string host,
+                 std::string path,
+                 std::shared_ptr<TConfiguration> config)
+    : THttpClient(transport, host, path, config) {}
+  uint32_t contentLength() const { return contentLength_; }
+  bool chunked() const { return chunked_; }
+};
+
+std::shared_ptr<TMemoryBuffer> wireBuffer(const std::string& wire,
+                                          std::shared_ptr<std::string>* keepAlive) {
+  *keepAlive = std::make_shared<std::string>(wire);
+  return std::make_shared<TMemoryBuffer>(
+      reinterpret_cast<uint8_t*>(const_cast<char*>((*keepAlive)->data())),
+      static_cast<uint32_t>((*keepAlive)->size()));
+}
+
+// A request whose only interesting part is the one header under test, with a
+// five byte body behind it so that a transport which believes the header can
+// go and fetch one.
+std::string request(const std::string& header) {
+  return "POST / HTTP/1.1\r\nHost: localhost\r\n" + header + "\r\n\r\nhello";
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(a_full_content_length_header_is_read) {
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpServer trans(wireBuffer(request("Content-length: 5"), &keepAlive),
+                       std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  BOOST_CHECK_EQUAL(trans.read(out, sizeof(out)), 5u);
+  BOOST_CHECK_EQUAL(std::string(reinterpret_cast<char*>(out), 5), "hello");
+  BOOST_CHECK_EQUAL(trans.contentLength(), 5u);
+}
+
+BOOST_AUTO_TEST_CASE(the_header_name_is_matched_in_full_and_not_by_prefix) {
+  // "C" is not a header name this transport knows, and no other party on the
+  // connection would read it as one either.
+  const char* const prefixes[] = {"C: 5", "Co: 5", "Content: 5", "Content-len: 5"};
+
+  for (const char* header : prefixes) {
+    std::shared_ptr<std::string> keepAlive;
+    TestHttpServer trans(wireBuffer(request(header), &keepAlive),
+                         std::make_shared<TConfiguration>());
+
+    uint8_t out[5];
+    // No content length, so there is no body to hand out.
+    trans.read(out, sizeof(out));
+    BOOST_CHECK_MESSAGE(trans.contentLength() == 0u,
+                        std::string("\"") + header + "\" was read as a content length");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(a_prefix_of_transfer_encoding_does_not_switch_on_chunking) {
+  const char* const prefixes[] = {"T: chunked", "Tr: chunked", "Transfer: chunked"};
+
+  for (const char* header : prefixes) {
+    std::shared_ptr<std::string> keepAlive;
+    TestHttpServer trans(wireBuffer(request(header), &keepAlive),
+                         std::make_shared<TConfiguration>());
+
+    uint8_t out[5];
+    // Reading a body that is not chunked as though it were runs the stream
+    // out, so both outcomes end in an exception here and only the parsed flag
+    // tells them apart.
+    try {
+      trans.read(out, sizeof(out));
+    } catch (const TTransportException&) {
+    }
+    BOOST_CHECK_MESSAGE(!trans.chunked(),
+                        std::string("\"") + header + "\" switched on chunked decoding");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(a_prefix_of_x_forwarded_for_does_not_set_the_origin) {
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpServer trans(wireBuffer(request("X: 203.0.113.7"), &keepAlive),
+                       std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  trans.read(out, sizeof(out));
+  BOOST_CHECK(trans.origin().empty());
+}
+
+BOOST_AUTO_TEST_CASE(the_full_transfer_encoding_header_still_works) {
+  std::string wire = "HTTP/1.1 200 OK\r\n"
+                     "Transfer-Encoding: chunked\r\n"
+                     "\r\n"
+                     "3\r\nhel\r\n"
+                     "2\r\nlo\r\n"
+                     "0\r\n\r\n";
+
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpClient client(wireBuffer(wire, &keepAlive), "localhost", "/",
+                        std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  BOOST_CHECK_EQUAL(client.readAll(out, sizeof(out)), 5u);
+  BOOST_CHECK_EQUAL(std::string(reinterpret_cast<char*>(out), 5), "hello");
+  BOOST_CHECK(client.chunked());
+}
+
+BOOST_AUTO_TEST_CASE(a_negative_content_length_is_refused_by_the_server) {
+  // atoi() gave -1, which the uint32_t member then held as 4294967295.
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpServer trans(wireBuffer(request("Content-length: -1"), &keepAlive),
+                       std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  BOOST_CHECK_THROW(trans.read(out, sizeof(out)), TTransportException);
+  // Not "did it throw" -- an over-declared length outruns a five byte body and
+  // throws END_OF_FILE on the unmodified library too. What is under test is
+  // that no length was taken from "-1" at all.
+  BOOST_CHECK_EQUAL(trans.contentLength(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(a_negative_content_length_is_refused_by_the_client) {
+  std::string wire = "HTTP/1.1 200 OK\r\nContent-Length: -1\r\n\r\nhello";
+
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpClient client(wireBuffer(wire, &keepAlive), "localhost", "/",
+                        std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  BOOST_CHECK_THROW(client.readAll(out, sizeof(out)), TTransportException);
+  BOOST_CHECK_EQUAL(client.contentLength(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(a_content_length_that_is_not_a_number_is_refused) {
+  const char* const values[] = {"Content-length: abc", "Content-length: ", "Content-length: 5x"};
+
+  for (const char* header : values) {
+    std::shared_ptr<std::string> keepAlive;
+    TestHttpServer trans(wireBuffer(request(header), &keepAlive),
+                         std::make_shared<TConfiguration>());
+
+    uint8_t out[5];
+    BOOST_CHECK_THROW(trans.read(out, sizeof(out)), TTransportException);
+    BOOST_CHECK_EQUAL(trans.contentLength(), 0u);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(a_content_length_beyond_uint32_is_refused) {
+  // atoi() has no way to say "that does not fit"; it is undefined behaviour,
+  // and in practice the value arrived truncated.
+  std::shared_ptr<std::string> keepAlive;
+  TestHttpServer trans(wireBuffer(request("Content-length: 99999999999"), &keepAlive),
+                       std::make_shared<TConfiguration>());
+
+  uint8_t out[5];
+  BOOST_CHECK_THROW(trans.read(out, sizeof(out)), TTransportException);
+  // Same trap as above: the unmodified library throws here as well, having
+  // stored the truncated 1215752191 and then run out of body. The number is
+  // the test.
+  BOOST_CHECK_EQUAL(trans.contentLength(), 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
[THRIFT-6192](https://issues.apache.org/jira/browse/THRIFT-6192)

`THttpServer::parseHeader` compares a header name for as many characters as the peer sent before the colon:

```cpp
size_t sz = colon - header;
if (THRIFT_strncasecmp(header, "Content-length", sz) == 0) ...
```

so every name that is a **prefix** of one the transport knows is accepted as that name. Measured against the unmodified library:

| header sent | `contentLength_` | `chunked_` |
|---|---|---|
| `Content-length: 5` | 5 | 0 |
| `C: 5` | **5** | 0 |
| `co: 7` | **7** | 0 |
| `Content-len: 9` | **9** | 0 |
| `Transfer-Encoding: chunked` | 0 | 1 |
| `T: chunked` | 0 | **1** |
| `Cookie: 5` | 0 | 0 |

`Cookie` is the control — not a prefix of either name, correctly ignored.

A header name is the whole token before the colon (RFC 9110 5.1). Reading it otherwise means this transport and every other party on the connection disagree about where a message ends: `C: 5` gives Thrift a five-byte body where a parser following the grammar sees none.

`TWebSocketServer::parseHeader` is the same idiom on the same base class, so `U: websocket`, `C: Upgrade` and `S: <key>` satisfy the handshake — and `S:` reaches the `Sec-WebSocket-Key` arm, which is tested before the version one. Fixed here too, along with the `std::string toHash = value + 1;` beside it, which steps over the space after the colon by assuming one is there and reads one past the terminator for a header with an empty value.

`Content-Length` went through `atoi()`, which cannot report a negative number, a value too large for the `uint32_t` member, or text that is not a number:

| header sent | `contentLength_` |
|---|---|
| `Content-length: -1` | 4294967295 |
| `Content-length: 99999999999` | 1215752191 |
| `Content-length: abc` | 0 |
| `Content-length: 5x` | 5 |

It is now parsed with `strtoll` against RFC 9110 8.6's `1*DIGIT`. `THttpClient` shares the new helper; its name comparison was already a full `boost::iequals` equality and needed nothing.

### Tests

Nine cases in a new `lib/cpp/test/THttpHeaderParseTest.cpp`, written before the change, wired into both `CMakeLists.txt` and `Makefile.am`. **Six fail against the unmodified library.** The two covering a bad number assert the length that was *parsed* rather than that the read threw — an over-declared length outruns a five-byte body and throws on the unmodified library too, so `BOOST_CHECK_THROW` alone would have passed either way.

`UnitTests` is otherwise unchanged: `TWebSocketServerTest` 14/14, `THttpBufferBoundTest` 4/4.

### Behaviour change

Refusing an abbreviated header name, and refusing a malformed `Content-Length`, can turn away traffic that works today. `lib/cpp/README.md` gains a Breaking Changes entry under 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
