### PR TITLE
THRIFT-5814: Wait for the server to start processing instead of sleeping

### DIFF
--- a/lib/go/thrift/simple_server_test.go
+++ b/lib/go/thrift/simple_server_test.go
@@ -168,8 +168,18 @@ func TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop(t *testing.T) {
 		t.Fatalf("Failed to listen: %v", err)
 	}
 
+	// Closed once the server is processing the connection, which is after
+	// TSimpleServer added it to the wait group Stop waits on. Sleeping
+	// instead makes the test fail whenever the accept and the goroutine
+	// start take longer than the nap.
+	processing := make(chan struct{})
+	markProcessing := sync.OnceFunc(func() {
+		close(processing)
+	})
+
 	proc := &mockProcessor{
 		ProcessFunc: func(in, out TProtocol) (bool, TException) {
+			markProcessing()
 			in.ReadMessageBegin(context.Background())
 			return false, nil
 		},
@@ -197,13 +207,22 @@ func TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop(t *testing.T) {
 
 	serv := NewTSimpleServer2(proc, trans)
 	go serv.Serve()
-	time.Sleep(networkWaitDuration)
 
 	netConn, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil || netConn == nil {
 		t.Fatalf("error when dial server: %v", err)
 	}
-	time.Sleep(networkWaitDuration)
+	// The connection must outlive Stop: it is what keeps the processor
+	// blocked in ReadMessageBegin.
+	t.Cleanup(func() {
+		netConn.Close()
+	})
+
+	select {
+	case <-processing:
+	case <-time.After(time.Minute):
+		t.Fatal("server did not start processing the connection")
+	}
 
 	const serverStopTimeout = 50 * time.Millisecond
 	backupServerStopTimeout := ServerStopTimeout


### PR DESCRIPTION
Fixes THRIFT-5814.

`TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop` slept 10 ms after starting the server and again after dialing it, then asserted that `Stop` took at least the 50 ms stop timeout. `Stop` waits on the wait group `TSimpleServer` fills in `innerAccept`, so whenever the accept and the goroutine start did not fit inside those naps, the group was still empty, `Stop` returned in microseconds, and the assertion failed. That is the roughly 1-in-100 flake in the report.

The processor now closes a channel when it is entered, and the test waits for that before calling `Stop`. `simple_server.go` calls `p.wg.Add(2)` in `innerAccept` before starting the goroutine that reaches the processor, so entering the processor is a sound barrier for what `Stop` waits on. Nothing unblocks the read in the window between the signal and `ReadMessageBegin`: `InterruptFunc` closes the listener, not the accepted connection — which is why that connection now lives until cleanup rather than going out of scope.

### Reproduction

The flake is reachable on demand under a single P, which is how this was verified rather than by waiting on chance:

```
$ GOMAXPROCS=1 go test -run TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop -count=500 .
--- FAIL: TestNoHangDuringStopFromClientNoDataSendDuringAcceptLoop (0.03s)
    simple_server_test.go:221: stop cost less time than server stop timeout, server stop timeout:50ms,cost time:136.625µs
```

With this change the same command passes 500 of 500. The test also passes 200 runs under `-race` at `GOMAXPROCS=1`, and the full package passes under `-race`.

Earlier attempts on the ticket changed the transport — unix domain socket, extra client-side handshakes — which left the timing assumption in place. This removes it.

*This change was created with AI assistance.*