### PR TITLE
THRIFT-5415: Link Thrift website and description in GitHub repository metadata

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,6 +8,8 @@ notifications:
   jira_options: link label worklog
 
 github:
+  description: "Apache Thrift"
+  homepage: https://thrift.apache.org/
   rulesets:
     - name: "Default Branch Protection"
       type: branch


### PR DESCRIPTION
JIRA: [THRIFT-5415](https://issues.apache.org/jira/browse/THRIFT-5415)
Client: build

### Description

Configure `github.description` and `github.homepage` in `.asf.yaml` so ASF GitBox synchronizes repository metadata to the GitHub "About" section.

*This change was created with AI assistance.*
