### PR TITLE
THRIFT-5420: Drop the testing import from the Go library

### DIFF
--- a/lib/go/thrift/logger.go
+++ b/lib/go/thrift/logger.go
@@ -22,7 +22,6 @@ package thrift
 import (
 	"log"
 	"os"
-	"testing"
 )
 
 // Logger is a simple wrapper of a logging function.
@@ -65,9 +64,15 @@ func StdLogger(logger *log.Logger) Logger {
 //
 // It fails the test when being called.
 //
+// The argument is declared as the one method the implementation calls rather
+// than as testing.TB, so that the library itself does not import testing.
+// A *testing.T, a *testing.B, or a testing.TB still satisfies it.
+//
 // Deprecated: This is no longer used by any thrift go library code,
 // will be removed in the future version.
-func TestLogger(tb testing.TB) Logger {
+func TestLogger(tb interface {
+	Errorf(format string, args ...any)
+}) Logger {
 	return func(msg string) {
 		tb.Errorf("logger called with msg: %q", msg)
 	}

--- a/lib/go/thrift/logger_test.go
+++ b/lib/go/thrift/logger_test.go
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thrift
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The library is linked into every program that speaks thrift, so none of its
+// non-test files may import testing: doing so registers the test flags and
+// pulls the testing machinery into production binaries.
+func TestLibraryDoesNotImportTesting(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+			continue
+		}
+		for _, imp := range f.Imports {
+			path, err := strconv.Unquote(imp.Path.Value)
+			if err != nil {
+				t.Errorf("%s: %v", name, err)
+				continue
+			}
+			if path == "testing" || strings.HasPrefix(path, "testing/") {
+				t.Errorf("%s imports %q", name, path)
+			}
+		}
+	}
+}
+
+// recordingTB stands in for testing.TB without being one.
+type recordingTB struct {
+	msgs []string
+}
+
+func (r *recordingTB) Errorf(format string, args ...any) {
+	r.msgs = append(r.msgs, format)
+}
+
+func TestTestLoggerAcceptsAnyErrorf(t *testing.T) {
+	rec := new(recordingTB)
+	TestLogger(rec)("boom")
+	if len(rec.msgs) != 1 {
+		t.Fatalf("expected one call, got %d", len(rec.msgs))
+	}
+}
+
+func TestTestLoggerAcceptsTestingTB(t *testing.T) {
+	// The point of the case is that it compiles: a testing.TB must keep
+	// working as the argument.
+	var tb testing.TB = t
+	if TestLogger(tb) == nil {
+		t.Error("expected a logger")
+	}
+}


### PR DESCRIPTION
Fixes THRIFT-5420.

`TestLogger` declared its parameter as `testing.TB`, which made `testing` a build dependency of `lib/go/thrift` itself: `go list -deps ./lib/go/thrift` listed `flag`, `runtime/trace` and `testing` before this change and lists none of them after.

The parameter is now the single method the function calls:

```go
func TestLogger(tb interface {
	Errorf(format string, args ...any)
}) Logger
```

A `*testing.T`, a `*testing.B` and a `testing.TB` all satisfy that, so existing callers compile unchanged. No exported identifier is added, which matters because the whole `Logger` API is already marked deprecated.

`TestLibraryDoesNotImportTesting` parses the package's non-test files and fails if any imports `testing`, so the dependency cannot come back unnoticed.

The alternative is to delete the deprecated `Logger` API outright, since it says it is no longer used by any library code. That is a breaking change and a separate decision, so this PR keeps the API and removes only the dependency.

*This change was created with AI assistance.*