### PR TITLE
Break after the operator in a Python test to satisfy flake8

### DIFF
--- a/lib/py/test/test_http_server_body_size.py
+++ b/lib/py/test/test_http_server_body_size.py
@@ -42,8 +42,8 @@ WAIT = 2.0
 
 def message(name=b'ping'):
     """A strict binary CALL header followed by an empty argument struct."""
-    return (struct.pack('!i', -2147418111) + struct.pack('!i', len(name)) + name
-            + struct.pack('!i', 0) + b'\x00')
+    return (struct.pack('!i', -2147418111) + struct.pack('!i', len(name)) + name +
+            struct.pack('!i', 0) + b'\x00')
 
 
 class RecordingProcessor(object):


### PR DESCRIPTION
The Static Code Analysis / lib-python job fails on flake8:

```
lib/py/test/test_http_server_body_size.py:46:13: W503 line break before binary operator
```

The repository's `.flake8` ignores `W504` but enforces `W503`, so a line has to
break *after* a binary operator, not before it. The `message()` helper wrapped a
byte-string concatenation before the `+`; this moves the operator to the end of
the line. No behaviour change — it is a test helper, and the produced bytes are
identical.

Verified by running a bare `flake8` from the repository root (the SCA job's exact
invocation) against a clean checkout of the branch: no violations.

No JIRA ticket — trivial lint fix.

Generated-by: Claude Opus 4.8
