### PR TITLE
THRIFT-6234: Configure apt retries and timeouts in GitHub Actions workflows

### DIFF
--- a/.github/apt/99-ci-network
+++ b/.github/apt/99-ci-network
@@ -1,0 +1,17 @@
+// apt settings for the GitHub Actions workflows. Copied into
+// /etc/apt/apt.conf.d/ before each apt-get update.
+//
+// The runner images resolve packages through a mirror list
+// (/etc/apt/apt-mirrors.txt) and apt only moves to the next mirror once an
+// item has failed on the current one. With the defaults (Acquire::Retries 3,
+// 30 second inactivity timeout, and the http method's own second attempt) a
+// stalled mirror costs about four minutes per item before apt falls over.
+// One retry and a 20 second timeout bound that to about 80 seconds per item
+// while still giving every mirror in the list a second chance, since a short
+// mirror outage can hit all of them at once.
+Acquire::Retries "1";
+Acquire::http::Timeout "20";
+Acquire::https::Timeout "20";
+// apt-get does not wait for the dpkg lock by default; another apt process (the
+// apt-daily timers, for example) can hold it briefly after the runner boots.
+DPkg::Lock::Timeout "120";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -255,6 +258,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -314,6 +320,9 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -423,6 +432,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -521,6 +533,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Set up Haxe
         run: |
           sudo apt-get update -qq
@@ -583,6 +598,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -655,6 +673,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -845,6 +866,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -898,6 +922,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -970,6 +997,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -1136,6 +1166,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -1236,6 +1269,9 @@ jobs:
           ruby-version: "4.0"
           bundler-cache: true
           working-directory: test/rb
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install openssl and certificates (for SSL tests)
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         timeout-minutes: 10
         run: |

--- a/.github/workflows/make-dist.yml
+++ b/.github/workflows/make-dist.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -71,6 +74,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -112,6 +118,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -206,6 +215,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -262,6 +274,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -303,6 +318,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |
@@ -352,6 +370,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
@@ -391,6 +412,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Configure apt retries and timeouts
+        run: sudo cp .github/apt/99-ci-network /etc/apt/apt.conf.d/
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Every Linux job installs packages with `apt-get` at apt's defaults. This adds one apt configuration fragment, `.github/apt/99-ci-network`, and copies it into `/etc/apt/apt.conf.d/` before each of the 22 `apt-get update` steps in `build.yml`, `cmake.yml`, `sca.yml` and `make-dist.yml`.

The runner images resolve packages through a mirror list (`mirror+file:/etc/apt/apt-mirrors.txt`: azure.archive.ubuntu.com, then archive.ubuntu.com, then security.ubuntu.com). apt only hands an item to the next mirror once it has failed on the current one, and on a transient failure it first retries the same mirror `Acquire::Retries` times, which already defaults to 3 in the apt 2.4 and 2.8 the runners ship. The http method also reconnects and resends once on its own before it reports a failure. A stalled mirror therefore costs 4 attempts x 2 x 30 s plus back-off, about four minutes per item, before apt falls over. That is how the compiler job of [run 34574616061](https://github.com/apache/thrift/actions/runs/34574616061/job/103184144542) fetched 8 of 132 packages in its 10 minute step budget.

The fragment sets `Acquire::Retries` to 1 and the http and https inactivity timeouts to 20 s, so a stalled item falls over to the next mirror after about 80 s instead of four minutes. One retry is kept rather than none because a package can stall on all three mirror names within 80 s: job `cross-test (rb.thin, java,kotlin)` of [run 34595468854](https://github.com/apache/thrift/actions/runs/34595468854) had `libboost-atomic-dev` do exactly that, and with no retries the job failed outright while the other stalls in the same run fell over to the next mirror after 40 s and passed. It also sets `DPkg::Lock::Timeout` to 120 s, which is an addition beyond the retry and timeout change: `apt-get` fails immediately when another apt process holds the lock, and this makes it wait instead.

This bounds intermittent stalls, which is what the failed run showed. A primary mirror that stalls on every connection still costs 80 s per package and would exceed a 10 minute step; only dropping the mirror from the list would fix that. The https timeout path is not exercised by the measurement below, and the loopback stall is a stand-in for the Azure network.

No open PR touches apt configuration. #3816 adds job-level timeouts to `build.yml` on different lines; whichever lands second rebases. Ticket: [THRIFT-6234](https://issues.apache.org/jira/browse/THRIFT-6234).

Verified: `apt-config dump` with the fragment mounted on `ubuntu:22.04` (apt 2.4.14) and `ubuntu:24.04` (apt 2.8.3) → all four settings present. Against a local mirror that accepts connections and never answers, `apt-get install sl` on `ubuntu:22.04` with the fragment → `.deb` ignored on the stalled mirror at 41 s and 82 s, fetched from the fallback mirror, install complete at 82 s (40 s with `Acquire::Retries` 0); the `apt-get update` phase with defaults had not reached the fallback mirror after 500 s. zizmor 1.30.1 on the four workflows → no findings.

*This change was created with AI assistance.*
