### PR TITLE
THRIFT-6242: Honour the transport configuration in the C++ TNonblockingServer

### DIFF
--- a/lib/cpp/src/thrift/TConfiguration.h
+++ b/lib/cpp/src/thrift/TConfiguration.h
@@ -34,11 +34,11 @@ public:
   const static int DEFAULT_MAX_FRAME_SIZE = 16384000;      // this value is used consistently across all Thrift libraries
   const static int DEFAULT_RECURSION_DEPTH = 64;
 
-  inline int  getMaxMessageSize() { return maxMessageSize_; }
-  inline void setMaxMessageSize(int maxMessageSize) { maxMessageSize_ = maxMessageSize; } 
-  inline int getMaxFrameSize() { return maxFrameSize_; }
+  inline int  getMaxMessageSize() const { return maxMessageSize_; }
+  inline void setMaxMessageSize(int maxMessageSize) { maxMessageSize_ = maxMessageSize; }
+  inline int getMaxFrameSize() const { return maxFrameSize_; }
   inline void setMaxFrameSize(int maxFrameSize) { maxFrameSize_ = maxFrameSize; }
-  inline int getRecursionLimit() { return recursionLimit_; }
+  inline int getRecursionLimit() const { return recursionLimit_; }
   inline void setRecursionLimit(int recursionLimit) { recursionLimit_ = recursionLimit; }
 
 private:

--- a/lib/cpp/src/thrift/server/TNonblockingServer.cpp
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.cpp
@@ -492,6 +492,19 @@ void TNonblockingServer::TConnection::workSocket() {
         close();
         return;
       }
+      // Refuse a frame the message-size budget cannot admit before the read
+      // buffer is grown for it. The accepted socket carries the server's
+      // configuration, so this bounds the allocation by the configured maximum
+      // message size, which may be tighter than the frame-size ceiling above.
+      // The check is stable across the life of the connection: the C++ socket
+      // budget gates each read and does not accumulate.
+      try {
+        tSocket_->checkReadBytesAvailable(readWant_);
+      } catch (const TTransportException& te) {
+        TOutput::instance().printf("TConnection::workSocket(): %s", te.what());
+        close();
+        return;
+      }
       // size known; now get the rest of the frame
       transition();
 
