### PR TITLE
THRIFT-5493: Order the chmod arguments in genmock.sh so BSD userland accepts them

### DIFF
--- a/test/go/genmock.sh
+++ b/test/go/genmock.sh
@@ -9,4 +9,4 @@ go install go.uber.org/mock/mockgen@v0.6.0
 gobin=$(go env GOBIN); [ -z "$gobin" ] && gobin=$(go env GOPATH)/bin
 "$gobin/mockgen" -destination=src/common/mock_handler.go -package=common github.com/apache/thrift/test/go/src/gen/thrifttest ThriftTest
 
-chmod a+w -R $GOPATH && rm -Rf $GOPATH
+chmod -R a+w "$GOPATH" && rm -Rf "$GOPATH"


### PR DESCRIPTION
Fixes THRIFT-5493, open since 2022.

`test/go/genmock.sh` ends with `chmod a+w -R $GOPATH && rm -Rf $GOPATH`. BSD `chmod`, macOS included, takes the first non-option argument as a file name, so the command fails with `chmod: -R: No such file or directory`. The script runs under `set -e`, so it exits there and leaves the temporary GOPATH behind. GNU `chmod` permutes its arguments, which is why CI on Ubuntu never saw it.

The path is quoted at the same time, since it comes from `mktemp`.

Verified: on macOS, `chmod a+w -R <dir>` exits 1 with that error and `chmod -R a+w <dir>` exits 0; `sh -n test/go/genmock.sh` passes.

*This change was created with AI assistance.*