### PR TITLE
Drop the gitignore entry for the removed contrib thrift-maven-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,6 @@ SKILL.md
 /contrib/fb303/py/fb303/__init__.py
 /contrib/fb303/py/fb303/constants.py
 /contrib/fb303/py/fb303/ttypes.py
-/contrib/thrift-maven-plugin/target/
 /depcomp
 /install-sh
 /lib/cl/backport-update.zip


### PR DESCRIPTION
The plugin directory went away with the plugin in THRIFT-6196, so `/contrib/thrift-maven-plugin/target/` no longer matches anything. The CHANGES.md mentions are historical release notes and stay.

*This change was created with AI assistance.*