### PR TITLE
THRIFT-6174: Enable TSSLSocket to build with OpenSSL 4.0

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.c
@@ -285,7 +285,12 @@ thrift_ssl_socket_close (ThriftTransport *transport, GError **error)
       SSL_shutdown(ssl_socket->ssl);
       SSL_free(ssl_socket->ssl);
       ssl_socket->ssl = NULL;
+      /* ERR_remove_state() has been an empty stub since OpenSSL 1.1.0 and was
+         removed altogether in 4.0. LibreSSL reports OPENSSL_VERSION_NUMBER as
+         0x20000000L but still implements it, so it keeps the call. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
       ERR_remove_state(0);
+#endif
   }
   return thrift_socket_close(transport, error);
 }
@@ -724,7 +729,10 @@ void thrift_ssl_socket_finalize_openssl(void)
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
+  /* See thrift_ssl_socket_close() for why this is version-gated. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
   ERR_remove_state(0);
+#endif
 }
 
 
@@ -845,6 +853,54 @@ SSL_CTX*
 thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GError **error)
 {
   SSL_CTX* context = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+  /* OpenSSL 4.0 removed the single-version SSLv3_method() / TLSv1_method() /
+     TLSv1_1_method() / TLSv1_2_method() family. The documented replacement is
+     TLS_method() pinned to one version with SSL_CTX_set_min_proto_version()
+     and SSL_CTX_set_max_proto_version(), both available since 1.1.0. This
+     mirrors the C++ binding in lib/cpp/src/thrift/transport/TSSLSocket.cpp. */
+  const SSL_METHOD* method = TLS_method();
+  int version = 0;
+  switch(ssl_protocol){
+    case SSLTLS:
+      /* Version-flexible: the protocol floor is set through
+         SSL_CTX_set_options() below, as it was before. */
+      break;
+#if !defined(OPENSSL_NO_SSL3) && OPENSSL_VERSION_NUMBER < 0x40000000L
+    case SSLv3:
+      /* SSLv3_method() is only gone in 4.0, which removes SSLv3 altogether, so
+         below that it is kept rather than expressed as a TLS_method() window:
+         SSL_CTX_set_min_proto_version() honours the security level and would
+         refuse SSL3_VERSION at the default level, where SSLv3_method() does
+         not. See the C++ binding for the same reasoning. */
+      method = SSLv3_method();
+      break;
+#endif
+    case TLSv1_0:
+      version = TLS1_VERSION;
+      break;
+    case TLSv1_1:
+      version = TLS1_1_VERSION;
+      break;
+    case TLSv1_2:
+      version = TLS1_2_VERSION;
+      break;
+    default:
+      g_set_error (error, THRIFT_TRANSPORT_ERROR,
+		   THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE,
+		   "The SSL protocol is unknown for %d", ssl_protocol);
+      return NULL;
+  }
+
+  context = SSL_CTX_new(method);
+  if (context != NULL && version != 0
+      && (SSL_CTX_set_min_proto_version(context, version) != 1
+          || SSL_CTX_set_max_proto_version(context, version) != 1)) {
+      /* The requested version is not available in this build of the library. */
+      SSL_CTX_free(context);
+      context = NULL;
+  }
+#else
   switch(ssl_protocol){
     case SSLTLS:
       context = SSL_CTX_new(SSLv23_method());
@@ -870,6 +926,7 @@ thrift_ssl_socket_context_initialize(ThriftSSLSocketProtocol ssl_protocol, GErro
       return NULL;
       break;
   }
+#endif
 
   if (context == NULL) {
       thrift_ssl_socket_get_error((const guchar*)"No cipher overlay", THRIFT_SSL_SOCKET_ERROR_CIPHER_NOT_AVAILABLE, error);

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
@@ -99,9 +99,9 @@ enum _ThriftSSLSocketProtocol {
   SSLTLS  = 0,  /* Supports SSLv2 and SSLv3 handshake but only negotiates at TLSv1_0 or later. */
 /*SSLv2   = 1,   HORRIBLY INSECURE! */
   SSLv3   = 2,  /* Supports SSLv3 only - also horribly insecure! */
-  TLSv1_0 = 3,  /* Supports TLSv1_0 or later. */
-  TLSv1_1 = 4,  /* Supports TLSv1_1 or later. */
-  TLSv1_2 = 5,  /* Supports TLSv1_2 or later. */
+  TLSv1_0 = 3,  /* Supports TLSv1_0 only. */
+  TLSv1_1 = 4,  /* Supports TLSv1_1 only. */
+  TLSv1_2 = 5,  /* Supports TLSv1_2 only. */
   LATEST  = TLSv1_2
 };
 typedef enum _ThriftSSLSocketProtocol ThriftSSLSocketProtocol;

--- a/lib/c_glib/test/testtransportsslsocket.c
+++ b/lib/c_glib/test/testtransportsslsocket.c
@@ -224,10 +224,20 @@ test_ssl_write_invalid_socket(void)
 
 
 
+/* OpenSSL 4.0 returns const pointers from the X509 name accessors. Every
+   function those values are passed to here has taken const since 1.1.0, so the
+   const types are used from there on as well. LibreSSL is excluded because it
+   keeps the pre-1.1.0 signatures. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#  define THRIFT_TEST_X509_CONST const
+#else
+#  define THRIFT_TEST_X509_CONST
+#endif
+
 /**
  * Print the common name of certificate
  */
-unsigned char * get_cn_name(X509_NAME* const name)
+unsigned char * get_cn_name(THRIFT_TEST_X509_CONST X509_NAME* const name)
 {
   int idx = -1;
   unsigned char *utf8 = NULL;
@@ -239,10 +249,10 @@ unsigned char * get_cn_name(X509_NAME* const name)
       idx = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
       if(!(idx > -1))  break; /* failed */
 
-      X509_NAME_ENTRY* entry = X509_NAME_get_entry(name, idx);
+      THRIFT_TEST_X509_CONST X509_NAME_ENTRY* entry = X509_NAME_get_entry(name, idx);
       if(!entry) break; /* failed */
 
-      ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
+      THRIFT_TEST_X509_CONST ASN1_STRING* data = X509_NAME_ENTRY_get_data(entry);
       if(!data) break; /* failed */
 
       int length = ASN1_STRING_to_UTF8(&utf8, data);
@@ -377,8 +387,8 @@ gboolean my_access_manager(ThriftTransport * transport, X509 *cert, struct socka
   THRIFT_UNUSED_VAR (sslSocket);
 
   g_info("Processing access to the server");
-  X509_NAME* iname = cert ? X509_get_issuer_name(cert) : NULL;
-  X509_NAME* sname = cert ? X509_get_subject_name(cert) : NULL;
+  THRIFT_TEST_X509_CONST X509_NAME* iname = cert ? X509_get_issuer_name(cert) : NULL;
+  THRIFT_TEST_X509_CONST X509_NAME* sname = cert ? X509_get_subject_name(cert) : NULL;
 
   /* Issuer is the authority we trust that warrants nothing useful */
   const unsigned char * issuer = get_cn_name(iname);
@@ -500,6 +510,69 @@ test_ssl_authorization_manager(void)
 
 
 static void
+test_ssl_context_explicit_protocol_window(void)
+{
+  /* An explicitly requested protocol has to pin the context to exactly that
+     version, the way the per-version TLSv1_x_method() functions it replaces
+     did. Checking the window rather than just "a context came back" is what
+     catches a remapping that silently leaves the floor to the library default.
+
+     SSL_CTX_get_min_proto_version() and SSL_CTX_get_max_proto_version() were
+     added in OpenSSL 1.1.1a. */
+#if OPENSSL_VERSION_NUMBER >= 0x1010101fL && !defined(LIBRESSL_VERSION_NUMBER)
+  static const struct {
+    ThriftSSLSocketProtocol protocol;
+    int version;
+  } expectations[] = {
+    { TLSv1_0, TLS1_VERSION },
+    { TLSv1_1, TLS1_1_VERSION },
+    { TLSv1_2, TLS1_2_VERSION },
+    { LATEST,  TLS1_2_VERSION }
+  };
+  guint i;
+
+  for (i = 0; i < G_N_ELEMENTS (expectations); i++) {
+      GError *error = NULL;
+      SSL_CTX *context = thrift_ssl_socket_context_initialize (expectations[i].protocol,
+                                                               &error);
+      g_assert_no_error (error);
+      g_assert (context != NULL);
+      g_assert_cmpint (SSL_CTX_get_min_proto_version (context), ==,
+                       expectations[i].version);
+      g_assert_cmpint (SSL_CTX_get_max_proto_version (context), ==,
+                       expectations[i].version);
+      SSL_CTX_free (context);
+  }
+#endif
+}
+
+static void
+test_ssl_context_unavailable_protocol(void)
+{
+#if defined(OPENSSL_NO_SSL3) || OPENSSL_VERSION_NUMBER >= 0x40000000L
+  /* SSLv3 is not available in this build of the library. That has to be
+     reported rather than quietly satisfied with some other version. */
+  GError *error = NULL;
+  SSL_CTX *context = thrift_ssl_socket_context_initialize (SSLv3, &error);
+
+  g_assert (context == NULL);
+  g_assert (error != NULL);
+  g_clear_error (&error);
+#endif
+
+  /* An out-of-range value is reported the same way. */
+  {
+    GError *error = NULL;
+    SSL_CTX *context = thrift_ssl_socket_context_initialize ((ThriftSSLSocketProtocol) 42,
+                                                             &error);
+
+    g_assert (context == NULL);
+    g_assert (error != NULL);
+    g_clear_error (&error);
+  }
+}
+
+static void
 thrift_socket_server (const int port)
 {
   int bytes = 0;
@@ -547,6 +620,8 @@ main(int argc, char *argv[])
   g_test_add_func ("/testtransportsslsocket/CreateAndDestroy", test_ssl_create_and_destroy);
   g_test_add_func ("/testtransportsslsocket/CreateAndSetProperties", test_ssl_create_and_set_properties);
   g_test_add_func ("/testtransportsslsocket/ContextDefaultMinVersion", test_ssl_context_default_min_version);
+  g_test_add_func ("/testtransportsslsocket/ContextExplicitProtocolWindow", test_ssl_context_explicit_protocol_window);
+  g_test_add_func ("/testtransportsslsocket/ContextUnavailableProtocol", test_ssl_context_unavailable_protocol);
   g_test_add_func ("/testtransportsslsocket/OpenAndCloseNonSSLServer", test_ssl_open_and_close_non_ssl_server);
   g_test_add_func ("/testtransportsslsocket/OpenAndWriteInvalidSocket", test_ssl_write_invalid_socket);
 

--- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
@@ -157,8 +157,10 @@ void cleanupOpenSSL() {
 #endif
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
-  // Do nothing unless an openssl derivative is detected
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+  // LibreSSL reports OPENSSL_VERSION_NUMBER as 0x20000000L but has never shipped
+  // OPENSSL_thread_stop(), so it is routed to ERR_remove_state() below, which it
+  // does implement. Do nothing unless an openssl derivative is detected
 #  if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
   // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
   OPENSSL_thread_stop();
@@ -180,6 +182,54 @@ static char uppercase(char c);
 
 // SSLContext implementation
 SSLContext::SSLContext(const SSLProtocol& protocol) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+  // OpenSSL 4.0 removed the single-version SSLv3_method() / TLSv1_method() /
+  // TLSv1_1_method() / TLSv1_2_method() family. The documented replacement is
+  // TLS_method() pinned to one version with SSL_CTX_set_min_proto_version() and
+  // SSL_CTX_set_max_proto_version(), both available since 1.1.0. Selecting the
+  // replacement from 1.1.0 onwards rather than only on 4.0 keeps a single code
+  // path under test, instead of one that no CI configuration ever compiles.
+  const SSL_METHOD* method = TLS_method();
+  int version = 0;
+  switch (protocol) {
+  case SSLTLS:
+    // Version-flexible: the protocol floor is set through SSL_CTX_set_options()
+    // below, as it was before.
+    break;
+#if !defined(OPENSSL_NO_SSL3) && OPENSSL_VERSION_NUMBER < 0x40000000L
+  case SSLv3:
+    // SSLv3_method() is only gone in 4.0, which removes SSLv3 altogether, so
+    // below that it is kept rather than expressed as a TLS_method() window:
+    // SSL_CTX_set_min_proto_version() honours the security level and would
+    // refuse SSL3_VERSION at the default level, where SSLv3_method() does not.
+    // This is also the one arm no CI configuration compiles, so leaving it
+    // alone keeps it behaving exactly as before.
+    method = SSLv3_method();
+    break;
+#endif
+  case TLSv1_0:
+    version = TLS1_VERSION;
+    break;
+  case TLSv1_1:
+    version = TLS1_1_VERSION;
+    break;
+  case TLSv1_2:
+    version = TLS1_2_VERSION;
+    break;
+  default:
+    /// UNKNOWN PROTOCOL!
+    throw TSSLException("SSL_CTX_new: Unknown protocol");
+  }
+
+  ctx_ = SSL_CTX_new(method);
+  if (ctx_ != nullptr && version != 0
+      && (SSL_CTX_set_min_proto_version(ctx_, version) != 1
+          || SSL_CTX_set_max_proto_version(ctx_, version) != 1)) {
+    // The requested version is not available in this build of the library.
+    SSL_CTX_free(ctx_);
+    ctx_ = nullptr;
+  }
+#else
   if (protocol == SSLTLS) {
     ctx_ = SSL_CTX_new(SSLv23_method());
 #ifndef OPENSSL_NO_SSL3
@@ -196,6 +246,7 @@ SSLContext::SSLContext(const SSLProtocol& protocol) {
     /// UNKNOWN PROTOCOL!
     throw TSSLException("SSL_CTX_new: Unknown protocol");
   }
+#endif
 
   if (ctx_ == nullptr) {
     string errors;
@@ -405,7 +456,8 @@ void TSSLSocket::close() {
     SSL_free(ssl_);
     ssl_ = nullptr;
     handshakeCompleted_ = false;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
+    // LibreSSL has no OPENSSL_thread_stop(); see cleanupOpenSSL() above.
     // Do nothing unless an openssl derivative is detected
 #  if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     // https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_thread_stop.html
@@ -810,9 +862,23 @@ void TSSLSocket::authorize() {
   //
   // Skipped entirely when the certificate presented a dNSName: it has already
   // had its say, and a non-matching one is an answer, not an absence.
+  //
+  // OpenSSL 4.0 made X509_get_subject_name(), X509_NAME_get_entry() and
+  // X509_NAME_ENTRY_get_data() return const pointers. Every function these
+  // values are then passed to has taken const since 1.1.0, so the const types
+  // are used from there on as well. LibreSSL is excluded because it keeps the
+  // pre-1.1.0 signatures.
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+  const X509_NAME* name = hasDnsName ? nullptr : X509_get_subject_name(cert);
+#else
   X509_NAME* name = hasDnsName ? nullptr : X509_get_subject_name(cert);
+#endif
   if (name != nullptr) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+    const X509_NAME_ENTRY* entry;
+#else
     X509_NAME_ENTRY* entry;
+#endif
     unsigned char* utf8;
     int last = -1;
     while (decision == AccessManager::SKIP) {
@@ -822,7 +888,11 @@ void TSSLSocket::authorize() {
       entry = X509_NAME_get_entry(name, last);
       if (entry == nullptr)
         continue;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+      const ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
+#else
       ASN1_STRING* common = X509_NAME_ENTRY_get_data(entry);
+#endif
       int size = ASN1_STRING_to_UTF8(&utf8, common);
       if (host.empty()) {
         host = (server() ? getPeerHost() : getHost());

--- a/lib/cpp/src/thrift/transport/TSSLSocket.h
+++ b/lib/cpp/src/thrift/transport/TSSLSocket.h
@@ -40,9 +40,9 @@ enum SSLProtocol {
   SSLTLS  = 0,  // Supports version-flexible TLS negotiation with TLSv1_2 as the default floor.
 //SSLv2   = 1,  // HORRIBLY INSECURE!
   SSLv3   = 2,  // Supports SSLv3 only - also horribly insecure!
-  TLSv1_0 = 3,  // Supports TLSv1_0 or later.
-  TLSv1_1 = 4,  // Supports TLSv1_1 or later.
-  TLSv1_2 = 5,  // Supports TLSv1_2 or later.
+  TLSv1_0 = 3,  // Supports TLSv1_0 only.
+  TLSv1_1 = 4,  // Supports TLSv1_1 only.
+  TLSv1_2 = 5,  // Supports TLSv1_2 only.
   LATEST  = TLSv1_2
 };
 

--- a/lib/cpp/test/SecurityFromBufferTest.cpp
+++ b/lib/cpp/test/SecurityFromBufferTest.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix) {
           continue;
         }
 
-#ifdef OPENSSL_NO_SSL3
+#if defined(OPENSSL_NO_SSL3) || OPENSSL_VERSION_NUMBER >= 0x40000000L
         if (si == 2 || ci == 2) {
           // Skip all SSLv3 cases - protocol not supported
           continue;

--- a/lib/cpp/test/SecurityTest.cpp
+++ b/lib/cpp/test/SecurityTest.cpp
@@ -329,6 +329,54 @@ BOOST_AUTO_TEST_CASE(custom_ssl_context_factory_validation)
     }
 }
 
+BOOST_AUTO_TEST_CASE(explicit_protocol_version_window)
+{
+    // An explicitly requested protocol has to pin the context to exactly that
+    // version, the way the per-version TLSv1_x_method() functions it replaces
+    // did. Checking the window rather than just "a context came back" is what
+    // catches a remapping that silently leaves the floor to the library
+    // default, which would make an explicit request laxer than SSLTLS.
+    //
+    // SSL_CTX_get_min_proto_version() and SSL_CTX_get_max_proto_version() were
+    // added in OpenSSL 1.1.1a.
+#if OPENSSL_VERSION_NUMBER >= 0x1010101fL && !defined(LIBRESSL_VERSION_NUMBER)
+    struct Expectation
+    {
+        apache::thrift::transport::SSLProtocol protocol;
+        const char* name;
+        int version;
+    };
+
+    const Expectation expectations[] = {
+        { apache::thrift::transport::TLSv1_0, "TLSv1_0", TLS1_VERSION   },
+        { apache::thrift::transport::TLSv1_1, "TLSv1_1", TLS1_1_VERSION },
+        { apache::thrift::transport::TLSv1_2, "TLSv1_2", TLS1_2_VERSION },
+        { apache::thrift::transport::LATEST,  "LATEST",  TLS1_2_VERSION }
+    };
+
+    for (const auto& expected : expectations)
+    {
+        BOOST_TEST_MESSAGE(boost::format("TEST: protocol = %1%") % expected.name);
+        apache::thrift::transport::SSLContext context(expected.protocol);
+        BOOST_CHECK_EQUAL(expected.version, SSL_CTX_get_min_proto_version(context.get()));
+        BOOST_CHECK_EQUAL(expected.version, SSL_CTX_get_max_proto_version(context.get()));
+    }
+#endif
+
+#if defined(OPENSSL_NO_SSL3) || OPENSSL_VERSION_NUMBER >= 0x40000000L
+    // SSLv3 is not available in this build of the library. That has to be
+    // reported rather than quietly satisfied with some other version.
+    try
+    {
+        apache::thrift::transport::SSLContext context(apache::thrift::transport::SSLv3);
+        BOOST_FAIL("Expected unavailable SSLv3 to throw");
+    }
+    catch (const TSSLException&)
+    {
+    }
+#endif
+}
+
 BOOST_AUTO_TEST_CASE(ssl_security_matrix)
 {
     try
@@ -357,7 +405,7 @@ BOOST_AUTO_TEST_CASE(ssl_security_matrix)
                     continue;
                 }
 
-#ifdef OPENSSL_NO_SSL3
+#if defined(OPENSSL_NO_SSL3) || OPENSSL_VERSION_NUMBER >= 0x40000000L
                 if (si == 2 || ci == 2)
                 {
                     // Skip all SSLv3 cases - protocol not supported

--- a/lib/cpp/test/TSSLSocketMatchNameTest.cpp
+++ b/lib/cpp/test/TSSLSocketMatchNameTest.cpp
@@ -20,6 +20,7 @@
 #define BOOST_TEST_MODULE TSSLSocketMatchNameTest
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
+#include <boost/version.hpp>
 #include <thrift/transport/TSSLSocket.h>
 #include <thrift/transport/TSSLServerSocket.h>
 #include <thrift/transport/TTransportException.h>
@@ -28,6 +29,9 @@
 #include <openssl/x509v3.h>
 
 #include <string>
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
 
 using apache::thrift::transport::AccessManager;
 using apache::thrift::transport::DefaultClientAccessManager;
@@ -36,6 +40,34 @@ using apache::thrift::transport::TSSLSocketFactory;
 using apache::thrift::transport::TSSLServerSocket;
 using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TTransportException;
+
+// Several of the cases below have the client reject the server's identity on
+// purpose, which tears the connection down mid-handshake. OpenSSL calls send()
+// without MSG_NOSIGPIPE, so the peer still writing to that socket takes a
+// SIGPIPE and the whole test binary dies with status 141. SecurityTest.cpp
+// ignores the signal for the same reason.
+struct GlobalFixture
+{
+    GlobalFixture()
+    {
+#ifdef __linux__
+        signal(SIGPIPE, SIG_IGN);
+#endif
+    }
+
+    virtual ~GlobalFixture()
+    {
+#ifdef __linux__
+        signal(SIGPIPE, SIG_DFL);
+#endif
+    }
+};
+
+#if (BOOST_VERSION >= 105900)
+BOOST_GLOBAL_FIXTURE(GlobalFixture);
+#else
+BOOST_GLOBAL_FIXTURE(GlobalFixture)
+#endif
 
 BOOST_AUTO_TEST_SUITE(TSSLSocketMatchNameTest)
 
@@ -122,11 +154,17 @@ Pem selfSigned(const std::string& commonName, const std::string& subjectAltName)
 #endif
   X509_set_pubkey(cert, key);
 
-  X509_NAME* subject = X509_get_subject_name(cert);
+  // Built up separately rather than through X509_get_subject_name(), which
+  // returns a const pointer as of OpenSSL 4.0. Both setters copy the name, so
+  // the local one is released again right away.
+  X509_NAME* subject = X509_NAME_new();
+  BOOST_REQUIRE(subject != nullptr);
   X509_NAME_add_entry_by_txt(subject, "CN", MBSTRING_ASC,
                              reinterpret_cast<const unsigned char*>(commonName.c_str()),
                              -1, -1, 0);
+  X509_set_subject_name(cert, subject);
   X509_set_issuer_name(cert, subject);
+  X509_NAME_free(subject);
 
   if (!subjectAltName.empty()) {
     X509V3_CTX extCtx;


### PR DESCRIPTION
One patch for OpenSSL 4.0, merging #3761, #3752 and #3736 together with the two
patches that were posted as comments rather than PRs. It supersedes all three.

Every enum value keeps working. `SSLv3_method()`, `TLSv1_method()`,
`TLSv1_1_method()` and `TLSv1_2_method()` are replaced by `TLS_method()` with the
protocol window pinned through `SSL_CTX_set_min_proto_version()` /
`SSL_CTX_set_max_proto_version()`, which is OpenSSL's documented migration and
reproduces the removed methods exactly -- `TLSv1_2_method()` meant TLS 1.2 only,
and `min == max == TLS1_2_VERSION` means the same. So `TLSv1_0`, `TLSv1_1`,
`TLSv1_2` and `LATEST` do not start throwing `"Unknown protocol"` on 4.0.

### Why the new path is gated at >= 1.1.0, not at >= 4.0

No CI configuration builds against OpenSSL 4.0. Gating the replacement at
`>= 0x40000000L` ships a code path that nothing in CI ever compiles, let alone
runs -- the objection I raised on #3761. The replacement APIs all exist since
1.1.0, so selecting them from there on puts the new code under the existing SSL
matrix tests on the OpenSSL 3.x that CI does have. Same reasoning for the `const`
qualifiers, whose consumers have taken `const` since 1.1.0.

LibreSSL is excluded throughout: it reports `OPENSSL_VERSION_NUMBER` as
`0x20000000L` but keeps the pre-1.1.0 signatures, so it stays on exactly the path
it compiles today.

`SSLTLS` is untouched. `SSLv23_method()` is *not* removed in 4.0 -- it is an
unconditional `#define SSLv23_method TLS_method` -- so that arm needed no change,
and its protocol floor still comes from the existing `SSL_CTX_set_options()` call.

`SSLv3` keeps `SSLv3_method()` below 4.0, the only release that removes it, rather
than becoming a window like the others: `SSL_CTX_set_min_proto_version()` consults
the security level and would refuse `SSL3_VERSION` at the default one, where the
method function does not -- and the context is built before
`TSSLSocketFactory::ciphers()` lowers it. On 4.0 the protocol is gone outright and
the arm is compiled out.

### Tests

- `SecurityTest` gains `explicit_protocol_version_window`, asserting the min/max
  window per enum value rather than just that a context came back -- the latter
  passes on a remapping that silently leaves the floor to the library default.
  Proven two-state: with the window not pinned it fails 8 assertions, `LATEST`
  among them, reporting floor `0`. It also asserts that an unavailable `SSLv3` is
  reported rather than quietly satisfied with some other version.
- Both matrix tests skip `SSLv3` on 4.0. `OPENSSL_NO_SSL3` is **not** defined
  there (verified), so without this they try SSLv3 and time out -- exactly what
  @loqs reported on #3752.
- `testtransportsslsocket` gains the same two cases for c_glib.
- `TSSLSocketMatchNameTest` built its subject name through
  `X509_get_subject_name()` and then mutated it; that is a hard compile error on
  4.0. **None of the three PRs covers this file, so none of them actually yields
  a tree that passes `make check -C lib/cpp` on 4.0.** It now builds a separate
  `X509_NAME`. While there I found it has no SIGPIPE handler although several
  cases deliberately provoke rejected handshakes: it dies with status 141 in 6 of
  20 runs on master today, and 11 of 20 with this change, since the allocation
  pattern shifts the race. It is ignored now, as `SecurityTest` already does, and
  25 of 25 runs pass.

### Verification

Built and ran `lib/cpp` and `lib/c_glib` against three libraries -- the
distribution **OpenSSL 3.0.2**, a from-source **4.0.2**, and a from-source
**3.0.2 configured with `enable-ssl3`** so that the `SSLv3` arm, which is
compiled out everywhere else, is covered too:

| | 3.0.2 | 4.0.2 | 3.0.2 +ssl3 |
|---|---|---|---|
| `SecurityTest` | 16/16 cells | 16/16 cells | 25/25 cells |
| `SecurityFromBufferTest` | 16/16 cells | 16/16 cells | -- |
| `TSSLSocketMatchNameTest` | pass, 25/25 stable | pass, 15/15 stable | -- |
| `testtransportsslsocket` | 7/7 | 7/7 | -- |

The matrix results are identical across versions and cell-for-cell identical to
an unpatched-master baseline built against the same libraries. Unpatched master
against 4.0.2 fails to compile with 7 errors in C++ and 5 in c_glib.

**Not verified here: LibreSSL.** The guard shapes are @brad0's unchanged, and he
confirmed #3761 built on OpenBSD; a re-confirmation on this branch would be
welcome.

### Credit

- @sebastianas -- #3761, the original patch and the thread
- @jaipaulcheernam -- #3752, the `TLS_method()` + min/max approach and the `const` work
- @brad0 -- #3736, the LibreSSL guards, kept on the outer `#if` as in his force-push
- @loqs -- the `OPENSSL_NO_SSL3` test guard and the c_glib context test cases
- @FinnRG -- the switch-computes-version structure and the `set_*_proto_version()` return-value check

### Deliberately out of scope

`lib/d` still will not link against libcrypto 4.0: `ERR_remove_state(0)` is
ungated at `transport/ssl.d:144` and `async/ssl.d:216`, and `ASN1_STRING_data` at
`internal/ssl.d:134` (`transport/ssl.d:503` *is* correctly guarded). That is the
same class of breakage as this ticket but a different `Client:`, so it wants its
own ticket -- I can file one.

Three smaller observations, noted rather than changed: `SSL_set1_host` is newly
deprecated in 4.0 at `thrift_ssl_socket.c:446` (a warning, not a removal);
`testtransportsslsocket` is listed in `Makefile.am` but not in
`lib/c_glib/test/CMakeLists.txt`, so `ctest` never runs it -- wiring it in works
and all 7 cases pass, but that is a pre-existing build-system gap; and there is no
c_glib CI job at all, while `cmake.yml` builds the compiler only
(`-DBUILD_LIBRARIES=OFF`), so nothing in CI exercises c_glib either way.

### Note on `make style`

Not run. `.clang-format` has drifted far from these files: on unmodified master
it wants to rewrite 285 lines of `TSSLSocket.cpp` and 293 of `SecurityTest.cpp`
(which is 4-space/Allman throughout while `.clang-format` is 2-space/attached),
and it mangles the commented-out `SSLv2` line in the enum. The change follows
each file's local convention instead; no hard tabs and no trailing whitespace
were introduced.
