### PR TITLE
THRIFT-5224: Replace the deprecated Buffer() constructor in the Node.js library

### DIFF
--- a/lib/nodejs/lib/thrift/binary_protocol.js
+++ b/lib/nodejs/lib/thrift/binary_protocol.js
@@ -124,15 +124,15 @@ TBinaryProtocol.prototype.writeBool = function (bool) {
 };
 
 TBinaryProtocol.prototype.writeByte = function (b) {
-  this.trans.write(new Buffer([b]));
+  this.trans.write(Buffer.from([b]));
 };
 
 TBinaryProtocol.prototype.writeI16 = function (i16) {
-  this.trans.write(binary.writeI16(new Buffer(2), i16));
+  this.trans.write(binary.writeI16(Buffer.alloc(2), i16));
 };
 
 TBinaryProtocol.prototype.writeI32 = function (i32) {
-  this.trans.write(binary.writeI32(new Buffer(4), i32));
+  this.trans.write(binary.writeI32(Buffer.alloc(4), i32));
 };
 
 TBinaryProtocol.prototype.writeI64 = function (i64) {
@@ -144,13 +144,13 @@ TBinaryProtocol.prototype.writeI64 = function (i64) {
 };
 
 TBinaryProtocol.prototype.writeDouble = function (dub) {
-  this.trans.write(binary.writeDouble(new Buffer(8), dub));
+  this.trans.write(binary.writeDouble(Buffer.alloc(8), dub));
 };
 
 TBinaryProtocol.prototype.writeStringOrBinary = function (name, encoding, arg) {
   if (typeof arg === "string") {
     this.writeI32(Buffer.byteLength(arg, encoding));
-    this.trans.write(new Buffer(arg, encoding));
+    this.trans.write(Buffer.from(arg, encoding));
   } else if (
     arg instanceof Buffer ||
     Object.prototype.toString.call(arg) == "[object Uint8Array]"
@@ -282,7 +282,7 @@ TBinaryProtocol.prototype.readDouble = function () {
 TBinaryProtocol.prototype.readBinary = function () {
   var len = this.readI32();
   if (len === 0) {
-    return new Buffer(0);
+    return Buffer.alloc(0);
   }
 
   if (len < 0) {

--- a/lib/nodejs/lib/thrift/buffered_transport.js
+++ b/lib/nodejs/lib/thrift/buffered_transport.js
@@ -27,7 +27,7 @@ function TBufferedTransport(buffer, callback) {
   THeaderTransport.call(this);
   this.defaultReadBufferSize = 1024;
   this.writeBufferSize = 512; // Soft Limit
-  this.inBuf = new Buffer(this.defaultReadBufferSize);
+  this.inBuf = Buffer.alloc(this.defaultReadBufferSize);
   this.readCursor = 0;
   this.writeCursor = 0; // for input buffer
   this.outBuffers = [];
@@ -38,7 +38,7 @@ function TBufferedTransport(buffer, callback) {
 Object.setPrototypeOf(TBufferedTransport.prototype, THeaderTransport.prototype);
 
 TBufferedTransport.prototype.reset = function () {
-  this.inBuf = new Buffer(this.defaultReadBufferSize);
+  this.inBuf = Buffer.alloc(this.defaultReadBufferSize);
   this.readCursor = 0;
   this.writeCursor = 0;
   this.outBuffers = [];
@@ -73,7 +73,7 @@ TBufferedTransport.receiver = function (callback, seqid, maxLength) {
       if (maxLength && newLength > maxLength) {
         newLength = maxLength;
       }
-      var buf = new Buffer(newLength);
+      var buf = Buffer.alloc(newLength);
       reader.inBuf.copy(buf, 0, 0, reader.writeCursor);
       reader.inBuf = buf;
     }
@@ -90,7 +90,7 @@ TBufferedTransport.prototype.commitPosition = function () {
     unreadSize * 2 > this.defaultReadBufferSize
       ? unreadSize * 2
       : this.defaultReadBufferSize;
-  var buf = new Buffer(bufSize);
+  var buf = Buffer.alloc(bufSize);
   if (unreadSize > 0) {
     this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor);
   }
@@ -126,7 +126,7 @@ TBufferedTransport.prototype.ensureAvailable = function (len) {
 
 TBufferedTransport.prototype.read = function (len) {
   this.ensureAvailable(len);
-  var buf = new Buffer(len);
+  var buf = Buffer.alloc(len);
   this.inBuf.copy(buf, 0, this.readCursor, this.readCursor + len);
   this.readCursor += len;
   return buf;
@@ -180,7 +180,7 @@ TBufferedTransport.prototype.consume = function (bytesConsumed) {
 
 TBufferedTransport.prototype.write = function (buf) {
   if (typeof buf === "string") {
-    buf = new Buffer(buf, "utf8");
+    buf = Buffer.from(buf, "utf8");
   }
   this.outBuffers.push(buf);
   this.outCount += buf.length;
@@ -196,7 +196,7 @@ TBufferedTransport.prototype.flush = function () {
     return;
   }
 
-  var msg = new Buffer(this.outCount),
+  var msg = Buffer.alloc(this.outCount),
     pos = 0;
   this.outBuffers.forEach(function (buf) {
     buf.copy(msg, pos, 0);

--- a/lib/nodejs/lib/thrift/compact_protocol.js
+++ b/lib/nodejs/lib/thrift/compact_protocol.js
@@ -364,7 +364,7 @@ TCompactProtocol.prototype.writeBool = function (value) {
 };
 
 TCompactProtocol.prototype.writeByte = function (b) {
-  this.trans.write(new Buffer([b]));
+  this.trans.write(Buffer.from([b]));
 };
 
 TCompactProtocol.prototype.writeI16 = function (i16) {
@@ -381,7 +381,7 @@ TCompactProtocol.prototype.writeI64 = function (i64) {
 
 // Little-endian, unlike TBinaryProtocol
 TCompactProtocol.prototype.writeDouble = function (v) {
-  var buff = new Buffer(8);
+  var buff = Buffer.alloc(8);
   var m, e, c;
 
   buff[7] = v < 0 ? 0x80 : 0x00;
@@ -444,7 +444,7 @@ TCompactProtocol.prototype.writeStringOrBinary = function (
 ) {
   if (typeof arg === "string") {
     this.writeVarint32(Buffer.byteLength(arg, encoding));
-    this.trans.write(new Buffer(arg, encoding));
+    this.trans.write(Buffer.from(arg, encoding));
   } else if (
     arg instanceof Buffer ||
     Object.prototype.toString.call(arg) == "[object Uint8Array]"
@@ -510,7 +510,7 @@ TCompactProtocol.prototype.writeCollectionBegin = function (elemType, size) {
  * Write an i32 as a varint. Results in 1-5 bytes on the wire.
  */
 TCompactProtocol.prototype.writeVarint32 = function (n) {
-  var buf = new Buffer(5);
+  var buf = Buffer.alloc(5);
   var wsize = 0;
   while (true) {
     if ((n & ~0x7f) === 0) {
@@ -521,7 +521,7 @@ TCompactProtocol.prototype.writeVarint32 = function (n) {
       n = n >>> 7;
     }
   }
-  var wbuf = new Buffer(wsize);
+  var wbuf = Buffer.alloc(wsize);
   buf.copy(wbuf, 0, 0, wsize);
   this.trans.write(wbuf);
 };
@@ -541,7 +541,7 @@ TCompactProtocol.prototype.writeVarint64 = function (n) {
     );
   }
 
-  var buf = new Buffer(10);
+  var buf = Buffer.alloc(10);
   var wsize = 0;
   var hi = n.buffer.readUInt32BE(0, true);
   var lo = n.buffer.readUInt32BE(4, true);
@@ -558,7 +558,7 @@ TCompactProtocol.prototype.writeVarint64 = function (n) {
       lo = lo | mask;
     }
   }
-  var wbuf = new Buffer(wsize);
+  var wbuf = Buffer.alloc(wsize);
   buf.copy(wbuf, 0, 0, wsize);
   this.trans.write(wbuf);
 };
@@ -802,7 +802,7 @@ TCompactProtocol.prototype.readDouble = function () {
 TCompactProtocol.prototype.readBinary = function () {
   var size = this.readVarint32();
   if (size === 0) {
-    return new Buffer(0);
+    return Buffer.alloc(0);
   }
 
   if (size < 0) {

--- a/lib/nodejs/lib/thrift/framed_transport.js
+++ b/lib/nodejs/lib/thrift/framed_transport.js
@@ -25,7 +25,7 @@ module.exports = TFramedTransport;
 
 function TFramedTransport(buffer, callback) {
   THeaderTransport.call(this);
-  this.inBuf = buffer || new Buffer(0);
+  this.inBuf = buffer || Buffer.alloc(0);
   this.outBuffers = [];
   this.outCount = 0;
   this.readPos = 0;
@@ -182,7 +182,7 @@ TFramedTransport.prototype.consume = function (bytesConsumed) {
 
 TFramedTransport.prototype.write = function (buf, encoding) {
   if (typeof buf === "string") {
-    buf = new Buffer(buf, encoding || "utf8");
+    buf = Buffer.from(buf, encoding || "utf8");
   }
   this.outBuffers.push(buf);
   this.outCount += buf.length;
@@ -194,7 +194,7 @@ TFramedTransport.prototype.flush = function () {
   var seqid = this._seqid;
   this._seqid = null;
 
-  var out = new Buffer(this.outCount),
+  var out = Buffer.alloc(this.outCount),
     pos = 0;
   this.outBuffers.forEach(function (buf) {
     buf.copy(out, pos, 0);
@@ -203,7 +203,7 @@ TFramedTransport.prototype.flush = function () {
 
   if (this.onFlush) {
     // TODO: optimize this better, allocate one buffer instead of both:
-    var msg = new Buffer(out.length + 4);
+    var msg = Buffer.alloc(out.length + 4);
     binary.writeI32(msg, out.length);
     out.copy(msg, 4, 0, out.length);
     if (this.onFlush) {

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -187,7 +187,7 @@ var HttpConnection = (exports.HttpConnection = function (options) {
         Object.prototype.toString.call(chunk) == "[object Uint8Array]"
       ) {
         // Wrap ArrayBuffer/string in a Buffer so data[i].copy will work
-        data.push(new Buffer(chunk));
+        data.push(Buffer.from(chunk));
       } else {
         data.push(chunk);
       }
@@ -195,7 +195,7 @@ var HttpConnection = (exports.HttpConnection = function (options) {
     });
 
     response.on("end", function () {
-      var buf = new Buffer(dataLen);
+      var buf = Buffer.alloc(dataLen);
       for (var i = 0, len = data.length, pos = 0; i < len; i++) {
         data[i].copy(buf, pos);
         pos += data[i].length;

--- a/lib/nodejs/lib/thrift/int64_util.js
+++ b/lib/nodejs/lib/thrift/int64_util.js
@@ -37,7 +37,7 @@ Int64Util.toDecimalString = function (i64) {
     if (negative) {
       // 2's complement
       var incremented = false;
-      var buffer = new Buffer(8);
+      var buffer = Buffer.alloc(8);
       for (var i = 7; i >= 0; --i) {
         buffer[i] = (~b[o + i] + (incremented ? 0 : 1)) & 0xff;
         incremented |= b[o + i];

--- a/lib/nodejs/lib/thrift/json_protocol.js
+++ b/lib/nodejs/lib/thrift/json_protocol.js
@@ -413,7 +413,7 @@ TJSONProtocol.prototype.writeString = function (arg) {
 /** Serializes a string */
 TJSONProtocol.prototype.writeBinary = function (arg) {
   if (typeof arg === "string") {
-    var buf = new Buffer(arg, "binary");
+    var buf = Buffer.from(arg, "binary");
   } else if (
     arg instanceof Buffer ||
     Object.prototype.toString.call(arg) == "[object Uint8Array]"
@@ -771,7 +771,7 @@ TJSONProtocol.prototype.readDouble = function () {
 };
 
 TJSONProtocol.prototype.readBinary = function () {
-  return new Buffer(this.readValue(), "base64");
+  return Buffer.from(this.readValue(), "base64");
 };
 
 TJSONProtocol.prototype.readString = function () {

--- a/lib/nodejs/lib/thrift/ws_connection.js
+++ b/lib/nodejs/lib/thrift/ws_connection.js
@@ -186,7 +186,7 @@ WSConnection.prototype.__onData = function (data) {
   if (Object.prototype.toString.call(data) === "[object ArrayBuffer]") {
     data = new Uint8Array(data);
   }
-  var buf = new Buffer(data);
+  var buf = Buffer.from(data);
   this.transport.receiver(this.__decodeCallback.bind(this))(buf);
 };
 

--- a/lib/nodejs/lib/thrift/xhr_connection.js
+++ b/lib/nodejs/lib/thrift/xhr_connection.js
@@ -153,7 +153,7 @@ XHRConnection.prototype.setRecvBuffer = function (buf) {
   if (Object.prototype.toString.call(buf) == "[object ArrayBuffer]") {
     var data = new Uint8Array(buf);
   }
-  var thing = new Buffer(data || buf);
+  var thing = Buffer.from(data || buf);
 
   this.transport.receiver(this.__decodeCallback.bind(this))(thing);
 };

--- a/lib/nodejs/test/header.test.js
+++ b/lib/nodejs/test/header.test.js
@@ -107,7 +107,7 @@ const cases = {
 
     const largeChunkSize = 2 * 100 * 1024 * 1024;
     const largeChunk = Buffer.alloc(largeChunkSize, "A");
-    const sizeBuffer = new Buffer(4);
+    const sizeBuffer = Buffer.alloc(4);
     sizeBuffer.writeInt32BE(largeChunkSize + 4, 0);
     onData(Buffer.concat([sizeBuffer, largeChunk]));
 

--- a/lib/nodejs/test/test-cases.mjs
+++ b/lib/nodejs/test/test-cases.mjs
@@ -92,10 +92,10 @@ export const simple = [
   ["testI64", -5],
   ["testI64", 734359738368],
   ["testI64", -734359738368],
-  ["testI64", new Int64(new Buffer([0, 0x20, 0, 0, 0, 0, 0, 1]))], // 2^53+1
+  ["testI64", new Int64(Buffer.from([0, 0x20, 0, 0, 0, 0, 0, 1]))], // 2^53+1
   [
     "testI64",
-    new Int64(new Buffer([0xff, 0xdf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])),
+    new Int64(Buffer.from([0xff, 0xdf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])),
   ], // -2^53-1
   ["testTypedef", 69],
   ["testUuid", "00112233-4455-6677-8899-aabbccddeeff"],

--- a/lib/nodejs/test/test_driver.mjs
+++ b/lib/nodejs/test/test_driver.mjs
@@ -76,13 +76,13 @@ export const ThriftTestDriver = function (client, callback) {
       for (let i = 0; i < 256; ++i) {
         arr[i] = 255 - i;
       }
-      let buf = new Buffer(arr);
+      let buf = Buffer.from(arr);
       client.testBinary(buf, function (err, response) {
         assert.error(err, "testBinary: no callback error");
         assert.equal(response.length, 256, "testBinary");
         assert.deepEqual(response, buf, "testBinary(Buffer)");
       });
-      buf = new Buffer(arr);
+      buf = Buffer.from(arr);
       client.testBinary(buf.toString("binary"), function (err, response) {
         assert.error(err, "testBinary: no callback error");
         assert.equal(response.length, 256, "testBinary");

--- a/lib/nodejs/test/thrift_4987_xhr_protocol.test.mjs
+++ b/lib/nodejs/test/thrift_4987_xhr_protocol.test.mjs
@@ -42,7 +42,7 @@
  * setRecvBuffer() (line 134) then does:
  *
  *   if ([object ArrayBuffer]) { data = new Uint8Array(buf); }  // line 140
- *   var thing = new Buffer(data || buf);                       // line 143
+ *   var thing = Buffer.from(data || buf);                      // line 143
  *
  * When `buf` is a string (which it always is from line 117), the ArrayBuffer
  * guard on line 140 is never reached — it is dead code.  `new Buffer(string)`
@@ -64,7 +64,7 @@
  *   self.setRecvBuffer(this.response);    // not this.responseText — line 117
  *
  * With responseType='arraybuffer', this.response is an ArrayBuffer, the
- * guard on line 140 fires, and new Buffer(Uint8Array) copies bytes verbatim.
+ * guard on line 140 fires, and Buffer.from(Uint8Array) copies bytes verbatim.
  *
  * ─────────────────────────────────────────────────────────────────────────
  * TEST APPROACH


### PR DESCRIPTION
Replace deprecated `new Buffer()` constructor calls with `Buffer.alloc()` and `Buffer.from()` across `lib/nodejs/lib` and `lib/nodejs/test`.

- `new Buffer(size)` -> `Buffer.alloc(size)`
- `new Buffer(data[, encoding])` -> `Buffer.from(data[, encoding])`

Eliminates the Node.js `DEP0005` runtime deprecation warning emitted whenever the library or tests run. Supersedes stale/closed PR #2163.

- [X] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket? (THRIFT-5224)
- [X] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [X] Did you squash your changes to a single commit?
- [X] Did you do your best to avoid breaking changes?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

*This change was created with AI assistance.*
