### PR TITLE
THRIFT-5828: Stop over-allocating in safeReadBytes

### DIFF
--- a/lib/go/thrift/binary_protocol.go
+++ b/lib/go/thrift/binary_protocol.go
@@ -590,18 +590,35 @@ func (p *TBinaryProtocol) getMinSerializedSize(ttype TType) int32 {
 // It tries to read size bytes from trans, in a way that prevents large
 // allocations when size is insanely large (mostly caused by malformed message),
 // or smaller than bytes.MinRead.
+//
+// Above bytes.MinRead the buffer starts small and doubles as the data arrives,
+// so a size the sender made up costs no more than the bytes it actually sends,
+// and the growth stops at size, so a well-formed message ends up in a buffer
+// holding exactly what it asked for.
 func safeReadBytes(size int32, trans io.Reader) ([]byte, error) {
 	if size < 0 {
 		return nil, nil
 	}
-	if size > bytes.MinRead {
-		// Use bytes.Buffer to prevent allocating size bytes when size is very large
-		buf := new(bytes.Buffer)
-		_, err := io.CopyN(buf, trans, int64(size))
-		return buf.Bytes(), err
+	if size <= bytes.MinRead {
+		// Allocate size bytes
+		b := make([]byte, size)
+		n, err := io.ReadFull(trans, b)
+		return b[:n], err
 	}
-	// Allocate size bytes
-	b := make([]byte, size)
-	n, err := io.ReadFull(trans, b)
-	return b[:n], err
+
+	want := int(size)
+	buf := make([]byte, 0, bytes.MinRead)
+	for len(buf) < want {
+		if len(buf) == cap(buf) {
+			grown := make([]byte, len(buf), min(cap(buf)*2, want))
+			copy(grown, buf)
+			buf = grown
+		}
+		n, err := trans.Read(buf[len(buf):cap(buf)])
+		buf = buf[:len(buf)+n]
+		if err != nil {
+			return buf, err
+		}
+	}
+	return buf, nil
 }

--- a/lib/go/thrift/binary_protocol_test.go
+++ b/lib/go/thrift/binary_protocol_test.go
@@ -22,6 +22,7 @@ package thrift
 import (
 	"bytes"
 	"math"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,42 @@ vel sem et.
 `
 	safeReadBytesSourceLen = len(safeReadBytesSource)
 )
+
+// The size asked for must decide the allocation exactly: reading n bytes must
+// not leave a buffer with capacity for more. See THRIFT-5828.
+func TestSafeReadBytesDoesNotOverAllocate(t *testing.T) {
+	for _, size := range []int{bytes.MinRead + 1, 4096, 32 * 1024} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			buf, err := safeReadBytes(int32(size), bytes.NewReader(make([]byte, size)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(buf) != size {
+				t.Fatalf("read %d bytes, want %d", len(buf), size)
+			}
+			if cap(buf) != size {
+				t.Errorf("read %d bytes into a buffer of capacity %d, want capacity %d", len(buf), cap(buf), size)
+			}
+		})
+	}
+}
+
+// A size the sender made up must not decide the allocation either: only the
+// data that actually arrives may.
+func TestSafeReadBytesLargeSizeShortData(t *testing.T) {
+	const dataSize = 1024
+
+	buf, err := safeReadBytes(math.MaxInt32, bytes.NewReader(make([]byte, dataSize)))
+	if err == nil {
+		t.Error("expected an error when the data ends early, got nil")
+	}
+	if len(buf) != dataSize {
+		t.Errorf("read %d bytes, want %d", len(buf), dataSize)
+	}
+	if max := 2 * dataSize; cap(buf) > max {
+		t.Errorf("allocated %d bytes for %d bytes of data, want at most %d", cap(buf), dataSize, max)
+	}
+}
 
 func TestSafeReadBytes(t *testing.T) {
 	srcData := []byte(safeReadBytesSource)
@@ -176,6 +213,11 @@ func BenchmarkSafeReadBytes(b *testing.B) {
 			label:     "normal",
 			askedSize: 100,
 			dataSize:  100,
+		},
+		{
+			label:     "exact-32k",
+			askedSize: 32 * 1024,
+			dataSize:  32 * 1024,
 		},
 		{
 			label:     "max-askedSize",


### PR DESCRIPTION
Fixes THRIFT-5828.

Above `bytes.MinRead`, `safeReadBytes` copied into a `bytes.Buffer` with `io.CopyN`. `bytes.Buffer.ReadFrom` grows by doubling and reserves at least `bytes.MinRead` before each read, so a well-formed message always landed in a buffer holding roughly twice what it asked for — reading 32 KiB allocated 64 KiB. That is what the reporter measured in 2024.

The buffer now starts at `bytes.MinRead` and doubles as data arrives, capped at the requested size. Both properties hold:

- a size the sender made up costs only the bytes actually sent (the CVE-2019-11939 guard that motivated the `bytes.Buffer` in the first place);
- a complete read ends in a buffer of exactly that size.

### Tests

`TestSafeReadBytesDoesNotOverAllocate` fails on master:

```
binary_protocol_test.go:69: read 32768 bytes into a buffer of capacity 65536, want capacity 32768
```

`TestSafeReadBytesLargeSizeShortData` pins the other half — `math.MaxInt32` declared, 1 KiB delivered, allocation stays proportional to the data. The pre-existing `TestSafeReadBytesAlloc` (THRIFT-5322) still passes.

### Numbers

A benchmark case for the exact-size read is added alongside the existing ones. Both figures include the benchmark's own 32 KiB source buffer:

| | B/op | allocs/op | ns/op |
|---|---|---|---|
| before | 130683 | 11 | 26798 |
| after | 65075 | 8 | 17106 |

Verified: `go test -race ./lib/go/thrift` passes.

*This change was created with AI assistance.*