### PR TITLE
THRIFT-6245: Grow the D TNonblockingServer read buffer as the payload arrives

### DIFF
--- a/lib/d/src/thrift/server/nonblocking.d
+++ b/lib/d/src/thrift/server/nonblocking.d
@@ -44,6 +44,7 @@ import core.stdc.stdlib : free, realloc;
 import core.time : Duration, dur;
 import core.thread : Thread, ThreadGroup;
 import deimos.event2.event;
+import std.algorithm : min;
 import std.array : empty;
 import std.conv : emplace, to;
 import std.exception : enforce;
@@ -941,6 +942,38 @@ private {
     }
 
     /**
+     * Grows the read buffer to hold at least target bytes, by doubling.
+     *
+     * Never shrinks it; a target that already fits is a no-op. Calls
+     * onOutOfMemoryError() if the reallocation fails, as the previous
+     * in-line growth did.
+     */
+    void growReadBuffer(size_t target) {
+      if (target <= readBufferSize_) return;
+
+      auto newSize = readBufferSize_ ? readBufferSize_ : 1;
+      while (newSize < target) {
+        auto doubled = newSize * 2;
+        if (doubled <= newSize) {
+          // The next doubling would overflow size_t. That needs a 32-bit
+          // size_t and a maxFrameSize raised past 2 GiB, but the old in-line
+          // loop would have spun forever on it. target is itself a valid
+          // size, so allocate exactly that rather than wrapping to a
+          // smaller buffer.
+          newSize = target;
+          break;
+        }
+        newSize = doubled;
+      }
+
+      auto newBuffer = cast(ubyte*)realloc(readBuffer_, newSize);
+      if (!newBuffer) onOutOfMemoryError();
+
+      readBuffer_ = newBuffer;
+      readBufferSize_ = newSize;
+    }
+
+    /**
      * Transitions the connection to the next state.
      *
      * This is called e.g. when the request has been read completely or all
@@ -1039,26 +1072,20 @@ private {
           return;
         case ConnectionState.READ_FRAME_SIZE:
           // We just read the request length, set up the buffers for reading
-          // the payload.
-          if (readWant_ > readBufferSize_) {
-            // The current buffer is too small, exponentially grow the buffer
-            // until it is big enough.
-
-            if (readBufferSize_ == 0) {
-              readBufferSize_ = 1;
-            }
-
-            auto newSize = readBufferSize_;
-            while (readWant_ > newSize) {
-              newSize *= 2;
-            }
-
-            auto newBuffer = cast(ubyte*)realloc(readBuffer_, newSize);
-            if (!newBuffer) onOutOfMemoryError();
-
-            readBuffer_ = newBuffer;
-            readBufferSize_ = newSize;
-          }
+          // the payload. Reserve only enough to start reading: the buffer
+          // grows towards readWant_ in SocketState.RECV as the payload
+          // actually arrives, so a peer that declares a large frame and then
+          // sends none of it does not make the server reserve the whole frame.
+          //
+          // The initial kilobyte deliberately equals
+          // DEFAULT_IDLE_READ_BUFFER_LIMIT: a connection that only ever
+          // carries small frames settles at exactly the size an idle
+          // connection is allowed to keep, so checkIdleBufferLimit() does not
+          // free and regrow it between requests. Keep this a fixed constant --
+          // deriving it from the configurable idle limit would mean raising
+          // that limit put every connection back to reserving on the header,
+          // which is the amplification this avoids.
+          growReadBuffer(min(readWant_, 1024));
 
           readBufferPos_= 0;
 
@@ -1136,10 +1163,30 @@ private {
           // If we already got all the data, we should be in the SEND state.
           assert(readBufferPos_ < readWant_);
 
+          // Grow the buffer towards the frame size only as far as the next
+          // read needs, so what is reserved tracks the payload received rather
+          // than the length the peer declared. Ask for double the current
+          // size, capped at the frame size; growReadBuffer() rounds up by
+          // doubling, so the buffer can still end up larger than the frame.
+          //
+          // readBufferSize_ is never 0 here: transition() reserved at least
+          // one byte for this frame before handing over, and readWant_ of 0
+          // never reaches this state. Doubling therefore always makes
+          // progress.
+          if (readBufferPos_ == readBufferSize_) {
+            growReadBuffer(readBufferSize_ > readWant_ / 2 ?
+              readWant_ : readBufferSize_ * 2);
+          }
+
           size_t bytesRead;
           try {
-            // Read as much as possible from the socket.
-            bytesRead = socket_.read(readBuffer_[readBufferPos_ .. readWant_]);
+            // Read as much as possible from the socket, but never past either
+            // the end of the buffer or the end of this frame. The buffer can
+            // be larger than the frame -- doubling may overshoot it, or it may
+            // have been kept from an earlier, larger request -- and bytes
+            // beyond readWant_ belong to the next frame.
+            bytesRead = socket_.read(
+              readBuffer_[readBufferPos_ .. min(readBufferSize_, readWant_)]);
           } catch (TTransportException te) {
             logError("Failed to read from client socket: %s", te);
             close();
@@ -1396,13 +1443,151 @@ unittest {
   });
 }
 
+version (unittest) {
+  private {
+    import core.sync.condition : Condition;
+
+    // Replies to every request with a single byte, so the client can tell a
+    // frame the server accepted from one it refused.
+    class ReplyProcessor : TProcessor {
+      override bool process(TProtocol iprot, TProtocol oprot,
+        Variant connectionContext = Variant()
+      ) {
+        // Consume the whole frame; processRequest() calls the processor again
+        // for as long as the input transport has data left.
+        ubyte[4096] request;
+        while (iprot.transport.peek()) iprot.transport.read(request);
+
+        ubyte[1] reply = [42];
+        oprot.transport.write(reply);
+        return true;
+      }
+    }
+
+    // Replies with the number of payload bytes it received and a hash over
+    // them, so a client can verify that a frame came back byte for byte.
+    class DigestProcessor : TProcessor {
+      override bool process(TProtocol iprot, TProtocol oprot,
+        Variant connectionContext = Variant()
+      ) {
+        ubyte[8192] chunk;
+        uint length;
+        uint hash = 2_166_136_261u;
+
+        while (iprot.transport.peek()) {
+          auto got = iprot.transport.read(chunk);
+          length += cast(uint)got;
+          foreach (b; chunk[0 .. got]) {
+            hash = (hash ^ b) * 16_777_619u;
+          }
+        }
+
+        auto netLength = hostToNet(length);
+        auto netHash = hostToNet(hash);
+        oprot.transport.write(cast(ubyte[])((&netLength)[0 .. 1]));
+        oprot.transport.write(cast(ubyte[])((&netHash)[0 .. 1]));
+        return true;
+      }
+    }
+
+    // The same hash the DigestProcessor computes, for the client side.
+    uint digestOf(in ubyte[] data) {
+      uint hash = 2_166_136_261u;
+      foreach (b; data) hash = (hash ^ b) * 16_777_619u;
+      return hash;
+    }
+
+    TNonblockingServer makeServer(TProcessor processor = null) {
+      return new TNonblockingServer(
+        processor is null ? new ReplyProcessor : processor, 0,
+        new TTransportFactory, new TBinaryProtocolFactory!());
+    }
+
+    // Runs server on an ephemeral port, hands dg the port it listens on, and
+    // stops the server once dg returns.
+    void withServerPort(TNonblockingServer server,
+      scope void delegate(ushort port) dg
+    ) {
+      auto mutex = new Mutex;
+      auto condition = new Condition(mutex);
+      ushort port;
+      bool done;
+
+      class PortHandler : TServerEventHandler {
+        void preServe() {
+          synchronized (mutex) {
+            port = to!ushort(server.listenSocket_.localAddress.toPortString());
+            condition.notifyAll();
+          }
+        }
+        Variant createContext(TProtocol input, TProtocol output) {
+          return Variant.init;
+        }
+        void deleteContext(Variant serverContext, TProtocol input,
+          TProtocol output) {}
+        void preProcess(Variant serverContext, TTransport transport) {}
+      }
+      server.eventHandler = new PortHandler;
+
+      auto cancel = new TCancellationOrigin;
+      auto serverThread = new Thread({
+        scope (exit) synchronized (mutex) {
+          done = true;
+          condition.notifyAll();
+        }
+        server.serve(cancel);
+      });
+      serverThread.isDaemon = true;
+
+      synchronized (mutex) {
+        serverThread.start();
+        while (port == 0 && !done) {
+          enforce(condition.wait(dur!"seconds"(10)), "Server did not start.");
+        }
+        enforce(port != 0, "Server did not start.");
+      }
+
+      scope (exit) {
+        cancel.trigger();
+        synchronized (mutex) {
+          while (!done) {
+            enforce(condition.wait(dur!"seconds"(10)), "Server did not stop.");
+          }
+        }
+        serverThread.join();
+      }
+
+      dg(port);
+    }
+
+    // As withServerPort, but hands dg a client already connected to the server.
+    void withServer(TNonblockingServer server,
+      scope void delegate(TSocket client) dg
+    ) {
+      withServerPort(server, (ushort port) {
+        auto client = new TSocket("127.0.0.1", port);
+        client.recvTimeout = dur!"seconds"(10);
+        client.open();
+        scope (exit) client.close();
+        dg(client);
+      });
+    }
+
+    void writeFrameSize(TSocket client, uint size) {
+      auto netSize = hostToNet(size);
+      client.write(cast(ubyte[])((&netSize)[0 .. 1]));
+    }
+  }
+}
+
 // maxFrameSize defaults to the 16384000 bytes the other Thrift libraries use,
 // a frame declaring one byte more closes the connection, and a limit the caller
 // raises is the one the server enforces.
 unittest {
-  import core.sync.condition : Condition;
   import std.exception : collectException;
 
+  // Temporarily silence the log sinks so the test output is not spammed with
+  // the server's startup and error messages.
   auto oldInfoLogSink = g_infoLogSink;
   auto oldErrorLogSink = g_errorLogSink;
   g_infoLogSink = null;
@@ -1410,94 +1595,6 @@ unittest {
   scope (exit) {
     g_infoLogSink = oldInfoLogSink;
     g_errorLogSink = oldErrorLogSink;
-  }
-
-  // Replies to every request with a single byte, so the client can tell a
-  // frame the server accepted from one it refused.
-  static class ReplyProcessor : TProcessor {
-    override bool process(TProtocol iprot, TProtocol oprot,
-      Variant connectionContext = Variant()
-    ) {
-      // Consume the whole frame; processRequest() calls the processor again
-      // for as long as the input transport has data left.
-      ubyte[4096] request;
-      while (iprot.transport.peek()) iprot.transport.read(request);
-
-      ubyte[1] reply = [42];
-      oprot.transport.write(reply);
-      return true;
-    }
-  }
-
-  static TNonblockingServer makeServer() {
-    return new TNonblockingServer(new ReplyProcessor, 0,
-      new TTransportFactory, new TBinaryProtocolFactory!());
-  }
-
-  // Runs server on an ephemeral port, hands dg a client connected to it, and
-  // stops the server once dg returns.
-  static void withServer(TNonblockingServer server,
-    scope void delegate(TSocket client) dg
-  ) {
-    auto mutex = new Mutex;
-    auto condition = new Condition(mutex);
-    ushort port;
-    bool done;
-
-    class PortHandler : TServerEventHandler {
-      void preServe() {
-        synchronized (mutex) {
-          port = to!ushort(server.listenSocket_.localAddress.toPortString());
-          condition.notifyAll();
-        }
-      }
-      Variant createContext(TProtocol input, TProtocol output) {
-        return Variant.init;
-      }
-      void deleteContext(Variant serverContext, TProtocol input,
-        TProtocol output) {}
-      void preProcess(Variant serverContext, TTransport transport) {}
-    }
-    server.eventHandler = new PortHandler;
-
-    auto cancel = new TCancellationOrigin;
-    auto serverThread = new Thread({
-      scope (exit) synchronized (mutex) {
-        done = true;
-        condition.notifyAll();
-      }
-      server.serve(cancel);
-    });
-    serverThread.isDaemon = true;
-
-    synchronized (mutex) {
-      serverThread.start();
-      while (port == 0 && !done) {
-        enforce(condition.wait(dur!"seconds"(10)), "Server did not start.");
-      }
-      enforce(port != 0, "Server did not start.");
-    }
-
-    scope (exit) {
-      cancel.trigger();
-      synchronized (mutex) {
-        while (!done) {
-          enforce(condition.wait(dur!"seconds"(10)), "Server did not stop.");
-        }
-      }
-      serverThread.join();
-    }
-
-    auto client = new TSocket("127.0.0.1", port);
-    client.recvTimeout = dur!"seconds"(10);
-    client.open();
-    scope (exit) client.close();
-    dg(client);
-  }
-
-  static void writeFrameSize(TSocket client, uint size) {
-    auto netSize = hostToNet(size);
-    client.write(cast(ubyte[])((&netSize)[0 .. 1]));
   }
 
   // The default is the shared limit, and it is enforced: the connection is
@@ -1532,6 +1629,105 @@ unittest {
       ubyte[5] reply;
       client.readAll(reply);
       assert(reply == expected);
+    });
+  }
+}
+
+// The read buffer tracks the payload that actually arrived rather than the
+// length the peer declared: a frame header on its own reserves next to
+// nothing, and a frame far larger than that initial reservation is still
+// assembled correctly as the buffer grows.
+unittest {
+  import std.conv : text;
+
+  // Temporarily silence the log sinks so the test output is not spammed with
+  // the server's startup and error messages.
+  auto oldInfoLogSink = g_infoLogSink;
+  auto oldErrorLogSink = g_errorLogSink;
+  g_infoLogSink = null;
+  g_errorLogSink = null;
+  scope (exit) {
+    g_infoLogSink = oldInfoLogSink;
+    g_errorLogSink = oldErrorLogSink;
+  }
+
+  // A header that declares a large frame and is followed by no payload at all
+  // must not make the server reserve the frame. The connection is closed
+  // afterwards so that it goes back on the idle stack, where its buffer can be
+  // read without racing the I/O thread.
+  {
+    enum uint declared = 64 * 1024 * 1024;
+
+    auto server = makeServer();
+    server.maxFrameSize = declared;
+    // Keep the buffer across disposal -- the default idle limit would free it
+    // and hide what had been reserved.
+    server.idleReadBufferLimit = 0;
+
+    size_t reserved = size_t.max;
+
+    withServerPort(server, (ushort port) {
+      auto client = new TSocket("127.0.0.1", port);
+      client.open();
+      writeFrameSize(client, declared);
+      client.close();
+
+      Connection connection;
+      foreach (_; 0 .. 1000) {
+        synchronized (server.connectionMutex_) {
+          if (!server.connectionStack_.empty) {
+            connection = server.connectionStack_[$ - 1];
+            break;
+          }
+        }
+        Thread.sleep(dur!"msecs"(10));
+      }
+      enforce(connection !is null,
+        "The server did not put the connection back on the idle stack.");
+      reserved = connection.readBufferSize_;
+    });
+
+    assert(reserved <= 64 * 1024, text("A frame header alone must not reserve "
+      ~ "the whole frame: the server reserved ", reserved, " bytes after a "
+      ~ "header declaring ", declared, "."));
+  }
+
+  // Payloads much larger than the initial reservation are assembled over many
+  // libevent callbacks while the buffer doubles. Two requests go over one
+  // connection with different content, so bytes left in the recycled buffer,
+  // a read bounded by the buffer instead of the frame, or a slice past the end
+  // of the buffer all show up as a mismatch rather than passing by chance.
+  {
+    enum uint payloadSize = 2 * 1024 * 1024;
+
+    auto server = makeServer(new DigestProcessor);
+    server.maxFrameSize = 16 * 1024 * 1024;
+
+    withServer(server, (TSocket client) {
+      foreach (uint seed; [0x5Au, 0xC3u]) {
+        auto payload = new ubyte[payloadSize];
+        // Position-dependent, so duplicated or reordered bytes fail too.
+        foreach (i, ref b; payload) b = cast(ubyte)(i * 31 + seed);
+
+        writeFrameSize(client, payloadSize);
+        client.write(payload);
+
+        // Four length bytes, then the echoed length and hash.
+        ubyte[4 + 4 + 4] reply;
+        client.readAll(reply);
+
+        uint replyLength, echoedLength, echoedHash;
+        (cast(ubyte*)&replyLength)[0 .. 4] = reply[0 .. 4];
+        (cast(ubyte*)&echoedLength)[0 .. 4] = reply[4 .. 8];
+        (cast(ubyte*)&echoedHash)[0 .. 4] = reply[8 .. 12];
+
+        assert(netToHost(replyLength) == 8);
+        assert(netToHost(echoedLength) == payloadSize,
+          text("The server saw ", netToHost(echoedLength), " payload bytes "
+            ~ "instead of ", payloadSize, "."));
+        assert(netToHost(echoedHash) == digestOf(payload),
+          "The payload did not survive the read buffer growing.");
+      }
     });
   }
 }


### PR DESCRIPTION
`TNonblockingServer` sizes the connection read buffer from the length the peer declared, in `transition()`'s `ConnectionState.READ_FRAME_SIZE` case, as soon as the four length bytes have been read and before any payload byte has arrived. A connection that announces a large frame and then sends nothing holds that buffer, rounded up to the next power of two, for as long as it stays open — and `DEFAULT_MAX_CONNECTIONS` is `int.max`.

This is the D counterpart of THRIFT-6243, which made the same change in C++. THRIFT-6241 lowered D's default frame size to the library-wide value; this bounds the allocation by what the peer actually sends.

### What changed

- `transition()` reserves about a kilobyte to begin reading, rather than the declared frame.
- The buffer grows toward the frame size in `SocketState.RECV` as bytes actually arrive, by the same doubling the up-front allocation used.
- The doubling moves into a `growReadBuffer()` helper that also stops before overflowing `size_t`; the old in-line loop would have spun forever on a 32-bit `size_t` with `maxFrameSize` raised past 2 GiB.

**One part is not a straight translation of the C++ change, and is worth a reviewer's eye.** The socket read was slicing `readBuffer_[readBufferPos_ .. readWant_]`, which only ever stayed inside the allocation *because* the whole frame had been reserved first. Once the buffer can be smaller than the frame, that slice runs past the end of it — and D does not bounds-check a slice taken from a raw pointer, even in a debug build. The read is therefore capped at `min(readBufferSize_, readWant_)`. The buffer can also be *larger* than the frame, whether because doubling overshot or because it was kept from an earlier, larger request, and bytes past `readWant_` belong to the next frame.

A frame that fully arrives ends at the same buffer size as before, so there is no change for legitimate traffic in the steady state and none at all for frames of a kilobyte or less. The initial reservation is deliberately `DEFAULT_IDLE_READ_BUFFER_LIMIT`, so a connection carrying only small frames settles at exactly the size `checkIdleBufferLimit()` lets an idle connection keep and is not freed and regrown between requests.

**Tradeoff:** a large frame that does arrive now pays the amortized doubling copy that any grow-as-you-go buffer pays — on the order of twice the frame size in copying over the life of the connection, against a single allocation before. That is the cost of not trusting the declared size.

### Tests

Two cases in `nonblocking.d`, both written before the change and both proven two-state:

- A header declaring 64 MiB followed by no payload leaves the connection's read buffer at a kilobyte. Before the change it was 67108864 bytes. The test closes the client so the connection goes back on the idle stack, where its buffer can be read without racing the I/O thread, with `idleReadBufferLimit` set to 0 so disposal does not free it first.
- Two 2 MiB requests over one connection, each filled with a position-dependent pattern and checked against a hash the server computes and returns. Each frame is far larger than the initial reservation, so it is assembled over many libevent callbacks while the buffer doubles, and it has to round-trip byte for byte.

Neutralising either half of the change fails: restoring the full-frame reservation puts the first case back to 67108864 bytes, and restoring the uncapped slice aborts the second with `free(): corrupted unsorted chunks`.

The existing frame-size unittest's server harness is hoisted to `version(unittest)` module scope, unchanged, so both tests can use it.

Verified with dmd 2.087.0, debug and release, three runs each, plus a clean `-w -wi` library build of `lib/d/src` in both modes. Note that no CI job builds D, so this local run is the only coverage.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
