### PR TITLE
THRIFT-6193: Hold the HTTP message body to the configured maximum message size

### DIFF
--- a/lib/cpp/README.md
+++ b/lib/cpp/README.md
@@ -291,6 +291,12 @@ not report a negative number, a value too large for the field, or text that is
 not a number at all -- `Content-length: -1` used to arrive as 4294967295 -- and
 all three are now refused with a `TTransportException`.
 
+The body of an HTTP message is held to `TConfiguration::maxMessageSize`, 100 MB
+by default, counting a chunked body by the sum of its chunks.  Nothing bounded
+it before: the declared length, or the number of chunks, was the peer's choice.
+A client or server that exchanges bodies larger than the configured maximum has
+to raise it, the same way it would for any other transport.
+
 ## 1.0.0
 
 THRIFT-4720:

--- a/lib/cpp/src/thrift/transport/THttpTransport.cpp
+++ b/lib/cpp/src/thrift/transport/THttpTransport.cpp
@@ -48,7 +48,8 @@ THttpTransport::THttpTransport(std::shared_ptr<TTransport> transport, std::share
     httpBuf_(nullptr),
     httpPos_(0),
     httpBufLen_(0),
-    httpBufSize_(1024) {
+    httpBufSize_(1024),
+    bodyBytesRead_(0) {
   init();
 }
 
@@ -85,6 +86,27 @@ uint32_t THttpTransport::parseContentLength(const char* value) {
   }
 
   return static_cast<uint32_t>(parsed);
+}
+
+void THttpTransport::chargeBodyBytes(uint32_t size) {
+  // The peer picks the declared content length, and in a chunked body it picks
+  // how many chunks there are; neither was measured against anything. The line
+  // buffer has had its own ceiling since the growth was bounded, but the body
+  // does not pass through it -- readContent() writes straight into readBuffer_.
+  const uint32_t remaining = maxBodySize() - bodyBytesRead_;
+  if (size > remaining) {
+    throw TTransportException(TTransportException::CORRUPTED_DATA,
+                              "HTTP body exceeds the configured maximum message size");
+  }
+  bodyBytesRead_ += size;
+}
+
+uint32_t THttpTransport::maxBodySize() {
+  const int configured = getConfiguration()->getMaxMessageSize();
+  if (configured < 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(configured);
 }
 
 void THttpTransport::init() {
@@ -183,6 +205,8 @@ uint32_t THttpTransport::parseChunkSize(char* line) {
 }
 
 uint32_t THttpTransport::readContent(uint32_t size) {
+  chargeBodyBytes(size);
+
   uint32_t need = size;
   while (need > 0) {
     uint32_t avail = httpBufLen_ - httpPos_;
@@ -274,6 +298,7 @@ void THttpTransport::refill() {
 
 void THttpTransport::readHeaders() {
   // Initialize headers state variables
+  bodyBytesRead_ = 0;
   contentLength_ = 0;
   chunked_ = false;
   chunkedDone_ = false;

--- a/lib/cpp/src/thrift/transport/THttpTransport.h
+++ b/lib/cpp/src/thrift/transport/THttpTransport.h
@@ -78,6 +78,11 @@ protected:
   uint32_t httpBufLen_;
   uint32_t httpBufSize_;
 
+  /// Body bytes taken for the message being read, reset with the headers.
+  /// The declared length, or the number of chunks, is the peer's choice, and
+  /// nothing else here holds either of them to TConfiguration::maxMessageSize.
+  uint32_t bodyBytesRead_;
+
   virtual void init();
 
   uint32_t readMoreData();
@@ -103,6 +108,13 @@ protected:
   /// it is a decimal number that fits contentLength_, which atoi() could
   /// neither check nor report on: "-1" used to arrive here as 4294967295.
   static uint32_t parseContentLength(const char* value);
+
+  /// Charges size bytes of body against the maximum message size, throwing
+  /// TTransportException once the message would exceed it.
+  void chargeBodyBytes(uint32_t size);
+
+  /// TConfiguration::maxMessageSize as an unsigned value.
+  uint32_t maxBodySize();
 
   static const char* CRLF;
   static const int CRLF_LEN;

--- a/lib/cpp/test/THttpBufferBoundTest.cpp
+++ b/lib/cpp/test/THttpBufferBoundTest.cpp
@@ -19,14 +19,20 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <cstring>
+#include <locale>
 #include <memory>
+#include <sstream>
 #include <string>
+#include <vector>
 
 #include <thrift/TConfiguration.h>
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/THttpClient.h>
 #include <thrift/transport/THttpServer.h>
 #include <thrift/transport/TTransportException.h>
+#include <thrift/transport/TVirtualTransport.h>
 
 /*
  * THttpTransport keeps the line it is reading in httpBuf_, and grows that
@@ -59,6 +65,49 @@ public:
     : THttpServer(transport, config) {}
 
   uint32_t bufferSize() const { return httpBufSize_; }
+};
+
+class TestHttpClient : public THttpClient {
+public:
+  TestHttpClient(std::shared_ptr<apache::thrift::transport::TTransport> transport,
+                 std::string host,
+                 std::string path,
+                 std::shared_ptr<TConfiguration> config)
+    : THttpClient(transport, host, path, config) {}
+};
+
+// Counts what the peer was asked to hand over.  A bound on a declared length
+// is only worth anything if it is applied before the bytes are read, and a
+// test that asks whether something threw cannot tell that apart from running
+// the stream out.
+class CountingTransport
+  : public apache::thrift::transport::TVirtualTransport<CountingTransport> {
+public:
+  explicit CountingTransport(std::string wire) : wire_(std::move(wire)), pos_(0), served_(0) {}
+
+  uint32_t read(uint8_t* buf, uint32_t len) {
+    if (pos_ >= wire_.size()) {
+      return 0;
+    }
+    const uint32_t n = static_cast<uint32_t>((std::min)(static_cast<size_t>(len),
+                                                        wire_.size() - pos_));
+    std::memcpy(buf, wire_.data() + pos_, n);
+    pos_ += n;
+    served_ += n;
+    return n;
+  }
+
+  void write(const uint8_t*, uint32_t) {}
+  bool isOpen() const override { return true; }
+  void open() override {}
+  void close() override {}
+
+  uint64_t served() const { return served_; }
+
+private:
+  std::string wire_;
+  size_t pos_;
+  uint64_t served_;
 };
 
 const uint32_t kMaxMessageSize = 64 * 1024;
@@ -122,6 +171,94 @@ BOOST_AUTO_TEST_CASE(a_long_but_bounded_header_line_still_works) {
   BOOST_CHECK_EQUAL(std::string(reinterpret_cast<char*>(out), 5), "hello");
   BOOST_CHECK_GT(trans->bufferSize(), 1024u);
   BOOST_CHECK_LE(trans->bufferSize(), kMaxMessageSize);
+}
+
+BOOST_AUTO_TEST_CASE(a_declared_body_larger_than_the_maximum_is_refused) {
+  // Four times the maximum is actually on the wire, so a transport that reads
+  // the body before looking at the number will take all of it and only then
+  // run out. The verdict is how much the peer was asked for.
+  const std::string body(4 * kMaxMessageSize, 'A');
+  const std::string wire = "POST / HTTP/1.1\r\nContent-length: 1000000\r\n\r\n" + body;
+
+  auto inner = std::make_shared<CountingTransport>(wire);
+  auto config = std::make_shared<TConfiguration>(static_cast<int>(kMaxMessageSize));
+  TestHttpServer trans(inner, config);
+
+  uint8_t out[16];
+  BOOST_CHECK_THROW(trans.read(out, sizeof(out)), TTransportException);
+  BOOST_CHECK_LT(inner->served(), kMaxMessageSize);
+}
+
+BOOST_AUTO_TEST_CASE(a_body_inside_the_maximum_is_read) {
+  const std::string body(kMaxMessageSize / 2, 'A');
+  const std::string wire = "POST / HTTP/1.1\r\nContent-length: " + std::to_string(body.size())
+                           + "\r\n\r\n" + body;
+
+  auto inner = std::make_shared<CountingTransport>(wire);
+  auto config = std::make_shared<TConfiguration>(static_cast<int>(kMaxMessageSize));
+  TestHttpServer trans(inner, config);
+
+  std::vector<uint8_t> out(body.size());
+  BOOST_CHECK_EQUAL(trans.readAll(out.data(), static_cast<uint32_t>(out.size())), out.size());
+  BOOST_CHECK_EQUAL(std::string(reinterpret_cast<char*>(out.data()), out.size()), body);
+}
+
+BOOST_AUTO_TEST_CASE(chunks_are_bounded_by_their_sum_and_not_one_at_a_time) {
+  // Every chunk on its own is far inside the maximum; what the peer chooses is
+  // how many of them there are. Without a running total this stream ends only
+  // when the peer stops sending.
+  const uint32_t chunkBytes = 4 * 1024;
+  std::ostringstream size;
+  // A chunk size is hex, and a stream follows whatever global locale is in
+  // force, so a grouping locale turns 4096 into "1.000" and it stops being a
+  // chunk size at all. THRIFT-6194 fixed the case that used to leave one set
+  // for the rest of this binary; this stays as the local guarantee, which is
+  // what TToString.h does for the same reason.
+  size.imbue(std::locale::classic());
+  size << std::hex << chunkBytes;
+  std::string wire = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+  for (uint32_t sent = 0; sent < 4 * kMaxMessageSize; sent += chunkBytes) {
+    wire += size.str() + "\r\n" + std::string(chunkBytes, 'A') + "\r\n";
+  }
+  wire += "0\r\n\r\n";
+
+  auto inner = std::make_shared<CountingTransport>(wire);
+  auto config = std::make_shared<TConfiguration>(static_cast<int>(kMaxMessageSize));
+  TestHttpClient client(inner, "localhost", "/", config);
+
+  // Read in pieces well under the maximum: read() has always refused a single
+  // request larger than it, and asking for the whole body at once would be
+  // stopped by that check instead of by the one under test.
+  std::vector<uint8_t> out(4096);
+  bool threw = false;
+  try {
+    for (uint32_t taken = 0; taken < 4 * kMaxMessageSize; taken += static_cast<uint32_t>(out.size())) {
+      client.readAll(out.data(), static_cast<uint32_t>(out.size()));
+    }
+  } catch (const TTransportException&) {
+    threw = true;
+  }
+  BOOST_CHECK(threw);
+  // The chunk framing costs a few bytes per chunk on top of the payload, so
+  // this is the maximum plus that overhead rather than the maximum exactly.
+  BOOST_CHECK_LT(inner->served(), 2 * kMaxMessageSize);
+}
+
+BOOST_AUTO_TEST_CASE(a_second_request_gets_its_own_allowance) {
+  // The maximum is per message. Two bodies that each fit have to both be read
+  // on one connection, or a keep-alive connection would run out of allowance.
+  const std::string body(kMaxMessageSize - 1024, 'A');
+  const std::string one = "POST / HTTP/1.1\r\nContent-length: " + std::to_string(body.size())
+                          + "\r\n\r\n" + body;
+
+  auto inner = std::make_shared<CountingTransport>(one + one);
+  auto config = std::make_shared<TConfiguration>(static_cast<int>(kMaxMessageSize));
+  TestHttpServer trans(inner, config);
+
+  std::vector<uint8_t> out(body.size());
+  BOOST_CHECK_EQUAL(trans.readAll(out.data(), static_cast<uint32_t>(out.size())), out.size());
+  trans.flush();
+  BOOST_CHECK_EQUAL(trans.readAll(out.data(), static_cast<uint32_t>(out.size())), out.size());
 }
 
 BOOST_AUTO_TEST_CASE(a_chunked_response_still_works) {


### PR DESCRIPTION
[THRIFT-6193](https://issues.apache.org/jira/browse/THRIFT-6193)

**Stacked on #3802** (THRIFT-6192) — same file, same README section. Review that one first; this PR's own diff is the last commit.

`THttpTransport::readContent()` accumulates the body into `readBuffer_` in a read loop, and nothing measures it against anything. The declared `Content-Length`, and in a chunked body the number of chunks, are numbers the peer chooses.

It is wider than one missing check. `countConsumedMessageBytes()` is **never called anywhere in this transport** — a grep over `THttp*.{h,cpp}` finds three `resetConsumedMessageSize()` and one `checkReadBytesAvailable(len)` in `read()`. So `remainingMessageSize_` is reset and never decremented, and that check is a ceiling on a single caller request against an allowance that never depletes.

The body does not pass through the line buffer whose growth was bounded by `421283a43`, so that bound does not cover this.

### Measured

With `maxMessageSize` at its 100 MB default, against the unmodified library:

| scenario | peer served | outcome | VmPeak | VmHWM |
|---|---|---|---|---|
| `Content-length: -1`, nothing sent after the headers | 39 B | `Could not refill buffer` | **+0 kB** | +92 kB |
| `Content-length: -1`, then 200 MB sent | 209715239 B | same | +262228 kB | **+205820 kB** |

Nothing is sized from the declared length up front, so a large declaration on its own costs nothing. What is not held is the accumulation: 200 MB arrived in one message against a 100 MB configured maximum, and a chunked body has no declared total at all — it simply runs until the peer stops sending.

### The change

`readContent()` charges what it is about to read against `maxMessageSize` and refuses the message once it would exceed it. The running total is reset by `readHeaders()`, so each message on a keep-alive connection gets its own allowance.

### Tests

Four cases added to `lib/cpp/test/THttpBufferBoundTest.cpp`. **Two fail against the unmodified library**, and both count the bytes the peer was *asked for* rather than asking whether something threw — an over-declared length runs the stream out and throws either way. 262188 bytes served against a 65536 maximum for the declared case, 262708 for the chunked one. The other two are regression guards: a body inside the maximum still arrives, and a second request on the same connection still gets a full allowance.

One thing worth knowing for future tests in this binary: the chunked test builds its chunk sizes through an `ostringstream`, and `ToStringTest.cpp:59` calls `std::locale::global(std::locale("de_DE.UTF-8"))` without restoring it, so a later stream groups digits and 4096 came out as `1.000`. The test imbues `std::locale::classic()`, which is what `TToString.h` does and for the same reason. It only shows up in a full run, since `ToStringTest` is disabled by default.

### Behaviour change

A client or server exchanging bodies larger than the configured maximum has to raise it, the same way it would for any other transport. `lib/cpp/README.md` gains a third paragraph under Breaking Changes 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
