### PR TITLE
THRIFT-6199: Call a container's DeepCopy() through the class that owns it

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.cc
@@ -154,6 +154,12 @@ void t_netstd_generator::init_generator()
 
     namespace_dir_ = subdir;
 
+    // has to be known before the first call site is written, not just before the
+    // extensions file is
+    set<t_program*> visited;
+    inherited_extension_owners.clear();
+    collect_inherited_extensions_types(program_, visited, inherited_extension_owners);
+
     while (!member_mapping_scopes.empty())
     {
         cleanup_member_name_mapping(member_mapping_scopes.back().scope_member);
@@ -935,7 +941,7 @@ bool t_netstd_generator::program_depends_on(t_program* from, t_program* program)
 // to. That requires two things: their generated code has to be part of every build that
 // contains ours, and their extension class has to land in the same C# namespace - a class
 // in another namespace is out of reach of our generated call sites.
-void t_netstd_generator::collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_type*>& result)
+void t_netstd_generator::collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_program*>& result)
 {
     const vector<t_program*>& includes = program->get_includes();
     vector<t_program*>::const_iterator incl_iter;
@@ -956,7 +962,12 @@ void t_netstd_generator::collect_inherited_extensions_types(t_program* program, 
         {
             map<string, t_type*> types;
             collect_extensions_types_of_program(include, types);
-            result.insert(types.begin(), types.end());
+
+            map<string, t_type*>::const_iterator type_iter;
+            for (type_iter = types.begin(); type_iter != types.end(); ++type_iter)
+            {
+                result.insert(std::make_pair(type_iter->first, include));
+            }
         }
 
         collect_inherited_extensions_types(include, visited, result);
@@ -970,14 +981,10 @@ void t_netstd_generator::collect_inherited_extensions_types(t_program* program, 
 // is in scope, theirs is too.
 void t_netstd_generator::remove_inherited_extensions_types(map<string, t_type*>& types)
 {
-    set<t_program*> visited;
-    map<string, t_type*> inherited;
-    collect_inherited_extensions_types(program_, visited, inherited);
-
     map<string, t_type*>::iterator iter = types.begin();
     while (iter != types.end())
     {
-        if (inherited.find(iter->first) != inherited.end())
+        if (inherited_extension_owners.find(iter->first) != inherited_extension_owners.end())
         {
             iter = types.erase(iter);
         }
@@ -1056,7 +1063,6 @@ void t_netstd_generator::generate_extensions(ostream& out, map<string, t_type*> 
             out << indent() << "return null;" << '\n' << '\n';
             indent_down();
 
-            string suffix("");
             string tmp_instance = tmp("tmp");
             if( (target_net_version < 5) && iter->second->is_set()) {
                 out << indent() << "var " << tmp_instance << " = new " << iter->first << "();" << '\n';
@@ -1066,28 +1072,28 @@ void t_netstd_generator::generate_extensions(ostream& out, map<string, t_type*> 
             if( iter->second->is_map())
             {
                 t_map* tmap = static_cast<t_map*>(iter->second);
-                string copy_key = get_deep_copy_method_call(tmap->get_key_type(), true, needs_typecast, suffix);
-                string copy_val = get_deep_copy_method_call(tmap->get_val_type(), true, needs_typecast, suffix);
+                string copy_key = deep_copy_expression("pair.Key", tmap->get_key_type(), true, needs_typecast);
+                string copy_val = deep_copy_expression("pair.Value", tmap->get_val_type(), true, needs_typecast);
                 bool null_key = type_can_be_null(tmap->get_key_type());
                 bool null_val = type_can_be_null(tmap->get_val_type());
 
                 out << indent() << "foreach (var pair in source)" << '\n';
                 indent_up();
                 if( target_net_version >= 6) {
-                    out << indent() << tmp_instance << ".Add(pair.Key" << copy_key;
-                    out << ", pair.Value" << copy_val;
+                    out << indent() << tmp_instance << ".Add(" << copy_key;
+                    out << ", " << copy_val;
                 } else {
                     out << indent() << tmp_instance << ".Add(";
                     if( null_key) {
-                        out << "(pair.Key != null) ? pair.Key" << copy_key << " : null";
+                        out << "(pair.Key != null) ? " << copy_key << " : null";
                     } else {
-                        out << "pair.Key" << copy_key;
+                        out << copy_key;
                     }
                     out << ", ";
                     if( null_val) {
-                        out << "(pair.Value != null) ? pair.Value" << copy_val << " : null";
+                        out << "(pair.Value != null) ? " << copy_val << " : null";
                     } else {
-                        out << "pair.Value" << copy_val;
+                        out << copy_val;
                     }
                 }
                 out << ");" << '\n';
@@ -1099,27 +1105,27 @@ void t_netstd_generator::generate_extensions(ostream& out, map<string, t_type*> 
                 if (iter->second->is_set())
                 {
                     t_set* tset = static_cast<t_set*>(iter->second);
-                    copy_elm = get_deep_copy_method_call(tset->get_elem_type(), true, needs_typecast, suffix);
+                    copy_elm = deep_copy_expression("elem", tset->get_elem_type(), true, needs_typecast);
                     null_elm = type_can_be_null(tset->get_elem_type());
                 }
                 else // list
                 {
                     t_list* tlist = static_cast<t_list*>(iter->second);
-                    copy_elm = get_deep_copy_method_call(tlist->get_elem_type(), true, needs_typecast, suffix);
+                    copy_elm = deep_copy_expression("elem", tlist->get_elem_type(), true, needs_typecast);
                     null_elm = type_can_be_null(tlist->get_elem_type());
                 }
 
                 out << indent() << "foreach (var elem in source)" << '\n';
                 indent_up();
                 if( target_net_version >= 6) {
-                    out << indent() << tmp_instance << ".Add(elem" << copy_elm;
+                    out << indent() << tmp_instance << ".Add(" << copy_elm;
                 } else {
                     out << indent() << tmp_instance << ".Add(";
                     if( null_elm)
                     {
-                        out << "(elem != null) ? elem" << copy_elm << " : null";
+                        out << "(elem != null) ? " << copy_elm << " : null";
                     } else {
-                        out << "elem" << copy_elm;
+                        out << copy_elm;
                     }
                 }
                 out << ");" << '\n';
@@ -1458,9 +1464,8 @@ void t_netstd_generator::generate_netstd_deepcopy_method(ostream& out, t_struct*
 
     for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
         bool needs_typecast = false;
-        string suffix("");
         t_type* ttype = (*m_iter)->get_type();
-        string copy_op = get_deep_copy_method_call(ttype, true, needs_typecast, suffix);
+        string copy_op = deep_copy_expression("this." + prop_name(*m_iter), ttype, true, needs_typecast);
 
         bool is_required = field_is_required(*m_iter);
         bool null_allowed = type_can_be_null((*m_iter)->get_type());
@@ -1483,7 +1488,7 @@ void t_netstd_generator::generate_netstd_deepcopy_method(ostream& out, t_struct*
         if( needs_typecast) {
             out << "(" << type_name(ttype) << ")";
         }
-        out << "this." << prop_name(*m_iter) << copy_op;
+        out << copy_op;
         out << (inline_assignment ? "," : ";") << '\n';
 
         generate_null_check_end( out, *m_iter);
@@ -1996,9 +2001,8 @@ void t_netstd_generator::generate_netstd_union_definition(ostream& out, t_struct
             for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter)
             {
                 bool needs_typecast = false;
-                string suffix("");
-                string copy_op = get_deep_copy_method_call((*f_iter)->get_type(), false, needs_typecast, suffix);
-                out << indent() << (*f_iter)->get_key() << " => new " << (*f_iter)->get_name() << "(As_" << (*f_iter)->get_name() << suffix << copy_op << ")," << '\n';
+                string copy_op = deep_copy_expression("As_" + (*f_iter)->get_name(), (*f_iter)->get_type(), false, needs_typecast, true);
+                out << indent() << (*f_iter)->get_key() << " => new " << (*f_iter)->get_name() << "(" << copy_op << ")," << '\n';
             }
             out << indent() << "_ => new ___undefined()" << '\n';
             indent_down();
@@ -2010,11 +2014,10 @@ void t_netstd_generator::generate_netstd_union_definition(ostream& out, t_struct
             for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter)
             {
                 bool needs_typecast = false;
-                string suffix("");
-                string copy_op = get_deep_copy_method_call((*f_iter)->get_type(), false, needs_typecast, suffix);
+                string copy_op = deep_copy_expression("As_" + (*f_iter)->get_name(), (*f_iter)->get_type(), false, needs_typecast, true);
                 out << indent() << "case " << (*f_iter)->get_key() << ":" << '\n';
                 indent_up();
-                out << indent() << "return new " << (*f_iter)->get_name() << "(As_" << (*f_iter)->get_name() << suffix << copy_op << ");" << '\n';
+                out << indent() << "return new " << (*f_iter)->get_name() << "(" << copy_op << ");" << '\n';
                 indent_down();
             }
             out << indent() << "default:" << '\n';
@@ -2108,9 +2111,8 @@ void t_netstd_generator::generate_netstd_union_class(ostream& out, t_struct* tun
         out << indent() << "{" << '\n';
         indent_up();
         bool needs_typecast = false;
-        string suffix("");
-        string copy_op = get_deep_copy_method_call(tfield->get_type(), true, needs_typecast, suffix);
-        out << indent() << "return new " << normalize_name(tfield->get_name()) << "(_data" << copy_op << ");" << '\n';
+        string copy_op = deep_copy_expression("_data", tfield->get_type(), true, needs_typecast);
+        out << indent() << "return new " << normalize_name(tfield->get_name()) << "(" << copy_op << ");" << '\n';
         indent_down();
         out << indent() << "}" << '\n' << '\n';
     }
@@ -3909,6 +3911,56 @@ string t_netstd_generator::get_deep_copy_method_call(t_type* ttype, bool is_not_
     }
 
     throw "UNEXPECTED TYPE IN get_deep_copy_method_call: " + ttype->get_name();
+}
+
+// The name of the extension class holding the container extension methods of a program.
+string t_netstd_generator::extensions_class_name(t_program* program)
+{
+    return make_valid_csharp_identifier(program->get_name()) + "Extensions";
+}
+
+// The extension class that carries the DeepCopy() of the given container type. That is
+// ours, unless the container was left to an included program (see THRIFT-6198).
+string t_netstd_generator::extensions_class_of(t_type* ttype)
+{
+    map<string, t_program*>::const_iterator iter = inherited_extension_owners.find(type_name(ttype));
+    return extensions_class_name((iter != inherited_extension_owners.end()) ? iter->second : program_);
+}
+
+// Builds the expression that deep-copies "source".
+//
+// A container's DeepCopy() is an extension method, and the same signature can exist in
+// more than one extension class of a C# namespace - THRIFT-6198 removes the duplicates it
+// can see, but two programs without an include relation between them cannot know of each
+// other (THRIFT-6199). Calling through the class that owns the method rather than through
+// extension method syntax keeps the call site unambiguous however many of those classes
+// happen to be in scope. Structs and unions have an ordinary DeepCopy() instance method
+// and are left alone.
+//
+// null_conditional picks the "source?.DeepCopy()" form for those, which is what the code
+// generated for unions needs.
+string t_netstd_generator::deep_copy_expression(const string& source, t_type* ttype, bool is_not_null, bool& needs_typecast, bool null_conditional)
+{
+    t_type* resolved = resolve_typedef(ttype);
+
+    if (!resolved->is_container())
+    {
+        string suffix("");
+        string copy_op = get_deep_copy_method_call(ttype, is_not_null, needs_typecast, suffix);
+        return source + (null_conditional ? suffix : "") + copy_op;
+    }
+
+    needs_typecast = false;
+
+    // if is_not_null is set, then the surrounding code already explicitly tests against != null
+    string null_check("");
+    if( target_net_version >= 8) {
+        null_check = is_not_null ? "!" : " ?? []";
+    } else if( target_net_version >= 6) {
+        null_check = is_not_null ? "!" : " ?? new()";
+    }
+
+    return extensions_class_of(resolved) + "." + DEEP_COPY_METHOD_NAME + "(" + source + ")" + null_check;
 }
 
 string t_netstd_generator::declare_field(t_field* tfield, bool init, bool allow_nullable, string prefix)

--- a/compiler/cpp/src/thrift/generate/t_netstd_generator.h
+++ b/compiler/cpp/src/thrift/generate/t_netstd_generator.h
@@ -197,6 +197,7 @@ private:
   vector<member_mapping_scope> member_mapping_scopes;
   map<string, t_type*> collected_extension_types;
   map<string, t_type*> checked_extension_types;
+  map<string, t_program*> inherited_extension_owners;   // containers left to an included program
   t_program* extensions_owner_;   // the program collect_extensions_types() recurses for
 
   string normalize_name(string name, bool is_arg_name = false);
@@ -210,10 +211,13 @@ private:
   string get_mapped_member_name(string oldname);
   string get_isset_name(const string& str);
   string get_deep_copy_method_call(t_type* ttype, bool is_not_null, bool& needs_typecast, string& suffix);
+  string deep_copy_expression(const string& source, t_type* ttype, bool is_not_null, bool& needs_typecast, bool null_conditional = false);
+  string extensions_class_name(t_program* program);
+  string extensions_class_of(t_type* ttype);
   void collect_extensions_types(t_struct* tstruct);
   void collect_extensions_types(t_type* ttype);
   void collect_extensions_types_of_program(t_program* program, map<string, t_type*>& result);
-  void collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_type*>& result);
+  void collect_inherited_extensions_types(t_program* program, set<t_program*>& visited, map<string, t_program*>& result);
   void remove_inherited_extensions_types(map<string, t_type*>& types);
   bool uses_type_of_program(t_type* ttype, t_program* program);
   bool uses_type_of_program(t_struct* tstruct, t_program* program);

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net10/Thrift.Compile.net10.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net10/Thrift.Compile.net10.csproj
@@ -85,6 +85,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift5795.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift6198.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net10 -r ../Thrift6199.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net10                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net8/Thrift.Compile.net8.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net8/Thrift.Compile.net8.csproj
@@ -84,6 +84,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift5795.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift6198.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net8 -r ../Thrift6199.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net8                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net9/Thrift.Compile.net9.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.net9/Thrift.Compile.net9.csproj
@@ -84,6 +84,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift5795.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift6198.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:wcf,union,serial,net9 -r ../Thrift6199.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd:net9                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/Thrift.Compile.netstd2.csproj
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift.Compile.netstd2/Thrift.Compile.netstd2.csproj
@@ -77,6 +77,7 @@
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift5382.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift5795.thrift" />
     <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift6198.thrift" />
+    <Exec Command="$(PathToThrift) -gen netstd:union,serial -r ../Thrift6199.thrift" />
     <!-- special options (see ticket) -->
     <Exec Command="$(PathToThrift) -gen netstd                  -r ../Thrift5794.thrift" />
   </Target>

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.first.thrift
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.first.thrift
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-6199, see Thrift6199.thrift.
+//
+// One of two sibling programs. It shares its C# namespace with the other one
+// and uses the same container types, but neither of the two includes the other,
+// so neither generator can know about the duplicate.
+
+namespace * Thrift6199
+
+struct FirstHolder {
+  1: list<i32> numbers
+  2: map<string, list<i32>> nested
+}

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.second.thrift
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.second.thrift
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-6199, see Thrift6199.thrift.
+//
+// The other of the two sibling programs, deliberately declaring the very same
+// container types as Thrift6199.first.thrift does.
+
+namespace * Thrift6199
+
+union SecondHolder {
+  1: list<i32> numbers
+  2: map<string, list<i32>> nested
+}

--- a/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.thrift
+++ b/lib/netstd/Tests/Thrift.Compile.Tests/Thrift6199.thrift
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Testcase for THRIFT-6199 CS0121 for container extension methods shared by
+// programs that have no include relation.
+//
+// Pulling both siblings in is what puts their two extension classes into one
+// compilation. They share a C# namespace and declare the same container
+// extension methods, but since neither includes the other, the duplicate
+// cannot be removed the way THRIFT-6198 removes it for an include.
+//
+// The generated call sites therefore have to name the class that owns the
+// method rather than rely on extension method syntax, or FirstHolder.cs and
+// SecondHolder.cs both fail with CS0121.
+
+namespace * Thrift6199
+
+include "Thrift6199.first.thrift"
+include "Thrift6199.second.thrift"
+
+struct BothHolders {
+  1: Thrift6199.first.FirstHolder first
+  2: Thrift6199.second.SecondHolder second
+  3: list<i32> numbers
+}


### PR DESCRIPTION
Fixes [THRIFT-6199](https://issues.apache.org/jira/browse/THRIFT-6199).

### What is left after THRIFT-6198

#3813 (THRIFT-6198, merged) drops a container extension method that an included program already emits. But the underlying conflict is not tied to the include relation at all — **any** two programs that end up in the same C# namespace and use the same container type declare the same extension method signature, and every call site seeing both classes fails with CS0121. Two topologies remain, both verified against master with #3813 in place:

**1. Siblings — the common one.** Two programs pulled into one build by a third, with no include relation between them:

```thrift
// A1.thrift  namespace * MyApp     struct S1 { 1: list<i32> nums }
// A2.thrift  namespace * MyApp     struct S2 { 1: list<i32> nums }
// B.thrift   namespace * MyApp     include both; struct B1 { 1: A1.S1 one, 2: A2.S2 two }
```

```
S1.cs(74,29): error CS0121: The call is ambiguous between the following methods or properties:
'A1Extensions.DeepCopy(List<int>?)' and 'A2Extensions.DeepCopy(List<int>?)'
S2.cs(74,29): error CS0121: ...
```

**2. Container over base types shared with an otherwise unused include** — where #3813 deliberately does not defer, because the including program's code would then depend on files it never references.

A generator instance only ever sees its own program and that program's include closure. In topology 1 neither sibling is in the other's closure, so **no per-program rule can decide this one.** A whole-run registry (first program in the run claims the type) was considered and dropped: it makes the content of `A1.Extensions.cs` depend on whether the compiler ran `-r` on a root program or per file, which breaks reproducible output.

### The fix: make the duplicates harmless

Two static classes declaring the same extension method is perfectly legal C# — only an *unqualified call* matching both is an error. So generated code now calls a container's `DeepCopy()` through the class that owns it:

```csharp
// before
tmp5.Inners = this.Inners.DeepCopy()!;

// after
tmp5.Inners = MyAppTypesExtensions.DeepCopy(this.Inners)!;
```

That resolves the same way however many extension classes of the namespace are in scope. It also has to cover the containers #3813 leaves to an included program, which is why the ownership map is now built in `init_generator()` rather than at close time — the first call site is written long before the extensions file is.

Struct and union `DeepCopy()` are ordinary instance methods, never ambiguous, and keep the syntax they had.

### Scope of the generated-code change, measured

I diffed the generated output of the whole `Thrift.Compile` corpus (253 files: CassandraTest, ThriftTest, fb303, optional_required_default, name_conflicts, Recursive, Thrift5253/5320/5382/5794/5795/6198) against the previous compiler:

| | net10 | netstd2 |
|---|---|---|
| changed lines | 306 | 296 |
| **changed lines not containing `DeepCopy`** | **0** | **0** |

Every one is a container `DeepCopy()` call site. A struct-typed field still reads `tmp15.Struct_thing = (global::ThriftTest.Xtruct)this.Struct_thing.DeepCopy()!;`, unchanged.

One semantic note: the union path went from `As_x?.DeepCopy() ?? []` to `Ext.DeepCopy(As_x) ?? []`. Equivalent — the generated container `DeepCopy()` opens with `if (source == null) return null;`.

### What this does not fix

The duplicate *declarations* still exist in those two topologies, so hand-written code calling `someList.DeepCopy()` in such a namespace still has to qualify. Removing them altogether needs the cross-program pass rejected above.

### Tests

`Thrift6199.thrift` pulls two sibling programs into one compilation; both share a namespace and declare `list<i32>` and `map<string, list<i32>>`. Wired into all four `Thrift.Compile` targets. Without the fix it is **8 × CS0121**, covering struct `DeepCopy()`, union `DeepCopy()`, and the nested container copies inside the extension methods themselves.

### Verification

* both residual topologies: CS0121 without this change, clean build with this change
* `lib/netstd` solution builds clean, all four targets (net8 / net9 / net10 / netstd2); only the two pre-existing CS0114 warnings remain
* `Thrift.Tests`: 84/84 pass
* `test/netstd` cross-language test app builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
