### PR TITLE
THRIFT-6202: Drop the netstandard targets from ApacheThrift.AspNetCore

### DIFF
--- a/lib/netstd/Thrift.AspNetCore/Thrift.AspNetCore.csproj
+++ b/lib/netstd/Thrift.AspNetCore/Thrift.AspNetCore.csproj
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyName>Thrift.AspNetCore</AssemblyName>
     <PackageId>ApacheThrift.AspNetCore</PackageId>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -63,11 +63,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" Condition="'$(TargetFramework.StartsWith(`netstandard2.`))' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework.StartsWith(`netstandard2.`))' == 'false'" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`ApacheThrift.AspNetCore` currently targets `netstandard2.1;netstandard2.0;net8.0;net9.0;net10.0`. ASP.NET Core has not shipped for .NET Standard since 2.x — from .NET Core 3.0 on it lives in the `Microsoft.AspNetCore.App` shared framework — so the two netstandard legs forced the package to reference the standalone `Microsoft.AspNetCore.Http.Abstractions` 2.3.x instead. That was the last reference to those packages anywhere in the repository.

This drops both, leaving `net8.0;net9.0;net10.0` with an unconditional `FrameworkReference` on `Microsoft.AspNetCore.App`.

### Impact

The core `ApacheThrift` package is untouched and keeps `netstandard2.0`, so .NET Framework consumers of the library itself — sockets, named pipes, `THttpClientTransport`, the async servers — are unaffected. The dependency runs `ApacheThrift.AspNetCore` → `ApacheThrift` and never the other way round. The only .NET Framework scenario removed is hosting ASP.NET Core 2.x middleware, which ASP.NET Core 3.0 ended anyway; classic ASP.NET was never a consumer in the first place, since `THttpServerTransport` takes a `Microsoft.AspNetCore.Http.HttpContext` rather than a `System.Web` one.

The broader removal is the `netstandard2.1` fallback that `netcoreapp3.1`, `net5.0`, `net6.0` and `net7.0` consumers were resolving; those now get `NU1202` at restore. All four are out of support, and the asset they resolved pulled the standalone ASP.NET Core 2.x packages into applications whose shared framework already provides them.

`ApacheThrift.AspNetCore` 0.24.0 is on nuget.org carrying both netstandard assets, so this is a breaking change for that narrow set of consumers and should be called out in the 0.25.0 release notes.

### Verification

There is no functional behaviour to test here — `THttpServerTransport` itself is unchanged. What was checked instead:

- All three remaining targets build clean.
- `dotnet pack` produces a package with exactly `lib/net8.0`, `lib/net9.0` and `lib/net10.0`, a `Microsoft.AspNetCore.App` framework reference in all three groups, and no `Microsoft.AspNetCore.Http.Abstractions` dependency left in any group.
- `lib/netstd/Thrift.slnx` builds clean and `Thrift.Tests` passes 84/84.
- `tutorial/netstd/Tutorial.slnx` — the only in-repo consumer of the package — builds clean.
- `test/netstd/ThriftTest.slnx` builds clean.

---
Investigated and written with AI assistance (Claude Opus 5); reviewed and submitted by Jens Geyer.
