### PR TITLE
Resolve config.h.in relative to ConfigureChecks.cmake

### DIFF
--- a/build/cmake/ConfigureChecks.cmake
+++ b/build/cmake/ConfigureChecks.cmake
@@ -97,6 +97,6 @@ set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 set(VERSION ${thrift_VERSION})
 
 # generate a config.h file
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/thrift/config.h")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/thrift/config.h")
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

This PR changes such that we resolve the path to `config.h.in` relative to `CMAKE_CURRENT_LIST_DIR`, instead of `CMAKE_CURRENT_SOURCE_DIR`. For us, this fixes an issue when `ConfigureChecks.cmake` is included from an out-of-project CMakeLists.txt. Note that `CMAKE_CURRENT_LIST_DIR` always points to `build/cmake` regardless of the caller, so this does not break the common use-case. 

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] ~~Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)~~
- [ ] ~~If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?~~
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] ~~If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.~~

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
