### PR TITLE
THRIFT-5807: Format out-of-range enums as EnumName(val) instead of <UNSET>

### DIFF
--- a/compiler/cpp/src/thrift/generate/go_validator_generator.cc
+++ b/compiler/cpp/src/thrift/generate/go_validator_generator.cc
@@ -239,7 +239,7 @@ void go_validator_generator::generate_enum_field_validator(std::ostream& out,
       }
     } else if (key == "vt.defined_only") {
       if (values[0]->get_bool()) {
-        out << indent() << "if (" << context.tgt << ").String() == \"<UNSET>\"";
+        out << indent() << "if !(" << context.tgt << ").IsDefined()";
       } else {
         continue;
       }

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -817,7 +817,7 @@ void t_go_generator::generate_typedef(t_typedef* ttypedef) {
  */
 void t_go_generator::generate_enum(t_enum* tenum) {
   begin_types_declaration();
-  std::ostringstream to_string_mapping, from_string_mapping, known_values_mapping;
+  std::ostringstream to_string_mapping, from_string_mapping, known_values_mapping, is_defined_mapping;
   std::string tenum_name(publicize(tenum->get_name()));
   generate_go_docstring(f_types_, tenum);
   generate_deprecation_comment(f_types_, tenum->annotations_);
@@ -835,6 +835,12 @@ void t_go_generator::generate_enum(t_enum* tenum) {
                       << ", error) {" << '\n';
   indent_up();
   from_string_mapping << indent() << "switch s {" << '\n';
+  indent_down();
+
+  generate_deprecation_comment(is_defined_mapping, tenum->annotations_);
+  is_defined_mapping << indent() << "func (p " << tenum_name << ") IsDefined() bool {" << '\n';
+  indent_up();
+  is_defined_mapping << indent() << "switch p {" << '\n';
   indent_down();
 
   vector<t_enum_value*> constants = tenum->get_constants();
@@ -877,10 +883,15 @@ void t_go_generator::generate_enum(t_enum* tenum) {
     indent_up();
     from_string_mapping << indent() << "return " << go_enum_name << ", nil" << '\n';
     indent_down();
+
+    is_defined_mapping << indent() << "case " << go_enum_name << ":" << '\n';
+    indent_up();
+    is_defined_mapping << indent() << "return true" << '\n';
+    indent_down();
   }
 
   to_string_mapping << indent() << "}" << '\n';
-  to_string_mapping << indent() << "return \"<UNSET>\"" << '\n';
+  to_string_mapping << indent() << "return fmt.Sprintf(\"" << tenum_name << "(%d)\", p)" << '\n';
   indent_down();
   to_string_mapping << indent() << "}" << '\n';
   indent_up();
@@ -889,6 +900,12 @@ void t_go_generator::generate_enum(t_enum* tenum) {
                       << " fmt.Errorf(\"not a valid " << tenum_name << " string\")" << '\n';
   indent_down();
   from_string_mapping << indent() << "}" << '\n';
+
+  indent_up();
+  is_defined_mapping << indent() << "}" << '\n';
+  is_defined_mapping << indent() << "return false" << '\n';
+  indent_down();
+  is_defined_mapping << indent() << "}" << '\n';
 
   if (constants.empty()) {
     known_values_mapping.str(std::string());
@@ -920,7 +937,8 @@ void t_go_generator::generate_enum(t_enum* tenum) {
   }
   f_types_ << known_values_mapping.str()
            << to_string_mapping.str() << '\n'
-           << from_string_mapping.str() << '\n';
+           << from_string_mapping.str() << '\n'
+           << is_defined_mapping.str() << '\n';
 
   // Generate a convenience function that converts an instance of an enum
   // (which may be a constant) into a pointer to an instance of that enum

--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -189,6 +189,22 @@ A typedef of a struct used as a key appears in the entry type as the underlying
 struct pointer: the generated `type KeyAlias *Key` is a defined pointer type and
 carries none of the struct's methods.
 
+A note about undefined enum values
+==================================
+
+An enum holding an integer the IDL does not define used to print `<UNSET>`
+from `String()`, which reads as "no value was sent" even though the integer
+arrived intact and is written back to the wire unchanged. `String()` now
+formats such a value as `Color(999)`, the shape `stringer` produces.
+`MarshalText`, and with it `encoding/json`, follow `String()`, so the text and
+JSON encoding of an undefined value changes the same way. Neither form
+round-trips through `UnmarshalText`, which still rejects any string that is not
+a defined name.
+
+Every enum also gains an `IsDefined() bool` method that reports whether the
+value is one of the IDL-defined constants. Code that compared `String()`
+against the literal `"<UNSET>"` should call `IsDefined()` instead.
+
 A note about server stop implementations
 ========================================
 

--- a/lib/go/test/tests/enum_values_test.go
+++ b/lib/go/test/tests/enum_values_test.go
@@ -42,3 +42,25 @@ func TestEnumValues(t *testing.T) {
 		}
 	}
 }
+
+func TestEnumString(t *testing.T) {
+	if got := constoptionalfielda.Foo_One.String(); got != "One" {
+		t.Errorf("Foo_One.String() = %q, want %q", got, "One")
+	}
+	outOfRange := constoptionalfielda.Foo(999)
+	if got := outOfRange.String(); got != "Foo(999)" {
+		t.Errorf("Foo(999).String() = %q, want %q", got, "Foo(999)")
+	}
+}
+
+func TestEnumIsDefined(t *testing.T) {
+	if !constoptionalfielda.Foo_One.IsDefined() {
+		t.Errorf("Expected Foo_One to be defined")
+	}
+	if !constoptionalfielda.Foo_Two.IsDefined() {
+		t.Errorf("Expected Foo_Two to be defined")
+	}
+	if constoptionalfielda.Foo(999).IsDefined() {
+		t.Errorf("Expected Foo(999) to NOT be defined")
+	}
+}


### PR DESCRIPTION
JIRA: [THRIFT-5807](https://issues.apache.org/jira/browse/THRIFT-5807)
Client: go

An enum holding a value the IDL does not define printed `<UNSET>`, which reads as "no value was sent" when in fact the integer arrived intact and was written back out unchanged. Rust prints `Enum0(10)`, and C++, Python and Node.js print the integer. Go now prints `Color(999)`, the shape `stringer` produces.

A generated `IsDefined() bool` comes with it, so callers have something to ask instead of comparing `String()` against a sentinel. `go_validator_generator` was doing exactly that comparison for `vt.defined_only` and now calls `IsDefined()`.

`lib/go/README.md` gains a "A note about undefined enum values" section covering the `String()`, `MarshalText` and JSON change and the new `IsDefined()`, in line with the notes for THRIFT-2063, THRIFT-6175 and THRIFT-6195.

## What else moves with String()

`MarshalText` returns `[]byte(p.String())`, so this changes text and JSON encoding for out-of-range values:

```
master:  json.Marshal(Color(999)) -> "<UNSET>"
here:    json.Marshal(Color(999)) -> "Color(999)"
```

Neither round-trips: `UnmarshalText` goes through `FromString`, which rejects both with `not a valid Color string`, so no encoding that used to survive a round trip stops surviving one. The new form at least says which value failed.

No import risk: the generated `FromString` already references `fmt` for every enum, so `fmt.Sprintf` needs no new import in any file.

## Blast radius

Regenerating every IDL under `test/`, `lib/go/test/` and `tutorial/` with both compilers, 73 of 650 generated files change, and the change is additive apart from one line per enum. Across the whole corpus the only removed lines are:

| Removed | Count |
|---|---|
| `return "<UNSET>"` | 153 |
| `if (p.Enum0).String() == "<UNSET>" {` | 1 |
| `if (*p.Enum1).String() == "<UNSET>" {` | 1 |

Everything else added is the new `IsDefined()` method, 153 of them, one per enum in the corpus. No existing generated logic is restructured.

## What can break

Code comparing `String()` to the literal `"<UNSET>"` to test for an undefined value. The two call sites of that pattern in this repository are the validator lines above; `IsDefined()` is the replacement, and it says what the caller meant.

Verified: `Color(999).String()` returns `Color(999)` and `Foo_One.String()` returns `One`; `json.Marshal` output as quoted above, read from a run against both compilers.

*This change was created with AI assistance.*
