### PR TITLE
THRIFT-3606: Fix TSaslClientTransport constructor `props` parameter type.

### DIFF
--- a/lib/java/src/main/java/org/apache/thrift/transport/TSaslClientTransport.java
+++ b/lib/java/src/main/java/org/apache/thrift/transport/TSaslClientTransport.java
@@ -65,7 +65,7 @@ public class TSaslClientTransport extends TSaslTransport {
       String authorizationId,
       String protocol,
       String serverName,
-      Map<String, String> props,
+      Map<String, ?> props,
       CallbackHandler cbh,
       TTransport transport)
       throws SaslException, TTransportException {


### PR DESCRIPTION
Fixes [THRIFT-3606](https://issues.apache.org/jira/browse/THRIFT-3606).

The `props` parameter is a pass through to `Sasl.createSaslClient` and previously had a narrower type than required by `Sasl.createSaslClient` which restricted use artificially.