### PR TITLE
Compare Go set and entry-slice map fields without regard to order

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -4235,6 +4235,19 @@ void t_go_generator::generate_go_equals_struct(ostream& out,
 /**
  * Compares any container type
  */
+/**
+ * Emits the head of a thrift.UnorderedEqual call, up to the opening brace of
+ * the element comparison. The caller fills in the body, which must return
+ * true when the two elements are equal, and closes the call.
+ */
+void t_go_generator::generate_go_equals_unordered(ostream& out,
+                                                  const string& go_type,
+                                                  const string& tgt,
+                                                  const string& src) {
+  out << indent() << "if !thrift.UnorderedEqual(" << indexable_go_expr(tgt) << ", "
+      << indexable_go_expr(src) << ", func(_tgt, _src " << go_type << ") bool {" << '\n';
+}
+
 void t_go_generator::generate_go_equals_container(ostream& out,
                                                   t_type* ttype,
                                                   string tgt,
@@ -4245,15 +4258,20 @@ void t_go_generator::generate_go_equals_container(ostream& out,
   indent_down();
   out << indent() << "}" << '\n';
   if (is_container_keyed_map(ttype)) {
+    // An entry slice stands in for a map, which is unordered, so the entries
+    // are compared as a collection rather than position by position.
     t_map* tmap = (t_map*)ttype;
-    out << indent() << "for i, _tgt := range " << tgt << " {" << '\n';
+    generate_go_equals_unordered(out, map_entry_type(tmap), tgt, src);
     indent_up();
-    string element_source = tmp("_src");
-    out << indent() << element_source << " := " << indexable_go_expr(src) << "[i]" << '\n';
-    generate_go_equals(out, tmap->get_key_type(), "_tgt.Key", element_source + ".Key");
-    generate_go_equals(out, tmap->get_val_type(), "_tgt.Value", element_source + ".Value");
+    generate_go_equals(out, tmap->get_key_type(), "_tgt.Key", "_src.Key");
+    generate_go_equals(out, tmap->get_val_type(), "_tgt.Value", "_src.Value");
+    out << indent() << "return true" << '\n';
     indent_down();
-    indent(out) << "}" << '\n';
+    out << indent() << "}) {" << '\n';
+    indent_up();
+    out << indent() << "return false" << '\n';
+    indent_down();
+    out << indent() << "}" << '\n';
   } else if (ttype->is_map()) {
     t_map* tmap = (t_map*)ttype;
     out << indent() << "for k, _tgt := range " << tgt << " {" << '\n';
@@ -4268,15 +4286,23 @@ void t_go_generator::generate_go_equals_container(ostream& out,
     generate_go_equals(out, tmap->get_val_type(), "_tgt", element_source);
     indent_down();
     indent(out) << "}" << '\n';
-  } else if (ttype->is_list() || ttype->is_set()) {
-    t_type* elem;
-    if (ttype->is_list()) {
-      t_list* temp = (t_list*)ttype;
-      elem = temp->get_elem_type();
-    } else {
-      t_set* temp = (t_set*)ttype;
-      elem = temp->get_elem_type();
-    }
+  } else if (ttype->is_set()) {
+    // A set is unordered, but Go represents it as a slice, so its elements
+    // are compared as a collection rather than position by position.
+    t_type* elem = ((t_set*)ttype)->get_elem_type();
+    generate_go_equals_unordered(out, type_to_go_type(elem), tgt, src);
+    indent_up();
+    generate_go_equals(out, elem, "_tgt", "_src");
+    out << indent() << "return true" << '\n';
+    indent_down();
+    out << indent() << "}) {" << '\n';
+    indent_up();
+    out << indent() << "return false" << '\n';
+    indent_down();
+    out << indent() << "}" << '\n';
+  } else if (ttype->is_list()) {
+    // A list is ordered, so position by position is the correct comparison.
+    t_type* elem = ((t_list*)ttype)->get_elem_type();
     out << indent() << "for i, _tgt := range " << tgt << " {" << '\n';
     indent_up();
     string element_source = tmp("_src");

--- a/compiler/cpp/src/thrift/generate/t_go_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.h
@@ -223,6 +223,10 @@ public:
   void generate_go_equals_struct(std::ostream& out, t_type* ttype, string tgt, string src);
 
   void generate_go_equals_container(std::ostream& out, t_type* ttype, string tgt, string src);
+  void generate_go_equals_unordered(std::ostream& out,
+                                    const string& go_type,
+                                    const string& tgt,
+                                    const string& src);
 
   void generate_go_docstring(std::ostream& out, t_struct* tstruct);
 

--- a/lib/go/test/tests/container_key_test.go
+++ b/lib/go/test/tests/container_key_test.go
@@ -158,3 +158,24 @@ func TestContainerKeyValidate(t *testing.T) {
 		t.Error("empty value must fail vt.value.min_size")
 	}
 }
+
+// An entry slice stands in for a map, which is unordered, so two values
+// holding the same entries in a different order are equal.
+func TestContainerKeyEqualsIgnoresOrder(t *testing.T) {
+	tgt := newContainerKeyStruct()
+	src := newContainerKeyStruct()
+	if len(src.ListKey) < 2 {
+		t.Fatalf("fixture needs at least two entries, got %d", len(src.ListKey))
+	}
+	src.ListKey[0], src.ListKey[1] = src.ListKey[1], src.ListKey[0]
+	if !tgt.Equals(src) {
+		t.Error("reordering map entries must not change equality")
+	}
+
+	// The entries themselves still have to match.
+	src = newContainerKeyStruct()
+	src.ListKey[0].Value = "changed"
+	if tgt.Equals(src) {
+		t.Error("changing an entry value must change equality")
+	}
+}

--- a/lib/go/test/tests/equals_test.go
+++ b/lib/go/test/tests/equals_test.go
@@ -292,3 +292,48 @@ func TestMapEqualsDetectsMissingKey(t *testing.T) {
 		t.Error("maps with different key sets must not be equal even when the zero value matches")
 	}
 }
+
+// A Thrift set is unordered, but Go represents it as a slice. Two values
+// holding the same members in a different order are equal.
+func TestSetEqualsIgnoresOrder(t *testing.T) {
+	tgt, src := genSetFoo(), genSetFoo()
+	reverse := func(s []int64) []int64 {
+		out := make([]int64, len(s))
+		for i, v := range s {
+			out[len(s)-1-i] = v
+		}
+		return out
+	}
+	src.I64SetFoo = reverse(src.I64SetFoo)
+	src.StructSetFoo[0], src.StructSetFoo[1] = src.StructSetFoo[1], src.StructSetFoo[0]
+	if !tgt.Equals(src) {
+		t.Error("reordering a set field must not change equality")
+	}
+
+	// Membership still has to match.
+	src = genSetFoo()
+	src.I64SetFoo[0] = -1
+	if tgt.Equals(src) {
+		t.Error("changing a set member must change equality")
+	}
+
+	// So does multiplicity, for a value assembled in memory.
+	tgt, src = genSetFoo(), genSetFoo()
+	tgt.I64SetFoo = []int64{1, 1, 2}
+	src.I64SetFoo = []int64{1, 2, 2}
+	if tgt.Equals(src) {
+		t.Error("sets differing in multiplicity must not be equal")
+	}
+}
+
+// A Thrift list is ordered, so its comparison stays position by position.
+func TestListEqualsKeepsOrder(t *testing.T) {
+	tgt, src := genListFoo(), genListFoo()
+	if !tgt.Equals(src) {
+		t.Error("identical lists must be equal")
+	}
+	src.I64ListFoo[0], src.I64ListFoo[1] = src.I64ListFoo[1], src.I64ListFoo[0]
+	if tgt.Equals(src) {
+		t.Error("reordering a list field must change equality")
+	}
+}

--- a/lib/go/thrift/unordered_equal.go
+++ b/lib/go/thrift/unordered_equal.go
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+// UnorderedEqual reports whether a and b hold the same elements, in any order,
+// comparing them with eq.
+//
+// Generated code calls this for the fields that stand in for an unordered
+// Thrift collection: a set, and a map whose key type forces the entry-slice
+// representation. Lists are ordered and are compared position by position
+// instead.
+//
+// The elements are compared position by position first, so two values that
+// agree on order, which includes any value that has just been deserialized,
+// cost one pass and allocate nothing. Only when that fails does each element
+// of a get matched against an unmatched element of b, which is quadratic.
+//
+// Matching consumes an element of b at most once, so a and b compare equal
+// only if they hold the same elements with the same multiplicities. That
+// matters for a value assembled in memory: the wire format rejects a set or
+// map that repeats an element, but nothing stops a caller from building one.
+func UnorderedEqual[T any](a, b []T, eq func(x, y T) bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	ordered := true
+	for i := range a {
+		if !eq(a[i], b[i]) {
+			ordered = false
+			break
+		}
+	}
+	if ordered {
+		return true
+	}
+
+	matched := make([]bool, len(b))
+	for i := range a {
+		found := false
+		for j := range b {
+			if matched[j] || !eq(a[i], b[j]) {
+				continue
+			}
+			matched[j] = true
+			found = true
+			break
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/go/thrift/unordered_equal_test.go
+++ b/lib/go/thrift/unordered_equal_test.go
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import "testing"
+
+func intEq(x, y int) bool { return x == y }
+
+func TestUnorderedEqual(t *testing.T) {
+	for name, c := range map[string]struct {
+		a, b []int
+		want bool
+	}{
+		"both nil":             {nil, nil, true},
+		"nil and empty":        {nil, []int{}, true},
+		"same order":           {[]int{1, 2, 3}, []int{1, 2, 3}, true},
+		"reversed":             {[]int{1, 2, 3}, []int{3, 2, 1}, true},
+		"rotated":              {[]int{1, 2, 3}, []int{2, 3, 1}, true},
+		"single element":       {[]int{1}, []int{1}, true},
+		"different element":    {[]int{1, 2}, []int{1, 3}, false},
+		"shorter":              {[]int{1, 2}, []int{1}, false},
+		"longer":               {[]int{1}, []int{1, 2}, false},
+		"disjoint":             {[]int{1, 2}, []int{3, 4}, false},
+		"same multiset":        {[]int{1, 1, 2}, []int{2, 1, 1}, true},
+		"different multiplic.": {[]int{1, 1, 2}, []int{1, 2, 2}, false},
+		"all duplicates":       {[]int{7, 7, 7}, []int{7, 7, 7}, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := UnorderedEqual(c.a, c.b, intEq); got != c.want {
+				t.Errorf("UnorderedEqual(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+			}
+			// The relation must not depend on which side is which.
+			if got := UnorderedEqual(c.b, c.a, intEq); got != c.want {
+				t.Errorf("UnorderedEqual(%v, %v) = %v, want %v (not symmetric)", c.b, c.a, got, c.want)
+			}
+		})
+	}
+}
+
+// Elements that cannot be Go map keys take the same path as any other.
+func TestUnorderedEqualNonComparable(t *testing.T) {
+	eq := func(x, y []string) bool {
+		if len(x) != len(y) {
+			return false
+		}
+		for i := range x {
+			if x[i] != y[i] {
+				return false
+			}
+		}
+		return true
+	}
+	a := [][]string{{"a"}, {"b", "c"}}
+	b := [][]string{{"b", "c"}, {"a"}}
+	if !UnorderedEqual(a, b, eq) {
+		t.Error("reordered slice elements should compare equal")
+	}
+	if UnorderedEqual(a, [][]string{{"a"}, {"b"}}, eq) {
+		t.Error("differing slice elements should compare unequal")
+	}
+}
+
+// Comparing values that agree on order must not allocate.
+func TestUnorderedEqualOrderedPathDoesNotAllocate(t *testing.T) {
+	a := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	b := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	if n := testing.AllocsPerRun(100, func() {
+		if !UnorderedEqual(a, b, intEq) {
+			t.Fatal("expected equal")
+		}
+	}); n != 0 {
+		t.Errorf("ordered comparison allocated %v times per run, want 0", n)
+	}
+}
+
+func BenchmarkUnorderedEqualSameOrder(b *testing.B) {
+	x := make([]int, 1000)
+	y := make([]int, 1000)
+	for i := range x {
+		x[i], y[i] = i, i
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !UnorderedEqual(x, y, intEq) {
+			b.Fatal("expected equal")
+		}
+	}
+}
+
+func BenchmarkUnorderedEqualReordered(b *testing.B) {
+	x := make([]int, 1000)
+	y := make([]int, 1000)
+	for i := range x {
+		x[i] = i
+		y[len(y)-1-i] = i
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !UnorderedEqual(x, y, intEq) {
+			b.Fatal("expected equal")
+		}
+	}
+}


### PR DESCRIPTION
Thrift defines `set` and `map` as unordered. The Go binding represents a `set`, and a `map` whose key type cannot be a Go map key, as a slice, and the generated `Equals` compared those slices position by position. Two values holding the same members in a different order therefore compared unequal.

This affects three constructs, because they share one code path in `generate_go_equals_container`:

| Thrift type | Go type | Since |
|---|---|---|
| `set<T>` | `[]T` | long-standing |
| `map<container, V>` | `[]thrift.MapEntry[K, V]` | THRIFT-2063 |
| `map<struct, V>` with `go:struct_key_entries` | `[]thrift.MapEntry[*K, V]` | THRIFT-6175, #3788 |

Java compares these with `HashSet` and `HashMap` equality and Python with `set` and `dict`, so both are order-insensitive without extra work. Go cannot use a native map or set here, because a slice, a map, or a struct holding either is not a valid Go map key. The slice representation is forced by the language; the positional comparison is not.

### What changed

Sets and entry slices now go through a new `thrift.UnorderedEqual`. Lists keep the positional comparison, because a list is ordered, so the list and set arm is split.

The helper compares position by position first and only then falls back to matching each element against an unmatched element of the other side. Values that agree on order, which includes anything that has just been deserialized, cost one pass and allocate nothing.

Matching consumes an element of the other side at most once. Without that a set holding `{a, a}` compares equal to one holding `{a, b}`, since both copies of `a` match the same element. `TestUnorderedEqual` pins that case and the symmetric one.

### Cost

The fallback is quadratic. A hashed index would make it linear for element types that can be Go map keys, but it needs a type predicate, a separate nil path, and per-type projections, and it is roughly twelve times slower than the positional pass on the common path when applied unconditionally. Trying positional first avoids paying that, and the hashed tier can be added later if a profile asks for it.

`TestUnorderedEqualOrderedPathDoesNotAllocate` pins the zero-allocation property of the fast path.

### Compatibility

This changes observable behaviour. Code whose tests depend on positional comparison of a set or an entry-slice map field will start seeing values compare equal that previously did not. Nothing semantically correct should break, since the change only makes `Equals` agree with what the Thrift type system already says these collections mean.

### Notes for the reviewer

- **No JIRA ticket yet.** I could not file one. Happy to add the key to the title and the branch name once it exists; the description above is the ticket text.
- Opened as a draft until the ticket exists and CI is green.
- Overlaps in spirit with #3788, but the two are independent and touch different functions. Once both land, struct-keyed maps generated with `go:struct_key_entries` pick this up automatically.
- The `-remote` packages for `includestest` fail to build on master already, with `undefined: includestest.Numberz`. That is unrelated and not part of the `check` target.

*This change was created with AI assistance.*
