### PR TITLE
THRIFT-6244: Stop TNonblockingServerTest racing its own teardown

### DIFF
--- a/lib/cpp/test/TNonblockingServerTest.cpp
+++ b/lib/cpp/test/TNonblockingServerTest.cpp
@@ -19,6 +19,7 @@
 
 #define BOOST_TEST_MODULE TNonblockingServerTest
 #include <boost/test/unit_test.hpp>
+#include <atomic>
 #include <climits>
 #include <fstream>
 #include <memory>
@@ -161,6 +162,17 @@ protected:
     if (thread) {
       thread->join();
     }
+    // Drain the thread pool while the server is still alive. server is declared
+    // after threadManager_, so it is destroyed first, and ~TNonblockingServer
+    // deletes every TConnection and the IO threads with their notification
+    // pipe. A task still unwinding at that point would call notifyIOThread() --
+    // and then close() -- on a deleted connection, which it holds by raw
+    // pointer. ThreadManager::stop() returns only once every worker has
+    // finished the task in its hands, so afterwards nothing is left to touch
+    // the objects about to be destroyed.
+    if (threadManager_) {
+      threadManager_->stop();
+    }
   }
 
   void setEventBase(event_base* user_event_base) {
@@ -187,6 +199,11 @@ protected:
 
   bool canCommunicate(int serverPort) {
     shared_ptr<transport::TSocket> socket(new transport::TSocket("localhost", serverPort));
+    // Without a timeout a server that never answers makes this block until the
+    // whole test binary is killed, which reports as one opaque timeout. The
+    // value only has to beat that: every call made here is a localhost
+    // round-trip of a few bytes.
+    socket->setRecvTimeout(10000);
     socket->open();
     test::ParentServiceClient client(make_shared<protocol::TBinaryProtocol>(
         make_shared<transport::TFramedTransport>(socket)));
@@ -313,21 +330,39 @@ BOOST_AUTO_TEST_CASE(default_max_frame_size_matches_configuration) {
 // that point, reading the arguments.
 struct FailsFirstCallProcessor : public TProcessor {
   explicit FailsFirstCallProcessor(const shared_ptr<TProcessor>& delegate)
-    : delegate_(delegate), failed_(false) {}
+    : delegate_(delegate), failed_(false), consumed_(false) {}
 
   bool process(shared_ptr<protocol::TProtocol> in,
                shared_ptr<protocol::TProtocol> out,
                void* connectionContext) override {
-    if (!failed_) {
-      failed_ = true;
+    // Both pool workers reach this, so the flag has to be claimed atomically:
+    // read-then-write let two calls each see it unset and both throw.
+    if (!failed_.exchange(true)) {
+      // Announce the claim before unwinding, so a caller can wait until the
+      // failure has been taken rather than guess.
+      {
+        Guard g(consumedMonitor_.mutex());
+        consumed_ = true;
+        consumedMonitor_.notifyAll();
+      }
       throw std::bad_alloc();
     }
     return delegate_->process(in, out, connectionContext);
   }
 
+  // Blocks until some call has consumed the injected failure.
+  void awaitFailure() {
+    Guard g(consumedMonitor_.mutex());
+    while (!consumed_) {
+      consumedMonitor_.wait();
+    }
+  }
+
 private:
   shared_ptr<TProcessor> delegate_;
-  bool failed_;
+  std::atomic<bool> failed_;
+  Monitor consumedMonitor_;
+  bool consumed_;
 };
 
 // A request that cannot be allocated is one request. Task::run() answered
@@ -348,8 +383,9 @@ private:
 // pre-existing, applies to every exception this catch handles, and differs from
 // the inline path, which closes the connection. Recorded separately.
 BOOST_FIXTURE_TEST_CASE(bad_alloc_does_not_end_the_process, Fixture) {
-  useThreadPool(make_shared<FailsFirstCallProcessor>(
-      make_shared<test::ParentServiceProcessor>(make_shared<Handler>())));
+  auto failing = make_shared<FailsFirstCallProcessor>(
+      make_shared<test::ParentServiceProcessor>(make_shared<Handler>()));
+  useThreadPool(failing);
 
   startServer(0);
   int port = server->getListenPort();
@@ -368,6 +404,13 @@ BOOST_FIXTURE_TEST_CASE(bad_alloc_does_not_end_the_process, Fixture) {
     client.send_addString("this one cannot be allocated");
     socket->close();
   }
+
+  // Wait until that call has actually taken the injected failure. The two pool
+  // workers are served in whatever order they are scheduled, so without this
+  // the call below can reach process() first, consume the failure itself and
+  // get no reply -- leaving the doomed call to be served normally and this test
+  // waiting on a reply that is never owed.
+  failing->awaitFailure();
 
   // The finding is that the process does not survive the above. A second
   // connection, served normally, is what says it did.


### PR DESCRIPTION
`bad_alloc_does_not_end_the_process` has failed intermittently on AppVeyor since it was added — 11 of 229 jobs, and 11 of 39 builds went red because of it — either crashing (ctest reports SEGFAULT) or hanging until the 300 s ctest timeout. There are two independent races, one behind each symptom, so both are fixed here. Test-only; no library change.

### The crash

The fixture stopped the server and joined the serve thread, but never stopped the `ThreadManager`. Members are destroyed in reverse declaration order, so `server` goes before `threadManager_`, and `~TNonblockingServer` deletes every `TConnection` and the IO threads along with their notification pipe. A pool task still unwinding from the injected failure then reached `notifyIOThread()` — and `close()` — on the `TConnection` it holds by raw pointer.

`~Fixture()` now stops the `ThreadManager` after joining the serve thread and before the members go. `ThreadManager::stop()` returns only once each worker has finished the task in its hands, so nothing is left running over the objects about to be destroyed.

### The hang

`FailsFirstCallProcessor` failed whichever call reached `process()` first, tracked in a plain `bool` that both pool workers read and wrote. When the call from `canCommunicate()` won that race it consumed the failure and got no reply — and its client had no receive timeout, so the test body blocked until ctest killed it.

The flag is now claimed with an atomic `exchange`, the processor signals a `Monitor` as it claims it, and the test waits for that signal before opening the second connection, so the failure is always taken by the call meant to receive it. The `exchange` matters on its own: read-then-write let two calls each see the flag unset and both throw, which is what the Windows logs showed as a doubled `bad_alloc` line.

`canCommunicate()` also gets a 10 s receive timeout. Every call it makes is a localhost round-trip of a few bytes, so this only bounds the failure mode: a regression now reports in seconds with the transport exception instead of as an opaque 300 s timeout.

### Verification

Rather than waiting on a race that is roughly 5 % on AppVeyor and 2 in 1200 here, each schedule was forced:

- **The hang** — delaying the first arrival at `process()` so the second connection claims the failure reproduces it exactly. Without the wait the case fails in 10 s with `THRIFT_EAGAIN (timed out)`; with it, the case passes.
- **The crash** — holding the failing task in flight past the end of the test body puts ASan straight on the use-after-free once the `ThreadManager` stop is removed:

  ```
  ERROR: AddressSanitizer: heap-use-after-free ... READ of size 8
    #0 TConnection::notifyIOThread()  TNonblockingServer.cpp:302
    #1 TConnection::Task::run()       TNonblockingServer.cpp:376
  freed by thread T0 here:
    ... ~TNonblockingServer()         TNonblockingServer.cpp:964
    ... Fixture::~Fixture()
  ```

  With the stop in place ASan reports nothing.

Then 5 clean runs of the full suite, and 200 runs of this case under ASan with eight in parallel.

### Not touched

`allocation_failure_on_the_io_thread_does_not_end_the_process` fails under ASan because its `RLIMIT_AS` child collides with ASan's own allocator. That reproduces identically on unmodified master and is unrelated to this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
