### PR TITLE
THRIFT-4244: Document the string literal syntax in tutorial.thrift and idl.md

### DIFF
--- a/doc/specs/idl.md
+++ b/doc/specs/idl.md
@@ -186,23 +186,27 @@ N.B.: These have some internal purpose at Facebook but serve no current purpose 
 
 ### Literal
 
-    [36] Literal         ::=  ('"' [^"]* '"') | ("'" [^']* "'")
+A literal is enclosed in double or single quotes and cannot contain a line break. Inside a literal, a backslash starts one of the escape sequences listed below; a backslash followed by any other character is an error.
+
+    [36] Literal         ::=  ('"' ( [^"\] | Escape )* '"') | ("'" ( [^'\] | Escape )* "'")
+
+    [37] Escape          ::=  '\' ( '"' | "'" | '\' | 'n' | 'r' | 't' )
 
 ### Identifier
 
-    [37] Identifier      ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' )*
+    [38] Identifier      ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' )*
 
-    [38] STIdentifier    ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' | '-' )*
+    [39] STIdentifier    ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' | '-' )*
 
 ### List Separator
 
-    [39] ListSeparator   ::=  ',' | ';'
+    [40] ListSeparator   ::=  ',' | ';'
 
 ### Letters and Digits
 
-    [40] Letter          ::=  ['A'-'Z'] | ['a'-'z']
+    [41] Letter          ::=  ['A'-'Z'] | ['a'-'z']
 
-    [41] Digit           ::=  ['0'-'9']
+    [42] Digit           ::=  ['0'-'9']
 
 ## Reserved keywords
 

--- a/tutorial/tutorial.thrift
+++ b/tutorial/tutorial.thrift
@@ -86,6 +86,25 @@ typedef i32 MyInteger
 const i32 INT32CONSTANT = 9853
 const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
 
+/*
+ * String literals like the ones in MAPCONSTANT can be enclosed in double or
+ * single quotes. The same syntax applies wherever a string literal appears,
+ * for example in include statements and annotation values.
+ *
+ * A literal must end on the line where it starts. The quote character that
+ * does not enclose it can be used as is, as in "don't" or 'say "hi"'. Inside
+ * a literal, a backslash starts one of these escape sequences:
+ *
+ *   \"  double quote        \n  line feed
+ *   \'  single quote        \r  carriage return
+ *   \\  backslash           \t  tab
+ *
+ * A backslash followed by any other character is an error, so a backslash
+ * meant literally has to be doubled: "C:\\Temp" is the string C:\Temp. There
+ * are no numeric escapes such as \x41 or \u00e4; non-ASCII characters are
+ * written directly.
+ */
+
 /**
  * You can define enums, which are just 32 bit integers. Values are optional
  * and start at 1 if not supplied, C style again.


### PR DESCRIPTION
Follow-up to #3786. The string literal syntax was not documented anywhere. Rule [36] in `doc/specs/idl.md`, which is also what https://thrift.apache.org/docs/idl shows, defined

    Literal ::= ('"' [^"]* '"') | ("'" [^']* "'")

Read literally, a backslash is an ordinary character, a double quote cannot appear in a double-quoted literal and line breaks are allowed. None of that matches the compiler, and it is the reading the THRIFT-4244 report was based on.

## Changes

- `doc/specs/idl.md`: rule [36] now allows escape sequences, a new rule [37] `Escape` lists the six the lexer accepts (`\"` `\'` `\\` `\n` `\r` `\t`), and one sentence covers line breaks and unknown escapes. The rules after it are renumbered; nothing refers to their numbers.
- `tutorial/tutorial.thrift`: describes the same syntax next to `MAPCONSTANT`. It is a plain `/* */` comment rather than a `/** */` doc comment, so the text never reaches generated code.

The tutorial deliberately gets no real constant with escapes: several generators do not escape string constants correctly for their language, and such a constant would break the rs and c_glib tutorial builds, for example. That is tracked in [THRIFT-6236](https://issues.apache.org/jira/browse/THRIFT-6236).

## Verification

Against a compiler built from current master (81103bf9c):

- Every statement in the tutorial comment was checked, including the negative ones, with values read back from generated Python. `\T` (in both quote styles), `\x`, `\u`, `\0` and `\ ` are rejected, and so is a line break, in both quote styles and right after a backslash. `include "d\\x/incd.thrift"` resolves a file in a directory named `d\x` (the same include with a missing directory fails), and annotation values follow the same rules.
- `tutorial.thrift` was generated with all 29 generators plus the option variants the tutorial builds use (`go:thrift_import=…`, `js:node`, `js:ts`, `js:node,ts`, `php:server`, `py:tornado`, `py:twisted`). All 279 files and the compiler output are byte-identical before and after. As a positive control, changing the text of the enum doc comment changes 21 of those files.
- `thrift -strict -v` reports the same warnings before and after; one line number shifts by the 19 inserted lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
