### PR TITLE
THRIFT-6198: Leave container extension methods to the included program that already has them

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -51,6 +51,7 @@ t_netstd_generator::t_netstd_generator(t_program* program, const map<string, str
     : t_oop_generator(program)
 {
     (void)option_string;
+    extensions_owner_ = program;
     target_net_version = 0;
     suppress_deepcopy = false;
     add_async_postfix = false;
@@ -751,7 +752,7 @@ void t_netstd_generator::collect_extensions_types(t_type* ttype)
             // included programs are processed by those programs' own generators, which
             // generate extension methods for their internal container types. Recursing
             // into them here would duplicate those extension method signatures (CS0121).
-            if (ttype->get_program() == program_)
+            if (ttype->get_program() == extensions_owner_)
             {
                 t_struct* tstruct = static_cast<t_struct*>(ttype);
                 collect_extensions_types(tstruct);
@@ -793,9 +794,206 @@ void t_netstd_generator::collect_extensions_types(t_type* ttype)
 }
 
 
+// Determine which container types the generator of an included program collects for
+// itself. Mirrors the collect_extensions_types() calls made while a program's structs,
+// exceptions and services are generated, but with that program as the recursion owner.
+void t_netstd_generator::collect_extensions_types_of_program(t_program* program, map<string, t_type*>& result)
+{
+    map<string, t_type*> saved_collected;
+    map<string, t_type*> saved_checked;
+    t_program* saved_owner = extensions_owner_;
+
+    saved_collected.swap(collected_extension_types);
+    saved_checked.swap(checked_extension_types);
+    extensions_owner_ = program;
+
+    const vector<t_struct*>& objects = program->get_objects();
+    vector<t_struct*>::const_iterator o_iter;
+    for (o_iter = objects.begin(); o_iter != objects.end(); ++o_iter)
+    {
+        collect_extensions_types(*o_iter);
+    }
+
+    const vector<t_service*>& services = program->get_services();
+    vector<t_service*>::const_iterator sv_iter;
+    for (sv_iter = services.begin(); sv_iter != services.end(); ++sv_iter)
+    {
+        const vector<t_function*>& functions = (*sv_iter)->get_functions();
+        vector<t_function*>::const_iterator fn_iter;
+        for (fn_iter = functions.begin(); fn_iter != functions.end(); ++fn_iter)
+        {
+            collect_extensions_types((*fn_iter)->get_arglist());
+            collect_extensions_types((*fn_iter)->get_xceptions());
+            collect_extensions_types((*fn_iter)->get_returntype());
+        }
+    }
+
+    result = collected_extension_types;
+
+    extensions_owner_ = saved_owner;
+    collected_extension_types.swap(saved_collected);
+    checked_extension_types.swap(saved_checked);
+}
+
+// True if the type - or, for a container, any of its element types - is declared in the
+// given program.
+bool t_netstd_generator::uses_type_of_program(t_type* ttype, t_program* program)
+{
+    ttype = resolve_typedef(ttype);
+
+    if (ttype->is_map())
+    {
+        t_map* tmap = static_cast<t_map*>(ttype);
+        return uses_type_of_program(tmap->get_key_type(), program) || uses_type_of_program(tmap->get_val_type(), program);
+    }
+
+    if (ttype->is_set())
+    {
+        return uses_type_of_program(static_cast<t_set*>(ttype)->get_elem_type(), program);
+    }
+
+    if (ttype->is_list())
+    {
+        return uses_type_of_program(static_cast<t_list*>(ttype)->get_elem_type(), program);
+    }
+
+    if (ttype->is_base_type())
+    {
+        return false;
+    }
+
+    return ttype->get_program() == program;
+}
+
+bool t_netstd_generator::uses_type_of_program(t_struct* tstruct, t_program* program)
+{
+    const vector<t_field*>& members = tstruct->get_members();
+    vector<t_field*>::const_iterator m_iter;
+    for (m_iter = members.begin(); m_iter != members.end(); ++m_iter)
+    {
+        if (uses_type_of_program((*m_iter)->get_type(), program))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// True if the code generated for "from" names at least one type declared in "program".
+// Such a pair can only ever be compiled together, so "from" may leave extension methods
+// to "program" instead of generating a second, ambiguous copy of them.
+bool t_netstd_generator::program_depends_on(t_program* from, t_program* program)
+{
+    const vector<t_struct*>& objects = from->get_objects();
+    vector<t_struct*>::const_iterator o_iter;
+    for (o_iter = objects.begin(); o_iter != objects.end(); ++o_iter)
+    {
+        if (uses_type_of_program(*o_iter, program))
+        {
+            return true;
+        }
+    }
+
+    const vector<t_const*>& consts = from->get_consts();
+    vector<t_const*>::const_iterator c_iter;
+    for (c_iter = consts.begin(); c_iter != consts.end(); ++c_iter)
+    {
+        if (uses_type_of_program((*c_iter)->get_type(), program))
+        {
+            return true;
+        }
+    }
+
+    const vector<t_service*>& services = from->get_services();
+    vector<t_service*>::const_iterator sv_iter;
+    for (sv_iter = services.begin(); sv_iter != services.end(); ++sv_iter)
+    {
+        t_service* extends = (*sv_iter)->get_extends();
+        if ((extends != nullptr) && (extends->get_program() == program))
+        {
+            return true;
+        }
+
+        const vector<t_function*>& functions = (*sv_iter)->get_functions();
+        vector<t_function*>::const_iterator fn_iter;
+        for (fn_iter = functions.begin(); fn_iter != functions.end(); ++fn_iter)
+        {
+            if (uses_type_of_program((*fn_iter)->get_returntype(), program)
+                || uses_type_of_program((*fn_iter)->get_arglist(), program)
+                || uses_type_of_program((*fn_iter)->get_xceptions(), program))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// Gather the container types generated by the included programs we can safely leave them
+// to. That requires two things: their generated code has to be part of every build that
+// contains ours, and their extension class has to land in the same C# namespace - a class
+// in another namespace is out of reach of our generated call sites.
+void t_netstd_generator::collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_type*>& result)
+{
+    const vector<t_program*>& includes = program->get_includes();
+    vector<t_program*>::const_iterator incl_iter;
+    for (incl_iter = includes.begin(); incl_iter != includes.end(); ++incl_iter)
+    {
+        t_program* include = *incl_iter;
+        if (!program_depends_on(program, include))
+        {
+            continue;   // an include we generate no reference to may not be around at all
+        }
+
+        if (!visited.insert(include).second)
+        {
+            continue;   // diamond-shaped include graph
+        }
+
+        if (include->get_namespace("netstd") == namespace_name_)
+        {
+            map<string, t_type*> types;
+            collect_extensions_types_of_program(include, types);
+            result.insert(types.begin(), types.end());
+        }
+
+        collect_inherited_extensions_types(include, visited, result);
+    }
+}
+
+// An included program generates extension methods for the container types it uses itself.
+// Whenever we use one of the same containers, both extension classes end up with the very
+// same signature, and since they also share the C# namespace every call site becomes
+// ambiguous (CS0121). Leave those to the included program - wherever our extension class
+// is in scope, theirs is too.
+void t_netstd_generator::remove_inherited_extensions_types(map<string, t_type*>& types)
+{
+    set<t_program*> visited;
+    map<string, t_type*> inherited;
+    collect_inherited_extensions_types(program_, visited, inherited);
+
+    map<string, t_type*>::iterator iter = types.begin();
+    while (iter != types.end())
+    {
+        if (inherited.find(iter->first) != inherited.end())
+        {
+            iter = types.erase(iter);
+        }
+        else
+        {
+            ++iter;
+        }
+    }
+}
+
 void t_netstd_generator::generate_extensions_file()
 {
-    if (collected_extension_types.empty())
+    map<string, t_type*> extension_types = collected_extension_types;
+    remove_inherited_extensions_types(extension_types);
+
+    if (extension_types.empty())
     {
         return;
     }
@@ -804,7 +1002,7 @@ void t_netstd_generator::generate_extensions_file()
     ofstream_with_content_based_conditional_update f_exts;
     f_exts.open(f_exts_name.c_str());
 
-    generate_extensions(f_exts, collected_extension_types);
+    generate_extensions(f_exts, extension_types);
 
     f_exts.close();
 }

--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.h
@@ -197,6 +197,7 @@ private:
   vector<member_mapping_scope> member_mapping_scopes;
   map<string, t_type*> collected_extension_types;
   map<string, t_type*> checked_extension_types;
+  t_program* extensions_owner_;   // the program collect_extensions_types() recurses for
 
   string normalize_name(string name, bool is_arg_name = false);
   string make_valid_csharp_identifier(string const& fromName);
@@ -211,6 +212,12 @@ private:
   string get_deep_copy_method_call(t_type* ttype, bool is_not_null, bool& needs_typecast, string& suffix);
   void collect_extensions_types(t_struct* tstruct);
   void collect_extensions_types(t_type* ttype);
+  void collect_extensions_types_of_program(t_program* program, map<string, t_type*>& result);
+  void collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_type*>& result);
+  void remove_inherited_extensions_types(map<string, t_type*>& types);
+  bool uses_type_of_program(t_type* ttype, t_program* program);
+  bool uses_type_of_program(t_struct* tstruct, t_program* program);
+  bool program_depends_on(t_program* from, t_program* program);
   void generate_extensions(ostream& out, map<string, t_type*> types);
   void reset_indent();
   void generate_null_check_begin(ostream& out, t_field* tfield);

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net10/Thrift.Compile.net10.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net10/Thrift.Compile.net10.csproj
@@ -84,6 +84,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift5795.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift6198.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net10                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net8/Thrift.Compile.net8.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net8/Thrift.Compile.net8.csproj
@@ -83,6 +83,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift5795.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift6198.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net8                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net9/Thrift.Compile.net9.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net9/Thrift.Compile.net9.csproj
@@ -83,6 +83,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift5795.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift6198.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net9                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/Thrift.Compile.netstd2.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/Thrift.Compile.netstd2.csproj
@@ -76,6 +76,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift5320.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift5795.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift6198.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6198.included.thrift
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6198.included.thrift
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-6198 CS0121 ambiguous extension methods generated for
+// container types referencing included structs.
+//
+// This is the included program. It deliberately shares its C# namespace with
+// the including program, and it uses the very same container types that the
+// including program uses.
+
+namespace * Thrift6198
+
+struct InnerStruct {
+  1: string data
+}
+
+typedef InnerStruct InnerAlias
+
+struct OuterInIncluded {
+  1: list<InnerAlias> inners
+  2: set<InnerAlias> inner_set
+  3: map<string, InnerAlias> inner_map
+  4: list<string> shared_base_container
+}

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6198.thrift
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6198.thrift
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-6198 CS0121 ambiguous extension methods generated for
+// container types referencing included structs.
+//
+// Both programs share the same C# namespace and both use the same container
+// types. Before the fix, both extension classes declared the same
+// DeepCopy()/Equals()/GetHashCode() signatures, so every call site became
+// ambiguous (CS0121).
+//
+// The fields below cover all three directions at once:
+// - values/value_set/value_map are also used by the included program, so they
+//   have to be left to it (a second copy would be CS0121 again)
+// - shared_base_container is a container over a base type that the included
+//   program uses as well, so the same applies
+// - own_container is ours alone and has to stay right here, or the generated
+//   call site in HoldsIncluded.DeepCopy() would not resolve at all (CS1061)
+//
+// Both the typedef'd and the directly named form of the included struct have
+// to end up as the same container type here.
+
+namespace * Thrift6198
+
+include "Thrift6198.included.thrift"
+
+typedef Thrift6198.included.InnerStruct IncludedAlias
+
+struct HoldsIncluded {
+  1: list<IncludedAlias> values
+  2: set<Thrift6198.included.InnerStruct> value_set
+  3: map<string, IncludedAlias> value_map
+  4: list<string> shared_base_container
+  5: list<double> own_container
+  6: Thrift6198.included.OuterInIncluded borrowed
+}


### PR DESCRIPTION
Fixes [THRIFT-6198](https://issues.apache.org/jira/browse/THRIFT-6198).

### The problem

`collect_extensions_types()` stops recursing at the program boundary since THRIFT-5998, but a program that uses a container type of its own still collects it — even when an included program uses the very same container. Both extension classes then declare the same `DeepCopy()` / `Equals()` / `GetHashCode()` signatures, and since both land in the same C# namespace, every call site becomes ambiguous:

```
error CS0121: The call is ambiguous between the following methods or properties:
'TypedefIncludeTestExtensions.DeepCopy(List<InnerStruct>)' and
'TypedefStructTestExtensions.DeepCopy(List<InnerStruct>)'
```

Reproduced against `master` with the ticket's IDL, compiled with `-gen netstd:net10`. Two observations that go beyond the ticket text:

* **The typedef is not part of the trigger.** `collect_extensions_types()` calls `resolve_typedef()` before it computes the map key, so plain `list<A.InnerStruct>` on both sides fails exactly the same way.
* **It is not limited to included structs.** Two programs that both use `list<i32>` collide identically — the element type never has to leave the base types.

### The fix

Determine which container types an included program collects for itself, and drop those from our own set. That is only safe where the included program's extension class is actually reachable from our generated code, so an include is consulted only when

* our generated code names at least one type declared in it — the two can then only ever be compiled together, and
* its C# namespace is ours — its extension class is then in scope wherever ours is.

Otherwise we keep our own copy, so no call site is ever left without a matching extension method. Verified against the cases that could go wrong:

| Scenario | Result |
|---|---|
| Ticket repro (typedef, shared namespace) | duplicate dropped, compiles |
| Same, without the typedef | duplicate dropped, compiles |
| Only the including program uses the container | kept — the include has nothing to hand over |
| Programs in **different** namespaces | both keep it — the other class is out of scope |
| `list<i32>` in both, including program references the include | duplicate dropped |

### Deliberately not covered

Two variants stay as they are, both predating this change, because neither can be decided from a single program's point of view:

* a container over base types only, shared with an include that the including program otherwise makes no use of;
* two programs that merely share a C# namespace with no include relation between them (e.g. two siblings of a common parent).

Both produce the same CS0121 and would need a rule that spans the whole generator run rather than one program. Happy to file a follow-up ticket if you want those tracked.

### Tests

`Thrift6198.thrift` + `Thrift6198.included.thrift`, wired into all four `Thrift.Compile` targets. They cover, in one build:

* `list` / `set` / `map` over a struct from the included program — CS0121 without the fix
* a base-type container used by both programs — CS0121 without the fix
* a container only the including program uses — CS1061 if the new filter takes away too much

Both directions therefore fail the build if the filter is ever wrong.

### Verification

* `lib/netstd` solution builds clean, all four `Thrift.Compile` targets (net8 / net9 / net10 / netstd2)
* `Thrift.Tests`: 84/84 pass
* `test/netstd` cross-language test app builds
* the ticket's IDL compiles as a standalone C# project

🤖 Generated with [Claude Code](https://claude.com/claude-code)
