### PR TITLE
THRIFT-6185: Build the D OpenSSL modules against OpenSSL 3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -965,6 +965,7 @@ jobs:
       # Keep in sync with build/docker/ubuntu-*/Dockerfile.
       D_VERSION: 2.087.0
       DEIMOS_LIBEVENT_REF: v2.0.2+2.0.16
+      DEIMOS_OPENSSL_REF: v2.0.0+1.1.0h
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -983,21 +984,24 @@ jobs:
           rm -f "dmd_$D_VERSION-0_amd64.deb"
           dmd --version
 
-      # The docker images also install the deimos OpenSSL 1.1.0h bindings, but
-      # the lib/d OpenSSL modules do not link against the OpenSSL 3.x that
-      # ubuntu-24.04 ships: ERR_put_error was dropped in 3.0 and
-      # SSL_get_peer_certificate was renamed to SSL_get1_peer_certificate.
-      # Leaving those headers out makes configure report
-      # "Building D SSL tests ... no", which drops the five OpenSSL-dependent
-      # modules from both the library and the test set. Install them here once
-      # THRIFT-6185 has taught lib/d to speak OpenSSL 3.x.
-      - name: Install deimos libevent bindings
+      # The deimos bindings are D headers for libevent and OpenSSL; the docker
+      # images install them but this runner does not. lib/d now builds its
+      # OpenSSL modules against the OpenSSL 3.x ubuntu-24.04 ships -- THRIFT-6185
+      # taught it to call SSL_get1_peer_certificate and the ERR_new/ERR_set_*
+      # family in place of the SSL_get_peer_certificate and ERR_put_error that
+      # 3.0 removed -- so installing the OpenSSL bindings here makes configure
+      # report "Building D SSL tests ... yes" and covers the five
+      # OpenSSL-dependent modules.
+      - name: Install deimos libevent and OpenSSL bindings
         run: |
           sudo mkdir -p /usr/include/dmd/druntime/import/deimos /usr/include/dmd/druntime/import/C
           git clone -q -b "$DEIMOS_LIBEVENT_REF" https://github.com/D-Programming-Deimos/libevent.git deimos-libevent
           sudo mv deimos-libevent/deimos/* /usr/include/dmd/druntime/import/deimos/
           sudo mv deimos-libevent/C/* /usr/include/dmd/druntime/import/C/
           rm -rf deimos-libevent
+          git clone -q -b "$DEIMOS_OPENSSL_REF" https://github.com/D-Programming-Deimos/openssl.git deimos-openssl
+          sudo mv deimos-openssl/deimos/* /usr/include/dmd/druntime/import/deimos/
+          rm -rf deimos-openssl
 
       - name: Run bootstrap
         run: ./bootstrap.sh
@@ -1010,8 +1014,10 @@ jobs:
           # configure disables a binding it cannot find rather than failing, and
           # the steps below would then pass without running a single test. A
           # green job that tests nothing is worse than no job, so insist that
-          # dmd was actually found.
+          # dmd was actually found, and that the OpenSSL modules are in the build
+          # rather than silently dropped for a missing dependency.
           echo "$summary" | grep -qE "Building D Library [.]+ : yes"
+          echo "$summary" | grep -qE "Building D SSL tests [.]+ : yes"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/configure.ac
+++ b/configure.ac
@@ -545,6 +545,7 @@ linker flags for OPTLINK. Please set DMD_LIBEVENT_FLAGS manually.])
   have_deimos_openssl=$success
 
   with_d_ssl_tests="no"
+  DMD_OPENSSL_VERSION_ID="use_openssl_1_0_x"
   if test "$have_deimos_openssl" = "yes"; then
     if test "x$DMD_OPENSSL_FLAGS" = "x"; then
       if test "$dmd_optlink" = "yes"; then
@@ -562,6 +563,21 @@ linker flags for OPTLINK. Please set DMD_OPENSSL_FLAGS manually.])
     else
       with_d_ssl_tests="yes"
     fi
+
+    # OpenSSL 3.0 removed SSL_get_peer_certificate and ERR_put_error, so the
+    # D SSL modules must be built with -version=use_openssl_3 there. Earlier
+    # OpenSSL keeps the version identifier the modules used before.
+    AC_MSG_CHECKING([which OpenSSL API version the D binding should target])
+    save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $OPENSSL_INCLUDES"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <openssl/opensslv.h>]], [[
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error OpenSSL is older than 3.0
+#endif
+    ]])],
+      [DMD_OPENSSL_VERSION_ID="use_openssl_3"; AC_MSG_RESULT([3.0 or newer])],
+      [AC_MSG_RESULT([older than 3.0])])
+    CPPFLAGS="$save_CPPFLAGS"
   fi
 fi
 
@@ -574,6 +590,7 @@ AC_SUBST(DMD_LIBEVENT_FLAGS)
 AM_CONDITIONAL(HAVE_DEIMOS_OPENSSL, [test "$have_deimos_openssl" = "yes"])
 AM_CONDITIONAL(WITH_D_SSL_TESTS, [test "$with_d_ssl_tests" = "yes"])
 AC_SUBST(DMD_OPENSSL_FLAGS)
+AC_SUBST(DMD_OPENSSL_VERSION_ID)
 
 AC_ARG_ENABLE([tests],
   AS_HELP_STRING([--enable-tests], [build tests [default=yes]]),

--- a/lib/d/Makefile.am
+++ b/lib/d/Makefile.am
@@ -97,7 +97,7 @@ d_main_modules = $(filter-out $(d_libevent_dependent_modules) \
 	$(d_openssl_dependent_modules),$(d_modules))
 
 
-d_lib_flags = -w -wi -Isrc -lib -version=use_openssl_1_0_x
+d_lib_flags = -w -wi -Isrc -lib -version=$(DMD_OPENSSL_VERSION_ID)
 all_targets =
 
 #
@@ -153,7 +153,7 @@ clean-local:
 #
 # Unit tests (built both in debug and release mode).
 #
-d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src -version=use_openssl_1_0_x
+d_test_flags = -unittest -w -wi -I$(top_srcdir)/lib/d/src -version=$(DMD_OPENSSL_VERSION_ID)
 
 # There just must be some way to reassign a variable without warnings in
 # Automake...

--- a/lib/d/src/thrift/internal/ssl.d
+++ b/lib/d/src/thrift/internal/ssl.d
@@ -30,6 +30,14 @@ import std.conv : to;
 import std.socket : Address;
 import thrift.transport.ssl;
 
+version (use_openssl_3) {
+  // OpenSSL 3.0 renamed SSL_get_peer_certificate to SSL_get1_peer_certificate
+  // and left the old name only as a header macro, so it is no longer an
+  // exported symbol the pinned deimos bindings can reach. Declare the current
+  // name here until those bindings carry it.
+  private extern (C) X509* SSL_get1_peer_certificate(const(SSL)* ssl);
+}
+
 /**
  * Checks if the peer is authorized after the SSL handshake has been
  * completed on the given connection and throws an TSSLException if not.
@@ -51,7 +59,11 @@ void authorize(SSL* ssl, TAccessManager accessManager,
       to!string(X509_verify_cert_error_string(rc)));
   }
 
-  auto cert = SSL_get_peer_certificate(ssl);
+  version (use_openssl_3) {
+    auto cert = SSL_get1_peer_certificate(ssl);
+  } else {
+    auto cert = SSL_get_peer_certificate(ssl);
+  }
   if (cert is null) {
     // Certificate is not present.
     if (SSL_get_verify_mode(ssl) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT) {
@@ -96,10 +108,13 @@ void authorize(SSL* ssl, TAccessManager accessManager,
   } else version(use_openssl_1_1_x) {
     enum _GEN_DNS = GEN_DNS;
     enum _GEN_IPADD = GEN_IPADD;
+  } else version(use_openssl_3) {
+    enum _GEN_DNS = GENERAL_NAME.GEN_DNS;
+    enum _GEN_IPADD = GENERAL_NAME.GEN_IPADD;
   } else {
-    static assert(false, `Must have version either use_openssl_1_0_x or use_openssl_1_1_x defined, e.g.
+    static assert(false, `Must have version use_openssl_1_0_x, use_openssl_1_1_x or use_openssl_3 defined, e.g.
 	"subConfigurations": {
-		"apache-thrift": "use_openssl_1_0"
+		"apache-thrift": "use_openssl_3"
 	}`);
   }
 

--- a/lib/d/src/thrift/internal/ssl_bio.d
+++ b/lib/d/src/thrift/internal/ssl_bio.d
@@ -38,6 +38,17 @@ import thrift.base;
 import thrift.internal.ssl;
 import thrift.transport.base;
 
+version (use_openssl_3) {
+  // OpenSSL 3.0 removed ERR_put_error (it dropped function codes from the
+  // error record). ERR_raise expands to this trio, which the pinned deimos
+  // bindings do not yet declare.
+  private extern (C) nothrow {
+    void ERR_new();
+    void ERR_set_debug(const(char)* file, int line, const(char)* func);
+    void ERR_set_error(int lib, int reason, const(char)* fmt, ...);
+  }
+}
+
 /**
  * Creates an SSL BIO object wrapping the given transport.
  *
@@ -71,8 +82,16 @@ private {
   }
 
   void setError(Exception e) nothrow {
-    ERR_put_error(ERR_LIB_D_EXCEPTION, ERR_F_D_EXCEPTION, ERR_R_D_EXCEPTION,
-      ERR_FILE_D_EXCEPTION, ERR_LINE_D_EXCEPTION);
+    version (use_openssl_3) {
+      // OpenSSL 3.0 replaced ERR_put_error with this sequence; the function
+      // code the old call carried was dropped from the error record.
+      ERR_new();
+      ERR_set_debug(ERR_FILE_D_EXCEPTION.ptr, ERR_LINE_D_EXCEPTION, null);
+      ERR_set_error(ERR_LIB_D_EXCEPTION, ERR_R_D_EXCEPTION, null);
+    } else {
+      ERR_put_error(ERR_LIB_D_EXCEPTION, ERR_F_D_EXCEPTION, ERR_R_D_EXCEPTION,
+        ERR_FILE_D_EXCEPTION, ERR_LINE_D_EXCEPTION);
+    }
     try { GC.addRoot(cast(void*)e); } catch (Throwable) {}
     ERR_set_error_data(cast(char*)e, ERR_FLAGS_D_EXCEPTION);
   }
@@ -187,4 +206,22 @@ private {
     &ttDestroy,
     null // callback_ctrl
   };
+}
+
+unittest {
+  // Round-trips a D exception through the OpenSSL error stack: setError pushes
+  // it, getSSLException recovers the very same object. On OpenSSL 3.0 this
+  // exercises the ERR_new/ERR_set_debug/ERR_set_error sequence that replaced
+  // ERR_put_error, so it also guards that the replacement actually records an
+  // error rather than merely linking.
+  import thrift.internal.ssl : getSSLException;
+  import deimos.openssl.err : ERR_clear_error;
+
+  ERR_clear_error();
+  auto planted = new Exception("d_bio_exception_marker");
+  setError(planted);
+
+  auto recovered = getSSLException();
+  assert(recovered !is null, "the planted exception was not recovered");
+  assert(recovered is planted, "a different exception came back off the stack");
 }


### PR DESCRIPTION
OpenSSL 3.0 removed `ERR_put_error` and made `SSL_get_peer_certificate` a macro
for `SSL_get1_peer_certificate`, so the OpenSSL-dependent modules in `lib/d`
failed to link against the OpenSSL 3.x that current distributions ship. On
Ubuntu 22.04 / 24.04 the first SSL unittest binary fails at link with undefined
references to both symbols, so `make -C lib/d check` cannot pass there — and the
same failure hits anyone using the D binding with TLS on a current distribution.

This adds a `use_openssl_3` build identifier that calls
`SSL_get1_peer_certificate` and the `ERR_new` / `ERR_set_debug` / `ERR_set_error`
sequence, declaring the handful of symbols the pinned deimos 1.1.0h bindings do
not yet carry (so no deimos bump is required). `configure` selects it
automatically when OpenSSL is 3.0 or newer; earlier OpenSSL keeps the identifier
the modules used before.

`make -C lib/d check` now builds and passes all five OpenSSL-dependent modules
(`async/ssl`, `internal/ssl`, `internal/ssl_bio`, `transport/ssl`,
`server/transport/ssl`) in both debug and release against OpenSSL 3.0.2. A
round-trip unit test in `internal/ssl_bio` covers the new error path. The
`lib-d` CI job installs the deimos OpenSSL bindings and asserts that the SSL
tests are actually enabled, so the modules are no longer silently dropped for a
missing dependency.

---
Investigated and written with AI assistance (Claude Opus 4.8); reviewed and submitted by Jens Geyer.