@@ -1041,6 +1054,9 @@ void TNonblockingServer::handleEvent(THRIFT_SOCKET fd, short which) {
  * Creates a socket to listen on and binds it to the local port.
  */
 void TNonblockingServer::createAndListenOnSocket() {
+  // Ensure every socket the server transport accepts is handed the server's
+  // configuration, even when the caller never called setConfiguration().
+  serverTransport_->setConfiguration(config_);
   serverTransport_->listen();
   serverSocket_ = serverTransport_->getSocketFD();
 }

--- a/lib/cpp/src/thrift/server/TNonblockingServer.h
+++ b/lib/cpp/src/thrift/server/TNonblockingServer.h
@@ -194,8 +194,10 @@ private:
   /// Limit for number of open connections
   size_t maxConnections_;
 
-  /// Limit for frame size
-  size_t maxFrameSize_;
+  /// Transport configuration applied to accepted connections. Its maximum
+  /// frame size is the frame size limit this server enforces, and its maximum
+  /// message size bounds each accepted socket.
+  std::shared_ptr<TConfiguration> config_;
 
   /// Time in milliseconds before an unperformed task expires (0 == infinite).
   int64_t taskExpireTime_;
@@ -289,7 +291,7 @@ private:
     connectionStackLimit_ = CONNECTION_STACK_LIMIT;
     maxActiveProcessors_ = MAX_ACTIVE_PROCESSORS;
     maxConnections_ = MAX_CONNECTIONS;
-    maxFrameSize_ = MAX_FRAME_SIZE;
+    config_ = std::make_shared<TConfiguration>();
     taskExpireTime_ = 0;
     overloadHysteresis_ = 0.8;
     overloadAction_ = T_OVERLOAD_NO_ACTION;
@@ -508,14 +510,40 @@ public:
    *
    * @return Maxium frame size, in bytes.
    */
-  size_t getMaxFrameSize() const { return maxFrameSize_; }
+  size_t getMaxFrameSize() const { return static_cast<size_t>(config_->getMaxFrameSize()); }
 
   /**
    * Set the maximum allowed frame size.
    *
    * @param maxFrameSize The new maximum frame size.
    */
-  void setMaxFrameSize(size_t maxFrameSize) { maxFrameSize_ = maxFrameSize; }
+  void setMaxFrameSize(size_t maxFrameSize) {
+    // TConfiguration stores the frame size as int. Clamp rather than let a
+    // value above INT_MAX wrap to a negative int, which getMaxFrameSize() would
+    // then read back as a huge size_t and so disable the limit.
+    config_->setMaxFrameSize(
+        maxFrameSize > static_cast<size_t>(INT_MAX) ? INT_MAX : static_cast<int>(maxFrameSize));
+  }
+
+  /**
+   * Get the transport configuration this server applies to accepted
+   * connections.
+   */
+  std::shared_ptr<TConfiguration> getConfiguration() const { return config_; }
+
+  /**
+   * Set the transport configuration applied to accepted connections. The
+   * configured maximum frame size becomes the frame size limit the server
+   * enforces (as getMaxFrameSize()/setMaxFrameSize() operate on it), and the
+   * configured maximum message size bounds each accepted socket. A null
+   * argument is ignored.
+   */
+  void setConfiguration(const std::shared_ptr<TConfiguration>& config) {
+    if (config) {
+      config_ = config;
+      serverTransport_->setConfiguration(config_);
+    }
+  }
 
   /**
    * Get fraction of maximum limits before an overload condition is cleared.

--- a/lib/cpp/src/thrift/transport/TNonblockingServerTransport.h
+++ b/lib/cpp/src/thrift/transport/TNonblockingServerTransport.h
@@ -20,6 +20,7 @@
 #ifndef _THRIFT_TRANSPORT_TNONBLOCKINGSERVERTRANSPORT_H_
 #define _THRIFT_TRANSPORT_TNONBLOCKINGSERVERTRANSPORT_H_ 1
 
+#include <thrift/TConfiguration.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportException.h>
 
@@ -60,7 +61,20 @@ public:
     if (!result) {
       throw TTransportException("accept() may not return nullptr");
     }
+    // Hand the accepted socket the server's configuration, so its message-size
+    // budget and the layered transports built on top of it use the operator's
+    // limits rather than each socket's own defaults. setConfiguration ignores a
+    // null argument, so an unconfigured server leaves the socket's default in
+    // place.
+    result->setConfiguration(config_);
     return result;
+  }
+
+  /**
+   * Sets the configuration handed to every subsequently accepted socket.
+   */
+  void setConfiguration(const std::shared_ptr<apache::thrift::TConfiguration>& config) {
+    config_ = config;
   }
 
   /**
@@ -83,6 +97,9 @@ public:
 
 protected:
   TNonblockingServerTransport() = default;
+
+  /// Configuration handed to accepted sockets; null until the server sets it.
+  std::shared_ptr<apache::thrift::TConfiguration> config_;
 
   /**
    * Subclasses should implement this function for accept.

--- a/lib/cpp/src/thrift/transport/TTransport.h
+++ b/lib/cpp/src/thrift/transport/TTransport.h
@@ -261,8 +261,14 @@ public:
 
   std::shared_ptr<TConfiguration> getConfiguration() { return configuration_; }
 
-  void setConfiguration(std::shared_ptr<TConfiguration> config) { 
-    if (config != nullptr) configuration_ = config; 
+  void setConfiguration(std::shared_ptr<TConfiguration> config) {
+    if (config != nullptr) {
+      configuration_ = config;
+      // Re-seed the message-size budget from the new configuration. Without
+      // this the budget keeps the value seeded at construction, so a
+      // configuration installed after construction never takes effect.
+      resetConsumedMessageSize();
+    }
   }
 
   /**

--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -19,6 +19,7 @@
 
 #define BOOST_TEST_MODULE TNonblockingServerTest
 #include <boost/test/unit_test.hpp>
+#include <climits>
 #include <memory>
 
 #include "thrift/TConfiguration.h"
@@ -94,6 +95,7 @@ private:
     shared_ptr<server::TNonblockingServer> server;
     shared_ptr<ListenEventHandler> listenHandler;
     shared_ptr<transport::TNonblockingServerSocket> socket;
+    shared_ptr<TConfiguration> configuration;
     Mutex mutex_;
 
     Runner() {
@@ -123,6 +125,9 @@ private:
               processor, make_shared<protocol::TBinaryProtocolFactory>(), socket, threadManager));
         } else {
           server.reset(new server::TNonblockingServer(processor, socket));
+        }
+        if (configuration) {
+          server->setConfiguration(configuration);
         }
         server->setServerEventHandler(listenHandler);
         if (userEventBase) {
@@ -166,6 +171,7 @@ protected:
     runner->processor = processor;
     runner->threadManager = threadManager_;
     runner->userEventBase = userEventBase_;
+    runner->configuration = configuration_;
 
     shared_ptr<ThreadFactory> threadFactory(
         new ThreadFactory(false));
@@ -188,9 +194,37 @@ protected:
     return strings.size() == 1 && !(strings[0].compare("foo"));
   }
 
+  // A raw client that announces a frame of declaredSize (optionally sending
+  // bodyBytes of payload) and reports whether the server closed the connection
+  // without replying. A receive timeout distinguishes a refusal (the server
+  // closed, read returns 0) from acceptance (the server waits for the rest of
+  // the frame and the read times out).
+  bool serverClosesOnFrame(int serverPort, uint32_t declaredSize, uint32_t bodyBytes) {
+    transport::TSocket sock("localhost", serverPort);
+    sock.setRecvTimeout(1500);
+    sock.open();
+    uint32_t netSize = htonl(declaredSize);
+    sock.write(reinterpret_cast<uint8_t*>(&netSize), sizeof(netSize));
+    if (bodyBytes) {
+      std::vector<uint8_t> body(bodyBytes, 0);
+      sock.write(body.data(), bodyBytes);
+    }
+    uint8_t buf[16];
+    try {
+      return sock.read(buf, sizeof(buf)) == 0;
+    } catch (const transport::TTransportException&) {
+      return false;
+    }
+  }
+
 private:
   shared_ptr<event_base> userEventBase_;
   shared_ptr<concurrency::ThreadManager> threadManager_;
+
+protected:
+  shared_ptr<TConfiguration> configuration_;
+
+private:
 
 protected:
   // Replaces the processor the fixture builds, and switches the server to the
@@ -261,6 +295,12 @@ BOOST_AUTO_TEST_CASE(default_max_frame_size_matches_configuration) {
 
   server.setMaxFrameSize(4096);
   BOOST_CHECK_EQUAL(server.getMaxFrameSize(), static_cast<size_t>(4096));
+
+  // The configuration stores the frame size as int, so a value above INT_MAX
+  // clamps rather than wrapping to a negative int (which would read back as a
+  // huge size_t and disable the limit).
+  server.setMaxFrameSize(static_cast<size_t>(INT_MAX) + 1000);
+  BOOST_CHECK_EQUAL(server.getMaxFrameSize(), static_cast<size_t>(INT_MAX));
 }
 
 // Fails the first call the way argument deserialization fails when a declared
@@ -407,5 +447,46 @@ BOOST_AUTO_TEST_CASE(allocation_failure_on_the_io_thread_does_not_end_the_proces
   }
 }
 #endif
+
+// The server enforces the maximum frame size from a configuration it is given,
+// not only the library default. A frame above the configured maximum -- but far
+// below the 16 MB default the server would otherwise apply -- is refused and the
+// connection closed. Before the server honoured a configuration this frame was
+// accepted and the server waited for its body.
+BOOST_FIXTURE_TEST_CASE(honours_configured_max_frame_size, Fixture) {
+  configuration_ = make_shared<TConfiguration>();
+  configuration_->setMaxFrameSize(1024);
+  startServer(0);
+  int port = server->getListenPort();
+
+  BOOST_CHECK(serverClosesOnFrame(port, 2000, 0));
+
+  server->stop();
+}
+
+// The accepted socket carries the server's configuration, so a frame larger
+// than the configured maximum message size is refused before the read buffer is
+// grown for it, even when it is below the frame-size ceiling. Before the socket
+// carried the configuration its budget was the 100 MB default and this frame was
+// accepted.
+BOOST_FIXTURE_TEST_CASE(honours_configured_max_message_size, Fixture) {
+  configuration_ = make_shared<TConfiguration>(1024 /* maxMessageSize */);
+  startServer(0);
+  int port = server->getListenPort();
+
+  BOOST_CHECK(serverClosesOnFrame(port, 2000, 0));
+
+  server->stop();
+}
+
+// A generous configuration leaves ordinary traffic untouched: a real framed
+// request still round-trips.
+BOOST_FIXTURE_TEST_CASE(generous_configuration_still_serves, Fixture) {
+  configuration_ = make_shared<TConfiguration>();
+  startServer(0);
+  BOOST_CHECK(canCommunicate(server->getListenPort()));
+
+  server->stop();
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`TNonblockingServer` kept its own frame-size limit (`maxFrameSize_`) and created every accepted socket with no `TConfiguration`, so an operator who configured a maximum frame or message size got no effect on the nonblocking server: it enforced only its own frame-size ceiling, and each accepted socket used the default 100 MB message budget. `TConfiguration` appeared in `TNonblockingServer` only as the source of the default frame-size constant (THRIFT-6183).

This wires the nonblocking server to a `TConfiguration`, following the precedent that the configuration is the authority (THRIFT-6182 for the transport layer, THRIFT-6183 for this server's default):

- The server holds a `std::shared_ptr<TConfiguration>`; `getMaxFrameSize()` / `setMaxFrameSize()` operate on it, so there is one source of truth for the frame-size limit.
- The configuration is handed to every accepted socket through the server transport (`TNonblockingServerTransport::accept()`), covering both the plain and TLS server sockets, so the operator's message-size limit bounds each connection and the layered transports built on top of it.
- A frame larger than the configured maximum message size is refused before the read buffer is grown for it, next to the existing frame-size check.

Along the way, `TTransport::setConfiguration()` is corrected to re-seed the message-size budget (it previously swapped the pointer without re-seeding, so a configuration installed after construction never took effect); it has no callers within the library. `setMaxFrameSize()` clamps to `INT_MAX`, since `TConfiguration` stores the frame size as `int`.

### Compatibility (breaking)

An operator who sets a `TConfiguration` with a maximum below what the server accepted before will start closing those connections — that is the point of honouring the configuration. Default behaviour is unchanged (a default `TConfiguration` carries the same 16,384,000 frame size and 100 MB message size the server used before).

### Test

Three cases added to `TNonblockingServerTest`: a frame above a configured maximum frame size is refused; a frame above a configured maximum message size (but below the frame ceiling) is refused before the buffer is grown; and a generous configuration still serves ordinary traffic.

### Related

This is part (2)+(3) of the nonblocking-server frame handling. Part (4), growing the read buffer as the payload arrives, is **THRIFT-6243** — an independent PR, not stacked on this one, but it also touches `TNonblockingServer.{h,cpp}`, so whichever lands second will need a small rebase.

---
Prepared with AI assistance (Claude Opus 4.8).
