### PR TITLE
THRIFT-6194: Restore the global locale after the ToStringTest cases that set it

### DIFF
--- a/lib/cpp/test/ToStringTest.cpp
+++ b/lib/cpp/test/ToStringTest.cpp
@@ -33,6 +33,26 @@ using apache::thrift::to_string;
 
 BOOST_AUTO_TEST_SUITE(ToStringTest)
 
+namespace {
+
+// The two cases below set the global locale to prove that to_string() does not
+// follow it.  Setting it is the point; leaving it set is not -- every stream
+// constructed later in this binary picks it up, including in suites that have
+// nothing to do with this one, and a number then formats with digit grouping.
+// That has already cost one debugging session in THttpBufferBoundTest, where a
+// hex chunk size of 4096 became "1.000".
+class ScopedGlobalLocale {
+public:
+  explicit ScopedGlobalLocale(const char* name)
+    : previous_(std::locale::global(std::locale(name))) {}
+  ~ScopedGlobalLocale() { std::locale::global(previous_); }
+
+private:
+  std::locale previous_;
+};
+
+} // namespace
+
 BOOST_AUTO_TEST_CASE(base_types_to_string) {
   BOOST_CHECK_EQUAL(to_string(10), "10");
   BOOST_CHECK_EQUAL(to_string(true), "1");
@@ -47,18 +67,18 @@ BOOST_AUTO_TEST_CASE(base_types_to_string) {
 #ifndef _WIN32
 BOOST_AUTO_TEST_CASE(locale_en_US_int_to_string) {
 #ifdef _WIN32
-  std::locale::global(std::locale("en-US.UTF-8"));
+  ScopedGlobalLocale locale("en-US.UTF-8");
 #else
-  std::locale::global(std::locale("en_US.UTF-8"));
+  ScopedGlobalLocale locale("en_US.UTF-8");
 #endif
   BOOST_CHECK_EQUAL(to_string(1000000), "1000000");
 }
 
 BOOST_AUTO_TEST_CASE(locale_de_DE_floating_point_to_string) {
 #ifdef _WIN32
-  std::locale::global(std::locale("de-DE.UTF-8"));
+  ScopedGlobalLocale locale("de-DE.UTF-8");
 #else
-  std::locale::global(std::locale("de_DE.UTF-8"));
+  ScopedGlobalLocale locale("de_DE.UTF-8");
 #endif
   BOOST_CHECK_EQUAL(to_string(1.5), "1.5");
   BOOST_CHECK_EQUAL(to_string(1.5f), "1.5");


### PR DESCRIPTION
[THRIFT-6194](https://issues.apache.org/jira/browse/THRIFT-6194)

Two cases in `ToStringTest` call `std::locale::global()` and never put back what was there:

```cpp
BOOST_AUTO_TEST_CASE(locale_de_DE_floating_point_to_string) {
  std::locale::global(std::locale("de_DE.UTF-8"));
  ...
}
```

Setting the global locale is the *point* of these cases — they prove `to_string()` does not follow it, which is why `TToString.h` imbues a default locale on the streams it builds. Leaving it set afterwards is not the point. Every stream constructed later in the same `UnitTests` binary picks it up, in suites that have nothing to do with this one, and numbers formatted through an `ostringstream` come out with digit grouping.

### Why it is worth fixing

It has already cost a debugging session. A case in `THttpBufferBoundTest` formats a chunk size:

```cpp
std::ostringstream size;
size << std::hex << 4096;   // expected "1000"
```

and got `1.000`, which is not a hex chunk size — so the HTTP transport under test read a completely different stream, and the case passed or failed depending on whether it ran alone or as part of a full run. `ToStringTest` is disabled by default and only runs when the whole binary does, so the two modes disagreed. An order-dependent result whose cause lives in an unrelated file is expensive to chase, and the next test in this binary that formats a number would hit it again.

### The change

A scoped guard that saves the previous global locale and restores it on exit, applied to both cases. What they assert is unchanged — the locale is still set for the duration of each case.

### Verified both ways

The defensive `imbue(std::locale::classic())` that `THttpBufferBoundTest` had to add for its own protection was removed, and a full `UnitTests` run repeated with and without this fix:

| | result |
|---|---|
| with this fix | chunked case passes |
| without it | `chunks_are_bounded_by_their_sum_and_not_one_at_a_time` fails, `inner->served() < 2 * kMaxMessageSize` → `262772 >= 131072` |

(The one unrelated failure in both runs is `TServerSocketTest/test_bind_to_address`, [THRIFT-6191](https://issues.apache.org/jira/browse/THRIFT-6191).)

Test-only; no shipped code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
